### PR TITLE
fix(auth): retain hashes across trust reuse

### DIFF
--- a/coordinator/api/code_attest_w5fix2_test.go
+++ b/coordinator/api/code_attest_w5fix2_test.go
@@ -1046,6 +1046,127 @@ func TestPersistOnAttestWritesThrough(t *testing.T) {
 	}
 }
 
+// TestHashlessRegistrationPersistsApplicationEvidenceHashForRestartReuse
+// models the production registration shape: the registration result carries no
+// binary hash, while the current SE-signed application evidence binds the
+// measured application hash to this exact SE identity and process key. A genuine
+// APNs nonce/signature round-trip must cache and persist that approved hash so a
+// coordinator restart can seed it and resume without another APNs push.
+func TestHashlessRegistrationPersistsApplicationEvidenceHashForRestartReuse(t *testing.T) {
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.SeedCodeAttestCache(context.Background())
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	provider := newCodeAttestProvider(kPubB64, sePubB64)
+	provider.Version = "0.8.17"
+	provider.AttestationResult.BinaryHash = ""
+	provider.ApplicationEvidence = registry.ApplicationEvidence{
+		SEPublicKey:        sePubB64,
+		ProcessPublicKey:   kPubB64,
+		BinaryHash:         trHashA,
+		EvidenceGeneration: 1,
+	}
+
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+	if !provider.GetFreshCodeAttested() {
+		t.Fatal("production-shape hashless registration did not complete its genuine APNs proof")
+	}
+	if got, ok := srv.codeAttestThrottle.reuseAttestationForTransition(
+		sePubB64, provider.APNsDeviceToken,
+	); !ok || got != trHashA {
+		t.Fatalf("in-memory APNs proof binary hash = %q, ok=%v; want application hash %q", got, ok, trHashA)
+	}
+
+	if !waitForCond(2*time.Second, func() bool {
+		rows, err := st.ListCodeAttestations(context.Background())
+		if err != nil {
+			return false
+		}
+		for _, row := range rows {
+			if row.SEPubKey == sePubB64 && row.Version == provider.Version &&
+				row.APNsToken == provider.APNsDeviceToken &&
+				row.NodePublicKey == kPubB64 && row.BinaryHash == trHashA {
+				return true
+			}
+		}
+		return false
+	}) {
+		t.Fatal("durable CodeAttestation did not retain the current application evidence hash")
+	}
+
+	restarted := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	fastBudgets(restarted)
+	restarted.SeedCodeAttestCache(context.Background())
+	if got, ok := restarted.codeAttestThrottle.reuseAttestationForTransition(
+		sePubB64, provider.APNsDeviceToken,
+	); !ok || got != trHashA {
+		t.Fatalf("restart-seeded APNs proof binary hash = %q, ok=%v; want %q", got, ok, trHashA)
+	}
+
+	reconnected := newCodeAttestProvider(kPubB64, sePubB64)
+	reconnected.Version = provider.Version
+	var pushes int32
+	restarted.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, _, _ string) error {
+		atomic.AddInt32(&pushes, 1)
+		return nil
+	}})
+	restarted.codeResumeSender = func(
+		_ string, message protocol.CodeAttestationResumeChallenge,
+	) error {
+		return completeResumeRoundTrip(
+			t, restarted, reconnected, "p1", kPriv, seKey, message)
+	}
+	restarted.codeAttestLoop(context.Background(), "p1", reconnected)
+	if got := atomic.LoadInt32(&pushes); got != 0 {
+		t.Fatalf("restart-seeded proof sent %d APNs pushes, want 0", got)
+	}
+	if !reconnected.GetCodeAttested() || !reconnected.GetFreshCodeAttested() {
+		t.Fatal("restart-seeded proof did not complete the live process-key resume")
+	}
+}
+
+// TestHashlessRegistrationWithoutApplicationEvidenceRemainsIdentityless
+// preserves the fail-closed boundary: a valid APNs proof still attests the live
+// process, but without either binary-identity source it cannot become a release-
+// transition proof.
+func TestHashlessRegistrationWithoutApplicationEvidenceRemainsIdentityless(t *testing.T) {
+	logger := quietLogger()
+	st := store.NewMemory(store.Config{})
+	srv := NewServer(registry.New(logger), st, ServerConfig{}, logger)
+	fastBudgets(srv)
+	srv.SeedCodeAttestCache(context.Background())
+
+	kPubB64, kPriv, seKey, sePubB64 := providerKeyMaterial(t)
+	provider := newCodeAttestProvider(kPubB64, sePubB64)
+	provider.Version = "0.8.17"
+	provider.AttestationResult.BinaryHash = ""
+	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, pubKeyB64, nonceB64 string) error {
+		return completeRoundTrip(t, srv, provider, "p1", kPriv, seKey, pubKeyB64, nonceB64)
+	}})
+	srv.codeAttestLoop(context.Background(), "p1", provider)
+	if !provider.GetFreshCodeAttested() {
+		t.Fatal("identity-less registration did not complete its genuine APNs proof")
+	}
+	if hash, ok := srv.codeAttestThrottle.reuseAttestationForTransition(
+		sePubB64, provider.APNsDeviceToken,
+	); ok || hash != "" {
+		t.Fatalf("identity-less proof authorized transition reuse: hash=%q ok=%v", hash, ok)
+	}
+
+	if !waitForCond(2*time.Second, func() bool {
+		rows, err := st.ListCodeAttestations(context.Background())
+		return err == nil && len(rows) == 1 && rows[0].BinaryHash == ""
+	}) {
+		t.Fatal("identity-less APNs proof was not persisted without manufacturing a binary hash")
+	}
+}
+
 // TestRestartTransitionDeactivatedReleaseProofForcesFreshAPNsChallenge closes
 // the Codex 05:55Z P1: a genuine APNs proof EARNED by release A must stop
 // authorizing transition resumes once A is DEACTIVATED (no longer an approved

--- a/coordinator/api/code_attest_w5fix2_test.go
+++ b/coordinator/api/code_attest_w5fix2_test.go
@@ -1109,8 +1109,16 @@ func TestHashlessRegistrationPersistsApplicationEvidenceHashForRestartReuse(t *t
 		t.Fatalf("restart-seeded APNs proof binary hash = %q, ok=%v; want %q", got, ok, trHashA)
 	}
 
-	reconnected := newCodeAttestProvider(kPubB64, sePubB64)
-	reconnected.Version = provider.Version
+	// Restart with a fresh process key. The persisted proof must compose with
+	// current generation-bound application evidence and authorize a live resume;
+	// exact-key reuse would not exercise the binary identity carried by this fix.
+	k2Pub, k2Priv, _, _ := providerKeyMaterial(t)
+	reconnected := crossVersionProvider(k2Pub, sePubB64, provider.Version)
+	reconnected.AttestationResult.BinaryHash = ""
+	armCrossVersionApplicationEvidenceWithPolicy(t, restarted, reconnected, sePubB64,
+		map[string][]approvedReleasePolicy{
+			trHashA: {{Version: provider.Version, Platform: "macos-arm64", Backend: provider.Backend}},
+		})
 	var pushes int32
 	restarted.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, _, _ string) error {
 		atomic.AddInt32(&pushes, 1)
@@ -1120,7 +1128,7 @@ func TestHashlessRegistrationPersistsApplicationEvidenceHashForRestartReuse(t *t
 		_ string, message protocol.CodeAttestationResumeChallenge,
 	) error {
 		return completeResumeRoundTrip(
-			t, restarted, reconnected, "p1", kPriv, seKey, message)
+			t, restarted, reconnected, "p1", k2Priv, seKey, message)
 	}
 	restarted.codeAttestLoop(context.Background(), "p1", reconnected)
 	if got := atomic.LoadInt32(&pushes); got != 0 {

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -3102,8 +3102,11 @@ func (s *Server) ApplyLateSecurityInfo(
 		return
 	}
 	ar := binding.attestation
+	binaryHash := providerApplicationBinaryHash(
+		binding.provider, ar.PublicKey, ar.BinaryHash,
+	)
 	if !s.recordLateTrustReuse(
-		binding.provider, ar.PublicKey, ar.SerialNumber, ar.BinaryHash,
+		binding.provider, ar.PublicKey, ar.SerialNumber, binaryHash,
 		true, true, udid,
 	) {
 		return

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -3035,6 +3035,9 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 		provider.SetMDMFailureReason("securityinfo-timeout")
 		return mdmVerifyTransient
 	}
+	binaryHash := providerApplicationBinaryHash(
+		provider, attestResult.PublicKey, attestResult.BinaryHash,
+	)
 
 	// Durable revocation is authoritative. Persist/recover the verified device
 	// evidence at the expected generation before touching live hardware trust;
@@ -3043,7 +3046,7 @@ func (s *Server) verifyProviderViaMDM(ctx context.Context, providerID string, pr
 		provider,
 		attestResult.PublicKey,
 		attestResult.SerialNumber,
-		attestResult.BinaryHash,
+		binaryHash,
 		mdmResult.MDMSIPEnabled,
 		mdmResult.MDMSecureBootFull,
 		mdmResult.UDID,

--- a/coordinator/api/provider_codeattest.go
+++ b/coordinator/api/provider_codeattest.go
@@ -685,11 +685,11 @@ func (s *Server) handleCodeAttestationResponse(providerID string, provider *regi
 	var sePubKey, attestedBinaryHash string
 	if provider.AttestationResult != nil {
 		sePubKey = provider.AttestationResult.PublicKey
-		// The SE-signed application challenge measured this binary; retain it
-		// on the cached APNs proof so a later release-transition resume is
-		// bound to the binary that EARNED the proof (Codex 05:55Z P1). A
-		// missing/unparseable hash leaves it empty — an identity-less record
-		// that never authorizes a transition (fail-closed).
+		// Prefer the binary identity measured during registration. Production
+		// registrations may omit it; after releasing Provider.mu below, current
+		// application evidence may supply the same SE- and process-bound identity.
+		// If neither source is usable, the proof remains identity-less and cannot
+		// authorize a release transition.
 		attestedBinaryHash, _ = normalizeSHA256Hex(
 			provider.AttestationResult.BinaryHash, "attested binary_hash")
 	}
@@ -697,6 +697,8 @@ func (s *Server) handleCodeAttestationResponse(providerID string, provider *regi
 	apnsToken := provider.APNsDeviceToken
 	nodeKey := provider.PublicKey
 	provider.Mu().Unlock()
+	attestedBinaryHash = providerApplicationBinaryHash(
+		provider, sePubKey, attestedBinaryHash)
 
 	if sePubKey == "" {
 		s.codeAttestMetric("verify_failed")

--- a/coordinator/api/provider_mdm_reliability_test.go
+++ b/coordinator/api/provider_mdm_reliability_test.go
@@ -415,13 +415,13 @@ func TestVerifyProviderViaMDM_SuccessGranted(t *testing.T) {
 	}
 }
 
-// TestVerifyProviderViaMDM_SuccessGrantedWithoutBinaryHash (review finding 2,
-// synchronous path): the self-reported binary hash is OPTIONAL — a provider
-// omitting it that passes the full live MDM SecurityInfo check must still be
-// upgraded to hardware trust. Only the durable reuse record requires the hash,
-// so nothing is persisted or cached and every reconnect re-runs the full
-// verification.
-func TestVerifyProviderViaMDM_SuccessGrantedWithoutBinaryHash(t *testing.T) {
+// TestVerifyProviderViaMDM_SuccessGrantedWithoutBinaryHashOrApplicationEvidence
+// (review finding 2, synchronous path): the self-reported binary hash is
+// OPTIONAL — a provider omitting it that passes the full live MDM SecurityInfo
+// check must still be upgraded to hardware trust. Without current bound
+// application evidence, only the durable reuse record lacks a hash, so nothing
+// is persisted or cached and every reconnect re-runs the full verification.
+func TestVerifyProviderViaMDM_SuccessGrantedWithoutBinaryHashOrApplicationEvidence(t *testing.T) {
 	fake := &fakeMDMServer{
 		device:            &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
 		commandUUID:       "cmd-ok",
@@ -446,6 +446,60 @@ func TestVerifyProviderViaMDM_SuccessGrantedWithoutBinaryHash(t *testing.T) {
 	}
 	if srv.trustReuseCache.hasFreshRecord("se-pub-key-bytes", "SERIAL-1") {
 		t.Fatal("hashless grant must not cache an unbindable reuse record")
+	}
+}
+
+// TestVerifyProviderViaMDM_HashlessRegistrationUsesBoundApplicationEvidence
+// proves a fresh SE-signed application challenge can supply the binary binding
+// absent from the registration. The evidence must be installed for the current
+// SE identity and process key before live MDM device evidence becomes reusable.
+func TestVerifyProviderViaMDM_HashlessRegistrationUsesBoundApplicationEvidence(t *testing.T) {
+	fake := &fakeMDMServer{
+		device:            &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true},
+		commandUUID:       "cmd-ok",
+		failMDARawCommand: true,
+	}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.SeedTrustReuseCache(context.Background())
+	binaryHash := strings.Repeat("b", 64)
+	verifiedAt := time.Now()
+	p.Mu().Lock()
+	p.ApplicationEvidence = registry.ApplicationEvidence{
+		SEPublicKey:        "se-pub-key-bytes",
+		Serial:             "SERIAL-1",
+		ProcessPublicKey:   p.PublicKey,
+		BinaryHash:         binaryHash,
+		VerifiedAt:         verifiedAt,
+		EvidenceGeneration: 1,
+	}
+	p.Mu().Unlock()
+
+	deliverWebhookWhenPushed(srv, fake, "UDID-1", "cmd-ok", true /*sip*/, true /*secureboot*/)
+
+	outcome := srv.verifyProviderViaMDM(context.Background(), "prov-mdm", p, attestResultOf(p))
+
+	if outcome != mdmVerifyGranted {
+		t.Errorf("outcome = %v, want mdmVerifyGranted for bound application evidence", outcome)
+	}
+	rows, err := srv.store.ListProviderTrustReuse(context.Background())
+	if err != nil {
+		t.Fatalf("list trust reuse: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("persisted reuse rows = %d, want 1", len(rows))
+	}
+	if got := rows[0].LastVerifiedBinaryHash; got != binaryHash {
+		t.Fatalf("LastVerifiedBinaryHash = %q, want application hash %q", got, binaryHash)
+	}
+	if rows[0].ApplicationProofVerifiedAt == nil || !rows[0].ApplicationProofVerifiedAt.Equal(verifiedAt) {
+		t.Fatalf("ApplicationProofVerifiedAt = %v, want %v", rows[0].ApplicationProofVerifiedAt, verifiedAt)
+	}
+	cached, ok := srv.trustReuseCache.reuseTrust("se-pub-key-bytes", "SERIAL-1", binaryHash)
+	if !ok {
+		t.Fatal("bound application hash did not cache reusable hardware proof")
+	}
+	if cached.lastVerifiedBinaryHash != binaryHash {
+		t.Fatalf("cached binary hash = %q, want %q", cached.lastVerifiedBinaryHash, binaryHash)
 	}
 }
 

--- a/coordinator/api/trust_reuse.go
+++ b/coordinator/api/trust_reuse.go
@@ -723,6 +723,29 @@ func (s *Server) SeedTrustReuseCache(ctx context.Context) error {
 	return nil
 }
 
+// providerApplicationBinaryHash resolves the binary measured for this
+// connection. A registration hash is authoritative when present. Hashless
+// registrations may use fresh application evidence only while it remains
+// installed and bound to both the verified SE identity and this provider
+// process's current public key.
+func providerApplicationBinaryHash(provider *registry.Provider, seKey, registrationHash string) string {
+	if registrationHash != "" {
+		return registrationHash
+	}
+	if provider == nil || seKey == "" {
+		return ""
+	}
+
+	provider.Mu().Lock()
+	defer provider.Mu().Unlock()
+	evidence := provider.ApplicationEvidence
+	if evidence.EvidenceGeneration == 0 || evidence.SEPublicKey != seKey ||
+		provider.PublicKey == "" || evidence.ProcessPublicKey != provider.PublicKey {
+		return ""
+	}
+	return evidence.BinaryHash
+}
+
 // recordTrustReuse persists a reviewed, synchronous full MDM/MDA verification.
 // It is the only path allowed to clear a durable revocation tombstone, and then
 // only at the exact generation observed before the write. A concurrent hard

--- a/coordinator/api/trust_reuse_test.go
+++ b/coordinator/api/trust_reuse_test.go
@@ -1292,6 +1292,49 @@ func TestApplyLateSecurityInfoGrantsWithoutBinaryHashPersistsNothing(t *testing.
 	}
 }
 
+// TestApplyLateSecurityInfoHashlessEvidencePersistsForRestart covers the
+// scheduler callback sibling of synchronous MDM verification. A production-
+// shape hashless registration with current SE/process-bound application
+// evidence must persist the approved hash and reseed reusable device evidence.
+func TestApplyLateSecurityInfoHashlessEvidencePersistsForRestart(t *testing.T) {
+	fake := &fakeMDMServer{device: &mdm.DeviceInfo{SerialNumber: "SERIAL-1", UDID: "UDID-1", EnrollmentStatus: true}}
+	srv, p := mdmReliabilityServer(t, fake)
+	srv.SeedTrustReuseCache(context.Background())
+	p.Mu().Lock()
+	p.ApplicationEvidence = registry.ApplicationEvidence{
+		SEPublicKey:        "se-pub-key-bytes",
+		ProcessPublicKey:   p.PublicKey,
+		BinaryHash:         trHashA,
+		EvidenceGeneration: 1,
+	}
+	p.Mu().Unlock()
+	bindLateSecurityInfoForTest(t, srv, p, "UDID-1")
+
+	srv.ApplyLateSecurityInfo(
+		"UDID-1", lateSecurityInfoCommandUUID,
+		&mdm.SecurityInfoResponse{
+			SystemIntegrityProtectionEnabled: true,
+			SecureBootLevel:                  "full",
+		},
+	)
+
+	rows, err := srv.store.ListProviderTrustReuse(context.Background())
+	if err != nil || len(rows) != 1 || rows[0].LastVerifiedBinaryHash != trHashA {
+		t.Fatalf("late hashless grant rows=%+v err=%v, want one row bound to %q", rows, err, trHashA)
+	}
+	if _, ok := srv.trustReuseCache.reuseTrust("se-pub-key-bytes", "SERIAL-1", trHashA); !ok {
+		t.Fatal("late hashless grant did not install reusable device evidence")
+	}
+
+	restarted := NewServer(registry.New(quietLogger()), srv.store, ServerConfig{}, quietLogger())
+	if err := restarted.SeedTrustReuseCache(context.Background()); err != nil {
+		t.Fatalf("restart seed: %v", err)
+	}
+	if _, ok := restarted.trustReuseCache.reuseTrust("se-pub-key-bytes", "SERIAL-1", trHashA); !ok {
+		t.Fatal("late hashless device evidence did not survive restart reseeding")
+	}
+}
+
 // --- Round 2 FIX 2: post-write epoch recheck (check-then-write TOCTOU) ---
 
 // TestRecordTrustReusePostWriteRecheckDeletesOnRacedUntrust proves FIX 2: a hard

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4843,9 +4843,10 @@ func (r *Registry) GetProvider(id string) *Provider {
 }
 
 // CountProvidersByBinaryHash returns the number of currently connected
-// providers whose registration attested the given provider binary hash. Used by
-// release administration to avoid removing a hash from the forced allowlist
-// while old-but-still-connected providers are draining/restarting into a newer
+// providers whose registration or current, connection-bound application
+// evidence attests the given provider binary hash. Used by release
+// administration to avoid removing a hash from the forced allowlist while
+// old-but-still-connected providers are draining/restarting into a newer
 // release.
 func (r *Registry) CountProvidersByBinaryHash(hash string) int {
 	normalized := strings.ToLower(strings.TrimSpace(hash))
@@ -4859,14 +4860,26 @@ func (r *Registry) CountProvidersByBinaryHash(hash string) int {
 	count := 0
 	for _, p := range r.providers {
 		p.mu.Lock()
-		status := p.Status
-		attestedHash := ""
-		if p.AttestationResult != nil {
-			attestedHash = p.AttestationResult.BinaryHash
+		if p.Status == StatusOffline {
+			p.mu.Unlock()
+			continue
 		}
+
+		registrationMatches := p.AttestationResult != nil &&
+			strings.EqualFold(p.AttestationResult.BinaryHash, normalized)
+		evidence := p.ApplicationEvidence
+		evidenceCurrent := evidence.EvidenceGeneration != 0 &&
+			(!r.releasePolicyRequired || evidence.PolicyGeneration == r.releasePolicyGeneration) &&
+			evidence.ProcessPublicKey == p.PublicKey &&
+			evidence.APNsToken == p.APNsDeviceToken
+		if evidenceCurrent && p.AttestationResult != nil {
+			evidenceCurrent = evidence.SEPublicKey == p.AttestationResult.PublicKey &&
+				evidence.Serial == p.AttestationResult.SerialNumber
+		}
+		evidenceMatches := evidenceCurrent && strings.EqualFold(evidence.BinaryHash, normalized)
 		p.mu.Unlock()
 
-		if status != StatusOffline && strings.EqualFold(attestedHash, normalized) {
+		if registrationMatches || evidenceMatches {
 			count++
 		}
 	}

--- a/coordinator/registry/release_policy_grant_race_test.go
+++ b/coordinator/registry/release_policy_grant_race_test.go
@@ -229,3 +229,131 @@ func TestFirstRequiredPolicyActivationKicksEvidencelessFleet(t *testing.T) {
 		}
 	}
 }
+
+func TestCountProvidersByBinaryHashUsesOnlyCurrentBoundApplicationEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Registry, *Provider)
+		want   int
+	}{
+		{name: "hashless registration with current tokenless evidence", want: 1},
+		{
+			name: "missing evidence generation",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.EvidenceGeneration = 0
+			},
+		},
+		{
+			name: "stale policy generation",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.PolicyGeneration--
+			},
+		},
+		{
+			name: "policy generation ignored when policy is not required",
+			mutate: func(reg *Registry, p *Provider) {
+				reg.releasePolicyRequired = false
+				p.ApplicationEvidence.PolicyGeneration--
+			},
+			want: 1,
+		},
+		{
+			name: "SE binding not required without registration evidence",
+			mutate: func(_ *Registry, p *Provider) {
+				p.AttestationResult = nil
+				p.ApplicationEvidence.SEPublicKey = "challenge-se-key"
+				p.ApplicationEvidence.Serial = "CHALLENGE-SERIAL"
+			},
+			want: 1,
+		},
+		{
+			name: "stale process key",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.ProcessPublicKey = "previous-process-key"
+			},
+		},
+		{
+			name: "stale APNs token",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.APNsToken = "previous-token"
+			},
+		},
+		{
+			name: "stale SE key",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.SEPublicKey = "previous-se-key"
+			},
+		},
+		{
+			name: "stale SE serial",
+			mutate: func(_ *Registry, p *Provider) {
+				p.ApplicationEvidence.Serial = "PREVIOUS-SERIAL"
+			},
+		},
+		{
+			name: "offline provider",
+			mutate: func(_ *Registry, p *Provider) {
+				p.Status = StatusOffline
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := New(testLogger())
+			reg.SetReleasePolicyGeneration(7, true, nil)
+			p := reg.Register("provider", nil, testRegisterMessage())
+			p.mu.Lock()
+			p.PublicKey = "current-process-key"
+			p.APNsDeviceToken = ""
+			p.AttestationResult = &attestation.VerificationResult{
+				Valid: true, PublicKey: "current-se-key", SerialNumber: "CURRENT-SERIAL",
+			}
+			p.ApplicationEvidence = ApplicationEvidence{
+				SEPublicKey: "current-se-key", Serial: "CURRENT-SERIAL",
+				ProcessPublicKey: "current-process-key", APNsToken: "",
+				BinaryHash: "application-hash", EvidenceGeneration: 1, PolicyGeneration: 7,
+			}
+			if tt.mutate != nil {
+				tt.mutate(reg, p)
+			}
+			p.mu.Unlock()
+
+			if got := reg.CountProvidersByBinaryHash("application-hash"); got != tt.want {
+				t.Fatalf("CountProvidersByBinaryHash() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountProvidersByBinaryHashPreservesRegistrationHashBehavior(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetReleasePolicyGeneration(7, true, nil)
+	p := reg.Register("provider", nil, testRegisterMessage())
+	p.mu.Lock()
+	p.PublicKey = "current-process-key"
+	p.APNsDeviceToken = "current-token"
+	p.AttestationResult = &attestation.VerificationResult{
+		Valid: true, PublicKey: "current-se-key", SerialNumber: "CURRENT-SERIAL",
+		BinaryHash: "release-hash",
+	}
+	// Matching evidence must not double-count the provider. Its stale bindings
+	// also demonstrate that a present registration hash remains authoritative.
+	p.ApplicationEvidence = ApplicationEvidence{
+		SEPublicKey: "stale-se-key", Serial: "STALE-SERIAL",
+		ProcessPublicKey: "stale-process-key", APNsToken: "stale-token",
+		BinaryHash: "release-hash", EvidenceGeneration: 1, PolicyGeneration: 6,
+	}
+	p.mu.Unlock()
+
+	if got := reg.CountProvidersByBinaryHash("release-hash"); got != 1 {
+		t.Fatalf("CountProvidersByBinaryHash() = %d, want one registration-hash match", got)
+	}
+
+	p.mu.Lock()
+	p.Status = StatusOffline
+	p.mu.Unlock()
+	if got := reg.CountProvidersByBinaryHash("release-hash"); got != 0 {
+		t.Fatalf("offline registration-hash provider count = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

PR #796 made the fresh SE-signed challenge hash authoritative when registration omits optional `binary_hash`, restoring immediate `ApplicationEvidence`. Review then found three downstream consumers still reading only `AttestationResult.BinaryHash`, which is empty for the production fleet:

1. APNs proof persistence produced an identity-less cached/durable proof, preventing restart reuse during the push cooldown.
2. Live MDM verification granted hardware only for the current connection and persisted no reusable device evidence.
3. Release in-use checks reported zero connected users for a hashless active release, allowing unsafe deactivation.

This follow-up carries the already-approved, generation-bound application hash through those three paths without manufacturing or weakening any identity:

- `providerApplicationBinaryHash` prefers a nonempty registration hash; otherwise it returns application evidence only when installed and bound to the same SE key and current process public key.
- APNs persistence resolves the hash after releasing `Provider.mu`, then writes it to both the in-memory proof and durable code-attestation row after genuine nonce and SE-signature verification.
- MDM persistence resolves the same bound hash for both synchronous verification and late scheduler callbacks before the existing normalization, revocation-CAS, hard-untrust epoch, and continuity write-through.
- `CountProvidersByBinaryHash` counts either the registration hash or current application evidence, requiring current policy generation, process key, APNs token, and SE identity bindings; each provider counts once.

When neither registration nor bound application evidence supplies a hash, existing fail-closed behavior remains: current-connection trust may be granted after live verification, but no reusable proof is persisted.

## Before

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A[Hashless provider passes fresh challenge] --> B[Immediate application evidence]
    B --> C[APNs proof persisted without binary identity]
    B --> D[MDM device proof not persisted]
    B --> E[Release in-use count remains zero]
    C --> F[Restart loses code-proof reuse]
    D --> G[Reconnect queues behind live MDM]
    E --> H[Active release can be deactivated]
    F --> I[Provider unroutable]
    G --> I
    H --> I
  end

  subgraph Code[Coordinator control flow]
    J[ApplicationEvidence.BinaryHash] -. unused .-> K[APNs persistence]
    J -. unused .-> L[recordTrustReuse]
    J -. unused .-> M[CountProvidersByBinaryHash]
    K --> N[AttestationResult.BinaryHash empty]
    L --> N
    M --> N
  end
```

## After

```mermaid
flowchart LR
  subgraph Behavior[Caller-visible behavior]
    A1[Hashless provider passes fresh challenge] --> B1[Bound application hash]
    B1 --> C1[Reusable APNs proof persisted]
    B1 --> D1[Reusable MDM device proof persisted]
    B1 --> E1[Connected release counted in use]
    C1 --> F1[Restart resume remains available]
    D1 --> G1[Continuity reuse remains available]
    E1 --> H1[Unsafe release removal blocked]
  end

  subgraph Code[Coordinator control flow]
    J1[providerApplicationBinaryHash] --> K1{Registration hash present?}
    K1 -- yes --> L1[Use registration hash]
    K1 -- no --> M1[Require bound current ApplicationEvidence]
    L1 --> N1[APNs persistence]
    M1 --> N1
    L1 --> O1[MDM trust-reuse persistence]
    M1 --> O1
    P1[CountProvidersByBinaryHash] --> Q1[Registration OR current bound application hash]
  end
```

## Security invariants

- No hash is synthesized from version, image tags, or release metadata.
- A nonempty registration hash remains authoritative.
- Application fallback requires nonzero evidence generation and exact SE/process binding.
- Release in-use fallback additionally requires current policy generation when enforced, current APNs token, and registration SE/serial agreement when present.
- APNs proof persistence remains after nonce ownership, encrypted process-key possession, and SE-signature verification.
- MDM persistence retains normalization, durable revocation CAS, hard-untrust epoch checks, and connection-only fallback when no reusable hash exists.
- Registration and application matches are ORed, so a provider is never double-counted.

## Tests

- Focused APNs/MDM/release-in-use production-shape tests passed.
- `go test ./api ./registry -count=1`
- Focused race tests across both packages passed.
- Repository pre-push checks passed.

Regression coverage includes:

- hashless APNs proof writes the bound application hash to memory and durable storage, then a fresh process key plus current application evidence proves transition-resume reuse after restart;
- no application evidence preserves identity-less fail-closed behavior;
- hashless synchronous and late-callback MDM grants with bound evidence persist reusable hardware proof and reseed it after restart;
- hashless MDM without evidence stays connection-only;
- release in-use counting accepts only current process/token/SE/policy-bound evidence and rejects stale generation, process, token, SE, serial, and offline providers;
- existing registration-hash behavior and single-count semantics remain unchanged.

## Deployment note

This is coordinator-only. No provider release, protocol change, database migration, or environment change is required. Production remains on the previous routable coordinator until this PR is reviewed, merged, built from its exact merge SHA, and preflighted. The continuity bootstrap must be refreshed immediately before the eventual 30-second swap because the existing coordinator predates continuous-coverage writes.