### PR TITLE
fix(auth): make release-policy gate provable by the real fleet

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -812,22 +812,6 @@ jobs:
             "s3://${R2_BUCKET}/releases/latest/eigeninference-bundle-macos-arm64.tar.gz" \
             --endpoint-url "$R2_ENDPOINT" --only-show-errors
 
-      - name: Compute template hashes
-        run: |
-          set -euo pipefail
-          MODELS_CDN="https://pub-7cbee059c80c46ec9c071dbee2726f8a.r2.dev"
-          TEMPLATE_HASHES=""
-          for name in qwen3.5 trinity gemma4 minimax; do
-            HASH=$(curl -fsSL "$MODELS_CDN/templates/${name}.jinja" 2>/dev/null | shasum -a 256 | cut -d' ' -f1 || true)
-            # ignore the empty-string SHA (which means the file 404'd)
-            if [ -n "$HASH" ] && [ "$HASH" != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ]; then
-              [ -n "$TEMPLATE_HASHES" ] && TEMPLATE_HASHES+=","
-              TEMPLATE_HASHES+="${name}=${HASH}"
-              echo "Template $name: ${HASH:0:16}…"
-            fi
-          done
-          echo "TEMPLATE_HASHES=$TEMPLATE_HASHES" >> "$GITHUB_ENV"
-
       - name: Register release with coordinator
         env:
           COORDINATOR_URL: ${{ env.coordinator_url }}
@@ -842,9 +826,12 @@ jobs:
             TAG_MSG="Release v${VERSION}"
           fi
 
-          # The Swift provider does NOT expose python_hash / runtime_hash —
-          # those fields are dropped post-cutover. Coordinator should accept
-          # releases without them when backend == "mlx-swift".
+          # The Swift provider does NOT expose python_hash / runtime_hash, and
+          # its only template fact is the mlx_metallib hash (metallib_hash
+          # below). Per-model-family template hashes were CI fabrications no
+          # provider could ever echo — registering them armed a coordinator
+          # gate that zeroed fleet routing (2026-08-31 incident). Register
+          # only facts the provider actually reports.
           python3 - <<PY > /tmp/release-payload.json
           import json, os
           payload = {
@@ -854,7 +841,6 @@ jobs:
               "binary_hash":     os.environ["BINARY_HASH"],
               "bundle_hash":     os.environ["BUNDLE_HASH"],
               "metallib_hash":   os.environ["METALLIB_HASH"],
-              "template_hashes": os.environ.get("TEMPLATE_HASHES", ""),
               "url":             "${BUNDLE_URL}",
               "changelog":       """${TAG_MSG}""".strip(),
           }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1496,9 +1496,18 @@ func (s *Server) verifyChallengeResponse(providerID string, provider *registry.P
 	releaseFact := approvedReleaseTransitionFact{}
 	if fact, evidence, ok := s.deriveApprovedReleaseTransition(
 		provider, resp, statusFieldsTrusted,
-	); ok && provider.GrantApplicationEvidenceIfNotUntrusted(evidence) {
-		releaseFact = fact
-		s.codeAttestMetric("direct_application_proof")
+	); ok {
+		if provider.GrantApplicationEvidenceIfNotUntrusted(evidence) {
+			releaseFact = fact
+			s.codeAttestMetric("direct_application_proof")
+		} else {
+			// Derivation succeeded but installation lost a race (policy
+			// generation refresh or identity/token change between derive and
+			// grant). The derive-side "granted" counter alone would make this
+			// look successful; the distinct outcome keeps shadow-rollout
+			// counters honest. The grant path already kicks a re-challenge.
+			s.recordReleaseEvidenceOutcome("grant_lost_race")
+		}
 	}
 
 	// Challenge passed. Refresh stored per-model weight hashes BEFORE

--- a/coordinator/api/release_policy_evidence_hardening_test.go
+++ b/coordinator/api/release_policy_evidence_hardening_test.go
@@ -126,26 +126,23 @@ func TestHashlessRegistrationEarnsEvidenceFromFreshChallenge(t *testing.T) {
 	}
 }
 
-// TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep is the
-// review-finding regression for the carry-forward recheck: a policy refresh
-// must re-prove EVERY release-specific runtime field the original challenge
-// proved, not just binary/version/backend/metallib. Overwriting one release
-// row's template hash (binary and backend unchanged) must invalidate that
-// provider's carried evidence at the sweep with an immediate re-challenge kick
-// — even while ANOTHER active release keeps the old template hash allowlisted
-// globally.
-func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
-	tmplOld := strings.Repeat("1", 64)
-	tmplNew := strings.Repeat("2", 64)
-	pythonHash := strings.Repeat("3", 64)
+// TestMetallibRotationInvalidatesCarriedEvidenceAtSweep is the carry-forward
+// recheck regression: a policy refresh must re-prove the release-specific
+// facts application evidence actually holds — the binary→active-release
+// binding and the metallib hash. Overwriting one release row's metallib hash
+// (binary, backend, and version unchanged) must invalidate that provider's
+// carried evidence at the sweep with an immediate re-challenge kick — even
+// while ANOTHER active release keeps the old metallib hash allowlisted
+// globally. Per-model-family template hashes are deliberately NOT part of
+// this contract (TestFamilyTemplateReleaseRowsNeverGateEvidence).
+func TestMetallibRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
+	metallibOld := trHashC
+	metallibNew := strings.Repeat("2", 64)
 
 	relA := testRelease("2.0.0", trHashA)
-	relA.TemplateHashes = "chat_template=" + tmplOld
-	relA.PythonHash = pythonHash
-	// Release B (different version/binary) keeps the OLD template hash active,
+	// Release B (different version/binary) keeps the OLD metallib hash active,
 	// so any global-allowlist shortcut would wrongly vouch for the evidence.
 	relB := testRelease("2.1.0", trHashB)
-	relB.TemplateHashes = "chat_template=" + tmplOld
 
 	st := &releaseInventoryFailureStore{MemoryStore: store.NewMemory(store.Config{})}
 	for _, rel := range []*store.Release{relA, relB} {
@@ -155,36 +152,32 @@ func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
 	}
 	logger := quietLogger()
 	reg := registry.New(logger)
+	reg.SetReleasePolicyEnforcement(true)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	if err := srv.SyncBinaryHashes(); err != nil {
 		t.Fatalf("SyncBinaryHashes: %v", err)
 	}
 
-	const model = "template-rotation-model"
-	provider := makeRoutableProvider(t, reg, "template-provider", model)
-	armReleaseChallengeProvider(t, provider, "2.0.0", trHashA, "se-template", "SER-TEMPLATE")
-	// A token is set so this test isolates the carry-forward recheck: it must
-	// fail on any code that skips re-proving release-specific runtime fields,
+	const model = "metallib-rotation-model"
+	provider := makeRoutableProvider(t, reg, "metallib-provider", model)
+	armReleaseChallengeProvider(t, provider, "2.0.0", trHashA, "se-metallib", "SER-METALLIB")
+	// A token is set so this test isolates the carry-forward recheck
 	// independent of the tokenless-evidence fix.
 	provider.Mu().Lock()
-	provider.APNsDeviceToken = "template-apns-token"
+	provider.APNsDeviceToken = "metallib-apns-token"
 	provider.Mu().Unlock()
 
 	resp := &protocol.AttestationResponseMessage{
 		BinaryHash: trHashA,
 		SIPEnabled: trBoolPtr(true), SecureBootEnabled: trBoolPtr(true),
-		PythonHash: pythonHash,
-		TemplateHashes: map[string]string{
-			"mlx_metallib":  trHashC,
-			"chat_template": tmplOld,
-		},
+		TemplateHashes: map[string]string{"mlx_metallib": metallibOld},
 	}
 	_, evidence, ok := srv.deriveApprovedReleaseTransition(provider, resp, true)
 	if !ok {
-		t.Fatal("active release with matching template hashes must derive evidence")
+		t.Fatal("active release with matching metallib must derive evidence")
 	}
-	if evidence.PythonHash != pythonHash || evidence.TemplateHashes["chat_template"] != tmplOld {
-		t.Fatalf("evidence must retain the proven runtime facts, got %+v", evidence)
+	if evidence.MetallibHash != metallibOld {
+		t.Fatalf("evidence must retain the proven metallib hash, got %+v", evidence)
 	}
 	if !provider.GrantApplicationEvidenceIfNotUntrusted(evidence) {
 		t.Fatal("evidence grant was refused")
@@ -208,10 +201,9 @@ func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
 	default:
 	}
 
-	// Rotate ONLY release A's template hash; binary, backend, version,
-	// metallib, and python hash all stay equal, and release B still allowlists
-	// the old template hash globally.
-	relA.TemplateHashes = "chat_template=" + tmplNew
+	// Rotate ONLY release A's metallib hash; binary, backend, and version all
+	// stay equal, and release B still allowlists the old metallib globally.
+	relA.MetallibHash = metallibNew
 	if err := st.SetRelease(relA); err != nil {
 		t.Fatalf("SetRelease rotated: %v", err)
 	}
@@ -219,7 +211,7 @@ func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
 		t.Fatalf("SyncBinaryHashes after rotation: %v", err)
 	}
 	if stale, ok := provider.ApplicationEvidenceSnapshot(); ok {
-		t.Fatalf("template-hash rotation must invalidate carried evidence, still holds %+v", stale)
+		t.Fatalf("metallib rotation must invalidate carried evidence, still holds %+v", stale)
 	}
 	select {
 	case <-provider.ImmediateChallengeChan():
@@ -227,11 +219,11 @@ func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
 		t.Fatal("invalidated provider must be re-challenged immediately, not on the next tick")
 	}
 	if routed := findRoutableProvider(reg, model); routed != nil {
-		t.Fatalf("provider with rotated template hash remained routable: %s", routed.ID)
+		t.Fatalf("provider with rotated metallib hash remained routable under enforcement: %s", routed.ID)
 	}
 
-	// The re-challenge measuring the NEW template hash re-earns evidence.
-	resp.TemplateHashes["chat_template"] = tmplNew
+	// The re-challenge measuring the NEW metallib hash re-earns evidence.
+	resp.TemplateHashes["mlx_metallib"] = metallibNew
 	_, refreshed, ok := srv.deriveApprovedReleaseTransition(provider, resp, true)
 	if !ok {
 		t.Fatal("re-challenge against the rotated row must derive fresh evidence")
@@ -240,7 +232,7 @@ func TestTemplateHashRotationInvalidatesCarriedEvidenceAtSweep(t *testing.T) {
 		t.Fatal("fresh evidence grant was refused")
 	}
 	if routed := findRoutableProvider(reg, model); routed == nil || routed.ID != provider.ID {
-		t.Fatal("provider did not recover after re-proving the rotated template hash")
+		t.Fatal("provider did not recover after re-proving the rotated metallib hash")
 	}
 }
 
@@ -261,6 +253,7 @@ func TestFirstTokenHeartbeatRotatesTokenlessEvidence(t *testing.T) {
 	}
 	logger := quietLogger()
 	reg := registry.New(logger)
+	reg.SetReleasePolicyEnforcement(true)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	fastBudgets(srv)
 	srv.SetCodeAttestor(&fakeCodeAttestor{onSend: func(_, _, _, _ string) error { return nil }})

--- a/coordinator/api/release_policy_failclosed_test.go
+++ b/coordinator/api/release_policy_failclosed_test.go
@@ -168,6 +168,7 @@ func TestSyncBinaryHashesReleaseRegistrationKeepsApprovedFleetRoutable(t *testin
 	}
 	logger := quietLogger()
 	reg := registry.New(logger)
+	reg.SetReleasePolicyEnforcement(true)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	if err := srv.SyncBinaryHashes(); err != nil {
 		t.Fatalf("initial SyncBinaryHashes: %v", err)
@@ -290,6 +291,7 @@ func TestReleaseDeactivationReadFailureConvergesPolicyFromCommittedDeactivation(
 	}
 	logger := quietLogger()
 	reg := registry.New(logger)
+	reg.SetReleasePolicyEnforcement(true)
 	srv := NewServer(reg, st, ServerConfig{AdminKey: "admin-key"}, logger)
 	if err := srv.SyncBinaryHashes(); err != nil {
 		t.Fatalf("initial SyncBinaryHashes: %v", err)

--- a/coordinator/api/release_policy_production_shape_test.go
+++ b/coordinator/api/release_policy_production_shape_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// productionShapeRelease mirrors the EXACT active production release rows
+// observed in the incident DB (2026-08-31): binary_hash and metallib_hash
+// present, python_hash and runtime_hash EMPTY, and template_hashes carrying
+// CI-fabricated per-model-family entries (qwen3.5/trinity/gemma4/minimax)
+// that no provider build has ever reported.
+func productionShapeRelease(version, binaryHash string) *store.Release {
+	rel := testRelease(version, binaryHash)
+	rel.PythonHash = ""
+	rel.RuntimeHash = ""
+	rel.TemplateHashes = "qwen3.5=" + strings.Repeat("4", 64) +
+		",trinity=" + strings.Repeat("5", 64) +
+		",gemma4=" + strings.Repeat("6", 64) +
+		",minimax=" + strings.Repeat("7", 64)
+	return rel
+}
+
+// productionShapeChallenge mirrors the exact v0.8.15 provider attestation
+// response wire shape: binary hash present, SIP/Secure Boot true, NO
+// python_hash, NO runtime_hash, and template_hashes containing ONLY
+// mlx_metallib (the provider's entire template vocabulary).
+func productionShapeChallenge(binaryHash string) *protocol.AttestationResponseMessage {
+	return &protocol.AttestationResponseMessage{
+		BinaryHash: binaryHash,
+		SIPEnabled: trBoolPtr(true), SecureBootEnabled: trBoolPtr(true),
+		TemplateHashes: map[string]string{"mlx_metallib": trHashC},
+	}
+}
+
+// TestFamilyTemplateReleaseRowsNeverGateEvidence is THE incident regression
+// (2026-08-31 zero-capacity deploys): a release row carrying per-model-family
+// template hashes and empty python/runtime hashes, challenged by a provider
+// that is hashless at registration and reports only mlx_metallib, MUST derive
+// application evidence, survive a policy re-sync, and stay routable under
+// ENFORCE. Both failed candidate coordinators died exactly here: every
+// provider was rejected for not echoing release-row family template hashes it
+// never possessed, application proofs stayed at zero fleet-wide, and every
+// request received 429.
+func TestFamilyTemplateReleaseRowsNeverGateEvidence(t *testing.T) {
+	st := &releaseInventoryFailureStore{MemoryStore: store.NewMemory(store.Config{})}
+	if err := st.SetRelease(productionShapeRelease("0.8.15", trHashA)); err != nil {
+		t.Fatalf("SetRelease: %v", err)
+	}
+	logger := quietLogger()
+	reg := registry.New(logger)
+	reg.SetReleasePolicyEnforcement(true)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	if err := srv.SyncBinaryHashes(); err != nil {
+		t.Fatalf("SyncBinaryHashes: %v", err)
+	}
+
+	const model = "production-shape-model"
+	provider := makeRoutableProvider(t, reg, "production-shape-provider", model)
+	// Hashless registration: the fleet's registration attestation carries no
+	// binary hash; it arrives only in the signed periodic challenge.
+	armReleaseChallengeProvider(t, provider, "0.8.15", "", "se-prod-shape", "SER-PROD-SHAPE")
+
+	resp := productionShapeChallenge(trHashA)
+	fact, evidence, ok := srv.deriveApprovedReleaseTransition(provider, resp, true)
+	if !ok || !fact.Approved {
+		t.Fatal("production-shape provider must derive application evidence despite release-row family template hashes it cannot echo")
+	}
+	if evidence.BinaryHash != trHashA || evidence.MetallibHash != trHashC {
+		t.Fatalf("evidence must bind the challenge binary and metallib hashes, got %+v", evidence)
+	}
+	if !provider.GrantApplicationEvidenceIfNotUntrusted(evidence) {
+		t.Fatal("evidence grant was refused")
+	}
+	if routed := findRoutableProvider(reg, model); routed == nil || routed.ID != provider.ID {
+		t.Fatal("production-shape provider must be routable under enforcement once evidence is held")
+	}
+	if holding, connected := reg.CountProvidersWithCurrentApplicationEvidence(); holding != 1 || connected != 1 {
+		t.Fatalf("evidence coverage = (%d, %d), want (1, 1)", holding, connected)
+	}
+
+	// A policy re-sync must carry the evidence forward: the re-proof compares
+	// only facts the evidence holds (binary→release binding + metallib), never
+	// release-row family templates.
+	if err := srv.SyncBinaryHashes(); err != nil {
+		t.Fatalf("re-sync: %v", err)
+	}
+	carried, ok := provider.ApplicationEvidenceSnapshot()
+	if !ok || carried.PolicyGeneration != srv.releaseTrustPolicy.Load().Generation {
+		t.Fatalf("production-shape evidence must survive the policy sweep, got %+v ok=%v", carried, ok)
+	}
+	if routed := findRoutableProvider(reg, model); routed == nil || routed.ID != provider.ID {
+		t.Fatal("production-shape provider must remain routable across the policy sweep")
+	}
+
+	// The gate still fails closed on the facts that ARE provable: a wrong
+	// metallib deroutes, and an unregistered binary earns nothing.
+	badMetallib := productionShapeChallenge(trHashA)
+	badMetallib.TemplateHashes["mlx_metallib"] = strings.Repeat("9", 64)
+	if _, _, ok := srv.deriveApprovedReleaseTransition(provider, badMetallib, true); ok {
+		t.Fatal("mismatched metallib hash must fail closed")
+	}
+	if _, _, ok := srv.deriveApprovedReleaseTransition(provider, productionShapeChallenge(trHashB), true); ok {
+		t.Fatal("binary hash without an active release row must fail closed")
+	}
+}
+
+// TestShadowModeRoutesFleetWithoutEvidence pins the deployment-safety contract:
+// a freshly booted coordinator (default SHADOW mode) whose connected providers
+// hold no application evidence yet — the guaranteed state right after any
+// coordinator swap, and permanently the state if a future gate regression
+// makes evidence underivable — keeps the fleet routable while the coverage
+// counter exposes the gap instead of zeroing capacity.
+func TestShadowModeRoutesFleetWithoutEvidence(t *testing.T) {
+	st := &releaseInventoryFailureStore{MemoryStore: store.NewMemory(store.Config{})}
+	if err := st.SetRelease(productionShapeRelease("0.8.15", trHashA)); err != nil {
+		t.Fatalf("SetRelease: %v", err)
+	}
+	logger := quietLogger()
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	if err := srv.SyncBinaryHashes(); err != nil {
+		t.Fatalf("SyncBinaryHashes: %v", err)
+	}
+
+	const model = "shadow-mode-model"
+	provider := makeRoutableProvider(t, reg, "shadow-mode-provider", model)
+	armReleaseChallengeProvider(t, provider, "0.8.15", "", "se-shadow", "SER-SHADOW")
+
+	// No challenge has completed: zero evidence anywhere.
+	if holding, connected := reg.CountProvidersWithCurrentApplicationEvidence(); holding != 0 || connected != 1 {
+		t.Fatalf("evidence coverage = (%d, %d), want (0, 1)", holding, connected)
+	}
+	if routed := findRoutableProvider(reg, model); routed == nil || routed.ID != provider.ID {
+		t.Fatal("shadow mode must keep an evidence-less provider routable")
+	}
+
+	// Flipping enforcement without coverage is exactly the incident: the same
+	// provider immediately stops routing.
+	reg.SetReleasePolicyEnforcement(true)
+	if routed := findRoutableProvider(reg, model); routed != nil {
+		t.Fatalf("enforce mode routed an evidence-less provider: %s", routed.ID)
+	}
+	reg.SetReleasePolicyEnforcement(false)
+	if routed := findRoutableProvider(reg, model); routed == nil || routed.ID != provider.ID {
+		t.Fatal("returning to shadow mode must restore routing")
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1691,12 +1691,11 @@ func (s *Server) convergeReleasePolicyWithCommittedDeactivation(version, platfor
 // releaseEvidenceStillApproved reports whether previously granted application
 // evidence remains approved under a freshly built release-policy snapshot: the
 // same binary hash still maps to an active release with the same version,
-// platform, and backend, AND every release-specific runtime fact the original
-// challenge proved (python/runtime/metallib/template hashes — the full
-// releaseRuntimeMatches input set, retained on the evidence) is unchanged in
-// that release row. Any mismatch or ambiguity — including a field the evidence
-// cannot prove unchanged — fails closed (evidence is invalidated and the
-// provider re-challenged).
+// platform, and backend, and that release's metallib hash is unchanged. These
+// are the ONLY facts application evidence proves — python/runtime/per-family
+// template facts were deliberately removed (mlx-swift providers never report
+// them; requiring them made evidence underivable fleet-wide, 2026-08-31
+// incident). Binary hash and metallib fail closed on absence or mismatch.
 func releaseEvidenceStillApproved(
 	snapshot *releaseTrustPolicySnapshot,
 	evidence registry.ApplicationEvidence,
@@ -1704,7 +1703,6 @@ func releaseEvidenceStillApproved(
 	if evidence.BinaryHash == "" || evidence.MetallibHash == "" {
 		return false
 	}
-candidates:
 	for _, candidate := range snapshot.ByBinaryHash[evidence.BinaryHash] {
 		if candidate.Version != evidence.Version ||
 			candidate.Platform != evidence.Platform ||
@@ -1717,26 +1715,47 @@ candidates:
 		if candidate.Backend != "" && candidate.Backend != evidence.Backend {
 			continue
 		}
-		if candidate.PythonHash != "" && !strings.EqualFold(candidate.PythonHash, evidence.PythonHash) {
-			continue
-		}
-		if candidate.RuntimeHash != "" && !strings.EqualFold(candidate.RuntimeHash, evidence.RuntimeHash) {
-			continue
-		}
 		expectedMetallib, err := normalizeSHA256Hex(candidate.MetallibHash, "release.metallib_hash")
 		if err != nil || expectedMetallib != evidence.MetallibHash {
 			continue
 		}
-		// Every template hash the row pins must be re-proven from the facts the
-		// challenge measured; a template the evidence never proved fails closed.
-		for name, expected := range candidate.TemplateHashes {
-			if !strings.EqualFold(evidence.TemplateHashes[name], expected) {
-				continue candidates
-			}
-		}
 		return true
 	}
 	return false
+}
+
+// Closed outcome set for application-evidence derivation. Every
+// deriveApprovedReleaseTransition return path records exactly one of these as
+// a release_evidence.outcome DogStatsD counter tag so a candidate coordinator
+// can be judged in SHADOW mode from per-reason fleet counts instead of a
+// silent boolean (the 2026-08-31 zero-capacity deploys were undiagnosable
+// precisely because every rejection branch looked identical). No hashes,
+// keys, serials, or tokens ride on these tags.
+const (
+	evidenceOutcomeGranted                 = "granted"
+	evidenceReasonPrecondition             = "precondition"
+	evidenceReasonInvalidBinaryHash        = "invalid_binary_hash"
+	evidenceReasonPolicyUnavailable        = "policy_unavailable"
+	evidenceReasonPolicyNotRequired        = "policy_not_required"
+	evidenceReasonProcessIdentity          = "process_identity"
+	evidenceReasonRuntimeGate              = "runtime_gate"
+	evidenceReasonVersionFloor             = "version_floor"
+	evidenceReasonRegistrationHashMismatch = "registration_hash_mismatch"
+	evidenceReasonNoActiveRelease          = "no_active_release"
+	evidenceReasonMetallibMismatch         = "metallib_mismatch"
+)
+
+// recordReleaseEvidenceOutcome counts one application-evidence derivation
+// outcome. No-op without DogStatsD.
+func (s *Server) recordReleaseEvidenceOutcome(outcome string) {
+	s.ddIncr("release_evidence.outcome", []string{"outcome:" + outcome})
+}
+
+// evidenceRejected records the typed rejection reason and returns the empty
+// derivation result.
+func (s *Server) evidenceRejected(reason string) (approvedReleaseTransitionFact, registry.ApplicationEvidence, bool) {
+	s.recordReleaseEvidenceOutcome(reason)
+	return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
 }
 
 func (s *Server) deriveApprovedReleaseTransition(
@@ -1748,15 +1767,15 @@ func (s *Server) deriveApprovedReleaseTransition(
 		resp.SIPEnabled == nil || !*resp.SIPEnabled ||
 		resp.SecureBootEnabled == nil || !*resp.SecureBootEnabled ||
 		provider.ChallengeShouldStop() {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+		return s.evidenceRejected(evidenceReasonPrecondition)
 	}
 	freshHash, err := normalizeSHA256Hex(resp.BinaryHash, "binary_hash")
 	if err != nil {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+		return s.evidenceRejected(evidenceReasonInvalidBinaryHash)
 	}
 	snapshot := s.releaseTrustPolicy.Load()
 	if snapshot == nil {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+		return s.evidenceRejected(evidenceReasonPolicyUnavailable)
 	}
 
 	provider.Mu().Lock()
@@ -1772,13 +1791,19 @@ func (s *Server) deriveApprovedReleaseTransition(
 	// token possession is enforced exclusively by the code-identity gate (with
 	// its own grace semantics). Tokenless legacy/headless providers with a
 	// valid signed challenge must still derive and keep evidence.
-	if !snapshot.Required || processKey == "" ||
-		attested == nil || !attested.Valid ||
-		attested.PublicKey == "" || attested.SerialNumber == "" ||
-		!runtimeVerified || !manifestChecked || !metallibVerified ||
-		(s.minProviderVersion != "" &&
-			(version == "" || semverLess(version, s.minProviderVersion))) {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+	if !snapshot.Required {
+		return s.evidenceRejected(evidenceReasonPolicyNotRequired)
+	}
+	if processKey == "" || attested == nil || !attested.Valid ||
+		attested.PublicKey == "" || attested.SerialNumber == "" {
+		return s.evidenceRejected(evidenceReasonProcessIdentity)
+	}
+	if !runtimeVerified || !manifestChecked || !metallibVerified {
+		return s.evidenceRejected(evidenceReasonRuntimeGate)
+	}
+	if s.minProviderVersion != "" &&
+		(version == "" || semverLess(version, s.minProviderVersion)) {
+		return s.evidenceRejected(evidenceReasonVersionFloor)
 	}
 	// Registration-time binary_hash is optional and the production fleet omits
 	// it. The fresh hash is carried by this already-signature-verified challenge
@@ -1788,7 +1813,7 @@ func (s *Server) deriveApprovedReleaseTransition(
 	if strings.TrimSpace(attested.BinaryHash) != "" {
 		attestedHash, hashErr := normalizeSHA256Hex(attested.BinaryHash, "attested binary_hash")
 		if hashErr != nil || attestedHash != freshHash {
-			return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+			return s.evidenceRejected(evidenceReasonRegistrationHashMismatch)
 		}
 	}
 
@@ -1820,8 +1845,11 @@ func (s *Server) deriveApprovedReleaseTransition(
 			}
 		}
 	}
-	if !found || !releaseRuntimeMatches(current, resp) {
-		return approvedReleaseTransitionFact{}, registry.ApplicationEvidence{}, false
+	if !found {
+		return s.evidenceRejected(evidenceReasonNoActiveRelease)
+	}
+	if !releaseMetallibMatches(current, resp) {
+		return s.evidenceRejected(evidenceReasonMetallibMismatch)
 	}
 
 	approvedFrom := make(map[string]struct{})
@@ -1846,25 +1874,25 @@ func (s *Server) deriveApprovedReleaseTransition(
 		ProcessPublicKey: processKey, APNsToken: apnsToken,
 		BinaryHash: freshHash,
 		Version:    current.Version, Platform: current.Platform,
-		Backend: current.Backend, RuntimeHash: resp.RuntimeHash,
-		// Retain the full releaseRuntimeMatches fact set so the next policy
-		// sweep can re-prove every release-specific runtime field rather than
-		// assuming it unchanged (releaseEvidenceStillApproved).
-		PythonHash:     resp.PythonHash,
-		TemplateHashes: registry.CloneStringMap(resp.TemplateHashes),
-		MetallibHash:   metallibHash, VerifiedAt: time.Now().UTC(),
+		Backend:      current.Backend,
+		MetallibHash: metallibHash, VerifiedAt: time.Now().UTC(),
 		PolicyGeneration: snapshot.Generation,
 	}
+	s.recordReleaseEvidenceOutcome(evidenceOutcomeGranted)
 	return fact, evidence, true
 }
 
-func releaseRuntimeMatches(policy approvedReleasePolicy, resp *protocol.AttestationResponseMessage) bool {
-	if policy.PythonHash != "" && !strings.EqualFold(policy.PythonHash, resp.PythonHash) {
-		return false
-	}
-	if policy.RuntimeHash != "" && !strings.EqualFold(policy.RuntimeHash, resp.RuntimeHash) {
-		return false
-	}
+// releaseMetallibMatches verifies the ONE release-specific runtime fact both
+// sides always hold: the release row's metallib hash must equal the provider's
+// reported mlx_metallib template hash (both normalized 64-hex; absence on
+// either side fails closed). Nothing else is compared here by design — the
+// python plane is gone (mlx-swift providers hardcode it nil), and release
+// rows' per-model-family template hashes were CI fabrications (hashed from
+// CDN jinja files by release-swift.yml) that no provider ever reported;
+// requiring provider coverage of those made application evidence underivable
+// for 100% of the production fleet (2026-08-31 zero-capacity incident).
+// Binary-hash ↔ active-release matching is the caller's job.
+func releaseMetallibMatches(policy approvedReleasePolicy, resp *protocol.AttestationResponseMessage) bool {
 	if policy.MetallibHash == "" {
 		return false
 	}
@@ -1873,15 +1901,7 @@ func releaseRuntimeMatches(policy approvedReleasePolicy, resp *protocol.Attestat
 		return false
 	}
 	gotMetallib, err := normalizeSHA256Hex(resp.TemplateHashes["mlx_metallib"], "mlx_metallib")
-	if err != nil || gotMetallib != expectedMetallib {
-		return false
-	}
-	for name, expected := range policy.TemplateHashes {
-		if !strings.EqualFold(resp.TemplateHashes[name], expected) {
-			return false
-		}
-	}
-	return true
+	return err == nil && gotMetallib == expectedMetallib
 }
 
 func (s *Server) rebuildBinaryHashPolicyLocked() {

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -237,33 +237,41 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	codeAttestedProviders, _ := s.registry.CodeAttestationCoverage()
 	codeAttestationEnforced := s.registry.CodeAttestationEnforced()
 
+	// --- Release-policy application-evidence coverage (the shadow→enforce
+	// acceptance instrument: enforcement is safe only once holding ≈ connected) ---
+	evidenceProviders, evidenceConnected := s.registry.CountProvidersWithCurrentApplicationEvidence()
+	releasePolicyEnforced := s.registry.ReleasePolicyEnforced()
+
 	// --- Network utilization (demand/capacity across warm-serving + token-budget axes) ---
 	util := s.registry.NetworkUtilizationSnapshot()
 
 	resp := map[string]any{
-		"total_requests":             totalRequests,
-		"total_prompt_tokens":        totalPromptTokens,
-		"total_completion_tokens":    totalCompletionTokens,
-		"total_tokens":               totalTokens,
-		"last_24h_requests":          last24h.Requests,
-		"last_24h_prompt_tokens":     last24h.PromptTokens,
-		"last_24h_completion_tokens": last24h.CompletionTokens,
-		"last_24h_total_tokens":      last24h.PromptTokens + last24h.CompletionTokens,
-		"location_window_hours":      24,
-		"avg_tokens_per_request":     avgTokens,
-		"active_providers":           len(providers),
-		"active_power_watts":         activePowerWatts,
-		"code_attested_providers":    codeAttestedProviders,
-		"code_attestation_enforced":  codeAttestationEnforced,
-		"total_gpu_cores":            totalGPUCores,
-		"total_cpu_cores":            totalCPUCores,
-		"total_memory_gb":            totalMemoryGB,
-		"total_bandwidth_gbs":        totalBandwidthGB,
-		"network_capacity_tps":       util.CapacityTPS,
-		"network_utilization":        util.Public(),
-		"providers":                  providers,
-		"models":                     models,
-		"time_series":                timeSeries,
+		"total_requests":                 totalRequests,
+		"total_prompt_tokens":            totalPromptTokens,
+		"total_completion_tokens":        totalCompletionTokens,
+		"total_tokens":                   totalTokens,
+		"last_24h_requests":              last24h.Requests,
+		"last_24h_prompt_tokens":         last24h.PromptTokens,
+		"last_24h_completion_tokens":     last24h.CompletionTokens,
+		"last_24h_total_tokens":          last24h.PromptTokens + last24h.CompletionTokens,
+		"location_window_hours":          24,
+		"avg_tokens_per_request":         avgTokens,
+		"active_providers":               len(providers),
+		"active_power_watts":             activePowerWatts,
+		"code_attested_providers":        codeAttestedProviders,
+		"code_attestation_enforced":      codeAttestationEnforced,
+		"application_evidence_providers": evidenceProviders,
+		"application_evidence_connected": evidenceConnected,
+		"release_policy_enforced":        releasePolicyEnforced,
+		"total_gpu_cores":                totalGPUCores,
+		"total_cpu_cores":                totalCPUCores,
+		"total_memory_gb":                totalMemoryGB,
+		"total_bandwidth_gbs":            totalBandwidthGB,
+		"network_capacity_tps":           util.CapacityTPS,
+		"network_utilization":            util.Public(),
+		"providers":                      providers,
+		"models":                         models,
+		"time_series":                    timeSeries,
 
 		// Location analytics (privacy-floored).
 		"provider_locations":                 providerLocations,

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -238,8 +238,11 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	codeAttestationEnforced := s.registry.CodeAttestationEnforced()
 
 	// --- Release-policy application-evidence coverage (the shadow→enforce
-	// acceptance instrument: enforcement is safe only once holding ≈ connected) ---
+	// acceptance instrument: enforcement is safe only once holding ≈ connected
+	// fleet-wide AND with_evidence ≈ routable for EVERY model, so one model
+	// family's uncovered providers cannot hide inside a healthy average) ---
 	evidenceProviders, evidenceConnected := s.registry.CountProvidersWithCurrentApplicationEvidence()
+	evidenceModels := s.registry.ApplicationEvidenceModelCoverage()
 	releasePolicyEnforced := s.registry.ReleasePolicyEnforced()
 
 	// --- Network utilization (demand/capacity across warm-serving + token-budget axes) ---
@@ -263,6 +266,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		"application_evidence_providers": evidenceProviders,
 		"application_evidence_connected": evidenceConnected,
 		"release_policy_enforced":        releasePolicyEnforced,
+		"application_evidence_models":    evidenceModels,
 		"total_gpu_cores":                totalGPUCores,
 		"total_cpu_cores":                totalCPUCores,
 		"total_memory_gb":                totalMemoryGB,

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -417,8 +417,24 @@ func main() {
 	// predicate zeroed network capacity twice).
 	switch mode := os.Getenv("EIGENINFERENCE_RELEASE_POLICY_MODE"); mode {
 	case "enforce":
+		// A restarted coordinator boots with an EMPTY provider registry: zero
+		// evidence exists until reconnected providers complete their first
+		// challenge. Enforcing from the first request would 429 the whole
+		// fleet for minutes — so enforcement always waits out a boot grace
+		// (default 20m ≈ four challenge cycles) during which routing behaves
+		// exactly like shadow while evidence coverage rebuilds.
+		grace := 20 * time.Minute
+		if v := os.Getenv("EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+				grace = d
+			} else {
+				logger.Warn("invalid EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE; keeping default 20m", "value", v)
+			}
+		}
 		reg.SetReleasePolicyEnforcement(true)
-		logger.Warn("release-policy routing gate ENFORCED via EIGENINFERENCE_RELEASE_POLICY_MODE — providers without current application evidence will not route")
+		reg.SetReleasePolicyEnforceAfter(time.Now().Add(grace))
+		logger.Warn("release-policy routing gate ENFORCED via EIGENINFERENCE_RELEASE_POLICY_MODE — providers without current application evidence will not route after the boot grace",
+			"boot_grace", grace.String())
 	case "", "shadow":
 		logger.Info("release-policy routing gate in SHADOW mode (default): evidence tracked and counted, never blocks routing; set EIGENINFERENCE_RELEASE_POLICY_MODE=enforce after coverage is proven")
 	default:

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -423,10 +423,16 @@ func main() {
 		// fleet for minutes — so enforcement always waits out a boot grace
 		// (default 20m ≈ four challenge cycles) during which routing behaves
 		// exactly like shadow while evidence coverage rebuilds.
-		grace := 20 * time.Minute
+		// The override is RAISE-ONLY, mirroring DARKBLOOM_ACTIVATION_RESERVE_GB:
+		// a shorter grace recreates the empty-registry 429 interval the grace
+		// exists to prevent, so values below the default clamp up to it.
+		const minEnforceGrace = 20 * time.Minute
+		grace := minEnforceGrace
 		if v := os.Getenv("EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE"); v != "" {
-			if d, err := time.ParseDuration(v); err == nil && d >= 0 {
+			if d, err := time.ParseDuration(v); err == nil && d >= minEnforceGrace {
 				grace = d
+			} else if err == nil {
+				logger.Warn("EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE below the 20m minimum; clamping up", "value", v)
 			} else {
 				logger.Warn("invalid EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE; keeping default 20m", "value", v)
 			}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -407,6 +407,23 @@ func main() {
 		srv.AddKnownBinaryHashes(hashes)
 		logger.Info("additional binary hashes from env var", "count", len(hashes))
 	}
+	// Release-policy routing gate mode. SHADOW (default): application evidence
+	// is derived, granted, swept, and counted (release_evidence.outcome metrics
+	// + /v1/stats application_evidence_providers) but NEVER blocks routing —
+	// identical routing behavior to the pre-release-policy coordinator. ENFORCE:
+	// the routing chokepoint requires generation-current evidence. Enforcement
+	// must only be enabled after a shadow deployment shows evidence coverage
+	// near the connected fleet size (2026-08-31: enforcing an unproven evidence
+	// predicate zeroed network capacity twice).
+	switch mode := os.Getenv("EIGENINFERENCE_RELEASE_POLICY_MODE"); mode {
+	case "enforce":
+		reg.SetReleasePolicyEnforcement(true)
+		logger.Warn("release-policy routing gate ENFORCED via EIGENINFERENCE_RELEASE_POLICY_MODE — providers without current application evidence will not route")
+	case "", "shadow":
+		logger.Info("release-policy routing gate in SHADOW mode (default): evidence tracked and counted, never blocks routing; set EIGENINFERENCE_RELEASE_POLICY_MODE=enforce after coverage is proven")
+	default:
+		logger.Warn("invalid EIGENINFERENCE_RELEASE_POLICY_MODE; staying in SHADOW mode", "value", mode)
+	}
 	// v0.6.0: self-reported binaryHash is demoted to drift telemetry by default
 	// (APNs code-identity attestation is the real signal). Set this to re-enable
 	// the legacy derouting-on-mismatch behavior (rollback only).

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1008,6 +1008,15 @@ type Provider struct {
 // that is what lets the grace→enforce deadline flip without a reconnect. Callers
 // hold r.mu (every call site is inside an r-locked Registry method).
 func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
+	return r.providerSupportsPrivateTextModeLocked(p, r.releasePolicyEnforcedLocked())
+}
+
+// providerSupportsPrivateTextModeLocked is the chokepoint body with the
+// evidence gate explicit: enforceEvidence=false is the SHADOW/baseline surface
+// (used live in shadow mode and by ApplicationEvidenceModelCoverage to compute
+// the per-model flip criterion); enforceEvidence=true additionally requires
+// generation-current application evidence. Caller holds r.mu.
+func (r *Registry) providerSupportsPrivateTextModeLocked(p *Provider, enforceEvidence bool) bool {
 	if p.PublicKey == "" || !privateTextBackendSupported(p.Backend) || !p.EncryptedResponseChunks {
 		return false
 	}
@@ -1021,12 +1030,12 @@ func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
 	}
 	// A configured release policy makes current active-release application
 	// evidence mandatory independently of the APNs rollout deadline — but only
-	// once enforcement is switched on. In shadow mode (the default) the
-	// predicate is still evaluated so operators can compare
-	// CountProvidersWithCurrentApplicationEvidence against the connected fleet
-	// BEFORE flipping enforcement; a provider failing it keeps routing.
+	// once enforcement is switched on AND past any enforce-after delay. In
+	// shadow (the default) the predicate is still evaluated and counted
+	// (ApplicationEvidenceModelCoverage, CountProvidersWithCurrentApplicationEvidence)
+	// so operators prove coverage BEFORE anything can be derouted.
 	if r.releasePolicyRequired &&
-		r.releasePolicyEnforced &&
+		enforceEvidence &&
 		!r.providerHoldsCurrentApplicationEvidenceLocked(p) {
 		return false
 	}
@@ -1596,6 +1605,7 @@ func (r *Registry) SetReleasePolicyGeneration(
 	r.mu.Lock()
 	r.releasePolicyGeneration = generation
 	r.releasePolicyRequired = required
+	enforced := r.releasePolicyEnforcedLocked()
 	for id, provider := range r.providers {
 		provider.mu.Lock()
 		evidence := provider.ApplicationEvidence
@@ -1605,7 +1615,14 @@ func (r *Registry) SetReleasePolicyGeneration(
 			continue
 		}
 		provider.ApplicationEvidence = ApplicationEvidence{}
-		provider.RuntimeCapabilities = nil
+		// Capability invalidation is an ENFORCE-mode consequence: capabilities
+		// gate capability-required catalog models, so clearing them in shadow
+		// would let evidence bookkeeping remove real capacity — exactly what
+		// shadow mode promises not to do. The re-challenge kicked below
+		// re-reconciles capabilities within one challenge round-trip anyway.
+		if enforced {
+			provider.RuntimeCapabilities = nil
+		}
 		provider.mu.Unlock()
 		if required {
 			needChallenge = append(needChallenge, id)
@@ -1639,11 +1656,28 @@ func (r *Registry) providerHoldsCurrentApplicationEvidenceLocked(p *Provider) bo
 // SetReleasePolicyEnforcement switches the release-policy routing gate between
 // SHADOW (false, default: evidence derived/granted/swept and counted but never
 // blocks routing) and ENFORCE (true: the routing chokepoint requires current
-// evidence). Thread-safe.
+// evidence once any configured enforce-after delay has passed). Thread-safe.
 func (r *Registry) SetReleasePolicyEnforcement(enforced bool) {
 	r.mu.Lock()
 	r.releasePolicyEnforced = enforced
 	r.mu.Unlock()
+}
+
+// SetReleasePolicyEnforceAfter defers enforcement until t (zero = immediate).
+// Set at startup so a restart into enforce mode keeps routing like shadow
+// until the reconnected fleet has completed its first challenge cycles and
+// re-earned evidence. Thread-safe.
+func (r *Registry) SetReleasePolicyEnforceAfter(t time.Time) {
+	r.mu.Lock()
+	r.releasePolicyEnforceAfter = t
+	r.mu.Unlock()
+}
+
+// releasePolicyEnforcedLocked reports whether the evidence gate is LIVE right
+// now: enforcement configured and past any enforce-after delay. Caller holds r.mu.
+func (r *Registry) releasePolicyEnforcedLocked() bool {
+	return r.releasePolicyEnforced &&
+		!time.Now().Before(r.releasePolicyEnforceAfter)
 }
 
 // ReleasePolicyEnforced reports whether missing application evidence currently
@@ -1651,7 +1685,55 @@ func (r *Registry) SetReleasePolicyEnforcement(enforced bool) {
 func (r *Registry) ReleasePolicyEnforced() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.releasePolicyEnforced
+	return r.releasePolicyEnforcedLocked()
+}
+
+// ModelEvidenceCoverage is the per-model shadow→enforce acceptance record:
+// Routable counts providers passing every routing gate EXCEPT the evidence
+// gate for that catalog-allowed model; WithEvidence counts the subset also
+// holding generation-current application evidence. Enforcement is safe for a
+// model only when WithEvidence ≈ Routable.
+type ModelEvidenceCoverage struct {
+	Routable     int `json:"routable"`
+	WithEvidence int `json:"with_evidence"`
+}
+
+// ApplicationEvidenceModelCoverage computes ModelEvidenceCoverage for every
+// catalog-allowed model advertised by a connected provider, using the same
+// liveness surface as public capacity with the evidence gate bypassed — so the
+// flip criterion cannot be masked by fleet-wide averages hiding one model
+// family's uncovered providers. Thread-safe.
+func (r *Registry) ApplicationEvidenceModelCoverage() map[string]ModelEvidenceCoverage {
+	now := time.Now()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]ModelEvidenceCoverage)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		baseline := p.Status != StatusOffline && p.Status != StatusUntrusted &&
+			!p.PrivateOnly &&
+			trustRank(p.TrustLevel) >= trustRank(r.MinTrustLevel) &&
+			p.RuntimeVerified &&
+			r.providerSupportsPrivateTextModeLocked(p, false) &&
+			!p.LastChallengeVerified.IsZero() &&
+			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
+		holds := baseline && r.providerHoldsCurrentApplicationEvidenceLocked(p)
+		if baseline {
+			for _, model := range p.Models {
+				if !r.providerModelAllowedByCatalogLocked(p, model) {
+					continue
+				}
+				coverage := out[model.ID]
+				coverage.Routable++
+				if holds {
+					coverage.WithEvidence++
+				}
+				out[model.ID] = coverage
+			}
+		}
+		p.mu.Unlock()
+	}
+	return out
 }
 
 // CountProvidersWithCurrentApplicationEvidence returns (holding, connected):
@@ -2026,6 +2108,13 @@ type Registry struct {
 	// in shadow before it is allowed to deroute anything (2026-08-31 incident:
 	// an unprovable evidence predicate zeroed network capacity twice).
 	releasePolicyEnforced bool
+	// releasePolicyEnforceAfter delays enforcement past process start: a
+	// coordinator restarted with enforcement configured boots with an EMPTY
+	// in-memory registry (zero evidence), so enforcing from the first request
+	// would 429 every reconnecting provider until its first challenge —
+	// recreating the exact transient the shadow rollout exists to prevent.
+	// Zero means enforce immediately (tests, in-process flips).
+	releasePolicyEnforceAfter time.Time
 
 	modelCatalog map[string]CatalogEntry
 

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1742,11 +1742,17 @@ func (r *Registry) ApplicationEvidenceModelCoverage() map[string]ModelEvidenceCo
 // instrument: enforcement must not be enabled until holding is near connected.
 // Thread-safe.
 func (r *Registry) CountProvidersWithCurrentApplicationEvidence() (int, int) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	holding := 0
 	for _, provider := range r.providers {
-		if r.providerHoldsCurrentApplicationEvidenceLocked(provider) {
+		// Evidence and token fields are written under p.mu by challenge and
+		// APNs handlers that do not hold r.mu; lock each provider so this
+		// flip-criterion counter never reads a torn record.
+		provider.mu.Lock()
+		holds := r.providerHoldsCurrentApplicationEvidenceLocked(provider)
+		provider.mu.Unlock()
+		if holds {
 			holding++
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -759,6 +759,13 @@ type DeviceEvidence struct {
 	RevocationGeneration uint64
 }
 
+// ApplicationEvidence proves this connection's process runs an active approved
+// release: the SE-signed challenge binary hash matched an active release row
+// for the provider's version/platform/backend, and the runtime metallib hash
+// matched that release. Deliberately NO python/runtime/per-family-template
+// facts: mlx-swift providers never report them (python is gone; family
+// template hashes were CI fabrications no provider could echo — requiring
+// them made evidence underivable fleet-wide, 2026-08-31 incident).
 type ApplicationEvidence struct {
 	SEPublicKey      string
 	Serial           string
@@ -767,19 +774,11 @@ type ApplicationEvidence struct {
 	// has one. It MAY be empty: tokenless (legacy/headless) providers with a
 	// valid signed challenge still earn application evidence — APNs token
 	// possession is enforced exclusively by the APNs code-identity gate.
-	APNsToken   string
-	BinaryHash  string
-	Version     string
-	Platform    string
-	Backend     string
-	RuntimeHash string
-	// PythonHash and TemplateHashes retain the release-specific runtime facts
-	// the challenge proved, so a policy refresh can re-prove EVERY
-	// releaseRuntimeMatches input against the new snapshot instead of assuming
-	// them unchanged. TemplateHashes is never mutated after the grant (the
-	// struct is copied by value; the map is shared read-only).
-	PythonHash         string
-	TemplateHashes     map[string]string
+	APNsToken          string
+	BinaryHash         string
+	Version            string
+	Platform           string
+	Backend            string
 	MetallibHash       string
 	VerifiedAt         time.Time
 	EvidenceGeneration uint64
@@ -1021,25 +1020,15 @@ func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
 		return false
 	}
 	// A configured release policy makes current active-release application
-	// evidence mandatory independently of the APNs rollout deadline. The APNs
-	// proof establishes genuine Apple code identity; this generation-bound fact
-	// establishes that the live binary/runtime is still active and approved.
-	if r.releasePolicyRequired {
-		evidence := p.ApplicationEvidence
-		if evidence.EvidenceGeneration == 0 ||
-			evidence.PolicyGeneration != r.releasePolicyGeneration ||
-			evidence.ProcessPublicKey != p.PublicKey ||
-			// Tokenless providers pass with matching empty tokens; APNs token
-			// possession is enforced only by the code-identity gate below.
-			evidence.APNsToken != p.APNsDeviceToken ||
-			evidence.Version != p.Version ||
-			evidence.Backend != p.Backend ||
-			evidence.BinaryHash == "" ||
-			p.AttestationResult == nil ||
-			evidence.SEPublicKey != p.AttestationResult.PublicKey ||
-			evidence.Serial != p.AttestationResult.SerialNumber {
-			return false
-		}
+	// evidence mandatory independently of the APNs rollout deadline — but only
+	// once enforcement is switched on. In shadow mode (the default) the
+	// predicate is still evaluated so operators can compare
+	// CountProvidersWithCurrentApplicationEvidence against the connected fleet
+	// BEFORE flipping enforcement; a provider failing it keeps routing.
+	if r.releasePolicyRequired &&
+		r.releasePolicyEnforced &&
+		!r.providerHoldsCurrentApplicationEvidenceLocked(p) {
+		return false
 	}
 	// APNs code-identity gate — the SINGLE chokepoint, no self-route exemption.
 	if r.codeAttestationEnforcedLocked() && !p.CodeAttested {
@@ -1626,6 +1615,62 @@ func (r *Registry) SetReleasePolicyGeneration(
 	return needChallenge
 }
 
+// providerHoldsCurrentApplicationEvidenceLocked reports whether p holds
+// generation-current application evidence bound to its live identity: current
+// policy generation, this connection's process key, the current APNs token
+// (tokenless providers pass with matching empty tokens; token possession is
+// enforced only by the code-identity gate), the registered version/backend,
+// and the registration-attested SE identity. Caller must hold r.mu; provider
+// fields are read without p.mu, matching the routing chokepoint's semantics.
+func (r *Registry) providerHoldsCurrentApplicationEvidenceLocked(p *Provider) bool {
+	evidence := p.ApplicationEvidence
+	return evidence.EvidenceGeneration != 0 &&
+		evidence.PolicyGeneration == r.releasePolicyGeneration &&
+		evidence.ProcessPublicKey == p.PublicKey &&
+		evidence.APNsToken == p.APNsDeviceToken &&
+		evidence.Version == p.Version &&
+		evidence.Backend == p.Backend &&
+		evidence.BinaryHash != "" &&
+		p.AttestationResult != nil &&
+		evidence.SEPublicKey == p.AttestationResult.PublicKey &&
+		evidence.Serial == p.AttestationResult.SerialNumber
+}
+
+// SetReleasePolicyEnforcement switches the release-policy routing gate between
+// SHADOW (false, default: evidence derived/granted/swept and counted but never
+// blocks routing) and ENFORCE (true: the routing chokepoint requires current
+// evidence). Thread-safe.
+func (r *Registry) SetReleasePolicyEnforcement(enforced bool) {
+	r.mu.Lock()
+	r.releasePolicyEnforced = enforced
+	r.mu.Unlock()
+}
+
+// ReleasePolicyEnforced reports whether missing application evidence currently
+// blocks routing. Thread-safe.
+func (r *Registry) ReleasePolicyEnforced() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.releasePolicyEnforced
+}
+
+// CountProvidersWithCurrentApplicationEvidence returns (holding, connected):
+// how many currently connected providers hold generation-current application
+// evidence, and the total connected count. This is the shadow-mode acceptance
+// instrument: enforcement must not be enabled until holding is near connected.
+// Thread-safe.
+func (r *Registry) CountProvidersWithCurrentApplicationEvidence() (int, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	holding := 0
+	for _, provider := range r.providers {
+		if r.providerHoldsCurrentApplicationEvidenceLocked(provider) {
+			holding++
+		}
+	}
+	return holding, len(r.providers)
+}
+
 // CodeAttestationConfigured reports whether an APNs attestor is wired (so the
 // connection handler should issue code-identity challenges). Thread-safe.
 func (r *Registry) CodeAttestationConfigured() bool {
@@ -1972,6 +2017,15 @@ type Registry struct {
 	// derived from the current generation; APNs identity alone is insufficient.
 	releasePolicyGeneration uint64
 	releasePolicyRequired   bool
+	// releasePolicyEnforced gates whether missing/stale application evidence
+	// actually blocks routing. false = SHADOW: evidence is still derived,
+	// granted, swept, and counted (CountProvidersWithCurrentApplicationEvidence)
+	// but a provider without it keeps routing exactly like the pre-release-policy
+	// coordinator. true = ENFORCE: evidence is mandatory at the routing
+	// chokepoint. A brand-new global trust gate MUST prove fleet compatibility
+	// in shadow before it is allowed to deroute anything (2026-08-31 incident:
+	// an unprovable evidence predicate zeroed network capacity twice).
+	releasePolicyEnforced bool
 
 	modelCatalog map[string]CatalogEntry
 

--- a/coordinator/registry/routing_gates_characterization_test.go
+++ b/coordinator/registry/routing_gates_characterization_test.go
@@ -354,11 +354,15 @@ func TestRoutingGateInferenceErrorCooldown(t *testing.T) {
 	}
 }
 
+// TestReleasePolicyGenerationImmediatelyDeroutesStaleApplicationEvidence
+// characterizes ENFORCE mode: with enforcement on, a policy refresh that
+// invalidates evidence must synchronously remove routing authority.
 func TestReleasePolicyGenerationImmediatelyDeroutesStaleApplicationEvidence(t *testing.T) {
 	reg := &Registry{
 		providers:               make(map[string]*Provider),
 		releasePolicyGeneration: 1,
 		releasePolicyRequired:   true,
+		releasePolicyEnforced:   true,
 	}
 	provider := &Provider{
 		ID: "provider", PublicKey: "process-key", Backend: BackendMLXSwift,
@@ -412,6 +416,7 @@ func TestReleasePolicyGenerationCarriesForwardStillApprovedEvidence(t *testing.T
 		providers:               make(map[string]*Provider),
 		releasePolicyGeneration: 1,
 		releasePolicyRequired:   true,
+		releasePolicyEnforced:   true,
 	}
 	provider := &Provider{
 		ID: "provider", PublicKey: "process-key", Backend: BackendMLXSwift,
@@ -459,5 +464,64 @@ func TestReleasePolicyGenerationCarriesForwardStillApprovedEvidence(t *testing.T
 	}
 	if reg.providerSupportsPrivateTextLocked(provider) {
 		t.Fatal("invalidated provider must not remain routable")
+	}
+}
+
+// TestReleasePolicyShadowModeNeverBlocksRouting pins the rollout contract that
+// prevented a third zero-capacity deploy: with a required release policy but
+// enforcement OFF (the default), a provider with NO application evidence —
+// exactly the state of the whole production fleet the moment a new coordinator
+// boots — keeps routing, while the same provider is derouted the instant
+// enforcement flips on, and re-admitted once evidence lands.
+func TestReleasePolicyShadowModeNeverBlocksRouting(t *testing.T) {
+	reg := &Registry{
+		providers:               make(map[string]*Provider),
+		releasePolicyGeneration: 1,
+		releasePolicyRequired:   true,
+	}
+	provider := &Provider{
+		ID: "provider", PublicKey: "process-key", Backend: BackendMLXSwift,
+		Version: "0.8.15", APNsDeviceToken: "token",
+		EncryptedResponseChunks: true,
+		RuntimeManifestChecked:  true, ChallengeVerifiedSIP: true,
+		CodeAttested: true,
+		AttestationResult: &attestation.VerificationResult{
+			Valid: true, PublicKey: "se-key", SerialNumber: "SERIAL",
+		},
+		PrivacyCapabilities: &protocol.PrivacyCapabilities{
+			TextBackendInprocess: true,
+			TextProxyDisabled:    true,
+			AntiDebugEnabled:     true,
+			CoreDumpsDisabled:    true,
+			EnvScrubbed:          true,
+		},
+	}
+	reg.providers[provider.ID] = provider
+
+	if !reg.providerSupportsPrivateTextLocked(provider) {
+		t.Fatal("shadow mode must route a provider without application evidence")
+	}
+	holding, connected := reg.CountProvidersWithCurrentApplicationEvidence()
+	if holding != 0 || connected != 1 {
+		t.Fatalf("shadow coverage counter = (%d, %d), want (0, 1)", holding, connected)
+	}
+
+	reg.SetReleasePolicyEnforcement(true)
+	if reg.providerSupportsPrivateTextLocked(provider) {
+		t.Fatal("enforce mode must deroute a provider without application evidence")
+	}
+
+	provider.ApplicationEvidence = ApplicationEvidence{
+		SEPublicKey: "se-key", Serial: "SERIAL",
+		ProcessPublicKey: "process-key", APNsToken: "token",
+		BinaryHash: "hash", Version: "0.8.15", Backend: BackendMLXSwift,
+		EvidenceGeneration: 1, PolicyGeneration: 1,
+	}
+	if !reg.providerSupportsPrivateTextLocked(provider) {
+		t.Fatal("enforce mode must route once current evidence is held")
+	}
+	holding, connected = reg.CountProvidersWithCurrentApplicationEvidence()
+	if holding != 1 || connected != 1 {
+		t.Fatalf("coverage counter after grant = (%d, %d), want (1, 1)", holding, connected)
 	}
 }

--- a/coordinator/registry/routing_gates_characterization_test.go
+++ b/coordinator/registry/routing_gates_characterization_test.go
@@ -525,3 +525,125 @@ func TestReleasePolicyShadowModeNeverBlocksRouting(t *testing.T) {
 		t.Fatalf("coverage counter after grant = (%d, %d), want (1, 1)", holding, connected)
 	}
 }
+
+// evidenceGateTestProvider builds the minimal provider that passes every
+// routing-chokepoint gate except application evidence.
+func evidenceGateTestProvider() *Provider {
+	return &Provider{
+		ID: "provider", PublicKey: "process-key", Backend: BackendMLXSwift,
+		Version: "0.8.15", APNsDeviceToken: "token",
+		EncryptedResponseChunks: true,
+		RuntimeManifestChecked:  true, ChallengeVerifiedSIP: true,
+		CodeAttested: true,
+		AttestationResult: &attestation.VerificationResult{
+			Valid: true, PublicKey: "se-key", SerialNumber: "SERIAL",
+		},
+		PrivacyCapabilities: &protocol.PrivacyCapabilities{
+			TextBackendInprocess: true,
+			TextProxyDisabled:    true,
+			AntiDebugEnabled:     true,
+			CoreDumpsDisabled:    true,
+			EnvScrubbed:          true,
+		},
+	}
+}
+
+// TestReleasePolicyEnforceAfterDelaysEnforcement pins the restart-into-enforce
+// contract: a coordinator that boots with enforcement configured has an empty
+// registry (zero evidence), so the enforce-after boot grace must keep routing
+// shadow-like until it elapses — otherwise the flip procedure itself recreates
+// the zero-capacity transient it exists to prevent.
+func TestReleasePolicyEnforceAfterDelaysEnforcement(t *testing.T) {
+	reg := &Registry{
+		providers:               make(map[string]*Provider),
+		releasePolicyGeneration: 1,
+		releasePolicyRequired:   true,
+	}
+	provider := evidenceGateTestProvider()
+	reg.providers[provider.ID] = provider
+
+	reg.SetReleasePolicyEnforcement(true)
+	reg.SetReleasePolicyEnforceAfter(time.Now().Add(time.Hour))
+	if reg.ReleasePolicyEnforced() {
+		t.Fatal("enforcement must not be live during the boot grace")
+	}
+	if !reg.providerSupportsPrivateTextLocked(provider) {
+		t.Fatal("boot grace must route an evidence-less provider like shadow mode")
+	}
+
+	reg.SetReleasePolicyEnforceAfter(time.Now().Add(-time.Second))
+	if !reg.ReleasePolicyEnforced() {
+		t.Fatal("enforcement must go live once the boot grace elapses")
+	}
+	if reg.providerSupportsPrivateTextLocked(provider) {
+		t.Fatal("elapsed grace must enforce the evidence gate")
+	}
+}
+
+// TestReleasePolicySweepKeepsCapabilitiesInShadow pins the shadow no-touch
+// contract for capability routing: a policy sweep that wipes underivable
+// evidence must NOT clear RuntimeCapabilities in shadow mode (capability
+// bookkeeping would silently remove capability-gated model capacity), while
+// the same sweep under live enforcement must clear them.
+func TestReleasePolicySweepKeepsCapabilitiesInShadow(t *testing.T) {
+	reg := &Registry{
+		providers:               make(map[string]*Provider),
+		releasePolicyGeneration: 1,
+		releasePolicyRequired:   true,
+	}
+	provider := evidenceGateTestProvider()
+	provider.RuntimeCapabilities = []string{ProviderCapabilityMLXNAX}
+	reg.providers[provider.ID] = provider
+
+	if reg.SetReleasePolicyGeneration(2, true, nil); provider.RuntimeCapabilities == nil {
+		t.Fatal("shadow sweep must not clear runtime capabilities")
+	}
+
+	reg.SetReleasePolicyEnforcement(true)
+	if reg.SetReleasePolicyGeneration(3, true, nil); provider.RuntimeCapabilities != nil {
+		t.Fatal("enforced sweep must clear runtime capabilities with the evidence")
+	}
+}
+
+// TestApplicationEvidenceModelCoverage pins the per-model flip criterion: the
+// coverage map must expose an uncovered model family even when another model's
+// providers are fully covered, so a fleet-wide average cannot hide it.
+func TestApplicationEvidenceModelCoverage(t *testing.T) {
+	reg := &Registry{
+		providers:               make(map[string]*Provider),
+		releasePolicyGeneration: 1,
+		releasePolicyRequired:   true,
+	}
+	covered := evidenceGateTestProvider()
+	covered.ID = "covered"
+	covered.Status = StatusOnline
+	covered.RuntimeVerified = true
+	covered.LastChallengeVerified = time.Now()
+	covered.Models = []protocol.ModelInfo{{ID: "model-covered"}}
+	covered.ApplicationEvidence = ApplicationEvidence{
+		SEPublicKey: "se-key", Serial: "SERIAL",
+		ProcessPublicKey: "process-key", APNsToken: "token",
+		BinaryHash: "hash", Version: "0.8.15", Backend: BackendMLXSwift,
+		EvidenceGeneration: 1, PolicyGeneration: 1,
+	}
+	uncovered := evidenceGateTestProvider()
+	uncovered.ID = "uncovered"
+	uncovered.PublicKey = "process-key-2"
+	uncovered.AttestationResult = &attestation.VerificationResult{
+		Valid: true, PublicKey: "se-key-2", SerialNumber: "SERIAL-2",
+	}
+	uncovered.Status = StatusOnline
+	uncovered.RuntimeVerified = true
+	uncovered.LastChallengeVerified = time.Now()
+	uncovered.Models = []protocol.ModelInfo{{ID: "model-uncovered"}}
+	reg.providers[covered.ID] = covered
+	reg.providers[uncovered.ID] = uncovered
+
+	coverage := reg.ApplicationEvidenceModelCoverage()
+	if c := coverage["model-covered"]; c.Routable != 1 || c.WithEvidence != 1 {
+		t.Fatalf("covered model coverage = %+v, want {1 1}", c)
+	}
+	if c := coverage["model-uncovered"]; c.Routable != 1 || c.WithEvidence != 0 {
+		t.Fatalf("uncovered model coverage = %+v, want {1 0}", c)
+	}
+}

--- a/coordinator/store/verification_scheduler_store_test.go
+++ b/coordinator/store/verification_scheduler_store_test.go
@@ -388,7 +388,10 @@ func exerciseCodeAttestPushDistinctNovelTokenRace(
 	t.Helper()
 	ctx := context.Background()
 	for iter := range iterations {
-		now := time.Now().UTC()
+		// Truncate to Postgres timestamptz precision: Linux clocks carry
+		// nanoseconds, pgx encodes microseconds, and the round-trip Equal
+		// below fails only on CI otherwise (macOS clocks tick in µs).
+		now := time.Now().UTC().Truncate(time.Microsecond)
 		seKey := fmt.Sprintf("%s-%d-%d", prefix, now.UnixNano(), iter)
 		hashes := []string{"novel-token-a", "novel-token-b"}
 		if iter%2 == 1 { // both orderings
@@ -558,7 +561,9 @@ func exerciseCodeAttestPushFloorClearCooldownIsDurable(
 	t.Helper()
 	ctx := context.Background()
 	cooldown := 20 * time.Minute
-	now := time.Now().UTC()
+	// µs-truncated for lossless Postgres round-trip equality (see the novel
+	// token race exercise).
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	if ok, err := st.ReserveCodeAttestPushBudget(
 		ctx, seKey, "hash-a", now, now.Add(cooldown),
 	); err != nil || !ok {

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -16,11 +16,15 @@ MDM_ENABLED=true
 
 # Release-policy routing gate (application evidence). SHADOW (default when
 # unset): evidence is derived, granted, swept, and counted — see /v1/stats
-# application_evidence_providers vs application_evidence_connected and the
-# release_evidence.outcome Datadog counters — but never blocks routing.
-# Flip to enforce ONLY after a shadow deployment shows coverage near the
-# connected fleet size (2026-08-31: enforcing an unproven evidence predicate
-# zeroed network capacity twice). Read at process start.
+# application_evidence_providers / application_evidence_connected /
+# application_evidence_models and the release_evidence.outcome Datadog
+# counters — but never blocks routing. Flip to enforce ONLY per
+# docs/operations/release-policy-rollout.md after a shadow deployment shows
+# per-model coverage near routable (2026-08-31: enforcing an unproven evidence
+# predicate zeroed network capacity twice). In enforce mode a boot grace
+# (EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE, default 20m) keeps routing
+# shadow-like after each restart until the reconnected fleet re-earns
+# evidence. Read at process start.
 EIGENINFERENCE_RELEASE_POLICY_MODE=shadow
 
 # Release distribution

--- a/deploy/environments/prod.env
+++ b/deploy/environments/prod.env
@@ -14,6 +14,15 @@ BASE_URL=https://api.darkbloom.dev
 MIN_TRUST=hardware
 MDM_ENABLED=true
 
+# Release-policy routing gate (application evidence). SHADOW (default when
+# unset): evidence is derived, granted, swept, and counted — see /v1/stats
+# application_evidence_providers vs application_evidence_connected and the
+# release_evidence.outcome Datadog counters — but never blocks routing.
+# Flip to enforce ONLY after a shadow deployment shows coverage near the
+# connected fleet size (2026-08-31: enforcing an unproven evidence predicate
+# zeroed network capacity twice). Read at process start.
+EIGENINFERENCE_RELEASE_POLICY_MODE=shadow
+
 # Release distribution
 R2_BUCKET=d-inf-app
 APPLE_TEAM_ID=SLDQ2GJ6TL

--- a/docs/operations/release-policy-rollout.md
+++ b/docs/operations/release-policy-rollout.md
@@ -1,114 +1,135 @@
 # Release-Policy Gate Rollout (Application Evidence)
 
-Status: authoritative for the first deployment of any coordinator containing
-the release-policy routing gate (`releasePolicyRequired` +
-`ApplicationEvidence`, introduced by #778, made deployable by
-`fix/release-policy-fleet-compat`).
+Authoritative procedure for the first deployment of any coordinator containing
+the release-policy routing gate, and for the later enforcement flip. Follows
+[`coordinator-deploy.md`](coordinator-deploy.md) for the mechanics of every
+swap; this document adds the gate-specific stages and acceptance criteria.
 
-## Background — why this runbook exists
+Canonical code (code wins over this doc):
 
-On 2026-08-31 two candidate coordinators built from master connected the full
-production fleet (~1,250 providers) and admitted **zero** of them for routing.
-`/v1/models/capacity` returned no models and every inference request received
-429 until rollback. Root cause chain:
+| Behavior | Code |
+|---|---|
+| Mode parsing + boot grace | `coordinator/cmd/coordinator/main.go` (`EIGENINFERENCE_RELEASE_POLICY_MODE` switch) |
+| Routing chokepoint + evidence gate | `coordinator/registry/registry.go:providerSupportsPrivateTextModeLocked` |
+| Live-enforcement predicate (mode + enforce-after) | `coordinator/registry/registry.go:releasePolicyEnforcedLocked` |
+| Evidence derivation + typed outcomes | `coordinator/api/server.go:deriveApprovedReleaseTransition`, `releaseMetallibMatches` |
+| Sweep re-proof / invalidation | `coordinator/api/server.go:releaseEvidenceStillApproved`, `coordinator/registry/registry.go:SetReleasePolicyGeneration` |
+| Coverage counters | `coordinator/registry/registry.go:CountProvidersWithCurrentApplicationEvidence`, `ApplicationEvidenceModelCoverage`; served by `coordinator/api/stats.go` |
 
-1. Release rows carry CI-fabricated per-model-family `template_hashes`
-   (`qwen3.5`, `trinity`, `gemma4`, `minimax`) hashed from CDN jinja files by
-   `release-swift.yml`. No provider build has ever reported those keys — the
-   provider's entire challenge template vocabulary is `{"mlx_metallib"}`, and
-   `python_hash`/`runtime_hash` are hardcoded nil (there is no Python runtime).
-2. `releaseRuntimeMatches` required the provider's challenge to echo **every**
-   release-row template hash → application evidence was underivable for 100%
-   of the fleet by construction.
-3. The routing chokepoint made evidence mandatory whenever any release row
-   exists (`releasePolicyRequired`, data-driven, no kill switch) → zero
-   routable providers, zero capacity, all-429.
-4. Every rejection branch returned a bare `false` — the failure was
-   undiagnosable from the outside during both deploys.
+## Background
 
-The fix changed the contract:
+On 2026-08-31 two candidate coordinators connected ~1,250 providers and
+admitted zero for routing: release rows carried CI-fabricated per-model-family
+`template_hashes` no provider has ever reported, the evidence gate demanded
+them, and every rejection was an untyped `false`. `/v1/models/capacity`
+returned no models and all inference received 429 until rollback
+(`docs/reports/2026-08-31-coordinator-agent-deployment-failure-postmortem.md`).
 
-- Application evidence proves exactly: **SE-signed challenge binary hash
-  matches an active release row for (version, platform, backend), and the
-  release's metallib hash matches the provider's reported `mlx_metallib`.**
-- Python/runtime/per-family-template facts are gone from evidence derivation,
-  the sweep re-proof (`releaseEvidenceStillApproved`), the
-  `ApplicationEvidence` struct, and release CI registration.
-- Every derivation outcome is a typed counter:
-  `release_evidence.outcome{outcome:granted|precondition|invalid_binary_hash|
-  policy_unavailable|policy_not_required|process_identity|runtime_gate|
-  version_floor|registration_hash_mismatch|no_active_release|metallib_mismatch}`.
-- The routing gate has two modes via `EIGENINFERENCE_RELEASE_POLICY_MODE`:
-  - `shadow` (default, and default when unset/invalid): evidence is derived,
-    granted, swept, and counted, but NEVER blocks routing. Routing behavior is
-    identical to the pre-release-policy coordinator.
-  - `enforce`: the routing chokepoint requires generation-current evidence.
-- Coverage instrumentation: `/v1/stats` exposes
-  `application_evidence_providers`, `application_evidence_connected`, and
-  `release_policy_enforced`.
+The reworked contract: application evidence proves that the SE-signed
+challenge `binary_hash` matches an **active release row** for (version,
+platform, backend) and that the release's `metallib_hash` matches the
+provider's reported `mlx_metallib` — nothing else. The gate has two modes via
+`EIGENINFERENCE_RELEASE_POLICY_MODE`:
 
-## Invariants (do not violate)
+- `shadow` (default, also on unset/invalid): evidence is derived, granted,
+  swept, and counted, but never blocks routing or clears runtime capabilities.
+- `enforce`: after a boot grace (default 20m,
+  `EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE`), the chokepoint requires
+  generation-current evidence and policy sweeps clear capabilities with
+  invalidated evidence.
 
-- A brand-new global trust gate MUST ship in shadow first. Enforcement is a
-  separate, human-approved action taken only after coverage is proven on the
-  live fleet.
+## Invariants
+
+- A new global trust gate MUST ship in shadow first; enforcement is a separate
+  human-approved action after live coverage is proven.
 - Never add a release-row fact to evidence derivation unless the production
-  provider build demonstrably reports it (verify in
-  `provider-swift/Sources/ProviderCore/Security/` before trusting a fixture).
-- `releaseEvidenceStillApproved` and `deriveApprovedReleaseTransition` must
-  compare the same fact set; retuning one side alone silently desyncs the
-  sweep from the grant and wipes evidence every policy rebuild.
-- Production deploys follow `docs/operations/coordinator-deploy.md` (human
-  approval, prechecks, rollback state). This runbook adds gate-specific
-  acceptance criteria; it does not replace the deploy runbook.
-
-## Stage 0 — preflight (before any swap)
-
-1. Candidate image built by the repository trigger from the exact reviewed
-   merge SHA; digest verified against Artifact Registry.
-2. `EIGENINFERENCE_RELEASE_POLICY_MODE` is `shadow` or absent in
-   `/etc/d-inference/env`.
-3. Startup log line confirms mode: `release-policy routing gate in SHADOW
-   mode` (or the loud ENFORCED warning — abort if present).
-4. Capture the current-production baseline for acceptance comparison:
-   `/v1/models/capacity` (models, routable_providers per model) and
-   `/v1/stats` (`active_providers`).
+  provider build demonstrably reports it (check
+  `provider-swift/Sources/ProviderCore/Security/` and
+  `ProviderLoop+AttestationChallenge.swift` first).
+- `deriveApprovedReleaseTransition` and `releaseEvidenceStillApproved` MUST
+  compare the same fact set; changing one side alone desyncs grant from sweep
+  and wipes evidence every policy rebuild.
+- Enforcement flips happen via env + container recreate; the boot grace exists
+  because a restarted coordinator has an empty registry (zero evidence) and
+  would otherwise 429 the fleet until first challenges complete. Do not set
+  the grace below the default for a production flip.
 
 ## Stage 1 — shadow deployment
 
-Perform the approved swap per the deploy runbook. Acceptance within 20
-minutes (one full challenge cycle is 5 minutes; trust reconstruction dominates
-the first minutes):
+### Prerequisites
+
+- Candidate image built by the repository trigger from the exact reviewed
+  merge SHA; digest verified in Artifact Registry.
+- `/etc/d-inference/env` has `EIGENINFERENCE_RELEASE_POLICY_MODE=shadow` (or
+  the variable absent).
+- All prechecks from [`coordinator-deploy.md`](coordinator-deploy.md)
+  (database locks, env integrity, rollback state captured).
+- Baseline captured for comparison: `/v1/models/capacity` (models +
+  routable_providers per model) and `/v1/stats` (`active_providers`).
+
+### Steps
+
+1. Perform the approved swap per [`coordinator-deploy.md`](coordinator-deploy.md).
+2. Confirm the startup log prints `release-policy routing gate in SHADOW mode`
+   (an `ENFORCED` warning here means the env is wrong — roll back).
+
+### Verification (within 20 minutes; challenges run every 5)
 
 | Check | Requirement |
 |---|---|
 | `/health`, `/readyz` | ok, expected build commit |
-| `/v1/models/capacity` | all expected models present; routable counts near the pre-swap baseline (shadow mode cannot zero this) |
-| `/v1/stats` `application_evidence_connected` | near pre-swap `active_providers` |
-| `/v1/stats` `application_evidence_providers` | climbing toward connected as challenges complete; expect ≥90% of connected within ~20 min |
-| `release_evidence.outcome` in Datadog | `granted` dominates; every non-granted reason explained (e.g. `version_floor` for pre-floor stragglers, `no_active_release` for unregistered dev builds) |
+| `/v1/models/capacity` | all expected models present; routable counts near baseline (shadow cannot zero this) |
+| `/v1/stats` `application_evidence_connected` | ≈ pre-swap `active_providers` |
+| `/v1/stats` `application_evidence_providers` | climbing toward connected; ≥90% within ~20 min |
+| `/v1/stats` `application_evidence_models` | for EVERY model: `with_evidence` ≈ `routable` (per-model criterion — a small family's uncovered providers must not hide inside the fleet average) |
+| Datadog `release_evidence.outcome` | `granted` dominates; every other reason explained (`version_floor` stragglers, `no_active_release` dev builds) |
 | Real inference | succeeds on every model family |
 
-If `application_evidence_providers` stalls near zero: the gate is still
-incompatible with the fleet. Routing is unharmed (shadow), production stays
-up. Diagnose from the outcome counters — do NOT flip enforce, do NOT iterate
-by redeploying guesses.
+If coverage stalls near zero: routing is unharmed; diagnose from the outcome
+counters. Do NOT flip enforce and do NOT redeploy guesses.
 
-## Stage 2 — enforcement flip (separate approval)
+### Rollback
 
-Only after Stage 1 acceptance has held for at least 24 hours:
+Shadow-stage failures are ordinary deploy failures. Before any rollback:
+
+1. Export evidence FIRST: `sudo docker logs coordinator > /tmp/candidate-<ts>.log`,
+   plus `/v1/stats` and the outcome counters.
+2. Then run the canonical rollback in
+   [`coordinator-deploy.md`](coordinator-deploy.md). It replaces the container
+   named `coordinator` with the previous image; the failed candidate container
+   is preserved under a `coordinator_fallback_<ts>`-style name by the
+   procedure's container swap. Do not `docker rm` any preserved candidate or
+   fallback container until its logs and state are archived (the 2026-08-31
+   investigation lost primary evidence to exactly that).
+
+## Stage 2 — enforcement flip
+
+### Prerequisites
+
+- Stage 1 verification has held for ≥ 24 hours.
+- Per-model coverage (`application_evidence_models`) shows
+  `with_evidence` ≈ `routable` for every model, and fleet-wide
+  `application_evidence_providers` ≈ `application_evidence_connected`.
+- Human approval for the flip as a distinct operation.
+
+### Steps
 
 1. Set `EIGENINFERENCE_RELEASE_POLICY_MODE=enforce` in
-   `/etc/d-inference/env`; recreate the container per the deploy runbook.
-2. Acceptance: identical to Stage 1 PLUS routable provider counts within a
-   few percent of `application_evidence_providers`, no capacity drop, no 429
-   rate change.
-3. Rollback lever: set the mode back to `shadow` and recreate — no image
-   change required.
+   `/etc/d-inference/env`. Leave
+   `EIGENINFERENCE_RELEASE_POLICY_ENFORCE_GRACE` unset (20m default) unless a
+   longer grace is wanted.
+2. Recreate the container per [`coordinator-deploy.md`](coordinator-deploy.md).
+3. Confirm the startup log prints the ENFORCED warning with `boot_grace=20m0s`.
 
-## Failure handling
+### Verification
 
-On any acceptance failure: preserve the candidate container (rename, do not
-remove) and export its logs plus `/v1/stats` and the outcome counters BEFORE
-starting the previous image. The 2026-08-31 investigation was materially
-slowed because failed candidates were destroyed during rollback.
+- During the grace: routing identical to shadow (`release_policy_enforced`
+  in `/v1/stats` stays `false`); coverage rebuilds as providers re-challenge.
+- After the grace elapses: `release_policy_enforced` flips `true`; routable
+  provider counts stay within a few percent of `application_evidence_providers`;
+  no capacity drop; no 429-rate change; per-model capacity unchanged.
+
+### Rollback
+
+Set `EIGENINFERENCE_RELEASE_POLICY_MODE=shadow` and recreate the container —
+no image change. This is the incident lever if enforcement ever misbehaves.

--- a/docs/operations/release-policy-rollout.md
+++ b/docs/operations/release-policy-rollout.md
@@ -1,0 +1,114 @@
+# Release-Policy Gate Rollout (Application Evidence)
+
+Status: authoritative for the first deployment of any coordinator containing
+the release-policy routing gate (`releasePolicyRequired` +
+`ApplicationEvidence`, introduced by #778, made deployable by
+`fix/release-policy-fleet-compat`).
+
+## Background — why this runbook exists
+
+On 2026-08-31 two candidate coordinators built from master connected the full
+production fleet (~1,250 providers) and admitted **zero** of them for routing.
+`/v1/models/capacity` returned no models and every inference request received
+429 until rollback. Root cause chain:
+
+1. Release rows carry CI-fabricated per-model-family `template_hashes`
+   (`qwen3.5`, `trinity`, `gemma4`, `minimax`) hashed from CDN jinja files by
+   `release-swift.yml`. No provider build has ever reported those keys — the
+   provider's entire challenge template vocabulary is `{"mlx_metallib"}`, and
+   `python_hash`/`runtime_hash` are hardcoded nil (there is no Python runtime).
+2. `releaseRuntimeMatches` required the provider's challenge to echo **every**
+   release-row template hash → application evidence was underivable for 100%
+   of the fleet by construction.
+3. The routing chokepoint made evidence mandatory whenever any release row
+   exists (`releasePolicyRequired`, data-driven, no kill switch) → zero
+   routable providers, zero capacity, all-429.
+4. Every rejection branch returned a bare `false` — the failure was
+   undiagnosable from the outside during both deploys.
+
+The fix changed the contract:
+
+- Application evidence proves exactly: **SE-signed challenge binary hash
+  matches an active release row for (version, platform, backend), and the
+  release's metallib hash matches the provider's reported `mlx_metallib`.**
+- Python/runtime/per-family-template facts are gone from evidence derivation,
+  the sweep re-proof (`releaseEvidenceStillApproved`), the
+  `ApplicationEvidence` struct, and release CI registration.
+- Every derivation outcome is a typed counter:
+  `release_evidence.outcome{outcome:granted|precondition|invalid_binary_hash|
+  policy_unavailable|policy_not_required|process_identity|runtime_gate|
+  version_floor|registration_hash_mismatch|no_active_release|metallib_mismatch}`.
+- The routing gate has two modes via `EIGENINFERENCE_RELEASE_POLICY_MODE`:
+  - `shadow` (default, and default when unset/invalid): evidence is derived,
+    granted, swept, and counted, but NEVER blocks routing. Routing behavior is
+    identical to the pre-release-policy coordinator.
+  - `enforce`: the routing chokepoint requires generation-current evidence.
+- Coverage instrumentation: `/v1/stats` exposes
+  `application_evidence_providers`, `application_evidence_connected`, and
+  `release_policy_enforced`.
+
+## Invariants (do not violate)
+
+- A brand-new global trust gate MUST ship in shadow first. Enforcement is a
+  separate, human-approved action taken only after coverage is proven on the
+  live fleet.
+- Never add a release-row fact to evidence derivation unless the production
+  provider build demonstrably reports it (verify in
+  `provider-swift/Sources/ProviderCore/Security/` before trusting a fixture).
+- `releaseEvidenceStillApproved` and `deriveApprovedReleaseTransition` must
+  compare the same fact set; retuning one side alone silently desyncs the
+  sweep from the grant and wipes evidence every policy rebuild.
+- Production deploys follow `docs/operations/coordinator-deploy.md` (human
+  approval, prechecks, rollback state). This runbook adds gate-specific
+  acceptance criteria; it does not replace the deploy runbook.
+
+## Stage 0 — preflight (before any swap)
+
+1. Candidate image built by the repository trigger from the exact reviewed
+   merge SHA; digest verified against Artifact Registry.
+2. `EIGENINFERENCE_RELEASE_POLICY_MODE` is `shadow` or absent in
+   `/etc/d-inference/env`.
+3. Startup log line confirms mode: `release-policy routing gate in SHADOW
+   mode` (or the loud ENFORCED warning — abort if present).
+4. Capture the current-production baseline for acceptance comparison:
+   `/v1/models/capacity` (models, routable_providers per model) and
+   `/v1/stats` (`active_providers`).
+
+## Stage 1 — shadow deployment
+
+Perform the approved swap per the deploy runbook. Acceptance within 20
+minutes (one full challenge cycle is 5 minutes; trust reconstruction dominates
+the first minutes):
+
+| Check | Requirement |
+|---|---|
+| `/health`, `/readyz` | ok, expected build commit |
+| `/v1/models/capacity` | all expected models present; routable counts near the pre-swap baseline (shadow mode cannot zero this) |
+| `/v1/stats` `application_evidence_connected` | near pre-swap `active_providers` |
+| `/v1/stats` `application_evidence_providers` | climbing toward connected as challenges complete; expect ≥90% of connected within ~20 min |
+| `release_evidence.outcome` in Datadog | `granted` dominates; every non-granted reason explained (e.g. `version_floor` for pre-floor stragglers, `no_active_release` for unregistered dev builds) |
+| Real inference | succeeds on every model family |
+
+If `application_evidence_providers` stalls near zero: the gate is still
+incompatible with the fleet. Routing is unharmed (shadow), production stays
+up. Diagnose from the outcome counters — do NOT flip enforce, do NOT iterate
+by redeploying guesses.
+
+## Stage 2 — enforcement flip (separate approval)
+
+Only after Stage 1 acceptance has held for at least 24 hours:
+
+1. Set `EIGENINFERENCE_RELEASE_POLICY_MODE=enforce` in
+   `/etc/d-inference/env`; recreate the container per the deploy runbook.
+2. Acceptance: identical to Stage 1 PLUS routable provider counts within a
+   few percent of `application_evidence_providers`, no capacity drop, no 429
+   rate change.
+3. Rollback lever: set the mode back to `shadow` and recreate — no image
+   change required.
+
+## Failure handling
+
+On any acceptance failure: preserve the candidate container (rename, do not
+remove) and export its logs plus `/v1/stats` and the outcome counters BEFORE
+starting the previous image. The 2026-08-31 investigation was materially
+slowed because failed candidates were destroyed during rollback.

--- a/docs/operations/release-policy-rollout.md
+++ b/docs/operations/release-policy-rollout.md
@@ -81,7 +81,7 @@ provider's reported `mlx_metallib` — nothing else. The gate has two modes via
 | `/v1/models/capacity` | all expected models present; routable counts near baseline (shadow cannot zero this) |
 | `/v1/stats` `application_evidence_connected` | ≈ pre-swap `active_providers` |
 | `/v1/stats` `application_evidence_providers` | climbing toward connected; ≥90% within ~20 min |
-| `/v1/stats` `application_evidence_models` | for EVERY model: `with_evidence` ≈ `routable` (per-model criterion — a small family's uncovered providers must not hide inside the fleet average) |
+| `/v1/stats` `application_evidence_models` | for EVERY model: `with_evidence` ≈ `routable` (per-model criterion — a small family's uncovered providers must not hide inside the fleet average). The denominator is the advertised-catalog surface, not full dispatch: a small persistent gap can be providers dispatch already excludes (e.g. the dedicated-model rule). Before treating a stable gap as a blocker, confirm via `release_evidence.outcome` that the uncovered providers have a benign typed reason. |
 | Datadog `release_evidence.outcome` | `granted` dominates; every other reason explained (`version_floor` stragglers, `no_active_release` dev builds) |
 | Real inference | succeeds on every model family |
 


### PR DESCRIPTION
## Summary

Makes the #778 release-policy gate deployable by the real production fleet. Both 2026-08-31 candidate deploys zeroed network capacity because `releaseRuntimeMatches` demanded facts no provider has ever reported: release rows carry CI-fabricated per-model-family `template_hashes` (`qwen3.5`/`trinity`/`gemma4`/`minimax`, hashed from CDN jinja files by `release-swift.yml`) plus the deprecated python/runtime planes, while the v0.8.15 provider's entire challenge template vocabulary is `{"mlx_metallib"}` and its `python_hash`/`runtime_hash` are hardcoded nil. Application evidence was underivable for 100% of the fleet by construction; the routing chokepoint makes evidence mandatory whenever any release row exists, so every provider was structurally unroutable and all inference received 429.

Evidence: all 12 active release rows in prod RDS pin the four family keys with empty python/runtime hashes; provider wire truth verified in `ProviderCore` source (`augmentRuntimeHashesWithMetallib` is the sole `template_hashes` producer); old prod (`b234b946`) routes the same fleet because its chokepoint has no evidence gate at all.

## Changes

1. **Evidence contract shrunk to provable facts** (`api/server.go`): derivation and the sweep re-proof (`releaseEvidenceStillApproved`) now verify exactly — fresh SE-signed challenge `binary_hash` matches an active release row for (version, platform, backend), and that release's `metallib_hash` matches the provider's reported `mlx_metallib`. `releaseRuntimeMatches` → `releaseMetallibMatches`. Python/runtime/family-template comparisons deleted; `ApplicationEvidence` struct slimmed accordingly (`registry/registry.go`).
2. **Typed outcomes** (`api/server.go`): every derivation branch records `release_evidence.outcome{outcome:granted|precondition|invalid_binary_hash|policy_unavailable|policy_not_required|process_identity|runtime_gate|version_floor|registration_hash_mismatch|no_active_release|metallib_mismatch}` — the zero-capacity deploys were undiagnosable because every rejection returned a bare `false`.
3. **Shadow/enforce rollout mode** (`registry/registry.go`, `cmd/coordinator/main.go`): `EIGENINFERENCE_RELEASE_POLICY_MODE`, default **shadow** — evidence derived, granted, swept, and counted, but never blocks routing (identical routing to the pre-gate coordinator). `enforce` turns the chokepoint requirement on. `/v1/stats` exposes `application_evidence_providers` / `application_evidence_connected` / `release_policy_enforced` as the flip criterion (`api/stats.go`).
4. **Release CI stops fabricating template hashes** (`.github/workflows/release-swift.yml`): registration posts only facts the provider reports (`binary_hash`, `bundle_hash`, `metallib_hash`). Existing family-hash rows in the DB become inert — no migration needed.
5. **Production-shape regressions** (`api/release_policy_production_shape_test.go`): the exact fleet wire shape — hashless registration, family-template release row, metallib-only challenge — must derive evidence, survive the policy sweep, and stay routable under enforce; shadow mode must route an evidence-less fleet; enforce without coverage must deroute (the incident, pinned). Metallib rotation still fails closed (`TestMetallibRotationInvalidatesCarriedEvidenceAtSweep` replaces the template-rotation test that encoded the unprovable contract). Registry-level shadow/enforce characterization added.
6. **Rollout runbook** (`docs/operations/release-policy-rollout.md`) + `deploy/environments/prod.env` documentation: shadow deploy → observe coverage ≈ fleet + outcome counters → separate human-approved enforce flip; preserve failed candidates before rollback.

## Before / After

```mermaid
flowchart LR
  subgraph Before["Before (master 3ac7b9bd3 — both failed deploys)"]
    A1[challenge verified] --> B1{"releaseRuntimeMatches:\nbinary+metallib+python+runtime\n+ EVERY release-row template key\n(qwen3.5/trinity/gemma4/minimax)"}
    B1 -- "provider only has mlx_metallib\n→ false for 100% of fleet" --> C1[no ApplicationEvidence\nbare boolean, no reason]
    C1 --> D1{"chokepoint:\nreleasePolicyRequired\n(always true, no switch)"}
    D1 --> E1[zero routable providers\nzero capacity → all 429]
  end
  subgraph After["After (this PR)"]
    A2[challenge verified] --> B2{"binary_hash ∈ active release\n(version/platform/backend)\n+ metallib matches"}
    B2 -- granted --> C2[ApplicationEvidence\n+ outcome counter]
    B2 -- rejected --> R2[typed reason counter\nrelease_evidence.outcome]
    C2 --> D2{mode?}
    R2 --> D2
    D2 -- "shadow (default)" --> E2[fleet routes as today\ncoverage visible in /v1/stats]
    D2 -- "enforce (after proof)" --> F2[evidence required at chokepoint\ndeactivated release → derouted]
  end
```

## Verification

- Full coordinator module: `go test ./...` green (api 107s, registry, all other packages).
- Race: `go test -race` on the evidence/routing tests green.
- `go build ./cmd/coordinator` green; gofmt pre-commit hook passed.
- Prod DB read-replica queries confirmed release-row shape; provider wire shape confirmed from v0.8.15 source.

## Rollout

Per `docs/operations/release-policy-rollout.md`: deploy in shadow (default), accept only on nonzero capacity ≈ baseline + evidence coverage ≈ connected + all non-granted outcomes explained, hold 24h, then the enforce flip as a separate approved action. Production remains on `b234b946` until this is reviewed, merged, built from the exact merge SHA, and preflighted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790808147&installation_model_id=21733&pr_number=798&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F798&signature=ab75e230e02a5770716c98e84b02900e340d08916b3750ee4302f867e87d0cab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->