### PR TITLE
Fix CPU usage so the provider dashboard no longer reports 100%

### DIFF
--- a/provider-swift/Sources/ProviderCore/Hardware/SystemMetrics.swift
+++ b/provider-swift/Sources/ProviderCore/Hardware/SystemMetrics.swift
@@ -3,10 +3,10 @@ import Darwin
 
 public enum SystemMetricsCollector: Sendable {
 
-    public static func collect(cpuCores: UInt32) -> SystemMetrics {
+    public static func collect(cpuCores _: UInt32) -> SystemMetrics {
         SystemMetrics(
             memoryPressure: collectMemoryPressure() ?? 0.0,
-            cpuUsage: collectCPUUsage(cpuCores: cpuCores) ?? 0.0,
+            cpuUsage: collectCPUUsage() ?? 0.0,
             thermalState: mapThermalState(ProcessInfo.processInfo.thermalState)
         )
     }
@@ -62,11 +62,75 @@ private func collectMemoryPressure() -> Double? {
 
 // MARK: - CPU Usage
 
-// 1-minute load average normalized by core count.
-private func collectCPUUsage(cpuCores: UInt32) -> Double? {
-    var loadavg = [Double](repeating: 0.0, count: 3)
-    guard getloadavg(&loadavg, 3) != -1 else { return nil }
+/// Cumulative `HOST_CPU_LOAD_INFO` ticks. `cpu_ticks` is indexed by
+/// `CPU_STATE_USER/SYSTEM/IDLE/NICE` (0...3).
+struct CPUTickSample: Equatable, Sendable {
+    var user: UInt32
+    var system: UInt32
+    var idle: UInt32
+    var nice: UInt32
 
-    let cores = cpuCores > 0 ? Double(cpuCores) : 1.0
-    return min(max(loadavg[0] / cores, 0.0), 1.0)
+    static func readHost() -> CPUTickSample? {
+        var info = host_cpu_load_info()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<host_cpu_load_info>.size / MemoryLayout<integer_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                host_statistics(
+                    mach_host_self(),
+                    HOST_CPU_LOAD_INFO,
+                    intPtr,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return CPUTickSample(
+            user: info.cpu_ticks.0,
+            system: info.cpu_ticks.1,
+            idle: info.cpu_ticks.2,
+            nice: info.cpu_ticks.3
+        )
+    }
+
+    /// Busy fraction in [0, 1] from a pair of cumulative tick samples.
+    ///
+    /// Load average / core count is **not** CPU utilization: macOS load
+    /// counts runnable + uninterruptible threads, which Metal/MLX work
+    /// inflates far past core count. That saturates the old 0...1 clamp at
+    /// 100% even when `top` shows the CPU mostly idle.
+    static func busyFraction(from previous: CPUTickSample, to current: CPUTickSample) -> Double {
+        let user = UInt64(current.user &- previous.user)
+        let system = UInt64(current.system &- previous.system)
+        let idle = UInt64(current.idle &- previous.idle)
+        let nice = UInt64(current.nice &- previous.nice)
+        let total = user + system + idle + nice
+        guard total > 0 else { return 0.0 }
+        let busy = user + system + nice
+        return min(max(Double(busy) / Double(total), 0.0), 1.0)
+    }
+}
+
+/// Heartbeats are 5s apart, so a previous sample is almost always available.
+/// The first reading after process start returns nil (reported as 0.0).
+private final class CPUTickSampler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var previous: CPUTickSample?
+
+    func nextUsage() -> Double? {
+        guard let current = CPUTickSample.readHost() else { return nil }
+        lock.lock()
+        let previous = self.previous
+        self.previous = current
+        lock.unlock()
+        guard let previous else { return nil }
+        return CPUTickSample.busyFraction(from: previous, to: current)
+    }
+}
+
+private let cpuTickSampler = CPUTickSampler()
+
+private func collectCPUUsage() -> Double? {
+    cpuTickSampler.nextUsage()
 }

--- a/provider-swift/Tests/ProviderCoreTests/SystemMetricsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SystemMetricsTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import ProviderCore
+
+@Suite("system CPU metrics")
+struct SystemMetricsTests {
+
+    @Test("tick delta reports idle, mixed, and fully busy fractions")
+    func busyFractionFromTicks() {
+        let origin = CPUTickSample(user: 10, system: 5, idle: 20, nice: 1)
+
+        #expect(
+            CPUTickSample.busyFraction(
+                from: origin,
+                to: CPUTickSample(user: 10, system: 5, idle: 120, nice: 1)
+            ) == 0.0
+        )
+
+        #expect(
+            CPUTickSample.busyFraction(
+                from: origin,
+                to: CPUTickSample(user: 110, system: 5, idle: 20, nice: 1)
+            ) == 1.0
+        )
+
+        let mixed = CPUTickSample.busyFraction(
+            from: origin,
+            to: CPUTickSample(user: 60, system: 25, idle: 70, nice: 1)
+        )
+        #expect(abs(mixed - 0.5) < 0.0001)
+    }
+
+    @Test("zero elapsed ticks is 0 rather than NaN")
+    func zeroElapsedTicks() {
+        let sample = CPUTickSample(user: 1, system: 2, idle: 3, nice: 4)
+        #expect(CPUTickSample.busyFraction(from: sample, to: sample) == 0.0)
+    }
+
+    @Test("UInt32 tick wrap uses wrapping subtract")
+    func wrappingTicks() {
+        let previous = CPUTickSample(user: UInt32.max - 5, system: 0, idle: 0, nice: 0)
+        let current = CPUTickSample(user: 4, system: 0, idle: 10, nice: 0)
+        // user delta = 10, idle delta = 10 → 50%
+        #expect(
+            abs(CPUTickSample.busyFraction(from: previous, to: current) - 0.5) < 0.0001
+        )
+    }
+
+    @Test("load-average / cores saturates to 100% on a thread-heavy Mac")
+    func loadAverageSaturatesUnlikeTickUtilization() {
+        // Observed on a serving M-series Mac: loadavg 30.58, 16 cores, while
+        // `top` reported ~42% busy / 58% idle. The old formula clamped to 1.0
+        // and the dashboard always showed 100% CPU.
+        let loadAverage = 30.58
+        let cores = 16.0
+        let loadUsage = min(max(loadAverage / cores, 0.0), 1.0)
+        #expect(loadUsage == 1.0)
+
+        let tickUsage = CPUTickSample.busyFraction(
+            from: CPUTickSample(user: 0, system: 0, idle: 0, nice: 0),
+            to: CPUTickSample(user: 2786, system: 1432, idle: 5780, nice: 0)
+        )
+        #expect(abs(tickUsage - 0.4218) < 0.001)
+        #expect(tickUsage < 1.0)
+    }
+
+    @Test("host tick samples produce a fraction in [0, 1]")
+    func liveHostSampleIsBounded() {
+        let first = CPUTickSample.readHost()
+        #expect(first != nil)
+        Thread.sleep(forTimeInterval: 0.15)
+        let second = CPUTickSample.readHost()
+        #expect(second != nil)
+        let usage = CPUTickSample.busyFraction(from: first!, to: second!)
+        #expect(usage >= 0.0 && usage <= 1.0)
+    }
+}


### PR DESCRIPTION
## Summary

The provider dashboard at `/providers` always showed **100% CPU** on serving Macs. The UI is fine — it renders `system_metrics.cpu_usage` as sent in heartbeats. The value itself was wrong.

`collectCPUUsage` used `getloadavg() / cpu_cores`, clamped to `[0, 1]`. macOS load average counts runnable **and** uninterruptible threads, not CPU busy time. Metal/MLX inference creates thousands of threads, so load routinely exceeds core count and the clamp saturates at 1.0.

On a live 16-core serving Mac while writing this:

| Source | Value |
| --- | --- |
| `top` | ~36% busy / 64% idle |
| `HOST_CPU_LOAD_INFO` tick delta | 30.4% busy |
| old formula (`loadavg 30.65 / 16`) | **100%** |

This also feeds warm-pool scoring (`- CPUUsage*100` in `warm_pool_controller.go`), so every serving machine took the maximum CPU penalty.

CPU usage is now `(user + system + nice) / (user + system + idle + nice)` from consecutive `HOST_CPU_LOAD_INFO` samples, matching `top`. The first heartbeat after process start reports 0 (no previous sample yet); later heartbeats (5s) have a real delta.

## Linked issue

No existing issue for the dashboard metric. Related but different: #365 (process actually spinning at 100%).

## Test plan

- [x] Unit tests in `SystemMetricsTests.swift`: idle / busy / 50% mixed, wraparound `UInt32` ticks, zero elapsed ticks, and a regression that the old load-average formula saturates to 1.0 on the observed 30.58/16 case while tick utilization stays ~42%.
- [x] Live Mach sample on a serving Mac: tick busy 30.4% vs load-average 100% vs `top` ~36% busy.
- [ ] `cd provider-swift && swift test --filter systemCPU` on CI (local tree is a sparse clone without `libs/mlx-swift`).

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

`cpu_usage` stays a 0...1 fraction in the heartbeat. Callers (`CardVitals`, telemetry, warm-pool score) do not need a change. The dashboard will show real CPU **after a provider release** that includes this fix.

## Notes for reviewers

- `collect(cpuCores:)` keeps its signature so call sites stay unchanged; core count is no longer used.
- First sample after start is 0.0 by design (need two tick snapshots). Heartbeats are 5s, so the dashboard is correct after the second beat.
- The signed production binary (`0.8.15`) still reports the old metric until this ships in a release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848319&installation_model_id=21733&pr_number=800&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F800&signature=3da91457dfea3bb815f605ce1f920958ddaddf9f4e6670defea02cfad674f952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->