### PR TITLE
fix(auth): accept hashless provider registrations

### DIFF
--- a/coordinator/api/release_policy_evidence_hardening_test.go
+++ b/coordinator/api/release_policy_evidence_hardening_test.go
@@ -81,6 +81,51 @@ func TestTokenlessProviderEarnsEvidenceAndStaysRoutable(t *testing.T) {
 	}
 }
 
+// TestHashlessRegistrationEarnsEvidenceFromFreshChallenge is the production
+// rollout regression: shipped providers omit binary_hash from their registration
+// attestation and report it only in the signed periodic challenge. Application
+// evidence must use that fresh approved-release fact while retaining the
+// registration cross-check whenever the optional field is present.
+func TestHashlessRegistrationEarnsEvidenceFromFreshChallenge(t *testing.T) {
+	st := &releaseInventoryFailureStore{MemoryStore: store.NewMemory(store.Config{})}
+	if err := st.SetRelease(testRelease("2.0.0", trHashA)); err != nil {
+		t.Fatalf("SetRelease: %v", err)
+	}
+	logger := quietLogger()
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	if err := srv.SyncBinaryHashes(); err != nil {
+		t.Fatalf("SyncBinaryHashes: %v", err)
+	}
+
+	provider := makeRoutableProvider(t, reg, "hashless-provider", "hashless-release-model")
+	armReleaseChallengeProvider(t, provider, "2.0.0", "", "se-hashless", "SER-HASHLESS")
+	resp := &protocol.AttestationResponseMessage{
+		BinaryHash: trHashA,
+		SIPEnabled: trBoolPtr(true), SecureBootEnabled: trBoolPtr(true),
+		TemplateHashes: map[string]string{"mlx_metallib": trHashC},
+	}
+	fact, evidence, ok := srv.deriveApprovedReleaseTransition(provider, resp, true)
+	if !ok || !fact.Approved {
+		t.Fatal("hashless registration did not derive evidence from the fresh signed challenge")
+	}
+	if evidence.BinaryHash != trHashA || evidence.SEPublicKey != "se-hashless" {
+		t.Fatalf("derived evidence lost challenge/SE binding: %+v", evidence)
+	}
+	if !provider.GrantApplicationEvidenceIfNotUntrusted(evidence) {
+		t.Fatal("hashless provider application evidence grant was refused")
+	}
+	if routed := findRoutableProvider(reg, "hashless-release-model"); routed == nil || routed.ID != provider.ID {
+		t.Fatal("hashless provider remained unroutable after fresh approved challenge")
+	}
+	provider.Mu().Lock()
+	provider.AttestationResult.BinaryHash = trHashB
+	provider.Mu().Unlock()
+	if _, _, ok := srv.deriveApprovedReleaseTransition(provider, resp, true); ok {
+		t.Fatal("present registration/challenge binary hash mismatch did not fail closed")
+	}
+}
+
 // TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep is the
 // review-finding regression for the carry-forward recheck: a policy refresh
 // must re-prove EVERY release-specific runtime field the original challenge

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1780,9 +1780,16 @@ func (s *Server) deriveApprovedReleaseTransition(
 			(version == "" || semverLess(version, s.minProviderVersion))) {
 		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
 	}
-	attestedHash, err := normalizeSHA256Hex(attested.BinaryHash, "attested binary_hash")
-	if err != nil || attestedHash != freshHash {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+	// Registration-time binary_hash is optional and the production fleet omits
+	// it. The fresh hash is carried by this already-signature-verified challenge
+	// from the same attested SE identity and is still required to match an active
+	// release below. When registration did carry a hash, keep the stronger
+	// cross-check and fail closed on a mismatch.
+	if strings.TrimSpace(attested.BinaryHash) != "" {
+		attestedHash, hashErr := normalizeSHA256Hex(attested.BinaryHash, "attested binary_hash")
+		if hashErr != nil || attestedHash != freshHash {
+			return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+		}
 	}
 
 	// Legacy release rows can carry an empty backend: the migration added the


### PR DESCRIPTION
## Summary

Merged coordinator release-policy enforcement requires generation-bound `ApplicationEvidence` before any provider is routable. Production providers omit `binary_hash` from their registration attestation and report it in the later SE-signed challenge. `deriveApprovedReleaseTransition` incorrectly required the optional registration hash to equal the fresh challenge hash, so no production provider could earn application evidence.

Observed during the production canary:

- approximately 1,250 providers connected;
- more than 1,000 providers passed code attestation;
- hundreds regained hardware trust through continuity reuse;
- zero routable models and zero network capacity.

The durable provider records confirmed the production wire shape: 1,267 recently seen providers and zero registration `attestation_result.binaryHash` values.

This hotfix treats registration `binary_hash` as the optional field it is:

- an omitted registration hash no longer blocks application evidence;
- the fresh hash is still read from the already-signature-verified challenge from the same attested Secure Enclave identity;
- the fresh hash must still match an active release and every configured version/backend/runtime/metallib/template fact;
- when registration does include a hash, a registration/challenge mismatch still fails closed.

No trust is granted from the hash alone. Hardware/device evidence and APNs code identity remain independent required gates.

## Before

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A[Provider connects] --> B[Hardware and code checks pass]
    B --> C[Registration binary hash absent]
    C --> D[Application evidence rejected]
    D --> E[Provider globally unroutable]
    E --> F[Zero model capacity]
    F --> G[Inference receives 429]
  end

  subgraph Code[Coordinator control flow]
    H[verifyChallengeResponse] --> I[deriveApprovedReleaseTransition]
    I --> J[Normalize fresh signed challenge hash]
    J --> K[Normalize registration attestation hash]
    K --> L{Hashes equal?}
    L -- empty registration hash --> M[return false]
    M --> N[No ApplicationEvidence]
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A1[Provider connects] --> B1[Fresh SE-signed challenge]
    B1 --> C1[Active release and runtime facts verified]
    C1 --> D1[Application evidence granted]
    D1 --> E1[Hardware plus code plus application gates pass]
    E1 --> F1[Provider routable]
  end

  subgraph Code[Coordinator control flow]
    H1[deriveApprovedReleaseTransition] --> I1[Normalize fresh challenge hash]
    I1 --> J1{Registration hash present?}
    J1 -- no --> K1[Skip optional cross-check]
    J1 -- yes --> L1[Require exact hash match]
    K1 --> M1[Match active release and runtime facts]
    L1 --> M1
    M1 --> N1[Grant generation-bound ApplicationEvidence]
  end
```

## Security invariants

- Challenge signature, nonce, SIP, and Secure Boot verification run before application-evidence derivation.
- The application evidence remains bound to the attested SE public key, serial, current process public key, APNs token when present, policy generation, active binary hash, version, platform, and backend.
- Runtime, Python, metallib, and pinned template hashes remain fail-closed.
- A present registration hash remains a stronger cross-check and mismatches still fail closed.
- Application evidence still does not set either APNs code-attestation flag or hardware trust.

## Tests

- `go test ./api -run 'TestHashlessRegistrationEarnsEvidenceFromFreshChallenge|TestTokenlessProviderEarnsEvidenceAndStaysRoutable|TestApprovedReleaseTransitionDerivedFromActiveRuntimePolicy' -count=20`
- `go test ./api -count=1`
- Repository pre-push checks passed.

The new production-shape regression proves an omitted registration hash plus a fresh signed active-release challenge grants application evidence and restores routing. The same test then supplies a mismatched registration hash and proves the stronger present-field check still fails closed.

## Deployment note

This is a coordinator-only compatibility fix. It requires no provider release, protocol change, database migration, or environment change. Production remains on the previous routable coordinator until this hotfix is reviewed, merged, built from the exact merge SHA, and passes a capacity canary before traffic acceptance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790803425&installation_model_id=21733&pr_number=796&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F796&signature=ef58adcac890419aa4696a2b2c98683544c125feffb6ea99f945e10ff4ed93a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->