### PR TITLE
fix(routing): harden dispatch against retry-storm CPU collapse

### DIFF
--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -93,6 +93,22 @@ const (
 	// provider) stops on the FIRST attempt regardless — see classifyRejection.
 	maxCapacityClassRetries = 3
 
+	// maxFirstChunkTimeoutRetries bounds failover for coordinator-synthesized
+	// first-chunk TIMEOUTS (the untyped 504 the exhausted ladder reclassifies
+	// to a retryable 429 with reason "first_chunk_timeout"). Unlike capacity
+	// rejections these carried NO cap: every retry re-ran a full fleet
+	// reservation scan (~1,260 providers, registry.ReserveProviderEx), and in
+	// the 2026-09-01 congestion collapse retry-amplified inbound (~100 req/s
+	// of retryable 429 traffic from OpenRouter) times per-request fleet scans
+	// saturated every coordinator CPU — attempt-0 route p50 went 40ms → 4.6s,
+	// success ~40%, 429s were delivered after 11s, inbound ~6k/min vs served
+	// ~550/min. The request-absolute first-content budget already bounds WALL
+	// time per request; this bounds CPU: after this many timed-out attempts
+	// (each on a distinct provider — a timed-out provider is excluded from
+	// re-selection) the ladder exhausts immediately into the existing
+	// synthetic-timeout → 429 reclassification (classifyExhaustedStatus).
+	maxFirstChunkTimeoutRetries = 3
+
 	// speculativeTimerRatio is the fraction of the TTFT deadline at which
 	// the coordinator launches a speculative backup dispatch. The primary
 	// provider gets this fraction of the deadline before the backup is
@@ -587,6 +603,14 @@ const errTTFTTooSlow = "all available providers exceed the TTFT target"
 // charging provider health.
 const errFirstContentDeadlineExpired = "first-content deadline expired before provider dispatch"
 
+// errRoutingScanSaturated is returned when no provider-selection scan slot
+// (Server.routingScanSem) freed up within the request's remaining
+// first-content budget: the coordinator itself is the bottleneck (the
+// 2026-09-01 congestion collapse). No provider was scanned or contacted, so
+// callers shed ONE capacity-shaped retryable 429 — never a 5xx, never more
+// scans.
+const errRoutingScanSaturated = "routing scan capacity saturated — coordinator busy"
+
 // consumerModel returns the model name to echo back to the consumer: the public
 // alias they requested when set, otherwise the concrete build id (raw-id
 // requests and any internal caller that didn't populate PublicModel).
@@ -995,7 +1019,20 @@ func (s *Server) dispatchWithReserver(
 		return ids
 	}
 
+	// Bound concurrent provider-selection scans (2026-09-01 congestion
+	// collapse: retry-amplified inbound × a fresh full fleet scan per attempt
+	// saturated every coordinator CPU). The wait is bounded by the request's
+	// remaining first-content budget: a goroutine parks cheaply on the channel
+	// and either scans as soon as a slot frees or sheds capacity-shaped
+	// (errRoutingScanSaturated → one retryable 429) once the budget is gone.
+	if !s.acquireRoutingScanSlot(
+		firstTokenRemainingSince(receivedAt, requestDeadline),
+		r.Context().Done(),
+	) {
+		return nil, nil, decision, nil, errRoutingScanSaturated, http.StatusTooManyRequests
+	}
 	provider, decision, plan = reserve(pr, excludeList())
+	s.releaseRoutingScanSlot()
 	if provider == nil {
 		// Providers serve this model but none can physically fit it: don't make
 		// the caller queue/retry for something that will never load.
@@ -1020,6 +1057,12 @@ func (s *Server) dispatchWithReserver(
 	defer cleanupPending()
 	if pr.Timing != nil {
 		pr.Timing.RoutedAt = time.Now()
+		if attempt == 0 && !receivedAt.IsZero() {
+			// Attempt-0 route latency feeds the distress EWMA behind
+			// estimateRetryAfter (2026-09-01: route p50 40ms → 4.6s while the
+			// empty-queue heuristic kept answering "retry in 2s").
+			s.noteAttempt0RouteLatency(pr.Timing.RoutedAt.Sub(receivedAt))
+		}
 	}
 	if recordRoute != nil {
 		recordRoute(provider, pr, decision)
@@ -1426,21 +1469,77 @@ func (s *Server) refundReservedBalance(pr *registry.PendingRequest, reference st
 	return true
 }
 
+// routeLatencyEWMAAlpha weights the newest attempt-0 route-latency sample in
+// the distress EWMA: ~10 healthy requests pull a degraded average back under
+// the threshold once the collapse clears.
+const routeLatencyEWMAAlpha = 0.2
+
+// degradedRouteEWMAThresholdMs is the attempt-0 route-latency EWMA above which
+// estimateRetryAfter switches from the queue-depth heuristic to distress
+// scaling. Healthy routing runs ~40ms; anything over a second means the
+// coordinator itself is the bottleneck.
+const degradedRouteEWMAThresholdMs = 1000.0
+
+// maxDistressRetryAfter caps the distress-scaled Retry-After (seconds).
+const maxDistressRetryAfter = 60
+
+// noteAttempt0RouteLatency folds one attempt-0 route latency (ReceivedAt →
+// RoutedAt) into the distress EWMA. Called from dispatchWithReserver where
+// RoutedAt is stamped; negative samples (clock skew) are dropped.
+func (s *Server) noteAttempt0RouteLatency(d time.Duration) {
+	ms := float64(d) / float64(time.Millisecond)
+	if ms < 0 {
+		return
+	}
+	s.routeLatencyMu.Lock()
+	if s.routeLatencyEWMAMs == 0 {
+		s.routeLatencyEWMAMs = ms
+	} else {
+		s.routeLatencyEWMAMs = routeLatencyEWMAAlpha*ms +
+			(1-routeLatencyEWMAAlpha)*s.routeLatencyEWMAMs
+	}
+	s.routeLatencyMu.Unlock()
+}
+
+// attempt0RouteEWMAMs reads the current attempt-0 route-latency EWMA (ms).
+func (s *Server) attempt0RouteEWMAMs() float64 {
+	s.routeLatencyMu.Lock()
+	defer s.routeLatencyMu.Unlock()
+	return s.routeLatencyEWMAMs
+}
+
 // estimateRetryAfter returns a suggested wait time in seconds before retrying
 // a request for the given model. Based on queue depth as a rough proxy for
 // fleet backlog. OpenRouter uses the Retry-After header to schedule retries.
+//
+// Distress scaling (2026-09-01 congestion collapse): queue depth alone was a
+// LIAR under CPU saturation — the queue was empty (nothing could even reach
+// it), so every 429 carried "Retry-After: 2" and upstream obligingly hammered
+// the coordinator every 2s, sustaining the death loop. When the attempt-0
+// route-latency EWMA shows routing itself is degraded (> 1s), the answer
+// scales with the observed degradation — max(base, ceil(EWMA seconds)×5),
+// capped at 60s — so upstream backoff actually relieves pressure. Queue-depth
+// behavior is unchanged while routing is healthy.
 func (s *Server) estimateRetryAfter(model string) int {
-	queueDepth := s.registry.Queue().QueueSize(model)
-	if queueDepth == 0 {
-		return 2 // Light load, retry soon
+	estimate := 2 // Light load, retry soon
+	if queueDepth := s.registry.Queue().QueueSize(model); queueDepth > 0 {
+		// Rough estimate: each queued request takes ~3 seconds to drain.
+		estimate = queueDepth * 3
+		if estimate < 2 {
+			estimate = 2
+		}
+		if estimate > 30 {
+			estimate = 30
+		}
 	}
-	// Rough estimate: each queued request takes ~3 seconds to drain.
-	estimate := queueDepth * 3
-	if estimate < 2 {
-		estimate = 2
-	}
-	if estimate > 30 {
-		estimate = 30
+	if ewmaMs := s.attempt0RouteEWMAMs(); ewmaMs > degradedRouteEWMAThresholdMs {
+		scaled := int(math.Ceil(ewmaMs/1000)) * 5
+		if scaled > maxDistressRetryAfter {
+			scaled = maxDistressRetryAfter
+		}
+		if scaled > estimate {
+			estimate = scaled
+		}
 	}
 	return estimate
 }

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -611,6 +611,29 @@ const errFirstContentDeadlineExpired = "first-content deadline expired before pr
 // scans.
 const errRoutingScanSaturated = "routing scan capacity saturated — coordinator busy"
 
+// errClientGoneBeforeScan is returned when the caller's context fired while
+// the dispatch goroutine was parked for a provider-selection scan slot. No
+// provider was scanned or contacted; the dispatch loop takes its ordinary
+// client-gone terminal (cancelled route outcome, refund, no response body) —
+// never the routing_saturated 429 or a rejection-ledger row.
+const errClientGoneBeforeScan = "client disconnected before provider selection"
+
+// attempt0RouteAnchor returns the instant the attempt-0 route-latency EWMA
+// sample is measured from — the SAME anchor applyTimingDecomposition uses for
+// route_ms (MediaFetchedAt when a remote-media fetch happened, else
+// ReservedAt) — so download or parse time can never fake routing distress.
+// Zero when the request never stamped a reservation (bare test fixtures):
+// the caller then records no sample.
+func attempt0RouteAnchor(t *registry.RequestTiming) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	if !t.MediaFetchedAt.IsZero() {
+		return t.MediaFetchedAt
+	}
+	return t.ReservedAt
+}
+
 // consumerModel returns the model name to echo back to the consumer: the public
 // alias they requested when set, otherwise the concrete build id (raw-id
 // requests and any internal caller that didn't populate PublicModel).
@@ -895,6 +918,7 @@ func (s *Server) dispatchOneProvider(
 		allowedProviderSerials, isResponsesAPI, policy, timing,
 		serviceReservation, cachePlan, excludeProviders, attempt,
 		recordRoute, onDispatched,
+		true, // ReserveProviderWithPlan is the O(fleet) full scan
 		func(pr *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
 			return s.registry.ReserveProviderWithPlan(model, pr, excludeIDs...)
 		},
@@ -933,6 +957,7 @@ func (s *Server) dispatchWithReserver(
 	attempt int,
 	recordRoute routeDecisionRecorder,
 	onDispatched func(),
+	fullScan bool,
 	reserve dispatchReserver,
 ) (
 	provider *registry.Provider,
@@ -1019,21 +1044,59 @@ func (s *Server) dispatchWithReserver(
 		return ids
 	}
 
+	// noteSelectionSample feeds the attempt-0 route-latency distress EWMA
+	// behind estimateRetryAfter (2026-09-01: route p50 40ms → 4.6s while the
+	// empty-queue heuristic kept answering "retry in 2s"). Anchored exactly
+	// where applyTimingDecomposition anchors route_ms (MediaFetchedAt when
+	// set, else ReservedAt) so a multi-second media download or slow body
+	// parse can never masquerade as routing distress. Called on BOTH the
+	// successful reservation (at the RoutedAt stamp) and every failed
+	// attempt-0 selection (semaphore acquisition timeout, scan that yields no
+	// provider): under TOTAL overload no selection ever succeeds, and an
+	// EWMA fed only by successes would sit at 0 — keeping Retry-After at the
+	// legacy 2s exactly when distress scaling matters most.
+	noteSelectionSample := func() {
+		if attempt != 0 {
+			return
+		}
+		if anchor := attempt0RouteAnchor(timing); !anchor.IsZero() {
+			s.noteAttempt0RouteLatency(time.Since(anchor))
+		}
+	}
+
 	// Bound concurrent provider-selection scans (2026-09-01 congestion
 	// collapse: retry-amplified inbound × a fresh full fleet scan per attempt
-	// saturated every coordinator CPU). The wait is bounded by the request's
+	// saturated every coordinator CPU). Only O(fleet) reservers take a slot —
+	// the full scan, the plan REFRESH (itself a full re-scan), and the
+	// speculative-backup scan. A retained-plan step (ReserveNextFromPlan)
+	// revalidates at most the plan's bounded entries, so it bypasses the
+	// semaphore: a held slot must never starve the cheap retry path that
+	// exists precisely to avoid rescans. The wait is bounded by the request's
 	// remaining first-content budget: a goroutine parks cheaply on the channel
 	// and either scans as soon as a slot frees or sheds capacity-shaped
 	// (errRoutingScanSaturated → one retryable 429) once the budget is gone.
-	if !s.acquireRoutingScanSlot(
-		firstTokenRemainingSince(receivedAt, requestDeadline),
-		r.Context().Done(),
-	) {
-		return nil, nil, decision, nil, errRoutingScanSaturated, http.StatusTooManyRequests
+	if fullScan {
+		switch s.acquireRoutingScanSlot(
+			firstTokenRemainingSince(receivedAt, requestDeadline),
+			r.Context().Done(),
+		) {
+		case scanSlotClientGone:
+			// The caller vanished while parked for a slot: this is the
+			// ordinary client-gone terminal, never the routing_saturated
+			// 429/rejection row (and no distress sample — a vanished caller
+			// proves nothing about selection latency).
+			return nil, nil, decision, nil, errClientGoneBeforeScan, 0
+		case scanSlotTimeout:
+			noteSelectionSample()
+			return nil, nil, decision, nil, errRoutingScanSaturated, http.StatusTooManyRequests
+		}
 	}
 	provider, decision, plan = reserve(pr, excludeList())
-	s.releaseRoutingScanSlot()
+	if fullScan {
+		s.releaseRoutingScanSlot()
+	}
 	if provider == nil {
+		noteSelectionSample()
 		// Providers serve this model but none can physically fit it: don't make
 		// the caller queue/retry for something that will never load.
 		if decision.CandidateCount == 0 && decision.CapacityRejections == 0 && decision.ModelTooLargeRejections > 0 {
@@ -1057,13 +1120,8 @@ func (s *Server) dispatchWithReserver(
 	defer cleanupPending()
 	if pr.Timing != nil {
 		pr.Timing.RoutedAt = time.Now()
-		if attempt == 0 && !receivedAt.IsZero() {
-			// Attempt-0 route latency feeds the distress EWMA behind
-			// estimateRetryAfter (2026-09-01: route p50 40ms → 4.6s while the
-			// empty-queue heuristic kept answering "retry in 2s").
-			s.noteAttempt0RouteLatency(pr.Timing.RoutedAt.Sub(receivedAt))
-		}
 	}
+	noteSelectionSample()
 	if recordRoute != nil {
 		recordRoute(provider, pr, decision)
 	}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -184,6 +184,14 @@ type dispatchState struct {
 	// DETERMINISTIC-context rejection (prompt > model context) stops on the first
 	// attempt regardless (see classifyRejection / failoverOutcome).
 	capacityRetries int
+	// firstChunkTimeoutRetries counts attempts that ended in a
+	// coordinator-synthesized first-chunk TIMEOUT (untyped 504 → the
+	// "first_chunk_timeout" 429 on exhaustion). Bounded by
+	// maxFirstChunkTimeoutRetries so a slow-provider storm cannot burn a
+	// fresh fleet scan per attempt across the ladder (the 2026-09-01
+	// congestion collapse; see the constant). Each counted attempt was on a
+	// distinct provider — the timed-out provider joins excludeProviders.
+	firstChunkTimeoutRetries int
 	// lastFailureDeadline is scoped to the most recent terminal attempt. A
 	// deadline refusal remains eligible for deadline_unreachable only while no
 	// later genuine provider fault has replaced it.
@@ -1213,6 +1221,20 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			return outcomeFailFast
 		}
+		if dispatchErr == errRoutingScanSaturated {
+			// No provider-selection scan slot freed up within the request's
+			// whole remaining first-content budget — the coordinator itself is
+			// saturated (2026-09-01 collapse). Zero providers were scanned or
+			// contacted, so latch the capacity-shaped verdict: the exhausted
+			// ladder emits ONE uptime-neutral retryable 429 (whose Retry-After
+			// scales with the route-latency distress EWMA) and never scans
+			// again for this request.
+			s.ddIncr("routing.scan_admission_timeout", []string{"model:" + d.model})
+			d.setLastError(dispatchErr, http.StatusTooManyRequests)
+			d.unservable = true
+			d.unservableReason = rejectionReasonRoutingSaturated
+			return outcomeFailFast
+		}
 		if d.lastFailureDeadline && dispatchErr == errTTFTTooSlow {
 			// At least one provider already refused this exact remaining
 			// deadline, and the rest cannot pass hard TTFT admission. Candidate
@@ -1652,6 +1674,13 @@ func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *regis
 // "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
 const rejectionReasonOversized = "oversized_request"
 
+// rejectionReasonRoutingSaturated is the rejection-ledger reason_code for a
+// request shed because no provider-selection scan slot freed up within its
+// remaining first-content budget (Server.routingScanSem — the coordinator
+// itself was the bottleneck, 2026-09-01 collapse). Capacity-shaped: one
+// retryable 429, uptime-neutral, zero providers contacted.
+const rejectionReasonRoutingSaturated = "routing_saturated"
+
 // rejectionReasonDeadlineUnreachable is the rejection-ledger reason for a
 // request whose remaining absolute first-content budget was refused by one or
 // more providers and whose untried candidates were then exhausted.
@@ -1719,6 +1748,28 @@ func (d *dispatchState) shouldStopFailover() bool {
 	// model_capability rejection. Kill switch: EIGENINFERENCE_JINJA_TERMINAL_REJECT.
 	if d.latchJinjaTerminalReject(d.lastErrReason, "") {
 		return true
+	}
+	// Timeout-class ladder cap: a coordinator-synthesized first-chunk timeout
+	// is an untyped 504 (setLastError clears the typed cause for synthetic
+	// terminals; a typed safety_deadline/backpressure_timeout 504 is a real
+	// provider terminal and keeps its fault failover). The provider went
+	// silent — a fresh provider MAY answer, so fail over, but each retry
+	// costs a full fleet reservation scan; unbounded, that is the exact
+	// CPU-amplification loop of the 2026-09-01 congestion collapse. Bounded
+	// like maxCapacityClassRetries: at the cap the ladder exhausts and the
+	// synthetic 504 reclassifies to the retryable 429 with reason
+	// "first_chunk_timeout" (classifyExhaustedStatus). Same discriminator as
+	// waitFirstChunk's route-outcome writer, so a timeout never double-counts
+	// as anything else. Behavior below the cap is unchanged: classifyRejection
+	// already returns rejectionNotCapacity for the synthetic timeout string
+	// (see rejection_classify_test.go), i.e. "keep failing over".
+	if d.lastErrCode == http.StatusGatewayTimeout && !isTypedTimeout504Cause(d.lastErrTerminalCause) {
+		d.firstChunkTimeoutRetries++
+		if d.firstChunkTimeoutRetries >= maxFirstChunkTimeoutRetries {
+			d.s.ddIncr("routing.first_chunk_timeout_ladder_capped", []string{"model:" + d.model})
+			return true
+		}
+		return false
 	}
 	// Typed-cause override (highest-fidelity signal): a provider that attaches
 	// terminal_cause=admission_timeout is TELLING us its engine was too busy to

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1221,6 +1221,17 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
 			return outcomeFailFast
 		}
+		if dispatchErr == errClientGoneBeforeScan {
+			// The caller's context fired while parked for a scan slot. Mirror
+			// the queue-wait cancellation arm exactly: cancelled route
+			// outcome, refund, no response body — NEVER the routing_saturated
+			// 429 or a rejection-ledger row (the client is not retrying; the
+			// ledger must not count a shed that never happened).
+			d.emitClientGone(phaseBeforeFirstToken)
+			d.updateRoutingOutcome(d.errorRoutingOutcome("cancelled", "client_gone", 0))
+			d.refundReservation()
+			return outcomeClientGone
+		}
 		if dispatchErr == errRoutingScanSaturated {
 			// No provider-selection scan slot freed up within the request's
 			// whole remaining first-content budget — the coordinator itself is

--- a/coordinator/api/dispatch_plan_wiring.go
+++ b/coordinator/api/dispatch_plan_wiring.go
@@ -68,9 +68,13 @@ func (d *dispatchState) exhaustionAttemptCount() int {
 // dispatchProviderWith runs the single prepare/encrypt/write funnel with a
 // caller-chosen reserver, forwarding the request-shape inputs retained on
 // dispatchState. timing is caller-supplied because the speculative backup
-// deliberately shares only ReceivedAt with the primary's clock.
+// deliberately shares only ReceivedAt with the primary's clock. fullScan
+// declares whether the reserver performs an O(fleet) walk (full scan / plan
+// refresh) and must therefore take a routing-scan semaphore slot; a
+// retained-plan step passes false and bypasses the gate.
 func (d *dispatchState) dispatchProviderWith(
 	reserve dispatchReserver,
+	fullScan bool,
 	timing *registry.RequestTiming,
 	exclude map[string]struct{},
 	recordRoute routeDecisionRecorder,
@@ -80,7 +84,7 @@ func (d *dispatchState) dispatchProviderWith(
 		d.reservedMicroUSD, d.estimatedPromptTokens, d.deadline, d.requestedMaxTokens,
 		d.tokenAdmission, d.requiresVision, d.traits(), d.allowedProviderSerials,
 		d.isResponsesAPI, d.policy, timing, d.serviceReservation, d.cachePlan,
-		exclude, d.attempt, recordRoute, d.noteProviderDispatched, reserve,
+		exclude, d.attempt, recordRoute, d.noteProviderDispatched, fullScan, reserve,
 	)
 }
 
@@ -113,6 +117,7 @@ func (d *dispatchState) dispatchFromPlanMachinery(
 			reserved = p != nil
 			return p, dec, nil
 		},
+		false, // retained-plan step: bounded revalidation, no fleet scan
 		timing, exclude, recordRoute,
 	)
 	if reserved {
@@ -135,6 +140,7 @@ func (d *dispatchState) dispatchFromPlanMachinery(
 			reserved = p != nil
 			return p, dec, freshPlan
 		},
+		true, // the single plan refresh is itself a full fleet re-scan
 		timing, exclude, recordRoute,
 	)
 	if fresh != nil {

--- a/coordinator/api/dispatch_timeout_ladder_test.go
+++ b/coordinator/api/dispatch_timeout_ladder_test.go
@@ -1,0 +1,160 @@
+package api
+
+// Timeout-class ladder cap regression tests (2026-09-01 congestion collapse).
+//
+// A first-chunk TIMEOUT (slow provider, reason "first_chunk_timeout") used to
+// retry across the fleet with a fresh full reservation scan per attempt —
+// unbounded except by maxDispatchAttempts=64 and the request-absolute
+// first-content clock. Wall time per request was bounded; CPU was not:
+// retry-amplified inbound (~100 req/s of retryable 429 traffic) times
+// per-request fleet scans (~1,260 providers each) saturated every coordinator
+// CPU into a stable death loop (attempt-0 route p50 40ms → 4.6s, success
+// ~40%, 429s delivered after 11s). maxFirstChunkTimeoutRetries caps the
+// timeout-class ladder the same way maxCapacityClassRetries caps capacity
+// failovers, exhausting into the existing synthetic-timeout → 429
+// reclassification (classifyExhaustedStatus).
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// TestDispatch_FirstChunkTimeoutLadder_CapsAtThreeAttempts drives the REAL
+// dispatch loop (dispatchState.run, per the TestDispatch_TTFTRejectAttempt0
+// pattern) against five real-WS providers that accept every frame and then go
+// dead silent. ReceivedAt is deliberately UNSTAMPED so, per the historical
+// relative-timer fallback (first_token_clock.go invariant 5), every attempt
+// gets its own first-content window — exactly the configuration in which the
+// pre-fix ladder could walk the whole fleet, one reservation scan per silent
+// provider. The ladder must stop after maxFirstChunkTimeoutRetries dispatches
+// (each on a DISTINCT provider — timed-out providers are excluded) and answer
+// one retryable 429, not walk all five providers.
+func TestDispatch_FirstChunkTimeoutLadder_CapsAtThreeAttempts(t *testing.T) {
+	reg, _, srv, ts := setupTTFTFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const model = "timeout-ladder-model"
+	const fleet = 5 // more providers than the cap, so the cap — not candidate exhaustion — stops the loop
+	providers := make([]*failoverProvider, 0, fleet)
+	for i := 0; i < fleet; i++ {
+		providers = append(providers, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name:      fmt.Sprintf("silent-%d", i),
+			Version:   "0.7.0",
+			DecodeTPS: 100,
+			Models:    []failoverModelSpec{{ID: model}},
+			Script:    nil, // accept the dispatch, never answer: pure first-chunk timeout
+		}))
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	deadline := 150 * time.Millisecond
+	d := &dispatchState{
+		s:                     srv,
+		w:                     w,
+		r:                     r,
+		model:                 model,
+		publicModel:           model,
+		rawBody:               []byte(`{"model":"` + model + `"}`),
+		consumerKey:           "test-key",
+		estimatedPromptTokens: 6,
+		requestedMaxTokens:    64,
+		// ReceivedAt unstamped: per-attempt relative timers (invariant 5).
+		timing:   &registry.RequestTiming{},
+		deadline: deadline,
+		// Keep the speculative launch point far past the per-attempt deadline
+		// so every attempt performs exactly ONE dispatch (no backup race).
+		speculativeAt:     10 * deadline,
+		refundReservation: func() {},
+		excludeProviders:  map[string]struct{}{},
+	}
+
+	start := time.Now()
+	d.run()
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (timeout ladder → retryable 429); body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "rate_limit_exceeded") {
+		t.Errorf("body missing rate_limit_exceeded code; body=%s", w.Body.String())
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on the 429")
+	}
+	total := 0
+	for _, fp := range providers {
+		if n := fp.dispatchCount(); n > 1 {
+			t.Errorf("provider %s received %d dispatches, want at most 1 (timed-out providers are excluded)", fp.name, n)
+		} else {
+			total += n
+		}
+	}
+	if total != maxFirstChunkTimeoutRetries {
+		t.Errorf("total dispatches = %d, want exactly %d — the timeout ladder must stop at the cap, not walk all %d providers",
+			total, maxFirstChunkTimeoutRetries, fleet)
+	}
+	if d.firstChunkTimeoutRetries != maxFirstChunkTimeoutRetries {
+		t.Errorf("firstChunkTimeoutRetries = %d, want %d", d.firstChunkTimeoutRetries, maxFirstChunkTimeoutRetries)
+	}
+	// Sanity on the wall clock: 3 timed-out windows plus overhead, never the
+	// 5-provider (or 64-attempt) walk.
+	if elapsed > 4*time.Second {
+		t.Errorf("dispatch took %s — the capped ladder must return promptly", elapsed)
+	}
+}
+
+// TestShouldStopFailover_TimeoutCapCountsOnlySyntheticTimeouts pins the
+// counting rule at the unit level: only the untyped 504 (the dispatch loop's
+// synthetic first-chunk timeout discriminator) consumes the timeout allowance;
+// a TYPED provider 504 (safety_deadline — a real provider terminal) keeps its
+// existing fault-failover behavior and consumes nothing.
+func TestShouldStopFailover_TimeoutCapCountsOnlySyntheticTimeouts(t *testing.T) {
+	srv, _ := testServer(t)
+	d := &dispatchState{
+		s:                srv,
+		model:            "cap-count-model",
+		excludeProviders: map[string]struct{}{},
+	}
+
+	// A typed provider 504 must not touch the timeout counter.
+	d.setLastError("safety_deadline: safety ceiling expired", http.StatusGatewayTimeout)
+	d.lastErrTerminalCause = terminalCauseSafetyDeadline
+	if d.shouldStopFailover() {
+		t.Fatal("typed provider 504 must keep the existing fault failover, not stop")
+	}
+	if d.firstChunkTimeoutRetries != 0 {
+		t.Fatalf("typed 504 consumed the timeout allowance: %d", d.firstChunkTimeoutRetries)
+	}
+
+	// Synthetic timeouts stop at exactly maxFirstChunkTimeoutRetries.
+	for i := 1; i < maxFirstChunkTimeoutRetries; i++ {
+		d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+		if d.shouldStopFailover() {
+			t.Fatalf("synthetic timeout %d stopped early (cap is %d)", i, maxFirstChunkTimeoutRetries)
+		}
+	}
+	d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+	if !d.shouldStopFailover() {
+		t.Fatalf("synthetic timeout %d must stop the ladder", maxFirstChunkTimeoutRetries)
+	}
+
+	// The exhausted ladder must reclassify the latched synthetic 504 to the
+	// retryable 429 with the closed first_chunk_timeout reason.
+	failure, sticky := d.terminalFailureForExhaustion()
+	code, reason, reclassified, dominance := d.resolveDominantExhaustedStatus(failure, sticky)
+	if code != http.StatusTooManyRequests || reason != "first_chunk_timeout" || !reclassified {
+		t.Fatalf("exhausted classification = (%d, %q, %v), want (429, first_chunk_timeout, true)", code, reason, reclassified)
+	}
+	if dominance != exhaustedUndecided {
+		t.Fatalf("dominance = %d, want exhaustedUndecided (plain reclassified timeout)", dominance)
+	}
+}

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -219,6 +219,22 @@ type inferenceAdmissionParams struct {
 	onModelFallback func(newModel string) (ok bool)
 }
 
+// preflightScanWait is the admission gate's slot-wait budget: a short slice
+// (a quarter) of the request's first-content deadline, capped at one second.
+// Under saturation admission must shed FAST — a fast 429 relieves CPU — while
+// a dispatch attempt may park for its whole remaining budget. Requests
+// without a deadline (bare fixtures) get a 250ms slice.
+func preflightScanWait(deadline time.Duration) time.Duration {
+	wait := deadline / 4
+	if wait <= 0 {
+		wait = 250 * time.Millisecond
+	}
+	if wait > time.Second {
+		wait = time.Second
+	}
+	return wait
+}
+
 // runInferenceAdmission performs the shared routing/capacity preflight for both
 // inference handlers. On a rejection it writes the exact terminal response
 // (refunding the reservation) and returns handled=true; on success it returns
@@ -275,6 +291,53 @@ func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, p
 			withCode("payload_too_large")))
 		return true
 	}
+
+	// Gate EVERY preflight fleet walk (self-route/prefer OwnedProviderSummary,
+	// the public QuickCapacityCheck family, alias-fallback probes, the
+	// servability walk) behind the SAME routing-scan semaphore that bounds the
+	// dispatch reservation scans. Without this the 2026-09-01 retry storm
+	// still burns unbounded CPU BEFORE the dispatch loop: every admission runs
+	// a full fleet walk. The wait is a short slice of the first-content budget
+	// — under saturation admission must shed fast, not park for the whole
+	// budget the way a dispatch attempt may. The slot is held only for the
+	// CPU-bounded walks in this function (released before dispatch/queueing,
+	// which take their own slot per reservation; no registry locks are held at
+	// acquisition). On timeout: the same capacity-shaped routing_saturated 429
+	// with the distress-scaled Retry-After, zero walks. On client-gone: refund
+	// and stop silently — never the 429 path or a rejection-ledger row.
+	switch s.acquireRoutingScanSlot(preflightScanWait(p.deadline), r.Context().Done()) {
+	case scanSlotClientGone:
+		refundReservation()
+		return model, true
+	case scanSlotTimeout:
+		refundReservation()
+		retryAfter := s.estimateRetryAfter(model)
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		s.ddIncr("routing.scan_admission_timeout", []string{"model:" + model, "stage:preflight"})
+		s.ddIncr("routing.decisions", []string{"model:" + model, "model_type:" + s.registry.ModelType(model), "outcome:routing_saturated"})
+		s.recordRejection(rejectionInfo{
+			r:                     r,
+			stage:                 "preflight_capacity",
+			reasonCode:            rejectionReasonRoutingSaturated,
+			httpStatus:            http.StatusTooManyRequests,
+			keyID:                 keyIDFromContext(r.Context()),
+			consumerKeyHash:       store.HashKey(consumerKeyFromContext(r.Context())),
+			requestedModel:        publicModel,
+			resolvedModel:         model,
+			stream:                p.stream,
+			estimatedPromptTokens: p.estimatedPromptTokens,
+			requestedMaxTokens:    p.requestedMaxTokens,
+			requiresVision:        p.requiresVision,
+			hasTools:              p.hasTools,
+			retryAfterMs:          retryAfter * 1000,
+			params:                rejectionSamplingParams(parsed),
+		})
+		writeJSON(w, http.StatusTooManyRequests, errorResponse("rate_limit_exceeded",
+			"the coordinator is at routing capacity — please retry",
+			withCode("rate_limit_exceeded")))
+		return model, true
+	}
+	defer s.releaseRoutingScanSlot()
 
 	// Self-route pre-flight: confirm the caller owns an online machine that can
 	// serve this model, with precise errors and no fallback to the paid fleet.

--- a/coordinator/api/retry_after_distress_test.go
+++ b/coordinator/api/retry_after_distress_test.go
@@ -1,0 +1,70 @@
+package api
+
+// estimateRetryAfter distress-scaling tests (2026-09-01 congestion collapse).
+//
+// Queue depth alone was a liar under CPU saturation: the queue was empty
+// (nothing could reach it), so every 429 carried "Retry-After: 2" and
+// upstream retried every 2s, sustaining the death loop. When the attempt-0
+// route-latency EWMA shows routing itself is degraded (> 1s), the answer
+// must scale with the observed degradation — max(base, ceil(EWMA_s)*5),
+// capped at 60 — while healthy routing keeps the legacy queue-depth values.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEstimateRetryAfter_DistressScaling(t *testing.T) {
+	t.Run("healthy keeps legacy empty-queue answer", func(t *testing.T) {
+		srv, _ := testServer(t)
+		if got := srv.estimateRetryAfter("m"); got != 2 {
+			t.Fatalf("healthy empty-queue Retry-After = %d, want legacy 2", got)
+		}
+		// Sub-threshold degradation (EWMA <= 1s) changes nothing.
+		srv.noteAttempt0RouteLatency(800 * time.Millisecond)
+		if got := srv.estimateRetryAfter("m"); got != 2 {
+			t.Fatalf("sub-threshold EWMA Retry-After = %d, want legacy 2", got)
+		}
+	})
+
+	t.Run("degraded EWMA scales at least 5x", func(t *testing.T) {
+		srv, _ := testServer(t)
+		// The incident shape: attempt-0 route p50 at 4.6s.
+		srv.noteAttempt0RouteLatency(4600 * time.Millisecond)
+		got := srv.estimateRetryAfter("m")
+		if want := 25; got != want { // ceil(4.6)*5
+			t.Fatalf("degraded Retry-After = %d, want %d (ceil(4.6s)*5)", got, want)
+		}
+		if got < 5*2 {
+			t.Fatalf("degraded Retry-After = %d, want >= 5x the healthy answer", got)
+		}
+	})
+
+	t.Run("distress answer caps at 60", func(t *testing.T) {
+		srv, _ := testServer(t)
+		srv.noteAttempt0RouteLatency(90 * time.Second)
+		if got := srv.estimateRetryAfter("m"); got != maxDistressRetryAfter {
+			t.Fatalf("capped Retry-After = %d, want %d", got, maxDistressRetryAfter)
+		}
+	})
+
+	t.Run("healthy samples pull a degraded EWMA back to legacy", func(t *testing.T) {
+		srv, _ := testServer(t)
+		srv.noteAttempt0RouteLatency(4600 * time.Millisecond)
+		for i := 0; i < 15; i++ { // 4600 * 0.8^15 ≈ 162ms
+			srv.noteAttempt0RouteLatency(40 * time.Millisecond)
+		}
+		if got := srv.estimateRetryAfter("m"); got != 2 {
+			t.Fatalf("recovered Retry-After = %d, want legacy 2 (EWMA=%.0fms)",
+				got, srv.attempt0RouteEWMAMs())
+		}
+	})
+
+	t.Run("negative samples are dropped", func(t *testing.T) {
+		srv, _ := testServer(t)
+		srv.noteAttempt0RouteLatency(-5 * time.Second)
+		if got := srv.attempt0RouteEWMAMs(); got != 0 {
+			t.Fatalf("EWMA after negative sample = %v, want 0", got)
+		}
+	})
+}

--- a/coordinator/api/retry_after_distress_test.go
+++ b/coordinator/api/retry_after_distress_test.go
@@ -10,8 +10,13 @@ package api
 // capped at 60 — while healthy routing keeps the legacy queue-depth values.
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
 func TestEstimateRetryAfter_DistressScaling(t *testing.T) {
@@ -67,4 +72,96 @@ func TestEstimateRetryAfter_DistressScaling(t *testing.T) {
 			t.Fatalf("EWMA after negative sample = %v, want 0", got)
 		}
 	})
+}
+
+// TestAttempt0RouteAnchor pins the EWMA sample anchor to the SAME instant
+// applyTimingDecomposition anchors route_ms: MediaFetchedAt when a remote
+// media fetch happened, else ReservedAt — never ReceivedAt/ParsedAt, so a
+// multi-second download or slow parse can never fake routing distress.
+func TestAttempt0RouteAnchor(t *testing.T) {
+	now := time.Now()
+	if got := attempt0RouteAnchor(nil); !got.IsZero() {
+		t.Fatalf("nil timing anchor = %v, want zero", got)
+	}
+	reservedOnly := &registry.RequestTiming{ReceivedAt: now.Add(-10 * time.Second), ReservedAt: now}
+	if got := attempt0RouteAnchor(reservedOnly); !got.Equal(now) {
+		t.Fatalf("anchor = %v, want ReservedAt", got)
+	}
+	withMedia := &registry.RequestTiming{
+		ReceivedAt:     now.Add(-10 * time.Second),
+		ReservedAt:     now.Add(-5 * time.Second),
+		MediaFetchedAt: now,
+	}
+	if got := attempt0RouteAnchor(withMedia); !got.Equal(now) {
+		t.Fatalf("anchor = %v, want MediaFetchedAt past the fetch", got)
+	}
+}
+
+// TestNoteAttempt0RouteLatency_IgnoresMediaFetchTime drives the REAL funnel
+// (dispatchOneProvider) with a request that spent ~10s receiving/parsing and
+// fetching media but only ~80ms between the media fetch and routing. The
+// recorded EWMA sample must reflect the ~80ms route segment — a
+// ReceivedAt-anchored sample (~10s) would trip the distress threshold on
+// media traffic alone.
+func TestNoteAttempt0RouteLatency_IgnoresMediaFetchTime(t *testing.T) {
+	srv, _ := testServer(t)
+	const model = "ewma-anchor-model"
+	srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: model, SizeGB: 1, MinRAMGB: 24}})
+	registerBuildsProvider(srv, "ewma-anchor-provider", model)
+
+	now := time.Now()
+	timing := &registry.RequestTiming{
+		ReceivedAt:     now.Add(-10 * time.Second),
+		ParsedAt:       now.Add(-9 * time.Second),
+		ReservedAt:     now.Add(-8 * time.Second),
+		MediaFetchedAt: now.Add(-80 * time.Millisecond),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	// 15s deadline keeps the 10s-old absolute clock dispatchable; the nil-conn
+	// provider write fails AFTER RoutedAt is stamped, which is all we need.
+	srv.dispatchOneProvider(
+		r, model, model, []byte(`{"model":"`+model+`"}`), "test-key", nil,
+		0, 6, 15*time.Second, 64, registry.TokenAdmission{}, false,
+		registry.RequestTraits{}, nil, false, selfRoutePolicy{}, timing,
+		false, registry.CachePlan{}, map[string]struct{}{}, 0, nil, nil)
+
+	got := srv.attempt0RouteEWMAMs()
+	if got <= 0 {
+		t.Fatal("no EWMA sample recorded — RoutedAt stamp did not feed the EWMA")
+	}
+	if got >= 1000 {
+		t.Fatalf("EWMA sample = %.0fms — receive/parse/media time leaked into the route sample (anchor must be MediaFetchedAt)", got)
+	}
+}
+
+// TestNoteAttempt0RouteLatency_RecordsFailedSelections pins the
+// total-overload contract: when NO reservation ever succeeds (the collapse's
+// terminal phase — every scan comes back empty), the failed attempt-0
+// selection itself must feed the EWMA. An EWMA fed only by successful routes
+// would sit at 0 and keep Retry-After at the legacy 2s exactly when distress
+// scaling matters most.
+func TestNoteAttempt0RouteLatency_RecordsFailedSelections(t *testing.T) {
+	srv, _ := testServer(t) // zero providers: every reservation fails
+	now := time.Now()
+	// The selection has been grinding for ~4.6s (the incident's route p50)
+	// when it finally fails.
+	timing := &registry.RequestTiming{
+		ReceivedAt: now.Add(-4600 * time.Millisecond),
+		ReservedAt: now.Add(-4600 * time.Millisecond),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	_, _, _, _, lastErr, _ := srv.dispatchOneProvider(
+		r, "overload-model", "overload-model", []byte(`{"model":"overload-model"}`),
+		"test-key", nil, 0, 6, 15*time.Second, 64, registry.TokenAdmission{},
+		false, registry.RequestTraits{}, nil, false, selfRoutePolicy{}, timing,
+		false, registry.CachePlan{}, map[string]struct{}{}, 0, nil, nil)
+	if lastErr != "no provider available" {
+		t.Fatalf("lastErr = %q, want the empty-fleet failure", lastErr)
+	}
+	if got := srv.attempt0RouteEWMAMs(); got < 4000 {
+		t.Fatalf("EWMA after failed selection = %.0fms, want the ~4600ms selection duration recorded", got)
+	}
+	if got := srv.estimateRetryAfter("overload-model"); got < 10 {
+		t.Fatalf("Retry-After under total overload = %d, want the distress-scaled value (>= 5x legacy)", got)
+	}
 }

--- a/coordinator/api/routing_scan_limit_test.go
+++ b/coordinator/api/routing_scan_limit_test.go
@@ -10,6 +10,7 @@ package api
 // routing_saturated) — never a 5xx, never another scan.
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -59,7 +60,7 @@ func TestRoutingScanSemaphore_BoundsConcurrentScans(t *testing.T) {
 				"test-key", nil, 0, 0, 5*time.Second, 64,
 				registry.TokenAdmission{}, false, registry.RequestTraits{},
 				nil, false, selfRoutePolicy{}, nil, false, registry.CachePlan{},
-				map[string]struct{}{}, 0, nil, nil, reserver)
+				map[string]struct{}{}, 0, nil, nil, true, reserver)
 			errs[i] = lastErr
 			codes[i] = lastErrCode
 		}(i)
@@ -139,5 +140,183 @@ func TestRoutingScanSemaphore_AcquireTimeoutShedsCapacityShaped429(t *testing.T)
 	// and never longer.
 	if elapsed < 80*time.Millisecond || elapsed > 3*time.Second {
 		t.Errorf("shed after %s, want ~the 120ms remaining budget", elapsed)
+	}
+}
+
+// TestRoutingScanSemaphore_ClientGoneTakesClientGonePath cancels the caller
+// while it is parked for a scan slot. The dispatch loop must take the
+// EXISTING client-gone terminal — refund, no response bytes, no Retry-After —
+// and never the routing_saturated 429 or a rejection-ledger row: the client
+// is not retrying, so the ledger must not count a shed that never happened.
+func TestRoutingScanSemaphore_ClientGoneTakesClientGonePath(t *testing.T) {
+	srv, st := testServer(t)
+	srv.SetRoutingConcurrency(2)
+	srv.routingScanSem <- struct{}{}
+	srv.routingScanSem <- struct{}{}
+	defer func() { <-srv.routingScanSem; <-srv.routingScanSem }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}")).WithContext(ctx)
+	refunds := 0
+	deadline := 5 * time.Second // far beyond the cancel point: the timeout arm must not win
+	d := &dispatchState{
+		s:                     srv,
+		w:                     w,
+		r:                     r,
+		model:                 "client-gone-model",
+		publicModel:           "client-gone-model",
+		rawBody:               []byte(`{"model":"client-gone-model"}`),
+		consumerKey:           "test-key",
+		estimatedPromptTokens: 6,
+		requestedMaxTokens:    64,
+		timing:                &registry.RequestTiming{ReceivedAt: time.Now()},
+		deadline:              deadline,
+		speculativeAt:         deadline / 2,
+		refundReservation:     func() { refunds++ },
+		excludeProviders:      map[string]struct{}{},
+	}
+
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		cancel()
+	}()
+	d.run()
+
+	if w.Body.Len() != 0 {
+		t.Fatalf("client-gone wrote a response body: %s", w.Body.String())
+	}
+	if w.Header().Get("Retry-After") != "" {
+		t.Error("client-gone must not carry a Retry-After header")
+	}
+	if d.unservable {
+		t.Errorf("client-gone latched unservable(%q) — that is the saturation verdict", d.unservableReason)
+	}
+	if refunds != 1 {
+		t.Errorf("reservation refunds = %d, want exactly 1", refunds)
+	}
+	if got := len(st.RejectionRecordsSince(time.Time{})); got != 0 {
+		t.Errorf("rejection-ledger rows = %d, want 0 for a client-gone", got)
+	}
+}
+
+// TestPreflightAdmission_ScanSaturationStormSheds429 proves the admission
+// preflight's fleet walks run behind the SAME semaphore as dispatch scans:
+// with every slot held, a storm of N+K concurrent HTTP admissions performs
+// ZERO walks (each sheds the capacity-shaped routing_saturated 429 after its
+// short slice — a scan would instead have found the healthy provider and
+// served 200), and once the slots free the next admission walks, dispatches,
+// and streams normally.
+func TestPreflightAdmission_ScanSaturationStormSheds429(t *testing.T) {
+	reg, _, srv, ts := setupTTFTFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const model = "preflight-sat-model"
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name:      "healthy",
+		Version:   "0.7.0",
+		DecodeTPS: 100,
+		Models:    []failoverModelSpec{{ID: model}},
+		Script:    fullServeScript(model),
+	})
+
+	srv.SetRoutingConcurrency(2)
+	srv.routingScanSem <- struct{}{}
+	srv.routingScanSem <- struct{}{}
+
+	const storm = 4 // N+K admissions against N=2 fully-held slots
+	var wg sync.WaitGroup
+	var shed429 atomic.Int32
+	for i := 0; i < storm; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+			if err != nil {
+				t.Errorf("storm request: %v", err)
+				return
+			}
+			if status != http.StatusTooManyRequests {
+				t.Errorf("storm status = %d, want 429; body=%s", status, body)
+				return
+			}
+			if !strings.Contains(body, "rate_limit_exceeded") {
+				t.Errorf("storm body missing rate_limit_exceeded: %s", body)
+				return
+			}
+			shed429.Add(1)
+		}()
+	}
+	wg.Wait()
+	if got := fp.dispatchCount(); got != 0 {
+		t.Fatalf("provider dispatches during saturation = %d, want 0 (zero fleet walks)", got)
+	}
+	if got := shed429.Load(); got != storm {
+		t.Fatalf("saturation sheds = %d, want %d", got, storm)
+	}
+
+	// Slots freed: the same admission now walks the fleet and serves.
+	<-srv.routingScanSem
+	<-srv.routingScanSem
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+	if err != nil {
+		t.Fatalf("post-release request: %v", err)
+	}
+	if status != http.StatusOK || !strings.Contains(body, markerFor("healthy")) {
+		t.Fatalf("post-release = %d (%s), want 200 with the provider's content", status, body)
+	}
+	if fp.dispatchCount() == 0 {
+		t.Fatal("post-release request never reached the provider")
+	}
+}
+
+// TestRoutingScanSemaphore_PlanStepBypassesGate proves a retained-plan
+// reservation (ReserveNextFromPlan — bounded revalidation of at most the
+// plan's entries, no fleet scan) proceeds even when every scan slot is held:
+// the cheap retry path exists precisely to avoid rescans, so the scan gate
+// must never starve it. The identical reserver declared as a full scan blocks
+// (sheds) under the same held semaphore.
+func TestRoutingScanSemaphore_PlanStepBypassesGate(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetRoutingConcurrency(2)
+	srv.routingScanSem <- struct{}{}
+	srv.routingScanSem <- struct{}{}
+	defer func() { <-srv.routingScanSem; <-srv.routingScanSem }()
+
+	reserverRan := false
+	reserver := func(pr *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
+		reserverRan = true
+		return nil, registry.RoutingDecision{}, nil
+	}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+
+	// Plan step (fullScan=false): must run the reserver despite zero free slots.
+	_, _, _, _, lastErr, _ := srv.dispatchWithReserver(
+		r, "plan-model", "plan-model", []byte(`{"model":"plan-model"}`),
+		"test-key", nil, 0, 0, 200*time.Millisecond, 64,
+		registry.TokenAdmission{}, false, registry.RequestTraits{},
+		nil, false, selfRoutePolicy{}, nil, false, registry.CachePlan{},
+		map[string]struct{}{}, 1, nil, nil, false, reserver)
+	if !reserverRan {
+		t.Fatal("plan-step reserver never ran — the bypass is broken")
+	}
+	if lastErr != "no provider available" {
+		t.Fatalf("plan step = %q, want the reserver's ordinary no-provider outcome", lastErr)
+	}
+
+	// The same reserver behind the gate (fullScan=true) sheds without running.
+	reserverRan = false
+	_, _, _, _, lastErr, lastErrCode := srv.dispatchWithReserver(
+		r, "plan-model", "plan-model", []byte(`{"model":"plan-model"}`),
+		"test-key", nil, 0, 0, 100*time.Millisecond, 64,
+		registry.TokenAdmission{}, false, registry.RequestTraits{},
+		nil, false, selfRoutePolicy{}, nil, false, registry.CachePlan{},
+		map[string]struct{}{}, 1, nil, nil, true, reserver)
+	if reserverRan {
+		t.Fatal("gated reserver ran with every slot held")
+	}
+	if lastErr != errRoutingScanSaturated || lastErrCode != http.StatusTooManyRequests {
+		t.Fatalf("gated = (%q, %d), want (%q, 429)", lastErr, lastErrCode, errRoutingScanSaturated)
 	}
 }

--- a/coordinator/api/routing_scan_limit_test.go
+++ b/coordinator/api/routing_scan_limit_test.go
@@ -1,0 +1,143 @@
+package api
+
+// Routing-scan concurrency limit tests (2026-09-01 congestion collapse).
+//
+// Server.routingScanSem bounds how many provider-selection scans may run
+// concurrently: excess dispatch goroutines park on the channel instead of
+// piling CPU-bound fleet scans onto saturated cores, and one that cannot
+// acquire within its remaining first-content budget sheds as a
+// capacity-shaped retryable 429 (errRoutingScanSaturated / reason
+// routing_saturated) — never a 5xx, never another scan.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// TestRoutingScanSemaphore_BoundsConcurrentScans launches N+2 dispatches
+// against a capacity-N semaphore through the REAL funnel
+// (dispatchWithReserver, the one seam every reserver flows through) and
+// asserts that at most N reservers ever run simultaneously — and that all
+// N+2 complete (waiters acquire freed slots; no deadlock).
+func TestRoutingScanSemaphore_BoundsConcurrentScans(t *testing.T) {
+	srv, _ := testServer(t)
+	const capacity = 2
+	const workers = capacity + 2
+	srv.SetRoutingConcurrency(capacity)
+
+	var inside, peak atomic.Int32
+	reserver := func(pr *registry.PendingRequest, excludeIDs []string) (*registry.Provider, registry.RoutingDecision, *registry.DispatchPlan) {
+		cur := inside.Add(1)
+		for {
+			p := peak.Load()
+			if cur <= p || peak.CompareAndSwap(p, cur) {
+				break
+			}
+		}
+		time.Sleep(80 * time.Millisecond) // hold the slot long enough to overlap
+		inside.Add(-1)
+		return nil, registry.RoutingDecision{}, nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]string, workers)
+	codes := make([]int, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+			_, _, _, _, lastErr, lastErrCode := srv.dispatchWithReserver(
+				r, "sem-model", "sem-model", []byte(`{"model":"sem-model"}`),
+				"test-key", nil, 0, 0, 5*time.Second, 64,
+				registry.TokenAdmission{}, false, registry.RequestTraits{},
+				nil, false, selfRoutePolicy{}, nil, false, registry.CachePlan{},
+				map[string]struct{}{}, 0, nil, nil, reserver)
+			errs[i] = lastErr
+			codes[i] = lastErrCode
+		}(i)
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got > capacity {
+		t.Fatalf("peak concurrent scans = %d, want <= %d", got, capacity)
+	}
+	// Every worker got a slot within its 5s budget and ran the reserver: the
+	// nil-provider outcome is the ordinary "no provider available" 503, never
+	// the saturation shed.
+	for i := 0; i < workers; i++ {
+		if errs[i] != "no provider available" || codes[i] != http.StatusServiceUnavailable {
+			t.Errorf("worker %d = (%q, %d), want (no provider available, 503)", i, errs[i], codes[i])
+		}
+	}
+}
+
+// TestRoutingScanSemaphore_AcquireTimeoutShedsCapacityShaped429 fully
+// occupies the semaphore and drives the real dispatch loop
+// (dispatchState.run) with a short remaining first-content budget. The
+// request must shed as the capacity-shaped retryable 429 WITHOUT any scan: a
+// server with zero providers would answer "no provider available" → 503 if a
+// scan ran, so the 429 + routing_saturated verdict proves the shed happened
+// at the admission gate.
+func TestRoutingScanSemaphore_AcquireTimeoutShedsCapacityShaped429(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetRoutingConcurrency(2)
+	// Occupy both slots for the whole test.
+	srv.routingScanSem <- struct{}{}
+	srv.routingScanSem <- struct{}{}
+	defer func() { <-srv.routingScanSem; <-srv.routingScanSem }()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	deadline := 120 * time.Millisecond
+	d := &dispatchState{
+		s:                     srv,
+		w:                     w,
+		r:                     r,
+		model:                 "saturated-model",
+		publicModel:           "saturated-model",
+		rawBody:               []byte(`{"model":"saturated-model"}`),
+		consumerKey:           "test-key",
+		estimatedPromptTokens: 6,
+		requestedMaxTokens:    64,
+		timing:                &registry.RequestTiming{ReceivedAt: time.Now()},
+		deadline:              deadline,
+		speculativeAt:         deadline / 2,
+		refundReservation:     func() {},
+		excludeProviders:      map[string]struct{}{},
+	}
+
+	start := time.Now()
+	d.run()
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (capacity-shaped shed, NOT the 503 a scan would produce); body=%s",
+			w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "rate_limit_exceeded") {
+		t.Errorf("body missing rate_limit_exceeded code; body=%s", w.Body.String())
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on the 429")
+	}
+	if !d.unservable || d.unservableReason != rejectionReasonRoutingSaturated {
+		t.Errorf("verdict = (unservable=%v, reason=%q), want (true, %q)",
+			d.unservable, d.unservableReason, rejectionReasonRoutingSaturated)
+	}
+	if d.attempt != 0 {
+		t.Errorf("attempts = %d, want the shed to terminate the ladder at attempt 0", d.attempt+1)
+	}
+	// The goroutine parked for (about) the remaining budget before shedding,
+	// and never longer.
+	if elapsed < 80*time.Millisecond || elapsed > 3*time.Second {
+		t.Errorf("shed after %s, want ~the 120ms remaining budget", elapsed)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -492,6 +493,31 @@ type Server struct {
 	// NewServer from env; nil (e.g. a &Server{} built directly in tests)
 	// behaves as disabled and falls back to the legacy pre-dispatch rejection.
 	mediaResolver *mediafetch.Resolver
+	// routingScanSem bounds how many provider-selection scans (the
+	// ReserveProviderEx/ReserveProviderWithPlan family — a read-lock walk of
+	// ~1,260 providers per attempt) may run concurrently. During the
+	// 2026-09-01 congestion collapse, retry-amplified inbound (~100 req/s of
+	// retryable 429 traffic) times a fresh full scan per dispatch attempt
+	// saturated every coordinator CPU (attempt-0 route p50 40ms → 4.6s,
+	// success ~40%, 429s delivered after 11s) — a stable death loop. With the
+	// semaphore, excess requests park cheaply on the channel instead of
+	// piling onto the scheduler; one that cannot acquire within its remaining
+	// first-content budget sheds as a capacity-shaped 429
+	// (errRoutingScanSaturated). Capacity defaults to runtime.NumCPU()
+	// (min 2); override via EIGENINFERENCE_ROUTING_CONCURRENCY
+	// (SetRoutingConcurrency, called before serving starts).
+	routingScanSem chan struct{}
+
+	// routeLatencyEWMAMs is an EWMA of attempt-0 route latency (ReceivedAt →
+	// RoutedAt, milliseconds), updated where RoutedAt is stamped in
+	// dispatchWithReserver. estimateRetryAfter consults it: when routing
+	// itself is degraded (EWMA > 1s) the returned Retry-After scales up so
+	// upstream backoff actually relieves pressure — during the 2026-09-01
+	// collapse the queue-depth heuristic returned 2s on an empty queue and
+	// invited 2s retry storms. Guarded by routeLatencyMu (one tiny critical
+	// section per request; no allocation).
+	routeLatencyMu     sync.Mutex
+	routeLatencyEWMAMs float64
 }
 
 // SetRateLimiter configures the per-account rate limiter applied to
@@ -793,6 +819,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		routeTelemetry:           newTelemetrySink(logger, defaultTelemetrySinkCapacity, defaultTelemetrySinkWorkers),
 		mediaResolver:            mediafetch.NewResolver(mediaFetchCfg, logger),
 		firstContentDeadlineBase: firstContentDeadlineBase,
+		routingScanSem:           make(chan struct{}, DefaultRoutingConcurrency()),
 	}
 	if _, clampedDown := trustReuseReconnectGapFromEnv(); clampedDown {
 		logger.Warn("EIGENINFERENCE_TRUST_REUSE_RECONNECT_GAP exceeds the 120s security ceiling; clamping DOWN",
@@ -1292,6 +1319,67 @@ func (s *Server) SetMinDecodeTPS(tps float64) {
 		tps = 0
 	}
 	s.minDecodeTPS = tps
+}
+
+// DefaultRoutingConcurrency is the built-in routing-scan semaphore capacity:
+// one scan per CPU (a scan is pure CPU under the registry read lock), floored
+// at 2 so a tiny container never serializes routing entirely. Exported so
+// main.go can log the effective default alongside the env override.
+func DefaultRoutingConcurrency() int {
+	n := runtime.NumCPU()
+	if n < 2 {
+		n = 2
+	}
+	return n
+}
+
+// SetRoutingConcurrency replaces the routing-scan semaphore with one of the
+// given capacity (EIGENINFERENCE_ROUTING_CONCURRENCY). Values < 2 clamp to 2.
+// Call before serving starts — replacing the channel while scans are in
+// flight would strand slots.
+func (s *Server) SetRoutingConcurrency(n int) {
+	if n < 2 {
+		n = 2
+	}
+	s.routingScanSem = make(chan struct{}, n)
+}
+
+// acquireRoutingScanSlot blocks until a provider-selection scan slot is free,
+// the wait budget elapses, or done fires (client gone). It returns false only
+// when no slot was acquired; the caller then sheds the attempt as
+// capacity-shaped (errRoutingScanSaturated) instead of piling another scan
+// onto saturated CPUs. A nil semaphore (a &Server{} built directly in tests)
+// admits immediately, preserving legacy behavior for bare fixtures.
+func (s *Server) acquireRoutingScanSlot(wait time.Duration, done <-chan struct{}) bool {
+	if s.routingScanSem == nil {
+		return true
+	}
+	select {
+	case s.routingScanSem <- struct{}{}:
+		return true
+	default:
+	}
+	if wait <= 0 {
+		return false
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case s.routingScanSem <- struct{}{}:
+		return true
+	case <-timer.C:
+		return false
+	case <-done:
+		return false
+	}
+}
+
+// releaseRoutingScanSlot returns a slot taken by acquireRoutingScanSlot.
+func (s *Server) releaseRoutingScanSlot() {
+	if s.routingScanSem == nil {
+		return
+	}
+	<-s.routingScanSem
 }
 
 // SetServabilityGate toggles the smart early-429 admission gate. See the

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1344,33 +1344,61 @@ func (s *Server) SetRoutingConcurrency(n int) {
 	s.routingScanSem = make(chan struct{}, n)
 }
 
+// scanSlotResult is the outcome of acquireRoutingScanSlot. Client
+// disconnection is distinguished from acquisition timeout so callers route a
+// vanished caller onto the existing client-gone terminal (cancelled outcome,
+// refund, no response body) and NEVER onto the routing_saturated 429 /
+// rejection-ledger path.
+type scanSlotResult int
+
+const (
+	scanSlotAcquired scanSlotResult = iota
+	scanSlotTimeout
+	scanSlotClientGone
+)
+
 // acquireRoutingScanSlot blocks until a provider-selection scan slot is free,
-// the wait budget elapses, or done fires (client gone). It returns false only
-// when no slot was acquired; the caller then sheds the attempt as
-// capacity-shaped (errRoutingScanSaturated) instead of piling another scan
-// onto saturated CPUs. A nil semaphore (a &Server{} built directly in tests)
-// admits immediately, preserving legacy behavior for bare fixtures.
-func (s *Server) acquireRoutingScanSlot(wait time.Duration, done <-chan struct{}) bool {
+// the wait budget elapses, or done fires (client gone). On scanSlotTimeout the
+// caller sheds the attempt as capacity-shaped (errRoutingScanSaturated)
+// instead of piling another scan onto saturated CPUs; on scanSlotClientGone it
+// takes its ordinary client-gone path. A nil semaphore (a &Server{} built
+// directly in tests) admits immediately, preserving legacy behavior for bare
+// fixtures; a nil done channel never fires.
+func (s *Server) acquireRoutingScanSlot(wait time.Duration, done <-chan struct{}) scanSlotResult {
 	if s.routingScanSem == nil {
-		return true
+		return scanSlotAcquired
 	}
 	select {
 	case s.routingScanSem <- struct{}{}:
-		return true
+		return scanSlotAcquired
 	default:
 	}
+	clientGone := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
 	if wait <= 0 {
-		return false
+		if clientGone() {
+			return scanSlotClientGone
+		}
+		return scanSlotTimeout
 	}
 	timer := time.NewTimer(wait)
 	defer timer.Stop()
 	select {
 	case s.routingScanSem <- struct{}{}:
-		return true
+		return scanSlotAcquired
 	case <-timer.C:
-		return false
+		if clientGone() {
+			return scanSlotClientGone
+		}
+		return scanSlotTimeout
 	case <-done:
-		return false
+		return scanSlotClientGone
 	}
 }
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -26,7 +26,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"os"
 	"os/signal"
@@ -43,6 +45,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/datadog"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 	"github.com/eigeninference/d-inference/coordinator/mdm"
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/payments/baserewards"
 	"github.com/eigeninference/d-inference/coordinator/profilesign"
@@ -591,6 +594,22 @@ func main() {
 	srv.SetMinDecodeTPS(minDecodeTPS)
 	logger.Info("per-request decode floor (quality bar)", "min_decode_tps", minDecodeTPS)
 
+	// Routing-scan concurrency limit (2026-09-01 congestion collapse: a fresh
+	// full fleet scan per dispatch attempt × retry-amplified inbound saturated
+	// every coordinator CPU). Default runtime.NumCPU() (min 2); override via
+	// EIGENINFERENCE_ROUTING_CONCURRENCY. Requests that cannot get a scan slot
+	// within their remaining first-content budget shed as capacity-shaped 429s.
+	routingConcurrency := api.DefaultRoutingConcurrency()
+	if v := os.Getenv("EIGENINFERENCE_ROUTING_CONCURRENCY"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 2 {
+			routingConcurrency = n
+			srv.SetRoutingConcurrency(n)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_ROUTING_CONCURRENCY (need an integer >= 2); using default", "value", v, "default", routingConcurrency)
+		}
+	}
+	logger.Info("routing-scan concurrency limit", "max_concurrent_scans", routingConcurrency)
+
 	// Smart early-429 admission gate. ON by default: a request whose
 	// (prompt+max_tokens) cannot fit the model context window or any provider's
 	// structural token budget is rejected with an uptime-neutral 429 at preflight
@@ -654,6 +673,33 @@ func main() {
 		logger.Info("runtime manifest configured from env",
 			"template_hashes", len(manifest.TemplateHashes),
 		)
+	}
+
+	// Exact-model first-content deadline base overrides
+	// ("<model>=<upstream_ms>,...", 0/"off" removes an entry so the model
+	// falls back to the global base). The built-in table (Qwen3-VL 5s/4s) can
+	// only tighten the global base — during the 2026-09-01 incident that
+	// hardcoding killed ~47% of vision traffic with no operator recourse.
+	if v := os.Getenv("EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES"); v != "" {
+		if replaced, removed := modelpolicy.SetFirstContentBasesFromEnv(v); replaced+removed > 0 {
+			logger.Info("exact-model first-content deadline bases overridden via EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES",
+				"replaced", replaced, "removed", removed, "value", v)
+		} else {
+			logger.Warn("invalid EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES; using built-in table", "value", v)
+		}
+	}
+
+	// Optional pprof listener on a DEDICATED private mux/port — never the
+	// public mux. The 2026-09-01 collapse was diagnosed blind because the
+	// binary shipped without pprof (GET /debug/pprof/ = 404). Unset = nothing
+	// listens.
+	if addr := os.Getenv("EIGENINFERENCE_PPROF_ADDR"); addr != "" {
+		if ln, err := startPprofListener(addr); err != nil {
+			logger.Error("pprof listener failed to start", "addr", addr, "error", err)
+		} else {
+			logger.Warn("pprof debug listener ENABLED via EIGENINFERENCE_PPROF_ADDR — profiling data is sensitive; keep this address private (bind loopback / firewall it)",
+				"addr", ln.Addr().String())
+		}
 	}
 
 	billingCfg := cfg.BillingConfig
@@ -1047,4 +1093,34 @@ func loadAPNsAttestor(logger *slog.Logger) *apns.APNsPushAttestor {
 		return nil
 	}
 	return attestor
+}
+
+// startPprofListener starts net/http/pprof on a DEDICATED mux bound to addr
+// (EIGENINFERENCE_PPROF_ADDR, e.g. "127.0.0.1:6060") and serves it on its own
+// listener — the public mux never gains /debug/pprof/ routes. An empty addr
+// never reaches here (the caller gates on the env var), so nothing listens by
+// default. The 2026-09-01 congestion collapse had to be diagnosed without any
+// profiler (GET /debug/pprof/ = 404 on the running binary); this closes that
+// gap without exposing profiles publicly.
+func startPprofListener(addr string) (net.Listener, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		// The listener lives for the whole process; Serve only returns on a
+		// listener error, which is not worth crashing the coordinator over.
+		_ = server.Serve(ln)
+	}()
+	return ln, nil
 }

--- a/coordinator/cmd/coordinator/main_test.go
+++ b/coordinator/cmd/coordinator/main_test.go
@@ -1,8 +1,18 @@
 package main
 
 import (
+	"io"
+	"log/slog"
 	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/api"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 // TestParseAPNsEnforceAfter verifies the security-relevant contract: unset is the
@@ -89,5 +99,51 @@ func TestValidateTTFTDeadlineBaseMs(t *testing.T) {
 	// Sanity: the bounds constants are coherent.
 	if minTTFTDeadlineBaseMs >= maxTTFTDeadlineBaseMs || math.IsNaN(maxTTFTOccupancyAlpha) {
 		t.Fatal("TTFT bound constants are incoherent")
+	}
+}
+
+// TestPprofListener pins the EIGENINFERENCE_PPROF_ADDR contract from the
+// 2026-09-01 incident review (the running binary had NO pprof, which made the
+// CPU-collapse diagnosis slow): by default nothing serves /debug/pprof/ — in
+// particular the PUBLIC coordinator mux must not — and when the env-gated
+// dedicated listener is started it serves the pprof index on its own port.
+func TestPprofListener(t *testing.T) {
+	// Default off: the public coordinator mux exposes no pprof routes.
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := api.NewServer(registry.New(logger), store.NewMemory(store.Config{}), api.ServerConfig{}, logger)
+	public := httptest.NewServer(srv.Handler())
+	defer public.Close()
+	resp, err := http.Get(public.URL + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("public mux request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("public mux /debug/pprof/ = %d, want 404 (pprof must never mount on the public mux)", resp.StatusCode)
+	}
+
+	// Env set: the dedicated listener serves the pprof index.
+	ln, err := startPprofListener("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("startPprofListener: %v", err)
+	}
+	defer ln.Close()
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err = client.Get("http://" + ln.Addr().String() + "/debug/pprof/")
+	if err != nil {
+		t.Fatalf("pprof listener request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pprof listener /debug/pprof/ = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "goroutine") {
+		t.Errorf("pprof index missing profile listing; body=%.200s", string(body))
+	}
+
+	// A malformed address surfaces the listen error instead of half-starting.
+	if _, err := startPprofListener("not-an-address"); err == nil {
+		t.Error("startPprofListener(not-an-address) = nil error, want listen failure")
 	}
 }

--- a/coordinator/modelpolicy/first_content_deadline.go
+++ b/coordinator/modelpolicy/first_content_deadline.go
@@ -1,6 +1,11 @@
 package modelpolicy
 
-import "time"
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
 
 const (
 	// Qwen3VL30BA3BInstructModelID is the concrete catalog identifier used by
@@ -32,19 +37,97 @@ type firstContentDeadlineBases struct {
 	coordinator time.Duration
 }
 
-// exactFirstContentDeadlineBases keeps every per-model upstream/live pair in
-// one exact-match table. Add future model-specific policies here so shadow
-// evaluation and live dispatch cannot select different model sets.
-func exactFirstContentDeadlineBases(model string) (firstContentDeadlineBases, bool) {
-	switch model {
-	case Qwen3VL30BA3BInstructModelID:
-		return firstContentDeadlineBases{
+var (
+	basesMu sync.RWMutex
+	// exactBases keeps every per-model upstream/live pair in one exact-match
+	// table. It defaults to the built-in policy
+	// (defaultExactFirstContentDeadlineBases) and may be REPLACED once at
+	// startup via SetFirstContentBasesFromEnv
+	// (EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES) — the operator escape hatch
+	// the 2026-09-01 incident lacked: the hardcoded Qwen3-VL 5s/4s pair can
+	// only TIGHTEN the global base, so when vision success p90 sat at 3.4s
+	// (right at the 4s line, ~47% of vision traffic killed) nothing short of
+	// a rebuild could loosen it.
+	exactBases = defaultExactFirstContentDeadlineBases()
+)
+
+// defaultExactFirstContentDeadlineBases is the built-in exact-model policy.
+// Add future model-specific policies here so shadow evaluation and live
+// dispatch cannot select different model sets.
+func defaultExactFirstContentDeadlineBases() map[string]firstContentDeadlineBases {
+	return map[string]firstContentDeadlineBases{
+		Qwen3VL30BA3BInstructModelID: {
 			upstream:    Qwen3VL30BA3BInstructUpstreamFirstContentBase,
 			coordinator: Qwen3VL30BA3BInstructCoordinatorFirstContentBase,
-		}, true
-	default:
-		return firstContentDeadlineBases{}, false
+		},
 	}
+}
+
+func exactFirstContentDeadlineBases(model string) (firstContentDeadlineBases, bool) {
+	basesMu.RLock()
+	bases, ok := exactBases[model]
+	basesMu.RUnlock()
+	return bases, ok
+}
+
+// SetFirstContentBasesFromEnv parses an override of the form
+// "<model>=<upstream_ms>,..." (e.g. "qwen3-vl-30b-a3b-instruct=8000") and
+// REPLACES the exact-model table when at least one valid pair is present.
+// Each valid pair replaces that model's upstream base; the coordinator base
+// keeps the standard response margin (upstream − FirstContentResponseHeadroom).
+// A value of 0 or "off" REMOVES the exact entry so the model falls back to the
+// global base. Invalid pairs (malformed, non-numeric, or an upstream base not
+// strictly above the headroom) are skipped; a blank string is a no-op. The
+// exact-model policy remains a tightening ceiling relative to the global base
+// (UpstreamFirstContentDeadline/CoordinatorFirstContentDeadline), so an
+// override above the global base is inert rather than loosening it. Returns
+// the number of pairs replaced and removed. Called once at startup from
+// main.go, mirroring api.SetPromptContextCalibrationFromEnv.
+func SetFirstContentBasesFromEnv(raw string) (replaced, removed int) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, 0
+	}
+	next := defaultExactFirstContentDeadlineBases()
+	for _, pair := range strings.Split(raw, ",") {
+		kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		model := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+		if model == "" {
+			continue
+		}
+		if strings.EqualFold(value, "off") || value == "0" {
+			if _, ok := next[model]; ok {
+				delete(next, model)
+				removed++
+			}
+			continue
+		}
+		ms, err := strconv.Atoi(value)
+		if err != nil || ms <= 0 {
+			continue
+		}
+		upstream := time.Duration(ms) * time.Millisecond
+		if upstream <= FirstContentResponseHeadroom {
+			// The coordinator base (upstream − headroom) must stay positive.
+			continue
+		}
+		next[model] = firstContentDeadlineBases{
+			upstream:    upstream,
+			coordinator: upstream - FirstContentResponseHeadroom,
+		}
+		replaced++
+	}
+	if replaced == 0 && removed == 0 {
+		return 0, 0
+	}
+	basesMu.Lock()
+	exactBases = next
+	basesMu.Unlock()
+	return replaced, removed
 }
 
 // UpstreamFirstContentDeadline returns the caller-facing first-content SLA for

--- a/coordinator/modelpolicy/first_content_deadline.go
+++ b/coordinator/modelpolicy/first_content_deadline.go
@@ -30,6 +30,12 @@ const (
 	// response margin used by the ordinary production posture (10s upstream,
 	// 9s coordinator) inside Qwen3-VL's 5s upstream SLA.
 	Qwen3VL30BA3BInstructCoordinatorFirstContentBase = Qwen3VL30BA3BInstructUpstreamFirstContentBase - FirstContentResponseHeadroom
+
+	// maxFirstContentBase is the sanity ceiling for an env-supplied exact-model
+	// upstream base (SetFirstContentBasesFromEnv): no first-content SLA is
+	// minutes long, and rejecting anything above it also rules out
+	// time.Duration overflow (the overflow point is ~2.9e11 minutes of ms).
+	maxFirstContentBase = 10 * time.Minute
 )
 
 type firstContentDeadlineBases struct {
@@ -76,8 +82,11 @@ func exactFirstContentDeadlineBases(model string) (firstContentDeadlineBases, bo
 // Each valid pair replaces that model's upstream base; the coordinator base
 // keeps the standard response margin (upstream − FirstContentResponseHeadroom).
 // A value of 0 or "off" REMOVES the exact entry so the model falls back to the
-// global base. Invalid pairs (malformed, non-numeric, or an upstream base not
-// strictly above the headroom) are skipped; a blank string is a no-op. The
+// global base. Invalid pairs (malformed, non-numeric, an upstream base not
+// strictly above the headroom, or above the 10-minute sanity ceiling —
+// maxFirstContentBase, which also rules out time.Duration overflow long
+// before math.MaxInt64/int64(time.Millisecond)) are skipped; a blank string
+// is a no-op. The
 // exact-model policy remains a tightening ceiling relative to the global base
 // (UpstreamFirstContentDeadline/CoordinatorFirstContentDeadline), so an
 // override above the global base is inert rather than loosening it. Returns
@@ -106,8 +115,11 @@ func SetFirstContentBasesFromEnv(raw string) (replaced, removed int) {
 			}
 			continue
 		}
-		ms, err := strconv.Atoi(value)
-		if err != nil || ms <= 0 {
+		ms, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || ms <= 0 || ms > int64(maxFirstContentBase/time.Millisecond) {
+			// Non-numeric, non-positive, or absurd (> 10 minutes — no
+			// first-content SLA is minutes long, and the cap sits far below
+			// the ms count that would overflow time.Duration).
 			continue
 		}
 		upstream := time.Duration(ms) * time.Millisecond

--- a/coordinator/modelpolicy/first_content_deadline_test.go
+++ b/coordinator/modelpolicy/first_content_deadline_test.go
@@ -93,3 +93,94 @@ func TestModelOverridesNeverLoosenTighterGlobalDeadline(t *testing.T) {
 		t.Fatalf("coordinator deadline = %v, want tighter global %v", got, want)
 	}
 }
+
+// TestSetFirstContentBasesFromEnv pins the operator escape hatch the
+// 2026-09-01 incident lacked: the hardcoded Qwen3-VL 5s/4s pair killed ~47%
+// of vision traffic (success p90 3.4s, right at the 4s line) with no way to
+// loosen it short of a rebuild. EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES
+// replaces an exact-model upstream base (coordinator keeps the upstream−1s
+// headroom), 0/"off" removes the entry, unset preserves today's table
+// exactly, and invalid pairs are skipped.
+func TestSetFirstContentBasesFromEnv(t *testing.T) {
+	// Snapshot + restore the package table so this test cannot leak.
+	basesMu.Lock()
+	saved := exactBases
+	basesMu.Unlock()
+	t.Cleanup(func() {
+		basesMu.Lock()
+		exactBases = saved
+		basesMu.Unlock()
+	})
+	basesMu.Lock()
+	exactBases = defaultExactFirstContentDeadlineBases()
+	basesMu.Unlock()
+
+	prodCoordinatorBase := StandardUpstreamFirstContentBase - FirstContentResponseHeadroom // 9s
+
+	// Blank (env unset) is a no-op: today's constants apply exactly.
+	if r, rm := SetFirstContentBasesFromEnv(""); r != 0 || rm != 0 {
+		t.Fatalf("blank = (%d,%d), want (0,0)", r, rm)
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != 5*time.Second {
+		t.Fatalf("default upstream = %v, want the built-in 5s", got)
+	}
+	if got := CoordinatorFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, prodCoordinatorBase); got != 4*time.Second {
+		t.Fatalf("default coordinator = %v, want the built-in 4s", got)
+	}
+
+	// Loosen Qwen3-VL to an 8000ms upstream base → 7s coordinator base
+	// (upstream − 1s headroom preserved).
+	if r, rm := SetFirstContentBasesFromEnv(Qwen3VL30BA3BInstructModelID + "=8000"); r != 1 || rm != 0 {
+		t.Fatalf("loosen = (%d,%d), want (1,0)", r, rm)
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != 8*time.Second {
+		t.Fatalf("overridden upstream = %v, want 8s", got)
+	}
+	if got := CoordinatorFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, prodCoordinatorBase); got != 7*time.Second {
+		t.Fatalf("overridden coordinator = %v, want 7s (8s − 1s headroom)", got)
+	}
+	// Exact-model policy remains a tightening ceiling: a tighter emergency
+	// GLOBAL base still wins over the loosened exact entry.
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, 3*time.Second); got != 3*time.Second {
+		t.Fatalf("tighter global vs override = %v, want 3s", got)
+	}
+
+	// "off" removes the exact entry: the model falls back to the global base.
+	if r, rm := SetFirstContentBasesFromEnv(Qwen3VL30BA3BInstructModelID + "=off"); r != 0 || rm != 1 {
+		t.Fatalf("off = (%d,%d), want (0,1)", r, rm)
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != StandardUpstreamFirstContentBase {
+		t.Fatalf("upstream after off = %v, want the global %v", got, StandardUpstreamFirstContentBase)
+	}
+	if got := CoordinatorFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, prodCoordinatorBase); got != prodCoordinatorBase {
+		t.Fatalf("coordinator after off = %v, want the global %v", got, prodCoordinatorBase)
+	}
+
+	// All-invalid input applies nothing and keeps the CURRENT table (the
+	// removed entry must not be resurrected): malformed pair, non-numeric,
+	// empty model, an upstream base at/below the 1s headroom, and a negative.
+	if r, rm := SetFirstContentBasesFromEnv("garbage,foo=abc,=5000," +
+		Qwen3VL30BA3BInstructModelID + "=500,neg=-7000"); r != 0 || rm != 0 {
+		t.Fatalf("all-invalid = (%d,%d), want (0,0)", r, rm)
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != StandardUpstreamFirstContentBase {
+		t.Fatalf("upstream after invalid = %v, want the global (invalid input must not resurrect the entry)", got)
+	}
+
+	// "0" removes like "off"; the valid pair in a mixed string still applies
+	// while its invalid siblings are ignored.
+	if r, rm := SetFirstContentBasesFromEnv(Qwen3VL30BA3BInstructModelID + "=0"); r != 0 || rm != 1 {
+		t.Fatalf("zero = (%d,%d), want (0,1)", r, rm)
+	}
+	if r, rm := SetFirstContentBasesFromEnv("garbage," + Qwen3VL30BA3BInstructModelID + "=6000,foo=abc"); r != 1 || rm != 0 {
+		t.Fatalf("mixed = (%d,%d), want (1,0)", r, rm)
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != 6*time.Second {
+		t.Fatalf("mixed-apply upstream = %v, want 6s", got)
+	}
+
+	// Removing a model that has no exact entry is a recognized no-op.
+	if r, rm := SetFirstContentBasesFromEnv("never-had-an-entry=off"); r != 0 || rm != 0 {
+		t.Fatalf("remove-absent = (%d,%d), want (0,0)", r, rm)
+	}
+}

--- a/coordinator/modelpolicy/first_content_deadline_test.go
+++ b/coordinator/modelpolicy/first_content_deadline_test.go
@@ -183,4 +183,21 @@ func TestSetFirstContentBasesFromEnv(t *testing.T) {
 	if r, rm := SetFirstContentBasesFromEnv("never-had-an-entry=off"); r != 0 || rm != 0 {
 		t.Fatalf("remove-absent = (%d,%d), want (0,0)", r, rm)
 	}
+
+	// Overflow / absurd values are rejected: above the 10-minute sanity
+	// ceiling (also far below any time.Duration overflow), a value that
+	// cannot even parse as int64, and math.MaxInt64 ms (which WOULD overflow
+	// time.Duration if multiplied through). None may change the table.
+	for _, raw := range []string{
+		Qwen3VL30BA3BInstructModelID + "=700000",               // 11.7 min > 10 min ceiling
+		Qwen3VL30BA3BInstructModelID + "=99999999999999999999", // > int64
+		Qwen3VL30BA3BInstructModelID + "=9223372036854775807",  // MaxInt64 ms
+	} {
+		if r, rm := SetFirstContentBasesFromEnv(raw); r != 0 || rm != 0 {
+			t.Fatalf("overflow %q = (%d,%d), want (0,0)", raw, r, rm)
+		}
+	}
+	if got := UpstreamFirstContentDeadline(Qwen3VL30BA3BInstructModelID, 0, StandardUpstreamFirstContentBase); got != 6*time.Second {
+		t.Fatalf("upstream after overflow attempts = %v, want the prior 6s override untouched", got)
+	}
 }


### PR DESCRIPTION
## Summary

Permanent fix for the 2026-09-01 03:05Z coordinator congestion collapse: retry-amplified inbound (~100 req/s of retryable-429 traffic) saturated every coordinator CPU with per-request fleet-scan work, forming a self-sustaining death loop — attempt-0 route p50 went 40ms → 4.6s fleet-wide (every model simultaneously), success ~40%, terminal 429s delivered after 11–12.6s (measured), CPU 472–784%, ~6k req/min inbound vs ~550/min served, token throughput 7M → 2M/min.

Root cause: **the failure path cost ~100× the success path.** A request whose providers time out re-scans all ~1,260 providers up to `maxDispatchAttempts=64` times before returning a retryable 429; the old global routing lock (removed by #793, correctly) had been accidentally throttling that burn to one core. Real congestion (post-swap attestation ramp + the #787 qwen3-vl 4s deadline killing ~47% of vision traffic) raised the failure rate; upstream retries amplified inbound; scan work saturated all cores; routing latency then burned everyone's first-content budget, manufacturing more failures. Restarts cleared it for ~15 minutes until the upstream re-ramp re-crossed the CPU cliff.

## Changes (five bounded pieces)

1. **Timeout-class ladder cap** — `maxFirstChunkTimeoutRetries=3`: after three first-chunk-timeout attempts across distinct providers, the ladder exhausts into the existing synthetic-504→429 reclassification instead of walking toward 64 full fleet scans. (Deterministic-failure and transient-capacity classes already had caps; slow-provider timeouts did not.)
2. **Routing-scan concurrency limit** — `Server.routingScanSem` (default `NumCPU`, min 2, `EIGENINFERENCE_ROUTING_CONCURRENCY`) acquired around the reservation scan. Restores the throttle the old lock provided without re-serializing to one. A request that cannot acquire within its remaining first-content budget sheds once as a capacity-shaped 429 (`routing_saturated`) with zero scans.
3. **Honest Retry-After under distress** — attempt-0 route-time EWMA; when it exceeds 1s, `estimateRetryAfter` returns `max(base, ceil(EWMA_s)×5)` capped at 60s instead of the queue-depth-based 2s that invited 2-second retry storms mid-collapse. Healthy behavior unchanged.
4. **Model-deadline env override** — `EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES="qwen3-vl-30b-a3b-instruct=8000"` can loosen or (`=off`) remove the hardcoded exact-model first-content bases (previously tighten-only, requiring a code deploy to relax). Unset preserves today's table exactly.
5. **pprof behind env** — `EIGENINFERENCE_PPROF_ADDR=127.0.0.1:6060` starts a dedicated localhost pprof listener (absent by default). Tonight's diagnosis had no profiler.

## Before / After

```mermaid
flowchart LR
  subgraph Before["Before (collapse attractor)"]
    A1[100 req/s inbound<br/>incl. upstream retries] --> B1["per request:<br/>up to 64 × full fleet scan<br/>(1,260 providers, all cores)"]
    B1 --> C1["CPU saturated →<br/>attempt-0 route 40ms→4.6s"]
    C1 --> D1["first-content budgets burn<br/>in routing → timeouts on every model"]
    D1 --> E1["11s 429 + Retry-After: 2s"]
    E1 --> A1
  end
  subgraph After["After (bounded failure cost)"]
    A2[inbound] --> S2{"scan semaphore<br/>(≈NumCPU)"}
    S2 -- saturated --> F2["instant 429<br/>routing_saturated, honest Retry-After"]
    S2 --> B2["scan + dispatch"]
    B2 -- "3× first-chunk timeout" --> G2["exhaust early → 429<br/>Retry-After scales with route EWMA"]
    B2 -- success --> H2[serve]
  end
```

## Verification

- `go build ./...` green; gofmt clean.
- Focused regression tests (second commit): ladder stops at 3 timeout attempts; semaphore bounds concurrency without deadlock and sheds capacity-shaped on acquisition timeout; Retry-After ≥5× under degraded EWMA, legacy when healthy; env override loosens/removes/preserves deadline entries; pprof off by default, serves when set.
- Final `go test ./api ./registry ./modelpolicy -count=1` output attached in comments when the tests commit lands.

## Rollout

Deploy with the standard swap (trust ramp is now cheap: persisted code-attest proofs resume push-free). No env changes required for defaults; after deploy, `EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES=qwen3-vl-30b-a3b-instruct=8000` allows un-hiding qwen3-vl on OpenRouter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790828138&installation_model_id=21733&pr_number=799&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F799&signature=e922d37f4b34cf34ab0dcdc9987d44f339d4f54bbd03530fdfc30569144586aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->