### PR TITLE
fix(registry): stop serializing full-fleet provider scans

### DIFF
--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -153,7 +153,8 @@ type DispatchPlan struct {
 // dispatchPlanMaxAlternates lowest-cost non-winner candidates via insertion
 // into a fixed-capacity slice (O(n·8) comparisons, no full-pool sort, no
 // full-pool copy — only the ≤8 retained entries copy their ranking terms).
-// Caller holds r.mu (candidates reference live *Providers).
+// The scan pool is immutable; live provider identity/state is revalidated when
+// an entry is consumed.
 func newDispatchPlan(model string, scan candidateScan, winner *routingCandidate) *DispatchPlan {
 	plan := &DispatchPlan{
 		model:     model,

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -444,6 +444,82 @@ func TestConcurrentPrimaryScansRerankUntilUntriedCapacity(t *testing.T) {
 	}
 }
 
+// TestCommitCapacityRejectionSurvivesCandidateExclusion proves a provider that
+// becomes full between scan and commit remains classified as transient capacity
+// after it is excluded from the next scan.
+func TestCommitCapacityRejectionSurvivesCandidateExclusion(t *testing.T) {
+	reg := New(testLogger())
+	model := "commit-rejection-counters"
+	p := planTestProvider(t, reg, "only", model, 0)
+	scanned := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	reg.reservationAfterScan = func(string) {
+		once.Do(func() {
+			close(scanned)
+			<-release
+		})
+	}
+	type result struct {
+		provider *Provider
+		decision RoutingDecision
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		provider, decision := reg.ReserveProviderEx(
+			model, planTestRequest("commit-capacity-reject", 100, 100))
+		resultCh <- result{provider: provider, decision: decision}
+	}()
+	<-scanned
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100
+	p.mu.Unlock()
+	close(release)
+
+	got := <-resultCh
+	if got.provider != nil {
+		t.Fatalf("provider=%q, want nil after commit-time capacity loss", got.provider.ID)
+	}
+	if got.decision.CapacityRejections != 1 {
+		t.Fatalf("CapacityRejections=%d, want 1 preserved across exclusion", got.decision.CapacityRejections)
+	}
+}
+
+// TestCommitRejectsExpiredFirstContentDeadline proves scan and write-lock wait
+// time cannot produce a doomed pending debit after the absolute clock expires.
+func TestCommitRejectsExpiredFirstContentDeadline(t *testing.T) {
+	reg := New(testLogger())
+	model := "commit-deadline"
+	p := planTestProvider(t, reg, "deadline-provider", model, 0)
+	pr := planTestRequest("commit-deadline-request", 100, 100)
+	pr.FirstContentDeadline = time.Now().Add(time.Minute)
+
+	scanned := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	reg.reservationAfterScan = func(string) {
+		once.Do(func() {
+			close(scanned)
+			<-release
+		})
+	}
+	selected := make(chan *Provider, 1)
+	go func() {
+		provider, _, _ := reg.ReserveProviderWithPlan(model, pr)
+		selected <- provider
+	}()
+	<-scanned
+	pr.FirstContentDeadline = time.Now().Add(-time.Second)
+	close(release)
+
+	if provider := <-selected; provider != nil {
+		t.Fatalf("provider=%q, want nil after deadline expired before commit", provider.ID)
+	}
+	if pending := p.PendingCount(); pending != 0 {
+		t.Fatalf("pending=%d, want no debit for expired request", pending)
+	}
+}
+
 // TestHeartbeatResyncRestoresProviderReportedTruth: while a reservation is in
 // the heartbeat dark window, its coordinator-side debit gates admission; once
 // the provider's heartbeat reports the admitted work, committedTokenBudget

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -3,7 +3,9 @@ package registry
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // planTestProvider registers a token-budget provider whose routing cost is
@@ -378,6 +380,67 @@ func TestConcurrentReservationsCannotDoubleSpendReportedBudget(t *testing.T) {
 	}
 	if wins != 1 {
 		t.Fatalf("wins=%d, want exactly 1 of two concurrent reservations against one budget", wins)
+	}
+}
+
+// TestConcurrentPrimaryScansRerankUntilUntriedCapacity proves a scan cohort
+// cannot herd onto the same stale cheapest provider or stop after a fixed retry
+// count. Three requests first select p00 from the same empty snapshot; commits
+// must then observe prior debits and spread across p00, p01, and p02.
+func TestConcurrentPrimaryScansRerankUntilUntriedCapacity(t *testing.T) {
+	reg := New(testLogger())
+	model := "primary-rerank-model"
+	for i := range 3 {
+		p := planTestProvider(t, reg, fmt.Sprintf("p%02d", i), model, int64(i)*400)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].MaxConcurrency = 1
+		p.mu.Unlock()
+	}
+
+	arrived := make(chan struct{}, 3)
+	release := make(chan struct{})
+	var initialScans atomic.Int32
+	reg.reservationAfterScan = func(string) {
+		if initialScans.Add(1) > 3 {
+			return
+		}
+		arrived <- struct{}{}
+		<-release
+	}
+
+	selected := make([]*Provider, 3)
+	var wg sync.WaitGroup
+	for i := range selected {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			selected[i], _, _ = reg.ReserveProviderWithPlan(
+				model, planTestRequest(fmt.Sprintf("primary-rerank-%d", i), 100, 100))
+		}()
+	}
+	for range 3 {
+		select {
+		case <-arrived:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatal("primary scans serialized instead of reaching the shared-scan barrier")
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	winners := make(map[string]bool, 3)
+	for i, p := range selected {
+		if p == nil {
+			t.Fatalf("request %d returned nil while an untried provider remained", i)
+		}
+		winners[p.ID] = true
+	}
+	if len(winners) != 3 {
+		t.Fatalf("winner set=%v, want one request on each of p00, p01, and p02", winners)
+	}
+	for i, p := range selected {
+		p.RemovePending(fmt.Sprintf("primary-rerank-%d", i))
 	}
 }
 

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -3,7 +3,9 @@ package registry
 import (
 	"fmt"
 	"math"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
@@ -283,6 +285,94 @@ func TestPooledAdmissionCoResidencyDoubleSpend(t *testing.T) {
 		RequestID: "victim", Model: gemmaBuild, EstimatedPromptTokens: 100, RequestedMaxTokens: 1_900,
 	}); got != nil {
 		t.Fatalf("gemma admitted during the heartbeat gap — co-resident double-spend of the shared KV pool (provider %q)", got.ID)
+	}
+}
+
+// TestConcurrentReservationScansCommitPooledBudgetAtomically proves the
+// production primary path can scan different models concurrently without
+// double-spending one provider's cross-model token pool. Both scans rendezvous
+// after seeing the same empty heartbeat snapshot; the short serialized commit
+// must admit exactly one 2k request into the shared 3k pool.
+func TestConcurrentReservationScansCommitPooledBudgetAtomically(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "shared-box", gptossBuild, 93)
+	addAdvertisedModel(p, gemmaBuild)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 3_000
+	p.BackendCapacity.Slots = append(p.BackendCapacity.Slots, protocol.BackendSlotCapacity{
+		Model:                gemmaBuild,
+		State:                "running",
+		ActiveTokenBudgetMax: 3_000,
+	})
+	p.mu.Unlock()
+
+	arrived := make(chan string, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseScans := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseScans()
+	var seenMu sync.Mutex
+	seen := make(map[string]bool, 2)
+	reg.reservationAfterScan = func(model string) {
+		seenMu.Lock()
+		first := !seen[model]
+		seen[model] = true
+		seenMu.Unlock()
+		if !first {
+			return
+		}
+		arrived <- model
+		<-release
+	}
+
+	type result struct {
+		requestID string
+		provider  *Provider
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	for i, model := range []string{gptossBuild, gemmaBuild} {
+		go func() {
+			<-start
+			requestID := fmt.Sprintf("concurrent-%d", i)
+			provider, _, _ := reg.ReserveProviderWithPlan(model, &PendingRequest{
+				RequestID:             requestID,
+				Model:                 model,
+				EstimatedPromptTokens: 100,
+				RequestedMaxTokens:    1_900,
+			})
+			results <- result{requestID: requestID, provider: provider}
+		}()
+	}
+	close(start)
+
+	entered := make(map[string]bool, 2)
+	for len(entered) < 2 {
+		select {
+		case model := <-arrived:
+			entered[model] = true
+		case <-time.After(2 * time.Second):
+			releaseScans()
+			t.Fatalf("reservation scans serialized before commit; entered=%v", entered)
+		}
+	}
+	releaseScans()
+	reservations := make([]result, 0, 2)
+	admitted := 0
+	for range 2 {
+		res := <-results
+		reservations = append(reservations, res)
+		if res.provider != nil {
+			admitted++
+		}
+	}
+	for _, res := range reservations {
+		if res.provider != nil {
+			res.provider.RemovePending(res.requestID)
+		}
+	}
+	if admitted != 1 {
+		t.Fatalf("concurrent cross-model reservations admitted %d requests, want exactly 1", admitted)
 	}
 }
 

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -466,6 +467,51 @@ func TestReserveProviderExNodeHealthBreakerFailsOpen(t *testing.T) {
 	if decision.CandidateCount != 1 {
 		t.Fatalf("CandidateCount=%d, want 1 (bad still quarantined, good recovered)", decision.CandidateCount)
 	}
+}
+
+// TestReservationCommitRevalidatesBreakerFailOpen proves a stale fail-open scan
+// cannot commit a breaker-open provider after a healthy route recovers. The
+// normal-breaker pass is repeated inside the serialized commit before the bypass
+// is honored.
+func TestReservationCommitRevalidatesBreakerFailOpen(t *testing.T) {
+	reg := New(testLogger())
+	model := "breaker-commit-revalidate"
+	bad := makeSchedulerProvider(t, reg, "bad", model, 200)
+	good := makeSchedulerProvider(t, reg, "good", model, 50)
+	good.mu.Lock()
+	good.Status = StatusUntrusted
+	good.mu.Unlock()
+	for range providerBreakerConsecTrip {
+		reg.RecordProviderOutcome(bad.ID, false, 503, "internal error")
+	}
+
+	scanned := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	reg.reservationAfterScan = func(string) {
+		once.Do(func() {
+			close(scanned)
+			<-release
+		})
+	}
+	selected := make(chan *Provider, 1)
+	go func() {
+		p, _ := reg.ReserveProviderEx(model, &PendingRequest{
+			RequestID: "breaker-commit", Model: model, RequestedMaxTokens: 128,
+		})
+		selected <- p
+	}()
+	<-scanned
+	good.mu.Lock()
+	good.Status = StatusOnline
+	good.mu.Unlock()
+	close(release)
+
+	winner := <-selected
+	if winner == nil || winner.ID != good.ID {
+		t.Fatalf("winner=%v, want newly healthy provider %q instead of stale fail-open %q", winner, good.ID, bad.ID)
+	}
+	winner.RemovePending("breaker-commit")
 }
 
 // The PUBLIC PREFLIGHT (QuickCapacityCheck) must fail open on the node-health

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1985,6 +1985,10 @@ type Registry struct {
 	tpsRegistry *TPSRegistry
 
 	logger *slog.Logger
+	// reservationAfterScan is a test-only barrier invoked with r.mu held for
+	// shared reading after winner selection and before the serialized commit.
+	// Production leaves it nil; tests set it before starting concurrent scans.
+	reservationAfterScan func(model string)
 
 	onlineCount      atomic.Int64
 	modelProviders   map[string]*atomic.Int64

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -376,6 +376,7 @@ const (
 	reservationCommitted reservationCommitOutcome = iota
 	reservationNeedsRescan
 	reservationCandidateRejected
+	reservationDeadlineExpired
 )
 
 type providerReservationScan struct {
@@ -422,24 +423,34 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 	}
 
 	excluded := append([]string(nil), excludeIDs...)
+	carried := RoutingDecision{Model: model}
 	var last providerReservationScan
+	failedDecision := func() RoutingDecision {
+		decision := routingDecisionForFailedScan(model, last.candidates)
+		addRoutingRejections(&decision, carried)
+		return decision
+	}
 	for pr.RefreshFirstContentBudget(time.Now()) {
 		last = r.scanProviderReservation(model, pr, excluded...)
 		if last.selected == nil {
-			return nil, routingDecisionForFailedScan(model, last.candidates), nil
+			return nil, failedDecision(), nil
 		}
 
-		provider, candidate, outcome := r.commitProviderReservation(
+		provider, candidate, outcome, rejected := r.commitProviderReservation(
 			model, pr, last, excluded...)
 		switch outcome {
 		case reservationNeedsRescan:
 			continue
 		case reservationCandidateRejected:
+			addRoutingRejections(&carried, rejected)
 			excluded = append(excluded, last.selected.provider.ID)
 			continue
+		case reservationDeadlineExpired:
+			return nil, failedDecision(), nil
 		case reservationCommitted:
 			decision := routingDecisionForCandidate(
 				model, provider, candidate, last.candidates)
+			addRoutingRejections(&decision, carried)
 			r.currentTTFTShadow(
 				model, pr, candidate, excluded...).applyTo(&decision)
 			var plan *DispatchPlan
@@ -452,7 +463,7 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 		}
 	}
 
-	return nil, routingDecisionForFailedScan(model, last.candidates), nil
+	return nil, failedDecision(), nil
 }
 
 // scanProviderReservation performs the expensive fleet walk under a shared
@@ -513,22 +524,29 @@ func (r *Registry) commitProviderReservation(
 	pr *PendingRequest,
 	scan providerReservationScan,
 	excludeIDs ...string,
-) (*Provider, *routingCandidate, reservationCommitOutcome) {
+) (*Provider, *routingCandidate, reservationCommitOutcome, RoutingDecision) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// The shared scan and write-lock wait consume the same absolute request
+	// clock as queueing and provider handoff. Never debit capacity for work whose
+	// first-content budget is already gone.
+	if !pr.RefreshFirstContentBudget(time.Now()) {
+		return nil, nil, reservationDeadlineExpired, RoutingDecision{}
+	}
 
 	// Cache routing reconfiguration after the shared scan invalidates its cost
 	// ordering. Retry from a new scan rather than committing a stale discount.
 	if r.cacheRouting != scan.cacheTracker || r.cacheRoutingMode != scan.cacheMode {
-		return nil, nil, reservationNeedsRescan
+		return nil, nil, reservationNeedsRescan, RoutingDecision{}
 	}
 	selected := scan.selected
 	if selected == nil || selected.provider == nil {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 	p := selected.provider
 	if current, ok := r.providers[p.ID]; !ok || current != p {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 
 	// A breaker bypass is valid only while breaker-open providers remain the
@@ -541,13 +559,13 @@ func (r *Registry) commitProviderReservation(
 		if normalWinner != nil || !shouldBypassBreakerFailOpen(
 			normalWinner, normal.breakerRejected,
 			normal.capacityRejections, normal.ttftRejections) {
-			return nil, nil, reservationNeedsRescan
+			return nil, nil, reservationNeedsRescan, RoutingDecision{}
 		}
 	}
 
 	owned := providerOwnedBy(p, pr.OwnerAccountID)
 	if pr.SelfRouteOnly && !owned {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 	if len(pr.AllowedProviderSerials) > 0 {
 		allowed := make(map[string]struct{}, len(pr.AllowedProviderSerials))
@@ -555,30 +573,33 @@ func (r *Registry) commitProviderReservation(
 			allowed[serial] = struct{}{}
 		}
 		if !providerMatchesAllowedSerial(p, allowed) {
-			return nil, nil, reservationCandidateRejected
+			return nil, nil, reservationCandidateRejected, RoutingDecision{}
 		}
 	}
 	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
 	snapshot, ok := r.snapshotProviderLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker)
 	if !ok {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 	if pr.RequiresVision {
 		p.mu.Lock()
 		servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
 		p.mu.Unlock()
 		if !servesVision {
-			return nil, nil, reservationCandidateRejected
+			return nil, nil, reservationCandidateRejected,
+				routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
 		}
 	}
-	candidate, _, ok := r.buildCandidateWithReason(snapshot, pr)
+	candidate, reason, ok := r.buildCandidateWithReason(snapshot, pr)
 	if !ok {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, reason, false)
 	}
 	if pr.MaxTTFTMs > 0 && !pr.RequiresVision && snapshot.hasBackendCapacity &&
 		candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, rejectNone, true)
 	}
 	r.applyCacheRoutingDiscount(p, model, pr, snapshot, candidate)
 
@@ -589,7 +610,7 @@ func (r *Registry) commitProviderReservation(
 		snapshot.totalPending != selected.snapshot.totalPending ||
 		candidate.effectiveQueue != selected.effectiveQueue ||
 		candidate.costMs != selected.costMs {
-		return nil, nil, reservationNeedsRescan
+		return nil, nil, reservationNeedsRescan, RoutingDecision{}
 	}
 
 	p.mu.Lock()
@@ -597,7 +618,7 @@ func (r *Registry) commitProviderReservation(
 	if !r.providerCanAdmitLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
-		return nil, nil, reservationCandidateRejected
+		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 
 	pr.ProviderID = p.ID
@@ -621,7 +642,7 @@ func (r *Registry) commitProviderReservation(
 		pr.CacheSelectionEstimatedTTFTSavedMs = candidate.cacheEstimatedTTFTSavedMs
 		pr.CacheSelectionSelected = true
 	}
-	return p, candidate, reservationCommitted
+	return p, candidate, reservationCommitted, RoutingDecision{}
 }
 
 // currentTTFTShadow recomputes the observational signal from the winner's
@@ -644,6 +665,35 @@ func (r *Registry) currentTTFTShadow(
 		current = r.scanCandidatesLocked(model, pr, false, excludeIDs...)
 	}
 	return r.evaluateTTFTShadowLocked(model, pr, winner, current)
+}
+
+func routingDecisionForCommitRejection(model string, reason candidateRejection, ttft bool) RoutingDecision {
+	decision := RoutingDecision{Model: model}
+	switch reason {
+	case rejectCapacity:
+		decision.CapacityRejections = 1
+	case rejectModelTooLarge:
+		decision.ModelTooLargeRejections = 1
+	case rejectVisionUnsupported:
+		decision.VisionRejections = 1
+	}
+	if ttft {
+		decision.TTFTRejections = 1
+	}
+	return decision
+}
+
+func addRoutingRejections(dst *RoutingDecision, src RoutingDecision) {
+	if dst == nil {
+		return
+	}
+	dst.CapacityRejections += src.CapacityRejections
+	dst.ModelTooLargeRejections += src.ModelTooLargeRejections
+	dst.VisionRejections += src.VisionRejections
+	dst.TTFTRejections += src.TTFTRejections
+	if dst.BestTTFTMs == 0 {
+		dst.BestTTFTMs = src.BestTTFTMs
+	}
 }
 
 func routingDecisionForFailedScan(model string, scan candidateScan) RoutingDecision {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -370,6 +370,16 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	return p, decision
 }
 
+const reservationScanAttempts = 2
+
+type providerReservationScan struct {
+	selected     *routingCandidate
+	candidates   candidateScan
+	shadow       ttftShadowEval
+	cacheTracker *cacheRoutingTracker
+	cacheMode    string
+}
+
 // reserveProvider is the single selection+reservation implementation behind
 // ReserveProviderEx and ReserveProviderWithPlan (dispatch_plan.go). wantPlan
 // additionally retains a bounded DispatchPlan of provisional alternates drawn
@@ -379,24 +389,22 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 // modes; wantPlan=false skips plan construction entirely so legacy callers
 // pay nothing.
 //
-// In-flight token-budget ledger: the reservation itself IS the debit. The
-// r.mu WRITE lock below is held for the whole selection+reservation, so
-// reservations serialize fleet-wide, and addPendingLocked records the request
-// in p.pendingReqs before the lock is released. The reader that consults the
-// debit is the admission gate itself: every subsequent scan's
-// fillSnapshotPendingAndPool aggregates the pending prompt+max token budgets,
-// and freeMemoryAdmits charges them against the last-reported
-// active_token_budget (coordinatorExtra) and the reconstructed whole-box pool
-// (pooledBudgetAdmits) — so concurrent reservations between heartbeats cannot
-// double-spend the same reported headroom. Heartbeat re-sync makes the debit
-// safe rather than double-counting: coordinatorExtra subtracts
-// committedTokenBudget (the provider's own active/queued/potential report),
-// so as heartbeats begin reporting the admitted work the coordinator-side
-// charge for it shrinks to zero — in-flight work is charged exactly once,
-// provider-reported when known, coordinator-estimated only in the dark window.
-// Completion/cancel credits via RemovePending, disconnect drops the whole
-// pending set, and the budget clamp (budget_clamp.go) remains the backstop
-// for stale-optimistic reports.
+// In-flight token-budget ledger: the reservation itself IS the debit. Expensive
+// fleet scans share r.mu for reading; the winner is then re-snapshotted and
+// committed inside a short r.mu WRITE section. addPendingLocked records the
+// request before that section ends, so every later commit sees the debit through
+// fillSnapshotPendingAndPool and freeMemoryAdmits (including the reconstructed
+// whole-box pool) before it can reserve. Concurrent scans therefore do not
+// double-spend reported headroom across models. Heartbeat re-sync remains safe:
+// coordinatorExtra subtracts committedTokenBudget, so the coordinator-side
+// charge shrinks as the provider begins reporting the admitted work. Completion
+// and cancel credit through RemovePending; disconnect drops the whole pending
+// set; the budget clamp remains the stale-optimistic backstop.
+//
+// The two-phase boundary preserves the canonical r.mu → p.mu order. A changed
+// provider identity, cache configuration, gate, deadline, or capacity snapshot
+// rejects the optimistic commit and permits one fresh shared scan.
+
 func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bool, excludeIDs ...string) (*Provider, RoutingDecision, *DispatchPlan) {
 	if pr == nil || pr.RequestID == "" {
 		return nil, RoutingDecision{Model: model}, nil
@@ -407,7 +415,43 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 	if pr.RequestedMaxTokens <= 0 {
 		pr.RequestedMaxTokens = defaultRequestedMaxTokens
 	}
-	// Snapshot receipt-confirmed cache hints before taking the registry lock.
+
+	var last providerReservationScan
+	for range reservationScanAttempts {
+		last = r.scanProviderReservation(model, pr, excludeIDs...)
+		if last.selected == nil {
+			return nil, routingDecisionForFailedScan(model, last.candidates), nil
+		}
+
+		provider, candidate, committed := r.commitProviderReservation(model, pr, last)
+		if !committed {
+			continue
+		}
+
+		decision := routingDecisionForCandidate(model, provider, candidate, last.candidates)
+		last.shadow.applyTo(&decision)
+		var plan *DispatchPlan
+		if wantPlan {
+			// The scan pool is an immutable collection of value snapshots plus
+			// provider identities. Plan consumption revalidates both the live map
+			// identity and every admission gate before reserving an alternate.
+			plan = newDispatchPlan(model, last.candidates, last.selected)
+		}
+		return provider, decision, plan
+	}
+
+	// A concurrent commit changed the selected provider after both optimistic
+	// scans. Surface the last truthful fleet-wide scan rather than reserving from
+	// stale state; the caller's normal queue/429 path remains authoritative.
+	return nil, routingDecisionForFailedScan(model, last.candidates), nil
+}
+
+// scanProviderReservation performs the expensive fleet walk under a shared
+// registry lock. Concurrent requests may scan together; no provider capacity is
+// consumed until commitProviderReservation acquires the short write section and
+// revalidates the winner against current cross-model pending debits.
+func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, excludeIDs ...string) providerReservationScan {
+	// Snapshot receipt-confirmed cache hints before taking the registry scan lock.
 	// The tracker has its own mutex and must never be nested under r.mu.
 	r.mu.RLock()
 	cacheTracker, cacheMode := r.cacheRouting, r.cacheRoutingMode
@@ -428,125 +472,138 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 		pr.CacheSelectionMode = "active"
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
 	// Configuration can change while tracker hints are computed outside r.mu.
-	// Revalidate under the selection lock so an off transition is linearizable:
-	// once ConfigureCacheRouting(off) returns, no stale hint can receive a
-	// discount or publish active-selection metadata.
+	// Revalidate under the scan lock so an off/reconfigure transition is
+	// linearizable and stale hints never affect selection.
 	if cacheMode == CacheRoutingOff || r.cacheRoutingMode != cacheMode ||
 		r.cacheRouting != cacheTracker {
 		pr.cacheRoutingHints = nil
 		pr.CacheSelectionMode = ""
 	}
+	selected, candidates := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
+	shadow := r.evaluateTTFTShadowLocked(model, pr, selected, candidates)
+	if r.reservationAfterScan != nil {
+		// Test-only deterministic barrier. Production never configures this hook.
+		r.reservationAfterScan(model)
+	}
+	result := providerReservationScan{
+		selected:     selected,
+		candidates:   candidates,
+		shadow:       shadow,
+		cacheTracker: r.cacheRouting,
+		cacheMode:    r.cacheRoutingMode,
+	}
+	r.mu.RUnlock()
+	return result
+}
 
-	selected, scan := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
-	if selected == nil {
-		return nil, RoutingDecision{
-			Model:                   model,
-			CandidateCount:          scan.candidateCount,
-			CapacityRejections:      scan.capacityRejections,
-			ModelTooLargeRejections: scan.tooLargeRejections,
-			VisionRejections:        scan.visionRejections,
-			TTFTRejections:          scan.ttftRejections,
-			BestTTFTMs:              scan.bestTTFTMs,
-		}, nil
+// commitProviderReservation is the short serialized phase. It repeats the full
+// current-state capacity chain before adding the pending debit, so concurrent
+// scans cannot double-spend a provider's shared cross-model token pool.
+func (r *Registry) commitProviderReservation(model string, pr *PendingRequest, scan providerReservationScan) (*Provider, *routingCandidate, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Cache routing reconfiguration after the shared scan invalidates its cost
+	// ordering. Retry from a new scan rather than committing a stale discount.
+	if r.cacheRouting != scan.cacheTracker || r.cacheRoutingMode != scan.cacheMode {
+		return nil, nil, false
+	}
+	selected := scan.selected
+	if selected == nil || selected.provider == nil {
+		return nil, nil, false
+	}
+	p := selected.provider
+	if current, ok := r.providers[p.ID]; !ok || current != p {
+		return nil, nil, false
 	}
 
-	// Phase-0 shadow TTFT evaluation: computed here (r.mu held, no provider lock
-	// taken yet, so it can snapshot peer providers one-at-a-time without holding
-	// two p.mu) against the winner's PRE-reserve snapshot, so its occupancy
-	// excludes the request we are about to admit. No-op (zero value) when the
-	// admission mode is off — keeping default behavior byte-for-byte. Attached to
-	// the success decision below; discarded if the admit re-check rejects.
-	// excludeIDs is threaded through so the idle-spread scan honors the SAME
-	// retry/speculative-backup exclusions the selector applied (an excluded
-	// provider is not a routable spread alternative).
-	shadowEval := r.evaluateTTFTShadowLocked(model, pr, selected, excludeIDs...)
-
-	p := selected.provider
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	// Re-check capacity under the provider lock in case another goroutine
-	// changed the pending set between snapshot and reservation. relaxTrust
-	// mirrors selection: the trust floor (and private-only admission) is relaxed
-	// only when this is the caller's own machine — for exclusive self-route
-	// (always owned here) or for prefer when the winner happens to be owned.
-	owned := p.AccountID != "" && p.AccountID == pr.OwnerAccountID
-	relaxTrust := pr.SelfRouteOnly || (pr.PreferOwner && owned)
-	// Re-check the vision and trait gates under the provider lock too: the
-	// winner must still advertise a vision-capable build if the request carries
-	// media, and must still pass the trait gates — a render-broken build is
-	// fenced for every shape, the tools version floor for tool requests — and
-	// must not have entered the shape-keyed inference-error cooldown (all folded
-	// into providerCanAdmitLocked) between snapshot and reservation.
-	//
-	// Fail-open: if the winner is itself node-health-breaker-open, it can only
-	// have been chosen by selectBestCandidateLockedFull's breaker-bypassed
-	// fallback pass (the normal pass excludes breaker-open providers). Carry that
-	// fail-open decision into the admit re-check so the breaker does not reject
-	// the very candidate the safety valve selected. All under r.mu (held), so the
-	// breaker state cannot change between selection and this check.
-	ignoreBreaker := r.providerBreakerOpenLocked(p.ID, time.Now())
-	if !ignoreBreaker && healthEjectionEnabled() {
-		// Mirror the breaker carry-through for stable-identity health ejection: a
-		// health-ejected winner can ONLY have come from the bypass (fail-open) pass,
-		// so the admit re-check must also bypass ejection — otherwise it re-rejects
-		// the very candidate the safety valve selected and the model is zeroed out.
-		// p.mu is held (above), so read the identity directly (no re-lock).
-		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, time.Now()) {
-			ignoreBreaker = true
+	owned := providerOwnedBy(p, pr.OwnerAccountID)
+	if pr.SelfRouteOnly && !owned {
+		return nil, nil, false
+	}
+	if len(pr.AllowedProviderSerials) > 0 {
+		allowed := make(map[string]struct{}, len(pr.AllowedProviderSerials))
+		for _, serial := range pr.AllowedProviderSerials {
+			allowed[serial] = struct{}{}
+		}
+		if !providerMatchesAllowedSerial(p, allowed) {
+			return nil, nil, false
 		}
 	}
-	if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, ignoreBreaker) ||
+	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
+	snapshot, ok := r.snapshotProviderLockedEx(
+		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker)
+	if !ok {
+		return nil, nil, false
+	}
+	if pr.RequiresVision {
+		p.mu.Lock()
+		servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
+		p.mu.Unlock()
+		if !servesVision {
+			return nil, nil, false
+		}
+	}
+	candidate, _, ok := r.buildCandidateWithReason(snapshot, pr)
+	if !ok {
+		return nil, nil, false
+	}
+	if pr.MaxTTFTMs > 0 && !pr.RequiresVision && snapshot.hasBackendCapacity &&
+		candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+		return nil, nil, false
+	}
+	r.applyCacheRoutingDiscount(p, model, pr, snapshot, candidate)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !r.providerCanAdmitLockedEx(
+		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
-		return nil, RoutingDecision{
-			Model:                   model,
-			CandidateCount:          scan.candidateCount,
-			CapacityRejections:      scan.capacityRejections,
-			ModelTooLargeRejections: scan.tooLargeRejections,
-			VisionRejections:        scan.visionRejections,
-			TTFTRejections:          scan.ttftRejections,
-			BestTTFTMs:              scan.bestTTFTMs,
-		}, nil
+		return nil, nil, false
 	}
 
-	bd := selected.breakdown
-	if bd.CacheDiscountMs > 0 {
-		pr.CacheSelectionMode = "active"
-		pr.CacheSelectionTier = selected.cacheTier
-		pr.CacheSelectionDiscountMs = bd.CacheDiscountMs
-		pr.CacheSelectionEstimatedTTFTSavedMs = selected.cacheEstimatedTTFTSavedMs
-		pr.CacheSelectionSelected = pr.CacheSelectionMode == "active"
-	}
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
-	// If this pair's capacity-reject cooldown just EXPIRED, this reservation is
-	// its single half-open probe: claim it here (r.mu write lock is held for the
-	// whole selection+reservation, so concurrent reservations serialize) so the
-	// routing gate closes for everyone else until the probe's outcome lands —
-	// no thundering herd into a possibly-still-black-holed pair. A no-op (one
-	// map lookup) for the overwhelmingly common no-cooldown case.
 	r.claimCapacityProbeLocked(p.ID, model, time.Now())
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
-	if !slotStateModelLoaded(selected.snapshot.slotState) {
+	if !slotStateModelLoaded(candidate.snapshot.slotState) {
 		r.RecordWarmPoolColdDispatch(model)
 	}
-
-	// Register the RAW estimate with the calibrator so the first-content
-	// observation (API layer, RecordTTFTObservation) can be joined to it.
-	// Warm-slot winners only (StateMs == 0): a cold dispatch's actual includes
-	// model-load time the flow estimate does not model, which would poison the
-	// ratio sample. Text only: media decode and vision-tower work are also absent
-	// from the projection and must not train the text-prefill calibrator.
-	if !pr.RequiresVision && bd.RawTTFTMs > 0 && bd.StateMs == 0 {
-		ttftCalibration.notePrediction(pr.RequestID, pr.Attempt, model, selected.snapshot.chipFamily, bd.RawTTFTMs)
+	if !pr.RequiresVision && candidate.breakdown.RawTTFTMs > 0 && candidate.breakdown.StateMs == 0 {
+		ttftCalibration.notePrediction(
+			pr.RequestID, pr.Attempt, model, candidate.snapshot.chipFamily,
+			candidate.breakdown.RawTTFTMs)
 	}
-	decision := RoutingDecision{
-		ProviderID:                p.ID,
+	if candidate.breakdown.CacheDiscountMs > 0 {
+		pr.CacheSelectionMode = "active"
+		pr.CacheSelectionTier = candidate.cacheTier
+		pr.CacheSelectionDiscountMs = candidate.breakdown.CacheDiscountMs
+		pr.CacheSelectionEstimatedTTFTSavedMs = candidate.cacheEstimatedTTFTSavedMs
+		pr.CacheSelectionSelected = true
+	}
+	return p, candidate, true
+}
+
+func routingDecisionForFailedScan(model string, scan candidateScan) RoutingDecision {
+	return RoutingDecision{
+		Model:                   model,
+		CandidateCount:          scan.candidateCount,
+		CapacityRejections:      scan.capacityRejections,
+		ModelTooLargeRejections: scan.tooLargeRejections,
+		VisionRejections:        scan.visionRejections,
+		TTFTRejections:          scan.ttftRejections,
+		BestTTFTMs:              scan.bestTTFTMs,
+	}
+}
+
+func routingDecisionForCandidate(model string, provider *Provider, candidate *routingCandidate, scan candidateScan) RoutingDecision {
+	bd := candidate.breakdown
+	return RoutingDecision{
+		ProviderID:                provider.ID,
 		Model:                     model,
 		CostMs:                    bd.Total,
 		StateMs:                   bd.StateMs,
@@ -556,8 +613,8 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 		ThisReqMs:                 bd.ThisReqMs,
 		HealthMs:                  bd.HealthMs,
 		CapacityRateMs:            bd.CapacityRateMs,
-		CapacityRejectRate:        selected.capacityRejectRate,
-		EffectiveQueue:            selected.effectiveQueue,
+		CapacityRejectRate:        candidate.capacityRejectRate,
+		EffectiveQueue:            candidate.effectiveQueue,
 		CandidateCount:            scan.candidateCount,
 		CapacityRejections:        scan.capacityRejections,
 		ModelTooLargeRejections:   scan.tooLargeRejections,
@@ -565,23 +622,37 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 		TTFTRejections:            scan.ttftRejections,
 		BestTTFTMs:                scan.bestTTFTMs,
 		TTFTMs:                    bd.TTFTMs,
-		CacheTier:                 selected.cacheTier,
+		CacheTier:                 candidate.cacheTier,
 		CacheDiscountMs:           bd.CacheDiscountMs,
-		CacheEstimatedTTFTSavedMs: selected.cacheEstimatedTTFTSavedMs,
-		EffectiveTPS:              selected.effectiveTPS,
-		StaticTPS:                 selected.snapshot.decodeTPS,
+		CacheEstimatedTTFTSavedMs: candidate.cacheEstimatedTTFTSavedMs,
+		EffectiveTPS:              candidate.effectiveTPS,
+		StaticTPS:                 candidate.snapshot.decodeTPS,
 	}
-	shadowEval.applyTo(&decision)
-	// Plan retention (Routing v2 Phase 3): capture up to
-	// dispatchPlanMaxAlternates lowest-cost non-winner candidates from the SAME
-	// scan pool the selector just ranked, plus the full-pool aggregate tallies.
-	// Built only after the winner's reservation committed, so a rejected admit
-	// re-check never leaks a plan; skipped entirely for legacy callers.
-	var plan *DispatchPlan
-	if wantPlan {
-		plan = newDispatchPlan(model, scan, selected)
+}
+
+func (r *Registry) applyCacheRoutingDiscount(p *Provider, model string, pr *PendingRequest, snapshot routingSnapshot, candidate *routingCandidate) {
+	hint, ok := pr.cacheRoutingHints[p.ID]
+	if !ok || !hint.currentForProvider(p, model) {
+		return
 	}
-	return p, decision, plan
+	prefillTPS := resolvePrefillTPS(snapshot)
+	if prefillTPS <= 0 || math.IsNaN(prefillTPS) || math.IsInf(prefillTPS, 0) {
+		return
+	}
+	netSavedMs := float64(hint.PrefillTokensSaved)/prefillTPS*1000 - hint.StageMs
+	if netSavedMs <= 0 || math.IsNaN(netSavedMs) || math.IsInf(netSavedMs, 0) {
+		return
+	}
+	capMs := math.Min(r.cacheRoutingMaxDiscountMs, candidate.costMs*r.cacheRoutingMaxCostFraction)
+	discount := math.Min(netSavedMs, capMs)
+	if discount <= 0 {
+		return
+	}
+	candidate.breakdown.CacheDiscountMs = discount
+	candidate.cacheTier = "ssd"
+	candidate.cacheEstimatedTTFTSavedMs = netSavedMs
+	candidate.costMs -= discount
+	candidate.breakdown.Total = candidate.costMs
 }
 
 // selectBestCandidateLockedFull is the full-fidelity selection that
@@ -646,14 +717,15 @@ func shouldBypassBreakerFailOpen(winner *routingCandidate, breakerRejected, capa
 // idle-spread shadow scan (loadedIdleAlternativeExistsLocked) so the two can
 // never drift on which providers are routable.
 type candidateScan struct {
-	pool               []*routingCandidate
-	candidateCount     int
-	capacityRejections int
-	tooLargeRejections int
-	visionRejections   int
-	ttftRejections     int
-	bestTTFTMs         float64
-	breakerRejected    int
+	pool                  []*routingCandidate
+	candidateCount        int
+	capacityRejections    int
+	tooLargeRejections    int
+	visionRejections      int
+	ttftRejections        int
+	bestTTFTMs            float64
+	breakerRejected       int
+	ignoreProviderBreaker bool
 }
 
 // scanCandidatesLocked builds the eligible candidate pool for a request — every
@@ -807,25 +879,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			continue
 		}
 
-		if hint, ok := pr.cacheRoutingHints[p.ID]; ok &&
-			hint.currentForProvider(p, model) {
-			prefillTPS := resolvePrefillTPS(snap)
-			if prefillTPS > 0 && !math.IsNaN(prefillTPS) && !math.IsInf(prefillTPS, 0) {
-				savedTokens := hint.PrefillTokensSaved
-				netSavedMs := float64(savedTokens)/prefillTPS*1000 - hint.StageMs
-				if netSavedMs > 0 && !math.IsNaN(netSavedMs) && !math.IsInf(netSavedMs, 0) {
-					capMs := math.Min(r.cacheRoutingMaxDiscountMs, candidate.costMs*r.cacheRoutingMaxCostFraction)
-					discount := math.Min(netSavedMs, capMs)
-					if discount > 0 {
-						candidate.breakdown.CacheDiscountMs = discount
-						candidate.cacheTier = "ssd"
-						candidate.cacheEstimatedTTFTSavedMs = netSavedMs
-						candidate.costMs -= discount
-						candidate.breakdown.Total = candidate.costMs
-					}
-				}
-			}
-		}
+		r.applyCacheRoutingDiscount(p, model, pr, snap, candidate)
 		candidates = append(candidates, candidate)
 		candidateCount++
 	}
@@ -885,14 +939,15 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	}
 
 	return candidateScan{
-		pool:               pool,
-		candidateCount:     candidateCount,
-		capacityRejections: capacityRejections,
-		tooLargeRejections: tooLargeRejections,
-		visionRejections:   visionRejections,
-		ttftRejections:     ttftRejections,
-		bestTTFTMs:         bestTTFTMs,
-		breakerRejected:    breakerRejected,
+		pool:                  pool,
+		candidateCount:        candidateCount,
+		capacityRejections:    capacityRejections,
+		tooLargeRejections:    tooLargeRejections,
+		visionRejections:      visionRejections,
+		ttftRejections:        ttftRejections,
+		bestTTFTMs:            bestTTFTMs,
+		breakerRejected:       breakerRejected,
+		ignoreProviderBreaker: ignoreProviderBreaker,
 	}
 }
 

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -370,12 +370,17 @@ func (r *Registry) ReserveProviderEx(model string, pr *PendingRequest, excludeID
 	return p, decision
 }
 
-const reservationScanAttempts = 2
+type reservationCommitOutcome uint8
+
+const (
+	reservationCommitted reservationCommitOutcome = iota
+	reservationNeedsRescan
+	reservationCandidateRejected
+)
 
 type providerReservationScan struct {
 	selected     *routingCandidate
 	candidates   candidateScan
-	shadow       ttftShadowEval
 	cacheTracker *cacheRoutingTracker
 	cacheMode    string
 }
@@ -385,9 +390,8 @@ type providerReservationScan struct {
 // additionally retains a bounded DispatchPlan of provisional alternates drawn
 // from the SAME scan that picked the winner — the plan is a byproduct of the
 // one existing pass, never a second scan — and is nil whenever no provider is
-// reserved. Selection and reservation are byte-for-byte identical in both
-// modes; wantPlan=false skips plan construction entirely so legacy callers
-// pay nothing.
+// reserved. Selection and reservation are identical in both modes;
+// wantPlan=false skips plan construction entirely so legacy callers pay nothing.
 //
 // In-flight token-budget ledger: the reservation itself IS the debit. Expensive
 // fleet scans share r.mu for reading; the winner is then re-snapshotted and
@@ -402,9 +406,10 @@ type providerReservationScan struct {
 // set; the budget clamp remains the stale-optimistic backstop.
 //
 // The two-phase boundary preserves the canonical r.mu → p.mu order. A changed
-// provider identity, cache configuration, gate, deadline, or capacity snapshot
-// rejects the optimistic commit and permits one fresh shared scan.
-
+// ranking or cache configuration requests a fresh shared scan. A candidate that
+// became ineligible is excluded from this request's later scans, so reservation
+// keeps progressing through untried providers until the scan truthfully finds
+// none. The request-absolute first-content clock bounds the loop.
 func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bool, excludeIDs ...string) (*Provider, RoutingDecision, *DispatchPlan) {
 	if pr == nil || pr.RequestID == "" {
 		return nil, RoutingDecision{Model: model}, nil
@@ -416,33 +421,37 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 		pr.RequestedMaxTokens = defaultRequestedMaxTokens
 	}
 
+	excluded := append([]string(nil), excludeIDs...)
 	var last providerReservationScan
-	for range reservationScanAttempts {
-		last = r.scanProviderReservation(model, pr, excludeIDs...)
+	for pr.RefreshFirstContentBudget(time.Now()) {
+		last = r.scanProviderReservation(model, pr, excluded...)
 		if last.selected == nil {
 			return nil, routingDecisionForFailedScan(model, last.candidates), nil
 		}
 
-		provider, candidate, committed := r.commitProviderReservation(model, pr, last)
-		if !committed {
+		provider, candidate, outcome := r.commitProviderReservation(
+			model, pr, last, excluded...)
+		switch outcome {
+		case reservationNeedsRescan:
 			continue
+		case reservationCandidateRejected:
+			excluded = append(excluded, last.selected.provider.ID)
+			continue
+		case reservationCommitted:
+			decision := routingDecisionForCandidate(
+				model, provider, candidate, last.candidates)
+			r.currentTTFTShadow(
+				model, pr, candidate, excluded...).applyTo(&decision)
+			var plan *DispatchPlan
+			if wantPlan {
+				// The scan pool is immutable value snapshots plus provider
+				// identities. Plan consumption revalidates both before use.
+				plan = newDispatchPlan(model, last.candidates, last.selected)
+			}
+			return provider, decision, plan
 		}
-
-		decision := routingDecisionForCandidate(model, provider, candidate, last.candidates)
-		last.shadow.applyTo(&decision)
-		var plan *DispatchPlan
-		if wantPlan {
-			// The scan pool is an immutable collection of value snapshots plus
-			// provider identities. Plan consumption revalidates both the live map
-			// identity and every admission gate before reserving an alternate.
-			plan = newDispatchPlan(model, last.candidates, last.selected)
-		}
-		return provider, decision, plan
 	}
 
-	// A concurrent commit changed the selected provider after both optimistic
-	// scans. Surface the last truthful fleet-wide scan rather than reserving from
-	// stale state; the caller's normal queue/429 path remains authoritative.
 	return nil, routingDecisionForFailedScan(model, last.candidates), nil
 }
 
@@ -482,7 +491,6 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 		pr.CacheSelectionMode = ""
 	}
 	selected, candidates := r.selectBestCandidateLockedFull(model, pr, excludeIDs...)
-	shadow := r.evaluateTTFTShadowLocked(model, pr, selected, candidates)
 	if r.reservationAfterScan != nil {
 		// Test-only deterministic barrier. Production never configures this hook.
 		r.reservationAfterScan(model)
@@ -490,7 +498,6 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 	result := providerReservationScan{
 		selected:     selected,
 		candidates:   candidates,
-		shadow:       shadow,
 		cacheTracker: r.cacheRouting,
 		cacheMode:    r.cacheRoutingMode,
 	}
@@ -501,27 +508,46 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 // commitProviderReservation is the short serialized phase. It repeats the full
 // current-state capacity chain before adding the pending debit, so concurrent
 // scans cannot double-spend a provider's shared cross-model token pool.
-func (r *Registry) commitProviderReservation(model string, pr *PendingRequest, scan providerReservationScan) (*Provider, *routingCandidate, bool) {
+func (r *Registry) commitProviderReservation(
+	model string,
+	pr *PendingRequest,
+	scan providerReservationScan,
+	excludeIDs ...string,
+) (*Provider, *routingCandidate, reservationCommitOutcome) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	// Cache routing reconfiguration after the shared scan invalidates its cost
 	// ordering. Retry from a new scan rather than committing a stale discount.
 	if r.cacheRouting != scan.cacheTracker || r.cacheRoutingMode != scan.cacheMode {
-		return nil, nil, false
+		return nil, nil, reservationNeedsRescan
 	}
 	selected := scan.selected
 	if selected == nil || selected.provider == nil {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 	p := selected.provider
 	if current, ok := r.providers[p.ID]; !ok || current != p {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
+	}
+
+	// A breaker bypass is valid only while breaker-open providers remain the
+	// sole route. Re-run the normal pass at commit time; this rare emergency path
+	// may scan under the write lock so a newly healthy provider cannot race the
+	// fail-open decision.
+	if scan.candidates.ignoreProviderBreaker {
+		normalWinner, normal := r.selectBestCandidateScanLocked(
+			model, pr, false, excludeIDs...)
+		if normalWinner != nil || !shouldBypassBreakerFailOpen(
+			normalWinner, normal.breakerRejected,
+			normal.capacityRejections, normal.ttftRejections) {
+			return nil, nil, reservationNeedsRescan
+		}
 	}
 
 	owned := providerOwnedBy(p, pr.OwnerAccountID)
 	if pr.SelfRouteOnly && !owned {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 	if len(pr.AllowedProviderSerials) > 0 {
 		allowed := make(map[string]struct{}, len(pr.AllowedProviderSerials))
@@ -529,39 +555,49 @@ func (r *Registry) commitProviderReservation(model string, pr *PendingRequest, s
 			allowed[serial] = struct{}{}
 		}
 		if !providerMatchesAllowedSerial(p, allowed) {
-			return nil, nil, false
+			return nil, nil, reservationCandidateRejected
 		}
 	}
 	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
 	snapshot, ok := r.snapshotProviderLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker)
 	if !ok {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 	if pr.RequiresVision {
 		p.mu.Lock()
 		servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
 		p.mu.Unlock()
 		if !servesVision {
-			return nil, nil, false
+			return nil, nil, reservationCandidateRejected
 		}
 	}
 	candidate, _, ok := r.buildCandidateWithReason(snapshot, pr)
 	if !ok {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 	if pr.MaxTTFTMs > 0 && !pr.RequiresVision && snapshot.hasBackendCapacity &&
 		candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 	r.applyCacheRoutingDiscount(p, model, pr, snapshot, candidate)
+
+	// Another reservation changed this winner after the shared scan. Re-scan the
+	// fleet so cost ranking observes that debit instead of herding the whole scan
+	// cohort onto the formerly-cheapest provider.
+	if snapshot.pendingForModel != selected.snapshot.pendingForModel ||
+		snapshot.totalPending != selected.snapshot.totalPending ||
+		candidate.effectiveQueue != selected.effectiveQueue ||
+		candidate.costMs != selected.costMs {
+		return nil, nil, reservationNeedsRescan
+	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if !r.providerCanAdmitLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
-		return nil, nil, false
+		return nil, nil, reservationCandidateRejected
 	}
 
 	pr.ProviderID = p.ID
@@ -585,7 +621,29 @@ func (r *Registry) commitProviderReservation(model string, pr *PendingRequest, s
 		pr.CacheSelectionEstimatedTTFTSavedMs = candidate.cacheEstimatedTTFTSavedMs
 		pr.CacheSelectionSelected = true
 	}
-	return p, candidate, true
+	return p, candidate, reservationCommitted
+}
+
+// currentTTFTShadow recomputes the observational signal from the winner's
+// commit-time pre-reserve snapshot and a fresh, shared-lock candidate pool. It
+// runs after the pending debit is committed, so concurrent reservations cannot
+// leave occupancy and idle-alternative telemetry pinned to the original scan.
+func (r *Registry) currentTTFTShadow(
+	model string,
+	pr *PendingRequest,
+	winner *routingCandidate,
+	excludeIDs ...string,
+) ttftShadowEval {
+	if TTFTAdmissionModeValue() == TTFTAdmissionOff || winner == nil || pr == nil {
+		return ttftShadowEval{}
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var current candidateScan
+	if snapshotOccupancy(winner.snapshot) > 0 {
+		current = r.scanCandidatesLocked(model, pr, false, excludeIDs...)
+	}
+	return r.evaluateTTFTShadowLocked(model, pr, winner, current)
 }
 
 func routingDecisionForFailedScan(model string, scan candidateScan) RoutingDecision {

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -152,17 +152,17 @@ func (e ttftShadowEval) applyTo(d *RoutingDecision) {
 // candidate WITHOUT changing the routing decision. Returns the zero value (a
 // no-op for applyTo) when the admission mode is off.
 //
-// Caller holds r.mu and NO provider lock — the peer scan in
-// loadedIdleAlternativeExistsLocked snapshots each provider under its own p.mu,
-// so taking a provider lock here would risk holding two at once. winner.snapshot
-// is the PRE-reserve snapshot, so the winner's occupancy excludes the request
-// about to be admitted (the b, not b+1, the new request actually waits behind).
-//
-// excludeIDs are the same retry/speculative-backup exclusions ReserveProviderEx
-// passed to the real selector; they are threaded into the idle-spread scan so a
-// provider the selector would never have considered is never counted as a
-// routable idle alternative.
-func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, winner *routingCandidate, excludeIDs ...string) ttftShadowEval {
+// Caller holds r.mu and no provider lock. scan is the exact post-narrowing pool
+// that produced winner, so the idle-spread signal reuses it instead of walking
+// the fleet a second time. winner.snapshot is the PRE-reserve snapshot, so its
+// occupancy excludes the request about to be admitted (the b, not b+1, the new
+// request actually waits behind).
+func (r *Registry) evaluateTTFTShadowLocked(
+	model string,
+	pr *PendingRequest,
+	winner *routingCandidate,
+	scan candidateScan,
+) ttftShadowEval {
 	mode := ttftAdmissionMode
 	if mode == TTFTAdmissionOff || winner == nil || pr == nil {
 		return ttftShadowEval{}
@@ -196,9 +196,27 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 	// to. When herded, check whether an instantly-usable loaded-idle peer for the
 	// same model was routable.
 	if occ > 0 {
-		eval.IdleAlternativeExists = r.loadedIdleAlternativeExistsLocked(model, pr, winner.provider, excludeIDs...)
+		eval.IdleAlternativeExists = loadedIdleAlternativeExistsFromScan(scan, winner.provider)
 	}
 	return eval
+}
+
+// loadedIdleAlternativeExistsFromScan derives the shadow spread signal from the
+// selector's already-filtered pool. The scan and its snapshots are immutable.
+func loadedIdleAlternativeExistsFromScan(scan candidateScan, winner *Provider) bool {
+	winnerID := ""
+	if winner != nil {
+		winnerID = winner.ID
+	}
+	for _, candidate := range scan.pool {
+		if candidate.provider == nil || candidate.provider.ID == winnerID {
+			continue
+		}
+		if candidate.snapshot.modelLoaded && snapshotOccupancy(candidate.snapshot) == 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // loadedIdleAlternativeExistsLocked reports whether some provider OTHER than the
@@ -215,21 +233,6 @@ func (r *Registry) evaluateTTFTShadowLocked(model string, pr *PendingRequest, wi
 // can never count a peer the scheduler would have rejected. Caller holds r.mu and
 // no provider lock.
 func (r *Registry) loadedIdleAlternativeExistsLocked(model string, pr *PendingRequest, winner *Provider, excludeIDs ...string) bool {
-	winnerID := ""
-	if winner != nil {
-		winnerID = winner.ID
-	}
-	scan := r.scanCandidatesLocked(model, pr, false, excludeIDs...)
-	for _, c := range scan.pool {
-		if c.provider == nil || c.provider.ID == winnerID {
-			continue
-		}
-		// Instantly usable: the model is resident AND no work is occupying the box
-		// (a herded peer is not a spread target). The candidate already passed
-		// every selection gate via scanCandidatesLocked.
-		if c.snapshot.modelLoaded && snapshotOccupancy(c.snapshot) == 0 {
-			return true
-		}
-	}
-	return false
+	return loadedIdleAlternativeExistsFromScan(
+		r.scanCandidatesLocked(model, pr, false, excludeIDs...), winner)
 }

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -1,8 +1,12 @@
 package registry
 
 import (
+	"fmt"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
@@ -584,5 +588,71 @@ func TestLoadedIdleAlternativeHonorsMinDecodeTPS(t *testing.T) {
 	plain := &PendingRequest{RequestID: "rmd2", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128}
 	if !idleAlt(plain) {
 		t.Fatal("a plain retry must count the slow idle peer (proves it is otherwise eligible)")
+	}
+}
+
+// TestConcurrentReservationShadowUsesCommitTimeOccupancy proves a scan cohort
+// cannot publish the empty-fleet shadow snapshot after an earlier commit adds a
+// pending debit to the same winner. The second request must rescan and report
+// occupancy one.
+func TestConcurrentReservationShadowUsesCommitTimeOccupancy(t *testing.T) {
+	withTTFTConfig(t, 50, defaultTTFTDeadlineBaseMs, TTFTAdmissionShadow)
+	reg := New(testLogger())
+	model := "shadow-commit-occupancy"
+	p := planTestProvider(t, reg, "shadow-provider", model, 0)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].MaxConcurrency = 2
+	p.mu.Unlock()
+
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var initialScans atomic.Int32
+	reg.reservationAfterScan = func(string) {
+		if initialScans.Add(1) > 2 {
+			return
+		}
+		arrived <- struct{}{}
+		<-release
+	}
+
+	type result struct {
+		requestID string
+		provider  *Provider
+		decision  RoutingDecision
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for i := range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			requestID := fmt.Sprintf("shadow-commit-%d", i)
+			provider, decision, _ := reg.ReserveProviderWithPlan(
+				model, planTestRequest(requestID, 100, 100))
+			results <- result{requestID: requestID, provider: provider, decision: decision}
+		}()
+	}
+	for range 2 {
+		select {
+		case <-arrived:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatal("reservation scans did not overlap")
+		}
+	}
+	close(release)
+	wg.Wait()
+	close(results)
+
+	occupancies := make(map[int]int, 2)
+	for res := range results {
+		if res.provider == nil {
+			t.Fatalf("request %q failed reservation", res.requestID)
+		}
+		occupancies[res.decision.ShadowOccupancy]++
+		res.provider.RemovePending(res.requestID)
+	}
+	if occupancies[0] != 1 || occupancies[1] != 1 {
+		t.Fatalf("shadow occupancies=%v, want one commit at 0 and one at 1", occupancies)
 	}
 }

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -36,7 +36,7 @@ Before dispatch, the handler:
 
 ## 3. Provider Selection
 
-The production dispatch hot path calls `Registry.ReserveProviderEx` (`coordinator/registry/scheduler.go:213-292`). The candidate cost is the sum of (`coordinator/registry/scheduler.go:802-894`):
+The production primary dispatch path calls `Registry.ReserveProviderWithPlan`; its shared `reserveProvider` implementation performs a concurrent read-locked fleet scan followed by a short, fully revalidated atomic commit. The resulting request-local plan supplies bounded alternatives without a full re-scan. Candidate cost is the sum of (`coordinator/registry/scheduler.go`):
 
 | Term | Meaning |
 |---|---|

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -36,7 +36,7 @@ Before dispatch, the handler:
 
 ## 3. Provider Selection
 
-The production primary dispatch path calls `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); its shared `reserveProvider` implementation performs a concurrent read-locked fleet scan followed by a short, fully revalidated atomic commit (`coordinator/registry/scheduler.go:413-647`). The resulting request-local plan supplies bounded alternatives without a full re-scan (`coordinator/registry/dispatch_plan.go:151-205,326-565`). Candidate cost is the sum of (`coordinator/registry/scheduler.go:1671-1804`):
+The production primary dispatch path calls `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); its shared `reserveProvider` implementation performs a concurrent read-locked fleet scan followed by a short, deadline-checked, fully revalidated atomic commit (`coordinator/registry/scheduler.go:414-668`). The resulting request-local plan supplies bounded alternatives without a full re-scan (`coordinator/registry/dispatch_plan.go:151-205,326-565`). Candidate cost is the sum of (`coordinator/registry/scheduler.go:1721-1854`):
 
 | Term | Meaning |
 |---|---|

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -36,7 +36,7 @@ Before dispatch, the handler:
 
 ## 3. Provider Selection
 
-The production primary dispatch path calls `Registry.ReserveProviderWithPlan`; its shared `reserveProvider` implementation performs a concurrent read-locked fleet scan followed by a short, fully revalidated atomic commit. The resulting request-local plan supplies bounded alternatives without a full re-scan. Candidate cost is the sum of (`coordinator/registry/scheduler.go`):
+The production primary dispatch path calls `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); its shared `reserveProvider` implementation performs a concurrent read-locked fleet scan followed by a short, fully revalidated atomic commit (`coordinator/registry/scheduler.go:413-647`). The resulting request-local plan supplies bounded alternatives without a full re-scan (`coordinator/registry/dispatch_plan.go:151-205,326-565`). Candidate cost is the sum of (`coordinator/registry/scheduler.go:1671-1804`):
 
 | Term | Meaning |
 |---|---|

--- a/docs/architecture/operations/routing.md
+++ b/docs/architecture/operations/routing.md
@@ -1,12 +1,12 @@
 # Routing
 
-Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time (in milliseconds), and selects the lowest-cost candidate.
+Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time, selects the lowest-cost candidate, and retains a bounded request-local plan of alternatives.
 
-The canonical implementation is `Registry.ReserveProviderEx` in `coordinator/registry/scheduler.go:213-292`.
+The canonical primary entry point is `Registry.ReserveProviderWithPlan`; it and the legacy `ReserveProviderEx` wrapper share `reserveProvider` in `coordinator/registry/scheduler.go`.
 
 ![Routing request flow](../../assets/diagrams/routing-flow.svg)
 
-The flow above maps to the consumer handler in `coordinator/api/consumer.go`: auth and rate-limit, optional sender-seal (`coordinator/api/sender_encryption.go`), NaCl Box decryption (`consumer.go:448-510`), token estimation and balance reservation, then a `QuickCapacityCheck` (`scheduler.go:1079-1193`) before `ReserveProviderEx` selects a provider. The chosen request is re-encrypted with a fresh per-request NaCl Box to the provider's attested X25519 key and dispatched over the provider WebSocket as an `inference_request`.
+The flow above maps to the consumer handler in `coordinator/api/consumer.go`: auth and rate-limit, optional sender-seal, NaCl Box decryption, token estimation and balance reservation, then a `QuickCapacityCheck` before `ReserveProviderWithPlan` selects and reserves the primary provider. The request-local `DispatchPlan` supplies revalidated alternates for retries and hedges without repeating the full fleet scan. The chosen request is re-encrypted with a fresh per-request NaCl Box to the provider's attested X25519 key and dispatched over the provider WebSocket as an `inference_request`.
 
 ## Privacy boundary
 
@@ -19,23 +19,27 @@ Routing decisions are made after the coordinator has decrypted the request body:
 
 See the canonical privacy model in [`../../AGENTS.md`](../../AGENTS.md) and the overview in [`../overview.md`](../overview.md).
 
-## Entry point
+## Entry points
 
 ```go
-func (r *Registry) ReserveProviderEx(
+func (r *Registry) ReserveProviderWithPlan(
     model string,
     pr *PendingRequest,
     excludeIDs ...string,
-) (*Provider, RoutingDecision)
+) (*Provider, RoutingDecision, *DispatchPlan)
+
+func (r *Registry) ReserveNextFromPlan(
+    pr *PendingRequest,
+    plan *DispatchPlan,
+    excludeIDs ...string,
+) (*Provider, RoutingDecision, []PlanSkip)
 ```
 
-`ReserveProviderEx` is the only production path that both selects a provider and atomically reserves capacity. It returns a `RoutingDecision` (`scheduler.go:172-197`) so callers can emit metrics without reaching into registry internals.
-
-The public wrapper `ReserveProvider` (`scheduler.go:199-205`) discards the decision and is used by tests and legacy callers.
+`ReserveProviderWithPlan` is the production primary path. `ReserveProviderEx` and `ReserveProvider` remain legacy/test wrappers over the same selection and reservation implementation. A primary scan retains at most eight low-cost alternatives; every plan entry is identity-checked and passed through the current admission gates before reservation. One full refresh is available per request-local plan chain.
 
 ## Candidate selection and reservation
 
-`selectBestCandidateLockedFull` (`scheduler.go:302-462`) first collects every provider that passes the structural gates, then scores each one with `buildCandidateWithReason`. It returns the winner plus rejection counters:
+`selectBestCandidateLockedFull` collects providers that pass the structural gates, scores each with `buildCandidateWithReason`, and returns the winner plus the exact narrowed candidate pool and rejection counters:
 
 | Counter | Meaning |
 |---|---|
@@ -44,9 +48,14 @@ The public wrapper `ReserveProvider` (`scheduler.go:199-205`) discards the decis
 | `ModelTooLargeRejections` | Providers whose memory can never fit the model (permanent) |
 | `VisionRejections` | Providers that serve the model only as a text-only build when vision is required |
 
-The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are considered tied (`scheduler.go:427-432`); ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice (`scheduler.go:448-458`).
+The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are tied; ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice.
 
-After selection, `ReserveProviderEx` re-takes the provider lock and runs `providerCanAdmitLocked` (`scheduler.go:1029-1050`) to re-apply the routing gates and capacity/slot-state checks. If the provider's state changed between snapshot and reservation, the selection is rejected and the caller may retry.
+Reservation is deliberately two-phase:
+
+1. The full-fleet scan holds `Registry.mu` for shared reading, so independent model requests can scan concurrently. The TTFT shadow signal reuses that same candidate pool instead of running a second fleet scan.
+2. The winner is re-snapshotted under a short `Registry.mu` write section. The coordinator repeats the full structural, pooled token-budget, memory, TTFT, and final provider admission checks before `addPendingLocked` records the debit and the half-open capacity probe is claimed.
+
+The write phase preserves atomic capacity accounting across concurrent models sharing one provider. A stale provider identity, cache configuration, gate, deadline, or capacity snapshot rejects the optimistic commit and permits one fresh shared scan. Lock order remains `Registry.mu` → `Provider.mu`; cache, plan, quote, and hedge-governor locks remain leaf locks.
 
 ## Structural gates
 

--- a/docs/architecture/operations/routing.md
+++ b/docs/architecture/operations/routing.md
@@ -1,8 +1,8 @@
 # Routing
 
-Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time, selects the lowest-cost candidate, and retains a bounded request-local plan of alternatives (`coordinator/registry/scheduler.go:738-1101`, `coordinator/registry/dispatch_plan.go:151-205`).
+Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time, selects the lowest-cost candidate, and retains a bounded request-local plan of alternatives (`coordinator/registry/scheduler.go:788-1151`, `coordinator/registry/dispatch_plan.go:151-205`).
 
-The canonical primary entry point is `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); it and the legacy `ReserveProviderEx` wrapper share `reserveProvider` (`coordinator/registry/scheduler.go:383-647`).
+The canonical primary entry point is `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); it and the legacy `ReserveProviderEx` wrapper share `reserveProvider` (`coordinator/registry/scheduler.go:383-668`).
 
 ![Routing request flow](../../assets/diagrams/routing-flow.svg)
 
@@ -35,11 +35,11 @@ func (r *Registry) ReserveNextFromPlan(
 ) (*Provider, RoutingDecision, []PlanSkip)
 ```
 
-`ReserveProviderWithPlan` is the production primary path (`coordinator/registry/dispatch_plan.go:317-325`). `ReserveProviderEx` and `ReserveProvider` remain legacy/test wrappers over the same selection and reservation implementation (`coordinator/registry/scheduler.go:354-455`). A primary scan retains at most eight low-cost alternatives; every plan entry is identity-checked and passed through the current admission gates before reservation. One full refresh is available per request-local plan chain (`coordinator/registry/dispatch_plan.go:151-205,326-565`).
+`ReserveProviderWithPlan` is the production primary path (`coordinator/registry/dispatch_plan.go:317-325`). `ReserveProviderEx` and `ReserveProvider` remain legacy/test wrappers over the same selection and reservation implementation (`coordinator/registry/scheduler.go:354-468`). A primary scan retains at most eight low-cost alternatives; every plan entry is identity-checked and passed through the current admission gates before reservation. One full refresh is available per request-local plan chain (`coordinator/registry/dispatch_plan.go:151-205,326-565`).
 
 ## Candidate selection and reservation
 
-`selectBestCandidateLockedFull` collects providers that pass the structural gates, scores each with `buildCandidateWithReason`, and returns the winner plus the exact narrowed candidate pool and rejection counters (`coordinator/registry/scheduler.go:738-1029,1671-1804`):
+`selectBestCandidateLockedFull` collects providers that pass the structural gates, scores each with `buildCandidateWithReason`, and returns the winner plus the exact narrowed candidate pool and rejection counters (`coordinator/registry/scheduler.go:788-1079,1721-1854`):
 
 | Counter | Meaning |
 |---|---|
@@ -48,18 +48,18 @@ func (r *Registry) ReserveNextFromPlan(
 | `ModelTooLargeRejections` | Providers whose memory can never fit the model (permanent) |
 | `VisionRejections` | Providers that serve the model only as a text-only build when vision is required |
 
-The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are tied; ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice (`coordinator/registry/scheduler.go:1033-1101`).
+The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are tied; ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice (`coordinator/registry/scheduler.go:1084-1151`).
 
 Reservation is deliberately two-phase:
 
-1. The full-fleet scan holds `Registry.mu` for shared reading, so independent model requests can scan concurrently (`coordinator/registry/scheduler.go:462-507`).
-2. The winner is re-snapshotted under a short `Registry.mu` write section. The coordinator repeats the full structural, pooled token-budget, memory, TTFT, ranking, breaker fail-open, and final provider admission checks before `addPendingLocked` records the debit and the half-open capacity probe is claimed (`coordinator/registry/scheduler.go:511-627,1671-1804,2224-2248`). TTFT shadow telemetry is recomputed from the commit-time winner snapshot and a fresh shared-lock candidate pool (`coordinator/registry/scheduler.go:631-647`).
+1. The full-fleet scan holds `Registry.mu` for shared reading, so independent model requests can scan concurrently (`coordinator/registry/scheduler.go:473-518`).
+2. The winner is re-snapshotted under a short `Registry.mu` write section. The coordinator rechecks the absolute first-content deadline and repeats the full structural, pooled token-budget, memory, TTFT, ranking, breaker fail-open, and final provider admission checks before `addPendingLocked` records the debit and the half-open capacity probe is claimed (`coordinator/registry/scheduler.go:522-646,1721-1854,2274-2298`). Commit-time rejection counters are carried across excluded candidates. TTFT shadow telemetry is recomputed from the commit-time winner snapshot and a fresh shared-lock candidate pool (`coordinator/registry/scheduler.go:652-668`).
 
-The write phase preserves atomic capacity accounting across concurrent models sharing one provider. A stale provider identity, cache configuration, ranking, gate, deadline, or capacity snapshot triggers another shared scan; an ineligible candidate is excluded so the request progresses until no untried route remains (`coordinator/registry/scheduler.go:413-647`). Lock order remains `Registry.mu` → `Provider.mu`; cache, plan, quote, and hedge-governor locks remain leaf locks.
+The write phase preserves atomic capacity accounting across concurrent models sharing one provider. A stale provider identity, cache configuration, ranking, gate, deadline, or capacity snapshot triggers another shared scan; an ineligible candidate is excluded so the request progresses until no untried route remains (`coordinator/registry/scheduler.go:414-668`). Lock order remains `Registry.mu` → `Provider.mu`; cache, plan, quote, and hedge-governor locks remain leaf locks.
 
 ## Structural gates
 
-Before a provider becomes a candidate it must pass `providerPassesRoutingGatesLocked` (`coordinator/registry/scheduler.go:1255-1375`). Gates are evaluated in this order:
+Before a provider becomes a candidate it must pass `providerPassesRoutingGatesLocked` (`coordinator/registry/scheduler.go:1305-1425`). Gates are evaluated in this order:
 
 1. Catalog membership — advertises an allowed build of the model (`providerServesCatalogModelLocked`).
 2. Dispatch-load cooldown — skip a provider-model pair that recently failed to load with "insufficient memory" (`dispatchLoadCooldownActiveLocked`).

--- a/docs/architecture/operations/routing.md
+++ b/docs/architecture/operations/routing.md
@@ -1,12 +1,12 @@
 # Routing
 
-Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time, selects the lowest-cost candidate, and retains a bounded request-local plan of alternatives.
+Darkbloom's production dispatch path is a **cost-minimization scheduler**. For each inference request it builds every eligible provider into a candidate, computes an estimated completion time, selects the lowest-cost candidate, and retains a bounded request-local plan of alternatives (`coordinator/registry/scheduler.go:738-1101`, `coordinator/registry/dispatch_plan.go:151-205`).
 
-The canonical primary entry point is `Registry.ReserveProviderWithPlan`; it and the legacy `ReserveProviderEx` wrapper share `reserveProvider` in `coordinator/registry/scheduler.go`.
+The canonical primary entry point is `Registry.ReserveProviderWithPlan` (`coordinator/registry/dispatch_plan.go:317-325`); it and the legacy `ReserveProviderEx` wrapper share `reserveProvider` (`coordinator/registry/scheduler.go:383-647`).
 
 ![Routing request flow](../../assets/diagrams/routing-flow.svg)
 
-The flow above maps to the consumer handler in `coordinator/api/consumer.go`: auth and rate-limit, optional sender-seal, NaCl Box decryption, token estimation and balance reservation, then a `QuickCapacityCheck` before `ReserveProviderWithPlan` selects and reserves the primary provider. The request-local `DispatchPlan` supplies revalidated alternates for retries and hedges without repeating the full fleet scan. The chosen request is re-encrypted with a fresh per-request NaCl Box to the provider's attested X25519 key and dispatched over the provider WebSocket as an `inference_request`.
+The flow above maps to the consumer handler in `coordinator/api/consumer.go`: auth and rate-limit, optional sender-seal, NaCl Box decryption, token estimation and balance reservation, then a `QuickCapacityCheck` before `ReserveProviderWithPlan` selects and reserves the primary provider (`coordinator/api/consumer.go:813-888`). The request-local `DispatchPlan` supplies revalidated alternatives for retries and hedges without repeating the full fleet scan (`coordinator/registry/dispatch_plan.go:117-205,317-565`). The chosen request is re-encrypted with a fresh per-request NaCl Box to the provider's attested X25519 key and dispatched over the provider WebSocket as an `inference_request`.
 
 ## Privacy boundary
 
@@ -35,11 +35,11 @@ func (r *Registry) ReserveNextFromPlan(
 ) (*Provider, RoutingDecision, []PlanSkip)
 ```
 
-`ReserveProviderWithPlan` is the production primary path. `ReserveProviderEx` and `ReserveProvider` remain legacy/test wrappers over the same selection and reservation implementation. A primary scan retains at most eight low-cost alternatives; every plan entry is identity-checked and passed through the current admission gates before reservation. One full refresh is available per request-local plan chain.
+`ReserveProviderWithPlan` is the production primary path (`coordinator/registry/dispatch_plan.go:317-325`). `ReserveProviderEx` and `ReserveProvider` remain legacy/test wrappers over the same selection and reservation implementation (`coordinator/registry/scheduler.go:354-455`). A primary scan retains at most eight low-cost alternatives; every plan entry is identity-checked and passed through the current admission gates before reservation. One full refresh is available per request-local plan chain (`coordinator/registry/dispatch_plan.go:151-205,326-565`).
 
 ## Candidate selection and reservation
 
-`selectBestCandidateLockedFull` collects providers that pass the structural gates, scores each with `buildCandidateWithReason`, and returns the winner plus the exact narrowed candidate pool and rejection counters:
+`selectBestCandidateLockedFull` collects providers that pass the structural gates, scores each with `buildCandidateWithReason`, and returns the winner plus the exact narrowed candidate pool and rejection counters (`coordinator/registry/scheduler.go:738-1029,1671-1804`):
 
 | Counter | Meaning |
 |---|---|
@@ -48,18 +48,18 @@ func (r *Registry) ReserveNextFromPlan(
 | `ModelTooLargeRejections` | Providers whose memory can never fit the model (permanent) |
 | `VisionRejections` | Providers that serve the model only as a text-only build when vision is required |
 
-The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are tied; ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice.
+The lowest-cost candidate wins. Candidates within `nearTieCostWindowMs` (`3_000` ms) of the best are tied; ties are broken by lowest `effectiveQueue`, then lowest `totalPending`, then uniform random choice (`coordinator/registry/scheduler.go:1033-1101`).
 
 Reservation is deliberately two-phase:
 
-1. The full-fleet scan holds `Registry.mu` for shared reading, so independent model requests can scan concurrently. The TTFT shadow signal reuses that same candidate pool instead of running a second fleet scan.
-2. The winner is re-snapshotted under a short `Registry.mu` write section. The coordinator repeats the full structural, pooled token-budget, memory, TTFT, and final provider admission checks before `addPendingLocked` records the debit and the half-open capacity probe is claimed.
+1. The full-fleet scan holds `Registry.mu` for shared reading, so independent model requests can scan concurrently (`coordinator/registry/scheduler.go:462-507`).
+2. The winner is re-snapshotted under a short `Registry.mu` write section. The coordinator repeats the full structural, pooled token-budget, memory, TTFT, ranking, breaker fail-open, and final provider admission checks before `addPendingLocked` records the debit and the half-open capacity probe is claimed (`coordinator/registry/scheduler.go:511-627,1671-1804,2224-2248`). TTFT shadow telemetry is recomputed from the commit-time winner snapshot and a fresh shared-lock candidate pool (`coordinator/registry/scheduler.go:631-647`).
 
-The write phase preserves atomic capacity accounting across concurrent models sharing one provider. A stale provider identity, cache configuration, gate, deadline, or capacity snapshot rejects the optimistic commit and permits one fresh shared scan. Lock order remains `Registry.mu` → `Provider.mu`; cache, plan, quote, and hedge-governor locks remain leaf locks.
+The write phase preserves atomic capacity accounting across concurrent models sharing one provider. A stale provider identity, cache configuration, ranking, gate, deadline, or capacity snapshot triggers another shared scan; an ineligible candidate is excluded so the request progresses until no untried route remains (`coordinator/registry/scheduler.go:413-647`). Lock order remains `Registry.mu` → `Provider.mu`; cache, plan, quote, and hedge-governor locks remain leaf locks.
 
 ## Structural gates
 
-Before a provider becomes a candidate it must pass `providerPassesRoutingGatesLocked` (`scheduler.go:598-648`). Gates are evaluated in this order:
+Before a provider becomes a candidate it must pass `providerPassesRoutingGatesLocked` (`coordinator/registry/scheduler.go:1255-1375`). Gates are evaluated in this order:
 
 1. Catalog membership — advertises an allowed build of the model (`providerServesCatalogModelLocked`).
 2. Dispatch-load cooldown — skip a provider-model pair that recently failed to load with "insufficient memory" (`dispatchLoadCooldownActiveLocked`).


### PR DESCRIPTION
## Summary

OpenRouter requests are currently spending seconds inside coordinator provider selection before an inference frame reaches a provider. The production symptom is an upstream disconnect with no response status; OpenRouter reports that as HTTP 504.

The bottleneck is `Registry.reserveProvider`: it holds the process-wide `Registry.mu` write lock while scanning and scoring the entire provider fleet. Every model shares that lock, so a burst for one model serializes routing for all models. Under pressure, provider deadline refusals and failover attempts add more selections and create a positive feedback loop.

This PR changes primary reservation to a two-phase protocol:

1. Scan and rank the fleet under `Registry.mu.RLock`, allowing independent requests to scan concurrently.
2. Re-snapshot and commit the winner under a short `Registry.mu.Lock` section.

The commit rechecks the absolute first-content deadline, then repeats the current structural gates, pooled cross-model token-budget admission, memory admission, TTFT ceiling, provider identity check, ranking inputs, and final provider admission check before recording the pending debit. Concurrent scans therefore cannot overbook a provider, double-spend shared KV capacity, or reserve work whose upstream budget already expired.

TTFT shadow telemetry is recomputed from the winner's commit-time snapshot and a fresh shared-lock candidate pool, so concurrent commits cannot leave occupancy or idle-alternative signals pinned to the original scan.

## Incident evidence

Production Caddy and route telemetry showed the failure tracking coordinator routing delay rather than model execution:

| UTC hour | OpenRouter POSTs | Requests closed before any response status | Median coordinator route time |
|---|---:|---:|---:|
| 14:00 | 54,928 | 6,676 | 28 ms |
| 15:00 | 155,146 | 50,895 | 4.095 s |
| 16:00 | 195,885 | 111,542 | 6.387 s |
| 17:00 | 209,722 | 102,837 | 6.087 s |

At 17:00 UTC, median route time was simultaneously elevated across unrelated models: Gemma 6.322 s, GPT-OSS 6.344 s, Qwen 3.5 6.023 s, Qwen 3.6 5.405 s, and Qwen3-VL 3.087 s. The host still had 52 GiB available and the coordinator used roughly 2.8 of 30 CPU cores, consistent with lock contention rather than machine exhaustion.

## Before

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A[OpenRouter request] --> B[Wait behind unrelated model selections]
    B --> C[First-content budget consumed before dispatch]
    C --> D[Provider refusal or retry]
    D --> B
    C --> E[OpenRouter closes silent request]
    E --> F[OpenRouter records 504]
  end

  subgraph Code[Coordinator control flow]
    G[ReserveProviderWithPlan] --> H[Registry.mu write lock]
    H --> I[Scan and score entire fleet]
    I --> J[Optional second fleet scan for TTFT shadow]
    J --> K[Recheck winner]
    K --> L[addPendingLocked]
    M[Requests for every model] --> H
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A1[Requests for different models] --> B1[Concurrent fleet scans]
    B1 --> C1[Short atomic winner commit]
    C1 --> D1[Provider dispatch]
    C1 --> E1[Fast retryable rejection if state changed]
    D1 --> F1[Content inside upstream budget]
  end

  subgraph Code[Coordinator control flow]
    G1[ReserveProviderWithPlan] --> H1[Registry.mu read lock]
    H1 --> I1[Scan and rank fleet]
    I1 --> J1[Release read lock]
    J1 --> K1[Short Registry.mu write lock]
    K1 --> L1[Verify provider identity and breaker fail-open]
    L1 --> M1[Re-snapshot capacity and current ranking]
    M1 --> N1[Reapply pooled budget, memory, TTFT, and final gates]
    N1 --> O1[addPendingLocked and claim half-open probe]
    O1 --> P1[Fresh shared-lock TTFT shadow snapshot]
    P1 --> Q1[Return request-local DispatchPlan]
  end
```

## Correctness invariants preserved

- Lock order remains `Registry.mu -> Provider.mu`; no reverse acquisition is introduced.
- `BackendCapacity.Slots` remains authoritative when present, with legacy fallback unchanged.
- Cross-model pending work is charged against the provider's reconstructed whole-box token/KV pool before commit.
- The half-open capacity probe claim remains inside the serialized commit.
- Breaker fail-open is revalidated inside the serialized commit; a newly healthy route prevents a stale bypass.
- Vision, trust, runtime, request-trait, dedicated-model, memory, concurrency, deadline, ranking, and version-diversity behavior remain on the existing shared helpers.
- The request-local dispatch-plan and capacity-quote behavior added by #792 is unchanged.
- A changed ranking triggers a fresh shared scan. Ineligible winners are excluded and their commit-time rejection counters are preserved; scanning continues until an untried provider commits, no provider remains, or the absolute first-content deadline expires.

## Tests

- `go test ./registry -count=1`
- `go test -race ./registry -count=1`
- `go test ./...`
- Focused review regressions: concurrent re-ranking/progress, commit-time breaker fail-open validation, commit-time shadow occupancy, cross-model pooled-budget atomicity, rejection-counter preservation, and deadline expiry before commit.

Regression coverage now proves: different-model scans overlap without double-spending a shared token pool; a three-request stale scan cohort progresses across three single-admission providers; a healthy provider recovering between scan and commit defeats a stale breaker bypass; concurrent commits publish shadow occupancies `0` then `1`; a provider becoming full after scan remains classified as a capacity rejection; and a deadline expiring during scan/lock wait records no pending debit.

## Rollout and operational note

Deploying current `master` first is a useful incident mitigation because #792 replaces repeated retry/hedge fleet rescans with a bounded request-local plan and one refresh. Restarting the existing production image only clears the current waiter backlog; the same global full-scan lock will saturate again under sustained load.

After review, deploying this PR on top of current `master` addresses the remaining primary-scan serialization. The change requires no provider release, protocol change, database migration, or production configuration change. The short commit remains serialized; only the expensive read-only scan becomes concurrent.