### PR TITLE
feat(receipts): bind response attestation to model weights and request bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+- **Inference receipts** — Every completed inference seals a canonical
+  receipt binding the model (aggregate weight hash), the exact decrypted
+  request bytes (and therefore every sampling parameter), and the response
+  digest. `response_hash` becomes the receipt's SHA-256 hash; `se_signature`
+  keeps its existing contract (Secure Enclave signature over
+  `response_hash`); one new optional `receipt` field carries the record, so
+  older providers and consumers are unaffected. The coordinator checks the
+  receipt against the body it sealed, the provider's registered weight hash,
+  and the attested key, then serves receipt and verdict at public
+  `GET /v1/receipts/{hash}` (digests only, never prompt or response
+  content). A well formed, correctly signed receipt over a lie is refuted by
+  those cross checks (integration tested). Canonical encoding is byte
+  identical across Go (`coordinator/receipt`) and Swift
+  (`ProviderCore/Security/InferenceReceipt.swift`), pinned by independently
+  generated golden vectors (`fixtures/receipts/receipt_vectors.json`).
+  Spec: `docs/architecture/receipts.md`.
+
 ## Release candidate v0.8.15 (not shipped; 2026-08-28)
 
 - **Exact Qwen3.8 dense VLM artifact** — Providers serve

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/receipt"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/promptcontract"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
@@ -1046,6 +1047,9 @@ func (s *Server) dispatchOneProvider(
 		cleanupPending()
 		return nil, nil, decision, "failed to encrypt request", http.StatusInternalServerError
 	}
+	// Receipt binding: the digest of the exact plaintext bytes this
+	// provider will decrypt; its receipt's request_sha256 must match.
+	pr.DispatchedBodySHA256 = receipt.SHA256Hex(sealedBody)
 	if pr.Timing != nil {
 		pr.Timing.EncryptedAt = time.Now()
 	}
@@ -2225,12 +2229,15 @@ func (s *Server) handleStreamingResponseWithFirstChunkAndError(
 							pendingUsage["se_signature"] = pr.SESignature
 							pendingUsage["response_hash"] = pr.ResponseHash
 						}
+						if pr.Receipt != "" {
+							pendingUsage["receipt"] = pr.Receipt
+						}
 						attachChatCompletionMetadata(pendingUsage, pr)
 						if out := finalizeUsageChunk(pendingUsage, usage, pr); out != "" {
 							fmt.Fprintf(w, "%s\n\n", out)
 							flusher.Flush()
 						}
-					} else if pr.SESignature != "" || hasChatCompletionMetadata(pr) {
+					} else if pr.SESignature != "" || pr.Receipt != "" || hasChatCompletionMetadata(pr) {
 						// No held usage chunk to ride on: emit the signature and/or
 						// opt-in metadata as a fully-shaped chat.completion.chunk
 						// (id/object/created/model/choices) so strict decoders parse
@@ -2240,6 +2247,9 @@ func (s *Server) handleStreamingResponseWithFirstChunkAndError(
 						if pr.SESignature != "" {
 							event["se_signature"] = pr.SESignature
 							event["response_hash"] = pr.ResponseHash
+						}
+						if pr.Receipt != "" {
+							event["receipt"] = pr.Receipt
 						}
 						attachChatCompletionMetadata(event, pr)
 						sigEvent, _ := json.Marshal(event)
@@ -2560,6 +2570,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 									respObj := chatCompletionToResponses(
 										chatResp, consumerModel(pr), pr.SESignature,
 										pr.ResponseHash, pr.Traits)
+									respObj.Receipt = pr.Receipt
 									s.noteInferenceSuccess(pr)
 									writeJSON(w, http.StatusOK, respObj)
 									return
@@ -2576,6 +2587,9 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 							if pr.SESignature != "" {
 								obj["se_signature"] = pr.SESignature
 								obj["response_hash"] = pr.ResponseHash
+							}
+							if pr.Receipt != "" {
+								obj["receipt"] = pr.Receipt
 							}
 							if isChatCompletionsConsumer(pr) {
 								attachChatCompletionMetadata(obj, pr)
@@ -2604,15 +2618,18 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 					}
 					var resp any
 					if pr.IsResponsesAPI {
-						resp = buildResponsesResponse(
+						rr := buildResponsesResponse(
 							pr.RequestID, consumerModel(pr), msg, usage,
 							pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash,
 							pr.Traits)
+						rr.Receipt = pr.Receipt
+						resp = rr
 					} else if pr.ConsumerEndpoint == completionsEndpoint ||
 						pr.ConsumerEndpoint == messagesEndpoint {
 						resp = buildGenericEndpointResponse(pr, msg, usage)
 					} else {
 						chatResp := buildNonStreamingResponse(pr.RequestID, consumerModel(pr), msg, usage, pr.RequestedMaxTokens, pr.SESignature, pr.ResponseHash)
+						chatResp.Receipt = pr.Receipt
 						applyChatCompletionMetadataToResponse(&chatResp, pr)
 						resp = chatResp
 					}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/receipt"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 	"github.com/eigeninference/d-inference/coordinator/saferun"
@@ -1468,6 +1469,9 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		}
 		d.timing.EncryptedAt = time.Now()
 		d.pr.SessionPrivKey = &sessionKeys.PrivateKey
+		// Receipt binding: digest of the exact plaintext bytes this
+		// provider will decrypt (queued-path seal site).
+		d.pr.DispatchedBodySHA256 = receipt.SHA256Hex(sealedBody)
 		// pr.ReservedMicroUSD was already set in the struct literal and may
 		// have been increased by reserveAdditionalForProvider. Don't overwrite.
 		// Bound the provider write by the request-absolute first-token clock:

--- a/coordinator/api/generic_endpoint_response.go
+++ b/coordinator/api/generic_endpoint_response.go
@@ -122,6 +122,9 @@ func genericFinishReason(reason string, usage protocol.UsageInfo, maxTokens int)
 }
 
 func addResponseProof(response map[string]any, pr *registry.PendingRequest) {
+	if pr.Receipt != "" {
+		response["receipt"] = pr.Receipt
+	}
 	if pr.SESignature == "" {
 		return
 	}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1966,6 +1966,10 @@ func (s *Server) handleCompleteAt(
 	// Store SE signature for the consumer response headers.
 	pr.SESignature = msg.SESignature
 	pr.ResponseHash = msg.ResponseHash
+	pr.Receipt = msg.Receipt
+	if msg.Receipt != "" {
+		s.recordReceipt(providerID, pr, msg)
+	}
 	pr.MatchedStopSequence = allowedMatchedStopSequence(
 		pr.RequestedStopSequences, msg.StopSequence)
 	if msg.StopSequence != "" && pr.MatchedStopSequence == "" {

--- a/coordinator/api/receipt_integration_test.go
+++ b/coordinator/api/receipt_integration_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/receipt"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// Receipt end-to-end: a provider that seals a genuine receipt (signed with
+// the same P-256 key its attestation registered) must reach the consumer with
+// the receipt attached, and GET /v1/receipts/{address} must report every
+// binding check green. A provider that lies inside a well-formed, correctly
+// signed receipt must be flagged by the dispatched-request-digest and
+// weight-hash bindings — the forgery is internally consistent (that is the
+// attack) and the coordinator's cross-checks are what refute it.
+
+const receiptTestModel = "receipt-model"
+
+var receiptTestWeightHash = strings.Repeat("ab", 32)
+
+// runReceiptScenario spins up coordinator + one simulated provider,
+// sends one streaming chat completion, and returns the SSE body plus the
+// stored receipt record fetched from /v1/receipts/{address}.
+// mutateReceipt lets a scenario turn the honest receipt into a lie before
+// sealing; the receipt is always canonically encoded and correctly signed.
+func runReceiptScenario(
+	t *testing.T,
+	mutateReceipt func(*receipt.Receipt),
+) (sseBody string, stored map[string]any) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pubKeyB64 := testPublicKeyB64()
+	value, ok := testProviderKeys.Load(pubKeyB64)
+	if !ok {
+		t.Fatalf("missing cached provider keypair for %q", pubKeyB64)
+	}
+	keypair := value.(testProviderKeyPair)
+
+	models := []protocol.ModelInfo{{
+		ID: receiptTestModel, ModelType: "test", Quantization: "4bit",
+		WeightHash: receiptTestWeightHash,
+	}}
+	conn := connectProviderWithAttestation(
+		t, ctx, ts.URL, models, pubKeyB64,
+		createTestAttestationJSON(t, pubKeyB64))
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// The attestation helper registered the P-256 signer under the
+	// encryption key; the simulated provider signs receipts with it — the
+	// same key the coordinator holds as this provider's attested SE key.
+	rawKey, ok := testAttestationChallengeKeys.Load(pubKeyB64)
+	if !ok {
+		t.Fatal("no challenge signer registered")
+	}
+	sePriv := rawKey.(*ecdsa.PrivateKey)
+
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+
+	// Simulated provider loop: answer challenges; on the inference request,
+	// decrypt the body, seal a receipt over the DECRYPTED BYTES (or the
+	// scenario's mutation of the honest record), stream one chunk, complete.
+	go func() {
+		for {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			var env struct {
+				Type string `json:"type"`
+			}
+			json.Unmarshal(data, &env)
+
+			if env.Type == protocol.TypeAttestationChallenge {
+				conn.Write(ctx, websocket.MessageText,
+					makeValidChallengeResponse(data, pubKeyB64))
+				continue
+			}
+			if env.Type != protocol.TypeInferenceRequest {
+				continue
+			}
+
+			var inferReq protocol.InferenceRequestMessage
+			if err := json.Unmarshal(data, &inferReq); err != nil || inferReq.EncryptedBody == nil {
+				return
+			}
+			decrypted, err := e2e.DecryptWithPrivateKey(&e2e.EncryptedPayload{
+				EphemeralPublicKey: inferReq.EncryptedBody.EphemeralPublicKey,
+				Ciphertext:         inferReq.EncryptedBody.Ciphertext,
+			}, keypair.private)
+			if err != nil {
+				return
+			}
+
+			responseText := "ok"
+			writeEncryptedTestChunk(t, ctx, conn, protocol.InferenceRequestMessage{
+				RequestID:     inferReq.RequestID,
+				EncryptedBody: inferReq.EncryptedBody,
+			}, pubKeyB64,
+				`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"`+responseText+`"}}]}`+"\n\n")
+
+			rec := receipt.Receipt{
+				CompletionTokens: 1,
+				ModelID:          receiptTestModel,
+				ModelWeightHash:  receiptTestWeightHash,
+				PromptTokens:     5,
+				RequestID:        inferReq.RequestID,
+				RequestSHA256:    receipt.SHA256Hex(decrypted),
+				ResponseSHA256:   receipt.SHA256Hex([]byte(responseText)),
+				V:                receipt.Version,
+			}
+			if mutateReceipt != nil {
+				mutateReceipt(&rec)
+			}
+			wire := rec.Canonical()
+			addr := receipt.AddressOf(wire)
+			digest := sha256.Sum256([]byte(addr))
+			r, s, err := ecdsa.Sign(rand.Reader, sePriv, digest[:])
+			if err != nil {
+				return
+			}
+			sigDER, _ := asn1.Marshal(ecdsaSigHelper{R: r, S: s})
+
+			complete := protocol.InferenceCompleteMessage{
+				Type:         protocol.TypeInferenceComplete,
+				RequestID:    inferReq.RequestID,
+				Usage:        protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 1},
+				SESignature:  base64.StdEncoding.EncodeToString(sigDER),
+				ResponseHash: addr,
+				Receipt:      string(wire),
+			}
+			completeData, _ := json.Marshal(complete)
+			conn.Write(ctx, websocket.MessageText, completeData)
+			return
+		}
+	}()
+
+	chatBody := `{"model":"` + receiptTestModel + `","messages":[{"role":"user","content":"what is 2+2?"}],"stream":true}`
+	httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		ts.URL+"/v1/chat/completions", strings.NewReader(chatBody))
+	httpReq.Header.Set("Authorization", "Bearer test-key")
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("http request: %v", err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, bodyBytes)
+	}
+	sseBody = string(bodyBytes)
+
+	// Pull the receipt out of the stream to learn its address, then fetch
+	// the coordinator's stored verdict.
+	receiptJSON := extractSSEField(t, sseBody, "receipt")
+	address := receipt.AddressOf([]byte(receiptJSON))
+	recResp, err := http.Get(ts.URL + "/v1/receipts/" + address)
+	if err != nil {
+		t.Fatalf("get receipt: %v", err)
+	}
+	defer recResp.Body.Close()
+	if recResp.StatusCode != http.StatusOK {
+		t.Fatalf("receipt endpoint status = %d, want 200", recResp.StatusCode)
+	}
+	if err := json.NewDecoder(recResp.Body).Decode(&stored); err != nil {
+		t.Fatalf("decode stored receipt: %v", err)
+	}
+	return sseBody, stored
+}
+
+// extractSSEField scans SSE events for the named string field and returns its
+// value, failing the test when absent.
+func extractSSEField(t *testing.T, sse, field string) string {
+	t.Helper()
+	for _, line := range strings.Split(sse, "\n") {
+		line = strings.TrimPrefix(strings.TrimSpace(line), "data: ")
+		if line == "" || line == "[DONE]" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			continue
+		}
+		if v, ok := obj[field].(string); ok && v != "" {
+			return v
+		}
+	}
+	t.Fatalf("SSE stream carried no %q field:\n%s", field, sse)
+	return ""
+}
+
+func storedChecks(t *testing.T, stored map[string]any) map[string]any {
+	t.Helper()
+	checks, ok := stored["checks"].(map[string]any)
+	if !ok {
+		t.Fatalf("stored receipt has no checks object: %v", stored)
+	}
+	return checks
+}
+
+func TestIntegration_ReceiptGenuine(t *testing.T) {
+	sse, stored := runReceiptScenario(t, nil)
+
+	// The stream must carry receipt + address + signature together.
+	receiptJSON := extractSSEField(t, sse, "receipt")
+	responseHash := extractSSEField(t, sse, "response_hash")
+	_ = extractSSEField(t, sse, "se_signature")
+	if receipt.AddressOf([]byte(receiptJSON)) != responseHash {
+		t.Errorf("response_hash %q is not the receipt address", responseHash)
+	}
+
+	// The receipt must parse canonically and reproduce the request digest
+	// semantics: request_sha256 covers the decrypted body bytes.
+	rec, err := receipt.Parse([]byte(receiptJSON))
+	if err != nil {
+		t.Fatalf("consumer-side Parse: %v", err)
+	}
+	if rec.ModelID != receiptTestModel || rec.ModelWeightHash != receiptTestWeightHash {
+		t.Errorf("receipt model binding wrong: %+v", rec)
+	}
+
+	// Consumer-side signature verification using only public data from the
+	// receipts endpoint — the decentralized-verifier path.
+	sePub, _ := stored["se_public_key"].(string)
+	seSig, _ := stored["se_signature"].(string)
+	if sePub == "" || seSig == "" {
+		t.Fatalf("stored receipt missing public key or signature: %v", stored)
+	}
+	if err := receipt.VerifySignature(responseHash, seSig, sePub); err != nil {
+		t.Errorf("third-party signature verification failed: %v", err)
+	}
+
+	checks := storedChecks(t, stored)
+	for _, key := range []string{
+		"address_match",
+		"request_digest_match", "request_digest_checked",
+		"model_weight_hash_match", "model_weight_hash_checked",
+		"signature_valid", "signature_checked",
+	} {
+		if v, _ := checks[key].(bool); !v {
+			t.Errorf("check %s = %v, want true (checks: %v)", key, checks[key], checks)
+		}
+	}
+}
+
+func TestIntegration_ReceiptLyingProviderIsFlagged(t *testing.T) {
+	// The provider seals a WELL-FORMED, correctly signed receipt over a lie:
+	// a request digest for bytes it never ran and a weight hash for weights
+	// it never loaded. Internal consistency holds (address matches, signature
+	// verifies) — the coordinator's cross-checks against what it dispatched
+	// and what the provider registered are what refute the lie.
+	_, stored := runReceiptScenario(t, func(rec *receipt.Receipt) {
+		rec.RequestSHA256 = strings.Repeat("ee", 32)
+		rec.ModelWeightHash = strings.Repeat("cd", 32)
+	})
+
+	checks := storedChecks(t, stored)
+	if v, _ := checks["address_match"].(bool); !v {
+		t.Errorf("forged receipt should still be internally consistent (address_match)")
+	}
+	if v, _ := checks["signature_valid"].(bool); !v {
+		t.Errorf("forged receipt should still be correctly signed (that is the attack)")
+	}
+	if v, _ := checks["request_digest_match"].(bool); v {
+		t.Errorf("lying request digest passed the dispatched-body binding")
+	}
+	if v, _ := checks["request_digest_checked"].(bool); !v {
+		t.Errorf("request digest binding was not checked")
+	}
+	if v, _ := checks["model_weight_hash_match"].(bool); v {
+		t.Errorf("lying weight hash passed the registered-model binding")
+	}
+}

--- a/coordinator/api/receipts.go
+++ b/coordinator/api/receipts.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/receipt"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Inference receipts: coordinator-side verification and the public lookup.
+//
+// A v2 provider seals every completed inference into a canonical receipt
+// (coordinator/receipt) whose SHA-256 hash rides in `response_hash` and is
+// signed by the provider's Secure Enclave in `se_signature`. At completion the
+// coordinator checks every binding it can see — receipt address, dispatched
+// request digest, registered model weight hash, SE signature — and caches the
+// receipt with its verdict for `GET /v1/receipts/{address}`. Receipts carry
+// digests only, so the endpoint is public: anyone holding the plaintext
+// transcript (the consumer, or an auditor the consumer hands it to) can bind
+// the digests to content and replay the request against the same weights.
+
+// receiptCacheCap bounds the in-memory receipt cache. Receipts are
+// self-contained (the consumer receives the full receipt inline), so this
+// cache is a lookup convenience with bounded memory, not a durability layer.
+const receiptCacheCap = 8192
+
+type storedReceipt struct {
+	Address     string          `json:"address"`
+	Receipt     json.RawMessage `json:"receipt"`
+	SESignature string          `json:"se_signature,omitempty"`
+	SEPublicKey string          `json:"se_public_key,omitempty"`
+	Checks      receipt.Checks  `json:"checks"`
+	ParseError  string          `json:"parse_error,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+type receiptCache struct {
+	mu    sync.Mutex
+	byKa  map[string]*storedReceipt
+	order []string // FIFO eviction ring
+}
+
+func newReceiptCache() *receiptCache {
+	return &receiptCache{byKa: make(map[string]*storedReceipt)}
+}
+
+func (c *receiptCache) put(r *storedReceipt) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.byKa[r.Address]; !exists {
+		c.order = append(c.order, r.Address)
+		for len(c.order) > receiptCacheCap {
+			delete(c.byKa, c.order[0])
+			c.order = c.order[1:]
+		}
+	}
+	c.byKa[r.Address] = r
+}
+
+func (c *receiptCache) get(address string) (*storedReceipt, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.byKa[address]
+	return r, ok
+}
+
+// recordReceipt verifies and caches a provider's receipt at inference
+// completion. Verification failures never fail the request — the consumer
+// already has the response and the receipt travels to them regardless; a
+// failed binding is logged, counted, and visible on the receipt record so
+// auditors (and future routing policy) can act on it.
+func (s *Server) recordReceipt(
+	providerID string,
+	pr *registry.PendingRequest,
+	msg *protocol.InferenceCompleteMessage,
+) {
+	sePublicKey, weightHash := s.registry.ReceiptContext(providerID, pr.Model)
+	rec, checks, err := receipt.Verify(receipt.VerifyInput{
+		ReceiptJSON:       []byte(msg.Receipt),
+		ResponseHash:      msg.ResponseHash,
+		SESignatureB64:    msg.SESignature,
+		SEPublicKeyB64:    sePublicKey,
+		DispatchedSHA256:  pr.DispatchedBodySHA256,
+		CatalogWeightHash: weightHash,
+	})
+	stored := &storedReceipt{
+		Address:     receipt.AddressOf([]byte(msg.Receipt)),
+		Receipt:     json.RawMessage(msg.Receipt),
+		SESignature: msg.SESignature,
+		SEPublicKey: sePublicKey,
+		Checks:      checks,
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err != nil {
+		stored.ParseError = err.Error()
+		// A malformed receipt must not be served as JSON verbatim.
+		stored.Receipt = nil
+	}
+	s.receipts.put(stored)
+
+	switch {
+	case err != nil:
+		s.logger.Warn("receipt malformed",
+			"provider_id", providerID, "request_id", msg.RequestID, "error", err)
+		s.ddIncr("receipt.receipt_malformed", []string{"model:" + pr.Model})
+	case !checks.OK():
+		s.logger.Warn("receipt binding check failed",
+			"provider_id", providerID,
+			"request_id", msg.RequestID,
+			"model", pr.Model,
+			"address_match", checks.AddressMatch,
+			"request_digest_match", checks.RequestDigestMatch,
+			"request_digest_checked", checks.RequestDigestChecked,
+			"weight_hash_match", checks.ModelWeightHashMatch,
+			"weight_hash_checked", checks.ModelWeightHashChecked,
+			"signature_valid", checks.SignatureValid,
+			"signature_checked", checks.SignatureChecked,
+		)
+		s.ddIncr("receipt.receipt_check_failed", []string{"model:" + pr.Model})
+	default:
+		// Sanity binding the receipt can only get wrong by lying: its model
+		// and usage must agree with the completion message it rode in on.
+		if rec.ModelID != pr.Model || rec.CompletionTokens != int(msg.Usage.CompletionTokens) {
+			s.logger.Warn("receipt disagrees with completion message",
+				"provider_id", providerID, "request_id", msg.RequestID,
+				"receipt_model", rec.ModelID, "model", pr.Model)
+			s.ddIncr("receipt.receipt_check_failed", []string{"model:" + pr.Model})
+		} else {
+			s.ddIncr("receipt.receipt_verified", []string{"model:" + pr.Model})
+		}
+	}
+}
+
+// handleGetReceipt serves GET /v1/receipts/{address}. Public: the record
+// holds digests, a signature, and the provider's attestation public key —
+// no prompt or response content.
+func (s *Server) handleGetReceipt(w http.ResponseWriter, r *http.Request) {
+	address := strings.ToLower(strings.TrimSpace(r.PathValue("address")))
+	stored, ok := s.receipts.get(address)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse(
+			"invalid_request_error", "receipt not found"))
+		return
+	}
+	writeJSON(w, http.StatusOK, stored)
+}

--- a/coordinator/api/receipts_test.go
+++ b/coordinator/api/receipts_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestReceiptCacheBoundedFIFO(t *testing.T) {
+	c := newReceiptCache()
+	for i := 0; i < receiptCacheCap+10; i++ {
+		c.put(&storedReceipt{
+			Address:   fmt.Sprintf("addr-%d", i),
+			CreatedAt: time.Now(),
+		})
+	}
+	if len(c.byKa) != receiptCacheCap || len(c.order) != receiptCacheCap {
+		t.Fatalf("cache size = %d/%d, want %d", len(c.byKa), len(c.order), receiptCacheCap)
+	}
+	if _, ok := c.get("addr-0"); ok {
+		t.Error("oldest receipt should have been evicted")
+	}
+	if _, ok := c.get(fmt.Sprintf("addr-%d", receiptCacheCap+9)); !ok {
+		t.Error("newest receipt missing")
+	}
+
+	// Re-putting an existing address must not grow the ring.
+	before := len(c.order)
+	c.put(&storedReceipt{Address: fmt.Sprintf("addr-%d", receiptCacheCap+9)})
+	if len(c.order) != before {
+		t.Errorf("re-put grew the eviction ring: %d -> %d", before, len(c.order))
+	}
+}

--- a/coordinator/api/responses_stream.go
+++ b/coordinator/api/responses_stream.go
@@ -489,6 +489,9 @@ func (e *responsesStreamEmitter) finish(usage protocol.UsageInfo) {
 		snap["se_signature"] = e.pr.SESignature
 		snap["response_hash"] = e.pr.ResponseHash
 	}
+	if e.pr.Receipt != "" {
+		snap["receipt"] = e.pr.Receipt
+	}
 	e.emit(eventType, map[string]any{"response": snap})
 }
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -208,6 +208,7 @@ type Server struct {
 	codeResumeFallbackBeforeAPNs  func()              // test seam after nonce consume, before ctx recheck
 	codeAttestThrottle            *codeAttestThrottle // per-device APNs push budget + reuse cache (v0.6.0)
 	trustReuseCache               *trustReuseCache    // per-device trust-reuse cache: skip a fleet-wide live MDM herd on restart (DAR-326)
+	receipts                      *receiptCache       // inference receipts by hash for GET /v1/receipts/{address}
 
 	// Graceful-drain state (DAR-327 Phase 1, zero-downtime upgrades). Set
 	// coordinatorDraining=true before a restart/swap so the drain gate rejects
@@ -733,6 +734,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		apiKeyCache:              make(map[string]apiKeyCacheEntry),
 		codeAttestThrottle:       newCodeAttestThrottle(),
 		trustReuseCache:          newTrustReuseCache(),
+		receipts:                 newReceiptCache(),
 		settlements:              newSettlementHolder(),
 		zombieCanceller:          newZombieStreamCanceller(),
 		serviceReservations:      newServiceReservationManager(st, cfg.ServiceReservations),
@@ -1868,6 +1870,10 @@ func (s *Server) routes() {
 	// Attestation status — public, no auth needed. Raw device identity and MDA
 	// certificates remain coordinator-private because the leaf embeds serial/UDID.
 	s.mux.HandleFunc("GET /v1/providers/attestation", s.handleProviderAttestation)
+
+	// Receipt lookup — public, no auth needed: digests + signature only,
+	// never prompt/response content (see coordinator/receipt).
+	s.mux.HandleFunc("GET /v1/receipts/{address}", s.handleGetReceipt)
 
 	// Capacity snapshot — no auth needed. Upstream routers poll this.
 	s.mux.HandleFunc("GET /v1/models/capacity", s.handleModelsCapacity)

--- a/coordinator/api/types/types.go
+++ b/coordinator/api/types/types.go
@@ -72,7 +72,11 @@ type ChatCompletionResponse struct {
 	Usage        ChatCompletionUsage     `json:"usage"`
 	SESignature  string                  `json:"se_signature,omitempty"`
 	ResponseHash string                  `json:"response_hash,omitempty"`
-	Metadata     *ChatCompletionMetadata `json:"metadata,omitempty"`
+	// Receipt is the provider's canonical inference receipt JSON: when
+	// present, ResponseHash is its SHA-256 hash and SESignature signs that
+	// hash. Digests only (see coordinator/receipt).
+	Receipt  string                  `json:"receipt,omitempty"`
+	Metadata *ChatCompletionMetadata `json:"metadata,omitempty"`
 }
 
 // RequestTimingDetails is the X-Timing latency decomposition, in microseconds.
@@ -163,6 +167,9 @@ type ResponsesResponse struct {
 	Usage             ResponsesUsage             `json:"usage"`
 	SESignature       string                     `json:"se_signature,omitempty"`
 	ResponseHash      string                     `json:"response_hash,omitempty"`
+	// Receipt: canonical inference receipt JSON; ResponseHash is its hash
+	// (see coordinator/receipt).
+	Receipt string `json:"receipt,omitempty"`
 }
 
 // ── GET /v1/models ───────────────────────────────────────────────────

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -534,6 +534,14 @@ type InferenceCompleteMessage struct {
 	StopSequence string    `json:"stop_sequence,omitempty"` // Exact caller-authored stop string matched by the engine
 	SESignature  string    `json:"se_signature,omitempty"`  // SE-signed response hash
 	ResponseHash string    `json:"response_hash,omitempty"` // SHA-256 of response data
+	// Receipt is the canonical inference receipt JSON (receipt.Receipt) for
+	// this inference. When present, ResponseHash is the receipt hash
+	// (SHA-256 of the receipt bytes) and SESignature signs that address —
+	// the v1 signing contract unchanged, now over a record that binds the
+	// model weight hash, the exact request bytes (and therefore every
+	// sampling parameter), and the response digest. Digests only; never
+	// carries prompt or response plaintext. Absent on older providers.
+	Receipt string `json:"receipt,omitempty"`
 }
 
 // InferenceErrorMessage signals an error during inference.

--- a/coordinator/receipt/receipt.go
+++ b/coordinator/receipt/receipt.go
@@ -1,0 +1,290 @@
+// Package receipt implements inference receipts.
+//
+// A receipt is a canonical, content-addressed record of one inference:
+// which model (by aggregate weight hash) ran which request (by digest of the
+// exact decrypted request bytes, which bind every sampling parameter) and
+// produced which response (by digest of the full response text). Its receipt hash is the SHA-256 of its canonical
+// JSON bytes, and the provider's Secure Enclave signs that hash through the
+// existing response attestation channel (`se_signature` over
+// `response_hash`) unchanged: for a v2 provider, `response_hash` IS the
+// receipt hash of the `receipt` field.
+//
+// The receipt carries digests only — never prompt or response plaintext —
+// so it is publicly shareable without weakening the privacy model.
+package receipt
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Version is the receipt schema version this package produces and accepts.
+const Version = 2
+
+// Receipt is the canonical v2 inference receipt. Field names and their
+// alphabetical order define the canonical JSON form; the Swift provider
+// mirrors this exactly (InferenceReceipt.swift).
+type Receipt struct {
+	CompletionTokens int    `json:"completion_tokens"`
+	ModelID          string `json:"model_id"`
+	ModelWeightHash  string `json:"model_weight_hash"` // lowercase hex aggregate SHA-256; "" when unhashed
+	PromptTokens     int    `json:"prompt_tokens"`
+	RequestID        string `json:"request_id"`
+	RequestSHA256    string `json:"request_sha256"`  // SHA-256 of the exact decrypted request body bytes
+	ResponseSHA256   string `json:"response_sha256"` // SHA-256 of the full response text (UTF-8)
+	V                int    `json:"v"`
+}
+
+// Canonical returns the canonical JSON encoding of the receipt: single line,
+// keys in alphabetical order, minimal escaping, no HTML or slash escaping.
+// Both the receipt hash and the Secure Enclave signature cover these bytes'
+// SHA-256, so this encoding must stay byte-identical to the Swift encoder.
+func (r Receipt) Canonical() []byte {
+	var b strings.Builder
+	b.WriteByte('{')
+	writeIntField(&b, "completion_tokens", r.CompletionTokens, false)
+	writeStringField(&b, "model_id", r.ModelID)
+	writeStringField(&b, "model_weight_hash", r.ModelWeightHash)
+	writeIntField(&b, "prompt_tokens", r.PromptTokens, true)
+	writeStringField(&b, "request_id", r.RequestID)
+	writeStringField(&b, "request_sha256", r.RequestSHA256)
+	writeStringField(&b, "response_sha256", r.ResponseSHA256)
+	writeIntField(&b, "v", r.V, true)
+	b.WriteByte('}')
+	return []byte(b.String())
+}
+
+// Address returns the receipt hash: the lowercase hex SHA-256 of the canonical
+// bytes. For a v2 provider this is the value carried in `response_hash`.
+func (r Receipt) Address() string {
+	sum := sha256.Sum256(r.Canonical())
+	return hex.EncodeToString(sum[:])
+}
+
+// AddressOf returns the receipt hash of raw receipt bytes as received on the
+// wire, without re-encoding. Verifiers should prefer this over
+// Receipt.Address for wire bytes, exactly as attestation verification uses
+// the original signed bytes.
+func AddressOf(receiptJSON []byte) string {
+	sum := sha256.Sum256(receiptJSON)
+	return hex.EncodeToString(sum[:])
+}
+
+// Parse decodes receipt JSON strictly: unknown fields are rejected and the
+// bytes must already be in canonical form (re-encoding must reproduce the
+// input byte-for-byte). The canonical-form requirement makes the address
+// unambiguous — there is exactly one byte string for a given receipt.
+func Parse(receiptJSON []byte) (Receipt, error) {
+	var r Receipt
+	dec := json.NewDecoder(strings.NewReader(string(receiptJSON)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&r); err != nil {
+		return Receipt{}, fmt.Errorf("invalid receipt JSON: %w", err)
+	}
+	if dec.More() {
+		return Receipt{}, fmt.Errorf("trailing data after receipt")
+	}
+	if r.V != Version {
+		return Receipt{}, fmt.Errorf("unsupported receipt version %d", r.V)
+	}
+	if string(r.Canonical()) != string(receiptJSON) {
+		return Receipt{}, fmt.Errorf("receipt is not in canonical form")
+	}
+	if !validHex256(r.RequestSHA256) {
+		return Receipt{}, fmt.Errorf("request_sha256 is not lowercase hex-256")
+	}
+	if !validHex256(r.ResponseSHA256) {
+		return Receipt{}, fmt.Errorf("response_sha256 is not lowercase hex-256")
+	}
+	if r.ModelWeightHash != "" && !validHex256(r.ModelWeightHash) {
+		return Receipt{}, fmt.Errorf("model_weight_hash is not lowercase hex-256")
+	}
+	if r.RequestID == "" || r.ModelID == "" {
+		return Receipt{}, fmt.Errorf("request_id and model_id are required")
+	}
+	if r.CompletionTokens < 0 || r.PromptTokens < 0 {
+		return Receipt{}, fmt.Errorf("token counts must be non-negative")
+	}
+	return r, nil
+}
+
+// VerifySignature checks the provider's Secure Enclave signature over the
+// receipt hash. The signing contract matches the existing v1 response
+// attestation exactly: DER-encoded ECDSA P-256 over SHA-256 of the UTF-8
+// bytes of the lowercase hex address. publicKeyB64 is the provider's
+// attested SE public key (base64 raw uncompressed P-256 point).
+func VerifySignature(address, signatureB64, publicKeyB64 string) error {
+	pubBytes, err := base64.StdEncoding.DecodeString(publicKeyB64)
+	if err != nil {
+		return fmt.Errorf("invalid public key base64: %w", err)
+	}
+	pub, err := attestation.ParseP256PublicKey(pubBytes)
+	if err != nil {
+		return fmt.Errorf("invalid public key: %w", err)
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(signatureB64)
+	if err != nil {
+		return fmt.Errorf("invalid signature base64: %w", err)
+	}
+	var sig struct{ R, S *big.Int }
+	if _, err := asn1.Unmarshal(sigBytes, &sig); err != nil {
+		return fmt.Errorf("invalid DER signature: %w", err)
+	}
+	digest := sha256.Sum256([]byte(address))
+	if !ecdsa.Verify(pub, digest[:], sig.R, sig.S) {
+		return fmt.Errorf("signature verification failed")
+	}
+	return nil
+}
+
+// SHA256Hex returns the lowercase hex SHA-256 of data — the digest form used
+// for request_sha256 (over exact request body bytes) and response_sha256
+// (over the full response text UTF-8 bytes).
+func SHA256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// Checks is the coordinator-side verification verdict for one receipt.
+// Every binding is independent and tri-state: a *Checked field says whether
+// the coordinator had the input to run that check at completion time (e.g.
+// sealed-sender mode hides the plaintext body; an unattested provider has
+// no known SE key).
+type Checks struct {
+	// AddressMatch: SHA-256 of the wire receipt bytes equals response_hash.
+	AddressMatch bool `json:"address_match"`
+	// RequestDigestMatch: receipt's request_sha256 equals the digest of the
+	// plaintext body this coordinator sealed for the provider. False also
+	// when the coordinator never saw plaintext (sealed-sender mode); see
+	// RequestDigestChecked.
+	RequestDigestMatch   bool `json:"request_digest_match"`
+	RequestDigestChecked bool `json:"request_digest_checked"`
+	// ModelWeightHashMatch: receipt's model_weight_hash equals the registry
+	// catalog's aggregate weight hash for the model. Checked only when both
+	// sides have a hash.
+	ModelWeightHashMatch   bool `json:"model_weight_hash_match"`
+	ModelWeightHashChecked bool `json:"model_weight_hash_checked"`
+	// SignatureValid: SE signature over the address verifies against the
+	// provider's attested public key. Checked only when the key is known.
+	SignatureValid   bool `json:"signature_valid"`
+	SignatureChecked bool `json:"signature_checked"`
+}
+
+// OK reports whether every check that could be performed passed.
+func (c Checks) OK() bool {
+	if !c.AddressMatch {
+		return false
+	}
+	if c.RequestDigestChecked && !c.RequestDigestMatch {
+		return false
+	}
+	if c.ModelWeightHashChecked && !c.ModelWeightHashMatch {
+		return false
+	}
+	if c.SignatureChecked && !c.SignatureValid {
+		return false
+	}
+	return true
+}
+
+// VerifyInput carries everything the coordinator knows at inference_complete
+// time that a receipt can be checked against. Empty fields skip their check.
+type VerifyInput struct {
+	ReceiptJSON       []byte // wire bytes of the receipt field
+	ResponseHash      string // wire response_hash (expected receipt hash)
+	SESignatureB64    string // wire se_signature
+	SEPublicKeyB64    string // provider's attested SE public key, if known
+	DispatchedSHA256  string // digest of the plaintext body the coordinator sealed, if it saw plaintext
+	CatalogWeightHash string // registry aggregate weight hash for the model, if recorded
+}
+
+// Verify parses the receipt and runs every check the input allows.
+// It returns the parsed receipt alongside the verdict; the receipt is valid
+// to read even when some checks fail (the verdict says which).
+func Verify(in VerifyInput) (Receipt, Checks, error) {
+	var checks Checks
+	r, err := Parse(in.ReceiptJSON)
+	if err != nil {
+		return Receipt{}, checks, err
+	}
+	addr := AddressOf(in.ReceiptJSON)
+	checks.AddressMatch = addr == strings.ToLower(strings.TrimSpace(in.ResponseHash))
+	if in.DispatchedSHA256 != "" {
+		checks.RequestDigestChecked = true
+		checks.RequestDigestMatch = r.RequestSHA256 == in.DispatchedSHA256
+	}
+	if in.CatalogWeightHash != "" && r.ModelWeightHash != "" {
+		checks.ModelWeightHashChecked = true
+		checks.ModelWeightHashMatch = strings.EqualFold(r.ModelWeightHash, strings.TrimSpace(in.CatalogWeightHash))
+	}
+	if in.SEPublicKeyB64 != "" && in.SESignatureB64 != "" {
+		checks.SignatureChecked = true
+		checks.SignatureValid = VerifySignature(addr, in.SESignatureB64, in.SEPublicKeyB64) == nil
+	}
+	return r, checks, nil
+}
+
+func validHex256(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func writeIntField(b *strings.Builder, key string, v int, comma bool) {
+	if comma {
+		b.WriteByte(',')
+	}
+	fmt.Fprintf(b, "%q:%d", key, v)
+}
+
+func writeStringField(b *strings.Builder, key, v string) {
+	b.WriteByte(',')
+	b.WriteString(fmt.Sprintf("%q:", key))
+	b.WriteString(encodeJSONString(v))
+}
+
+// encodeJSONString escapes exactly what JSON requires and nothing more:
+// backslash, double quote, and control characters (U+0000..U+001F). No HTML
+// escaping, no slash escaping. The Swift encoder mirrors this table.
+func encodeJSONString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, ch := range s {
+		switch ch {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if ch < 0x20 {
+				fmt.Fprintf(&b, `\u%04x`, ch)
+			} else {
+				b.WriteRune(ch)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/coordinator/receipt/receipt_test.go
+++ b/coordinator/receipt/receipt_test.go
@@ -1,0 +1,314 @@
+package receipt
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleReceipt mirrors fixtures/receipts/receipt_vectors.json vector 0.
+// The Swift twin test (InferenceReceiptTests) consumes the same fixture, so
+// the canonical bytes and address here are the cross-language contract.
+func sampleReceipt() Receipt {
+	return Receipt{
+		CompletionTokens: 42,
+		ModelID:          "mlx-community/gemma-4-26b",
+		ModelWeightHash:  strings.Repeat("ab", 32),
+		PromptTokens:     17,
+		RequestID:        "req-0001",
+		RequestSHA256:    strings.Repeat("12", 32),
+		ResponseSHA256:   strings.Repeat("34", 32),
+		V:                Version,
+	}
+}
+
+func TestCanonicalFormIsStable(t *testing.T) {
+	got := string(sampleReceipt().Canonical())
+	want := `{"completion_tokens":42,` +
+		`"model_id":"mlx-community/gemma-4-26b",` +
+		`"model_weight_hash":"` + strings.Repeat("ab", 32) + `",` +
+		`"prompt_tokens":17,` +
+		`"request_id":"req-0001",` +
+		`"request_sha256":"` + strings.Repeat("12", 32) + `",` +
+		`"response_sha256":"` + strings.Repeat("34", 32) + `",` +
+		`"v":2}`
+	if got != want {
+		t.Fatalf("canonical form drifted:\n got  %s\n want %s", got, want)
+	}
+	// Canonical form must also be valid JSON that round-trips.
+	var check map[string]any
+	if err := json.Unmarshal([]byte(got), &check); err != nil {
+		t.Fatalf("canonical form is not valid JSON: %v", err)
+	}
+	if len(check) != 8 {
+		t.Fatalf("canonical form has %d fields, want 8", len(check))
+	}
+}
+
+func TestGoldenVectors(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "fixtures", "receipts", "receipt_vectors.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var vectors []struct {
+		Name      string          `json:"name"`
+		Receipt   json.RawMessage `json:"receipt"`
+		Canonical string          `json:"canonical"`
+		Address   string          `json:"address"`
+	}
+	if err := json.Unmarshal(data, &vectors); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if len(vectors) == 0 {
+		t.Fatal("fixture has no vectors")
+	}
+	for _, v := range vectors {
+		t.Run(v.Name, func(t *testing.T) {
+			var r Receipt
+			if err := json.Unmarshal(v.Receipt, &r); err != nil {
+				t.Fatalf("unmarshal receipt: %v", err)
+			}
+			if got := string(r.Canonical()); got != v.Canonical {
+				t.Errorf("canonical mismatch:\n got  %s\n want %s", got, v.Canonical)
+			}
+			if got := r.Address(); got != v.Address {
+				t.Errorf("address mismatch: got %s want %s", got, v.Address)
+			}
+			// Wire-byte addressing must agree with struct addressing for
+			// canonical bytes.
+			if got := AddressOf([]byte(v.Canonical)); got != v.Address {
+				t.Errorf("AddressOf mismatch: got %s want %s", got, v.Address)
+			}
+			// Canonical bytes must parse strictly.
+			parsed, err := Parse([]byte(v.Canonical))
+			if err != nil {
+				t.Fatalf("Parse rejected canonical bytes: %v", err)
+			}
+			if parsed != r {
+				t.Errorf("parse round-trip mismatch: %+v vs %+v", parsed, r)
+			}
+		})
+	}
+}
+
+func TestParseRejectsNonCanonicalForms(t *testing.T) {
+	canonical := string(sampleReceipt().Canonical())
+	bad := map[string]string{
+		"whitespace":       strings.Replace(canonical, ":", ": ", 1),
+		"reordered keys":   `{"v":2,` + canonical[1:len(canonical)-len(`,"v":2}`)] + `}`,
+		"unknown field":    canonical[:len(canonical)-1] + `,"extra":1}`,
+		"trailing data":    canonical + "x",
+		"uppercase hex":    strings.Replace(canonical, strings.Repeat("ab", 32), strings.Repeat("AB", 32), 1),
+		"short digest":     strings.Replace(canonical, strings.Repeat("12", 32), strings.Repeat("12", 31), 1),
+		"wrong version":    strings.Replace(canonical, `"v":2`, `"v":1`, 1),
+		"empty request id": strings.Replace(canonical, `"request_id":"req-0001"`, `"request_id":""`, 1),
+		"empty object":     `{}`,
+		"not json":         `hello`,
+	}
+	for name, input := range bad {
+		if _, err := Parse([]byte(input)); err == nil {
+			t.Errorf("%s: Parse accepted non-canonical/invalid input: %s", name, input)
+		}
+	}
+}
+
+// TestParseAcceptsEmptyWeightHash: a provider that has not hashed its model
+// yet still emits a valid receipt with model_weight_hash "".
+func TestParseAcceptsEmptyWeightHash(t *testing.T) {
+	r := sampleReceipt()
+	r.ModelWeightHash = ""
+	if _, err := Parse(r.Canonical()); err != nil {
+		t.Fatalf("Parse rejected empty weight hash: %v", err)
+	}
+}
+
+func testKey(t *testing.T) (*ecdsa.PrivateKey, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	raw := elliptic.Marshal(elliptic.P256(), priv.PublicKey.X, priv.PublicKey.Y)
+	return priv, base64.StdEncoding.EncodeToString(raw)
+}
+
+// signAddress signs exactly as the Swift Secure Enclave does: DER ECDSA over
+// SHA-256 of the UTF-8 bytes of the address string.
+func signAddress(t *testing.T, priv *ecdsa.PrivateKey, address string) string {
+	t.Helper()
+	digest := sha256.Sum256([]byte(address))
+	der, err := ecdsa.SignASN1(rand.Reader, priv, digest[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(der)
+}
+
+func TestVerifySignature(t *testing.T) {
+	priv, pubB64 := testKey(t)
+	addr := sampleReceipt().Address()
+	sig := signAddress(t, priv, addr)
+
+	if err := VerifySignature(addr, sig, pubB64); err != nil {
+		t.Fatalf("genuine signature rejected: %v", err)
+	}
+
+	// Tamper matrix: every mutation must fail loudly.
+	otherPriv, otherPubB64 := testKey(t)
+	otherAddr := AddressOf([]byte("different bytes"))
+	cases := map[string][3]string{
+		"wrong key":         {addr, sig, otherPubB64},
+		"wrong address":     {otherAddr, sig, pubB64},
+		"foreign signature": {addr, signAddress(t, otherPriv, addr), pubB64},
+		"garbage signature": {addr, base64.StdEncoding.EncodeToString([]byte("nope")), pubB64},
+		"garbage base64":    {addr, "!!!", pubB64},
+		"garbage pubkey":    {addr, sig, "AAAA"},
+	}
+	for name, c := range cases {
+		if err := VerifySignature(c[0], c[1], c[2]); err == nil {
+			t.Errorf("%s: tampered signature verified", name)
+		}
+	}
+}
+
+func TestVerifyEndToEnd(t *testing.T) {
+	priv, pubB64 := testKey(t)
+	requestBody := []byte(`{"model":"mlx-community/gemma-4-26b","messages":[{"role":"user","content":"capital of France?"}],"temperature":0,"seed":7}`)
+	responseText := "The capital of France is Paris."
+
+	r := sampleReceipt()
+	r.RequestSHA256 = SHA256Hex(requestBody)
+	r.ResponseSHA256 = SHA256Hex([]byte(responseText))
+	wire := r.Canonical()
+	addr := AddressOf(wire)
+	sig := signAddress(t, priv, addr)
+
+	in := VerifyInput{
+		ReceiptJSON:       wire,
+		ResponseHash:      addr,
+		SESignatureB64:    sig,
+		SEPublicKeyB64:    pubB64,
+		DispatchedSHA256:  SHA256Hex(requestBody),
+		CatalogWeightHash: r.ModelWeightHash,
+	}
+	parsed, checks, err := Verify(in)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if parsed != r {
+		t.Fatalf("parsed receipt mismatch")
+	}
+	if !checks.OK() || !checks.AddressMatch || !checks.RequestDigestMatch ||
+		!checks.ModelWeightHashMatch || !checks.SignatureValid {
+		t.Fatalf("genuine receipt failed checks: %+v", checks)
+	}
+	if !checks.RequestDigestChecked || !checks.ModelWeightHashChecked || !checks.SignatureChecked {
+		t.Fatalf("checks not marked as performed: %+v", checks)
+	}
+
+	t.Run("tampered request byte fails digest check", func(t *testing.T) {
+		bad := in
+		tampered := append([]byte(nil), requestBody...)
+		tampered[len(tampered)-2] ^= 1
+		bad.DispatchedSHA256 = SHA256Hex(tampered)
+		_, checks, err := Verify(bad)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if checks.OK() || checks.RequestDigestMatch {
+			t.Fatalf("tampered request passed: %+v", checks)
+		}
+	})
+
+	t.Run("model substitution fails weight hash check", func(t *testing.T) {
+		bad := in
+		bad.CatalogWeightHash = strings.Repeat("cd", 32)
+		_, checks, err := Verify(bad)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if checks.OK() || checks.ModelWeightHashMatch {
+			t.Fatalf("substituted model passed: %+v", checks)
+		}
+	})
+
+	t.Run("forged receipt fails address check", func(t *testing.T) {
+		forged := r
+		forged.CompletionTokens = 1
+		bad := in
+		bad.ReceiptJSON = forged.Canonical() // response_hash still the original
+		_, checks, err := Verify(bad)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if checks.OK() || checks.AddressMatch {
+			t.Fatalf("forged receipt passed: %+v", checks)
+		}
+	})
+
+	t.Run("resigned forgery fails request digest binding", func(t *testing.T) {
+		// A malicious provider CAN mint a well-formed receipt over a lie and
+		// sign it. The coordinator's dispatched-body digest refutes it.
+		forged := r
+		forged.RequestSHA256 = strings.Repeat("ee", 32)
+		wire := forged.Canonical()
+		addr := AddressOf(wire)
+		bad := VerifyInput{
+			ReceiptJSON:       wire,
+			ResponseHash:      addr,
+			SESignatureB64:    signAddress(t, priv, addr),
+			SEPublicKeyB64:    pubB64,
+			DispatchedSHA256:  SHA256Hex(requestBody),
+			CatalogWeightHash: r.ModelWeightHash,
+		}
+		_, checks, err := Verify(bad)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if checks.OK() || checks.RequestDigestMatch {
+			t.Fatalf("resigned forgery passed: %+v", checks)
+		}
+		if !checks.AddressMatch || !checks.SignatureValid {
+			t.Fatalf("forgery should be internally consistent (that is the point): %+v", checks)
+		}
+	})
+
+	t.Run("unchecked bindings are tri-state, not silently OK", func(t *testing.T) {
+		bare := VerifyInput{ReceiptJSON: wire, ResponseHash: addr}
+		_, checks, err := Verify(bare)
+		if err != nil {
+			t.Fatalf("Verify: %v", err)
+		}
+		if checks.SignatureChecked || checks.RequestDigestChecked || checks.ModelWeightHashChecked {
+			t.Fatalf("checks claimed without inputs: %+v", checks)
+		}
+		if !checks.OK() {
+			t.Fatalf("address-only verification should pass OK(): %+v", checks)
+		}
+	})
+}
+
+func TestEncodeJSONStringEscaping(t *testing.T) {
+	cases := map[string]string{
+		`plain`:      `"plain"`,
+		`sla/sh`:     `"sla/sh"`, // no slash escaping (Swift: .withoutEscapingSlashes)
+		`qu"ote`:     `"qu\"ote"`,
+		`back\slash`: `"back\\slash"`,
+		"tab\tnl\n":  `"tab\tnl\n"`,
+		"ctrl\x01":   `"ctrl\u0001"`,
+		`<html>&`:    `"<html>&"`, // no HTML escaping
+		"unicodé-κ":  `"unicodé-κ"`,
+	}
+	for in, want := range cases {
+		if got := encodeJSONString(in); got != want {
+			t.Errorf("encodeJSONString(%q) = %s, want %s", in, got, want)
+		}
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -218,6 +218,14 @@ type PendingRequest struct {
 	SessionPrivKey *[32]byte // E2E session private key for decrypting responses
 	SESignature    string    // SE signature over response hash
 	ResponseHash   string    // SHA-256 of response data
+	// Receipt is the provider's canonical inference receipt JSON (see
+	// coordinator/receipt). Empty for older providers. Digests only.
+	Receipt string
+	// DispatchedBodySHA256 is the SHA-256 of the exact plaintext body the
+	// coordinator sealed for the serving provider — the bytes the provider
+	// decrypts and the receipt's request_sha256 must match. Set at the
+	// encrypt sites; empty when the coordinator never saw plaintext.
+	DispatchedBodySHA256 string
 	// MetadataDetails asks chat-completions writers to include the same
 	// consumer-safe provider/attestation/timing details already returned in
 	// X-Provider-* / X-Timing headers in the JSON body. Opt-in so default
@@ -2763,6 +2771,33 @@ func (r *Registry) IsModelInCatalog(model string) bool {
 	}
 	_, ok := r.modelCatalog[model]
 	return ok
+}
+
+// ReceiptContext returns the provider's attested Secure Enclave public key
+// and its registered weight hash for modelID, for receipt verification at
+// inference completion. An empty string means "unknown — skip that check".
+// The weight hash read here has already been cross-checked against the model
+// catalog at registration, so a receipt matching it is transitively bound to
+// the catalog's expected weights.
+func (r *Registry) ReceiptContext(providerID, modelID string) (sePublicKey, weightHash string) {
+	r.mu.RLock()
+	p, ok := r.providers[providerID]
+	r.mu.RUnlock()
+	if !ok {
+		return "", ""
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.AttestationResult != nil {
+		sePublicKey = p.AttestationResult.PublicKey
+	}
+	for i := range p.Models {
+		if p.Models[i].ID == modelID {
+			weightHash = p.Models[i].WeightHash
+			break
+		}
+	}
+	return sePublicKey, weightHash
 }
 
 // UpdateModelWeightHashes replaces stored per-model weight hashes from a

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -27,6 +27,7 @@ This directory is the source of truth for how Darkbloom works. The code in `coor
 |---|---|
 | [security/encryption.md](security/encryption.md) | NaCl Box encryption between consumer, coordinator, and provider |
 | [security/attestation.md](security/attestation.md) | Secure Enclave, MDM/MDA, APNs code identity, and trust levels |
+| [receipts.md](receipts.md) | Inference receipts: binding the response attestation to model weights, request bytes, and response |
 | [security/enrollment.md](security/enrollment.md) | Device enrollment: MDM, SCEP, and profile generation |
 | [security/identity-binding.md](security/identity-binding.md) | How APNs, X25519, SE P-256, and MDA identities bind together |
 

--- a/docs/architecture/receipts.md
+++ b/docs/architecture/receipts.md
@@ -1,0 +1,127 @@
+# Inference Receipts
+
+Darkbloom's trust stack proves privacy end to end: NaCl Box per hop, Secure
+Enclave attestation, MDM, Hardened Runtime. Receipts close the one gap that
+stack leaves open. Before receipts, nothing proved that a provider actually
+ran the claimed model on the submitted request and returned its real output.
+The response attestation signed `sha256(requestId:completionTokens:responseBody)`,
+which binds neither the model weights, nor the request content, nor any
+sampling parameter. A provider serving one model at another model's price
+produced perfectly valid attestations.
+
+A receipt is a canonical record of one inference. Its receipt hash is the
+SHA-256 of its canonical JSON bytes, and the provider's Secure Enclave signs
+that hash. Receipts carry digests only, never prompt or response plaintext,
+so they are public by construction.
+
+## The record
+
+```json
+{"completion_tokens":42,
+ "model_id":"mlx-community/gemma-4-26b",
+ "model_weight_hash":"<aggregate SHA-256 of the served weights>",
+ "prompt_tokens":17,
+ "request_id":"<coordinator request id>",
+ "request_sha256":"<SHA-256 of the exact decrypted request body bytes>",
+ "response_sha256":"<SHA-256 of the full response text, UTF-8>",
+ "v":2}
+```
+
+Shown wrapped; the canonical form is a single line, keys in alphabetical
+order, minimal escaping, no HTML or slash escaping. The Go encoder is
+`coordinator/receipt/receipt.go`, the Swift twin is
+`provider-swift/Sources/ProviderCore/Security/InferenceReceipt.swift`, and
+`fixtures/receipts/receipt_vectors.json`, generated independently of both,
+pins them byte for byte.
+
+Two decisions keep the record small:
+
+- **The request digest binds every sampling parameter.** Temperature, seed,
+  max_tokens, messages, and tools all live inside the request bytes, so one
+  digest binds them all. No float canonicalization, no parameter list to
+  keep in sync.
+- **The wire contract is the existing contract.** `se_signature` has always
+  meant "Secure Enclave signature over `response_hash`". For a v2 provider,
+  `response_hash` is the receipt hash and the new optional `receipt` field
+  carries the record. Older providers omit the field and keep today's
+  behavior; older consumers see the same fields they always saw.
+
+## Who verifies what
+
+| Binding | Verifier | How |
+|---|---|---|
+| Receipt bytes to hash | anyone | SHA-256 of the `receipt` field equals `response_hash` |
+| Hash to provider | anyone | `se_signature` verifies against the provider's attested P-256 key (served by `GET /v1/receipts/{hash}`) |
+| Request bytes to digest | whoever sealed the request | the coordinator checks automatically at completion; sealed sender consumers recompute over their own plaintext |
+| Weights to hash | coordinator and provider | the receipt's `model_weight_hash` must equal the hash the provider registered, which registration already cross checks against the model catalog |
+| Response text to digest | consumer | recompute SHA-256 over the assembled response text |
+
+The coordinator runs its checks at `inference_complete`
+(`coordinator/api/receipts.go`), records the verdict, and serves it publicly:
+
+```
+GET /v1/receipts/{hash}
+→ { "address", "receipt", "se_signature", "se_public_key",
+    "checks": { "address_match", "request_digest_match", …,
+                "signature_valid", "signature_checked" },
+    "created_at" }
+```
+
+Every check has a paired `*_checked` field. A check runs only when the
+coordinator had the input to check against; for example, sealed sender mode
+hides the plaintext body, so `request_digest_checked` is false and the
+consumer holds that binding instead. A failed binding never fails the
+request. It is logged, counted (`receipts.check_failed`), and visible on the
+record.
+
+## The forgery result (tested)
+
+A malicious provider can mint a well formed receipt over a lie and sign it.
+Internal consistency is not the defense; cross checking is:
+
+- `TestIntegration_ReceiptGenuine`: an honest provider passes every
+  check, and a third party verifies the signature using only public endpoint
+  data.
+- `TestIntegration_ReceiptLyingProviderIsFlagged`: a correctly signed,
+  canonically encoded receipt claiming a different request digest and weight
+  hash keeps `address_match` and `signature_valid` true (that is the attack)
+  while `request_digest_match` and `model_weight_hash_match` refute it.
+- `coordinator/receipt/receipt_test.go`: canonical form strictness (exactly
+  one byte string per receipt), golden vectors, and the tamper matrix. The
+  Swift twins live in `Tests/ProviderCoreTests/InferenceReceiptTests.swift`.
+
+## Replay audits (future work)
+
+Because `darkbloom start --local` runs the identical engine on any Apple
+Silicon Mac, anyone holding a transcript can escalate from digest checks to
+replay: rerun the request bytes named by `request_sha256` against the
+weights named by `model_weight_hash` and compare output. Two facts must be
+measured on real hardware before replay verdicts are trusted:
+
+1. **The determinism envelope.** Production decode runs inside a continuous
+   batch; a replay runs alone. Whether greedy decode replays byte identical
+   on the same machine, and across machines and chip generations, is an open
+   measurement. The sampler RNG is keyed on (seed, requestID, step), so a
+   replay must reuse the receipt's `request_id`.
+2. **The comparator.** If byte identity holds, replay verdicts are boolean.
+   If not, the verdict becomes a divergence token index with a tolerance.
+   The receipt commitment is unchanged either way.
+
+Canary audits compound this: any party may submit seeded requests as
+ordinary paid traffic and check the receipts that come back against local
+replays. A provider cannot distinguish auditors from customers, so cheating
+on a fraction f of traffic against a canary rate e survives R requests with
+probability (1 − ef)^R. A signed receipt, the transcript, and a refuting
+replay together form a self contained fraud proof, which is the natural
+input to cryptoeconomic enforcement if the project ever wants it. All of
+this is future work; this document only records that the receipt layer was
+designed to make it possible.
+
+## Privacy
+
+The public record contains hashes, a signature, and the provider's
+attestation public key, which is already the provider's pseudonymous
+identity. Only holders of the plaintext can bind a receipt to content. The
+receipt cache is in memory and bounded (`receiptCacheCap`); the receipt
+itself travels inline to the consumer, so the endpoint is a convenience,
+not a custody layer.

--- a/fixtures/receipts/receipt_vectors.json
+++ b/fixtures/receipts/receipt_vectors.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "basic",
+    "receipt": {
+      "completion_tokens": 42,
+      "model_id": "mlx-community/gemma-4-26b",
+      "model_weight_hash": "abababababababababababababababababababababababababababababababab",
+      "prompt_tokens": 17,
+      "request_id": "req-0001",
+      "request_sha256": "1212121212121212121212121212121212121212121212121212121212121212",
+      "response_sha256": "3434343434343434343434343434343434343434343434343434343434343434",
+      "v": 2
+    },
+    "canonical": "{\"completion_tokens\":42,\"model_id\":\"mlx-community/gemma-4-26b\",\"model_weight_hash\":\"abababababababababababababababababababababababababababababababab\",\"prompt_tokens\":17,\"request_id\":\"req-0001\",\"request_sha256\":\"1212121212121212121212121212121212121212121212121212121212121212\",\"response_sha256\":\"3434343434343434343434343434343434343434343434343434343434343434\",\"v\":2}",
+    "address": "1c8bb23f0b435fa9b0fcf1143c33159eae58b591ac635c9cd015c75d3d4c69fc"
+  },
+  {
+    "name": "empty-weight-hash",
+    "receipt": {
+      "completion_tokens": 1,
+      "model_id": "gpt-oss-20b",
+      "model_weight_hash": "",
+      "prompt_tokens": 1,
+      "request_id": "b2c3d4e5-0000-4000-8000-000000000000",
+      "request_sha256": "1f58b9145b24d108d7ac38887338b3ea3229833b9c1e418250343f907bfd1047",
+      "response_sha256": "a9f4b3d22a523fdada41c85c175425bcd15b32b4cd0f54d9433accd52d7195a1",
+      "v": 2
+    },
+    "canonical": "{\"completion_tokens\":1,\"model_id\":\"gpt-oss-20b\",\"model_weight_hash\":\"\",\"prompt_tokens\":1,\"request_id\":\"b2c3d4e5-0000-4000-8000-000000000000\",\"request_sha256\":\"1f58b9145b24d108d7ac38887338b3ea3229833b9c1e418250343f907bfd1047\",\"response_sha256\":\"a9f4b3d22a523fdada41c85c175425bcd15b32b4cd0f54d9433accd52d7195a1\",\"v\":2}",
+    "address": "4705bae3a0ccab62e0e950af9fdfa436c597463e7d3a611529d735bf608c0453"
+  },
+  {
+    "name": "unicode-model-id",
+    "receipt": {
+      "completion_tokens": 0,
+      "model_id": "mlx-community/Qwen3-8B-κ",
+      "model_weight_hash": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+      "prompt_tokens": 2048,
+      "request_id": "req/with\\slash\"quote",
+      "request_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "response_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "v": 2
+    },
+    "canonical": "{\"completion_tokens\":0,\"model_id\":\"mlx-community/Qwen3-8B-κ\",\"model_weight_hash\":\"0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f\",\"prompt_tokens\":2048,\"request_id\":\"req/with\\\\slash\\\"quote\",\"request_sha256\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"response_sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"v\":2}",
+    "address": "acef35f6c2be27af942557c7514c2e861ce7da6c7c5bdffd9aacb0eadab22ab4"
+  },
+  {
+    "name": "zero-tokens",
+    "receipt": {
+      "completion_tokens": 0,
+      "model_id": "m",
+      "model_weight_hash": "",
+      "prompt_tokens": 0,
+      "request_id": "r",
+      "request_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "response_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "v": 2
+    },
+    "canonical": "{\"completion_tokens\":0,\"model_id\":\"m\",\"model_weight_hash\":\"\",\"prompt_tokens\":0,\"request_id\":\"r\",\"request_sha256\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"response_sha256\":\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\",\"v\":2}",
+    "address": "e5da59a60f7b8c0e4d0dd182502737e3daa31619f59b65bb15bd64211e77218d"
+  }
+]

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -143,14 +143,16 @@ public enum CoordinatorClientCodec {
             let usage,
             let stopSequence,
             let seSignature,
-            let responseHash
+            let responseHash,
+            let receipt
         ):
             return .inferenceComplete(ProviderMessage.InferenceComplete(
                 requestId: requestId,
                 usage: usage,
                 stopSequence: stopSequence,
                 seSignature: seSignature,
-                responseHash: responseHash
+                responseHash: responseHash,
+                receipt: receipt
             ))
 
         case .inferenceError(let requestId, let failure):

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -221,7 +221,8 @@ public enum OutboundMessage: Sendable {
         usage: UsageInfo,
         stopSequence: String?,
         seSignature: String?,
-        responseHash: String?
+        responseHash: String?,
+        receipt: String?
     )
     case inferenceError(
         requestId: String,

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -335,19 +335,25 @@ public enum ProviderMessage: Sendable, Equatable {
         public var stopSequence: String?
         public var seSignature: String?
         public var responseHash: String?
+        /// Canonical inference receipt JSON (InferenceReceipt). When present,
+        /// `responseHash` is the receipt hash and `seSignature` signs that
+        /// hash. Digests only, never plaintext.
+        public var receipt: String?
 
         public init(
             requestId: String,
             usage: UsageInfo,
             stopSequence: String? = nil,
             seSignature: String? = nil,
-            responseHash: String? = nil
+            responseHash: String? = nil,
+            receipt: String? = nil
         ) {
             self.requestId = requestId
             self.usage = usage
             self.stopSequence = stopSequence
             self.seSignature = seSignature
             self.responseHash = responseHash
+            self.receipt = receipt
         }
     }
 
@@ -773,6 +779,7 @@ extension ProviderMessage: Codable {
         case stopSequence = "stop_sequence"
         case seSignature = "se_signature"
         case responseHash = "response_hash"
+        case receipt
         // InferenceError
         case error
         case failureCode = "failure_code"
@@ -898,6 +905,7 @@ extension ProviderMessage: Codable {
             try container.encodeIfPresent(c.stopSequence, forKey: .stopSequence)
             try container.encodeIfPresent(c.seSignature, forKey: .seSignature)
             try container.encodeIfPresent(c.responseHash, forKey: .responseHash)
+            try container.encodeIfPresent(c.receipt, forKey: .receipt)
 
         case .inferenceError(let e):
             try container.encode(TypeValue.inferenceError, forKey: .type)
@@ -1105,7 +1113,8 @@ extension ProviderMessage: Codable {
                 usage: try container.decode(UsageInfo.self, forKey: .usage),
                 stopSequence: try container.decodeIfPresent(String.self, forKey: .stopSequence),
                 seSignature: try container.decodeIfPresent(String.self, forKey: .seSignature),
-                responseHash: try container.decodeIfPresent(String.self, forKey: .responseHash)
+                responseHash: try container.decodeIfPresent(String.self, forKey: .responseHash),
+                receipt: try container.decodeIfPresent(String.self, forKey: .receipt)
             ))
 
         case .inferenceError:

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -487,6 +487,12 @@ extension ProviderLoop {
         let providerStats = self.stats
         let registry = self.cancellationRegistry
         let signingIdentity = self.signer
+        // Receipt bindings, captured before the task: the digest of the
+        // exact decrypted request bytes (which bind every sampling parameter)
+        // and the verified aggregate weight hash of the serving model ("" when
+        // the model has no live verified hash — the receipt says so honestly).
+        let requestBodySHA256 = sha256Hex(decryptedData)
+        let receiptModelWeightHash = liveModelHashes[modelId] ?? ""
         let log = self.logger
         let tokenizer = slot.tokenizer
         // Read modelType from the loaded SLOT, not advertisedModels: the latter
@@ -1154,12 +1160,21 @@ extension ProviderLoop {
             // Update state
             await me.updateAggregateCapacity()
 
-            // Send completion
-            let attestation = computeResponseAttestation(
+            // Send completion, sealed as a receipt: response_hash becomes
+            // the receipt hash and se_signature signs it — the v1
+            // signing contract unchanged, now binding model weights, the
+            // exact request bytes, and the response digest.
+            let attestation = computeReceiptAttestation(
                 identity: signingIdentity,
-                requestId: requestId,
-                completionTokens: UInt64(max(completionTokens, 0)),
-                responseBody: fullResponseText
+                receipt: InferenceReceipt(
+                    completionTokens: max(completionTokens, 0),
+                    modelId: modelId,
+                    modelWeightHash: receiptModelWeightHash,
+                    promptTokens: max(promptTokens, 0),
+                    requestId: requestId,
+                    requestSha256: requestBodySHA256,
+                    responseSha256: sha256Hex(Data(fullResponseText.utf8))
+                )
             )
             let cacheResult = remoteCache.scope == nil ? nil : v2UsageSignal.lookupResult
             let usageInfo = UsageInfo(
@@ -1178,7 +1193,8 @@ extension ProviderLoop {
                     usage: usageInfo,
                     stopSequence: v2UsageSignal.matchedStopSequence,
                     seSignature: attestation.signature,
-                    responseHash: attestation.hash),
+                    responseHash: attestation.address,
+                    receipt: attestation.receipt),
                 fallbackFailure: .policy,
                 send: send)
 

--- a/provider-swift/Sources/ProviderCore/Security/InferenceReceipt.swift
+++ b/provider-swift/Sources/ProviderCore/Security/InferenceReceipt.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Inference receipt: the canonical record of one inference.
+///
+/// The receipt binds the model (aggregate weight hash), the exact decrypted
+/// request bytes (whose digest transitively binds every sampling parameter —
+/// temperature, seed, max_tokens, messages), and the full response text. Its
+/// receipt hash is the SHA-256 of its canonical JSON bytes; the Secure
+/// Enclave signs that hash through the existing response attestation
+/// channel unchanged: `response_hash` carries the hash, `se_signature`
+/// signs it, and the new `receipt` field carries the canonical JSON.
+///
+/// Digests only — the receipt never contains prompt or response plaintext,
+/// so it is safe to publish.
+///
+/// The canonical encoding is mirrored byte-for-byte by the coordinator
+/// (`coordinator/receipt/receipt.go`) and pinned by the shared golden vectors
+/// in `fixtures/receipts/receipt_vectors.json`. Keys are in alphabetical order;
+/// strings escape exactly what JSON requires (backslash, quote, control
+/// characters) and nothing more — no HTML escaping, no slash escaping.
+public struct InferenceReceipt: Sendable, Equatable {
+    public static let version = 2
+
+    public let completionTokens: Int
+    public let modelId: String
+    /// Lowercase hex aggregate SHA-256 of the model weights; "" when the
+    /// provider has no verified hash for the model.
+    public let modelWeightHash: String
+    public let promptTokens: Int
+    public let requestId: String
+    /// SHA-256 (lowercase hex) of the exact decrypted request body bytes.
+    public let requestSha256: String
+    /// SHA-256 (lowercase hex) of the full response text (UTF-8).
+    public let responseSha256: String
+
+    public init(
+        completionTokens: Int,
+        modelId: String,
+        modelWeightHash: String,
+        promptTokens: Int,
+        requestId: String,
+        requestSha256: String,
+        responseSha256: String
+    ) {
+        self.completionTokens = completionTokens
+        self.modelId = modelId
+        self.modelWeightHash = modelWeightHash
+        self.promptTokens = promptTokens
+        self.requestId = requestId
+        self.requestSha256 = requestSha256
+        self.responseSha256 = responseSha256
+    }
+
+    /// Canonical JSON: single line, alphabetical keys, minimal escaping.
+    /// Must stay byte-identical to `Receipt.Canonical()` in Go.
+    public func canonicalJSON() -> String {
+        var out = "{"
+        out += "\"completion_tokens\":\(completionTokens)"
+        out += ",\"model_id\":\(Self.encodeJSONString(modelId))"
+        out += ",\"model_weight_hash\":\(Self.encodeJSONString(modelWeightHash))"
+        out += ",\"prompt_tokens\":\(promptTokens)"
+        out += ",\"request_id\":\(Self.encodeJSONString(requestId))"
+        out += ",\"request_sha256\":\(Self.encodeJSONString(requestSha256))"
+        out += ",\"response_sha256\":\(Self.encodeJSONString(responseSha256))"
+        out += ",\"v\":\(Self.version)"
+        out += "}"
+        return out
+    }
+
+    /// Receipt hash: lowercase hex SHA-256 of the canonical receipt bytes.
+    public func address() -> String {
+        sha256Hex(Data(canonicalJSON().utf8))
+    }
+
+    /// Escape exactly what JSON requires and nothing more. Mirrors
+    /// `encodeJSONString` in coordinator/receipt/receipt.go.
+    static func encodeJSONString(_ s: String) -> String {
+        var out = "\""
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            case "\t": out += "\\t"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        out += "\""
+        return out
+    }
+}
+
+/// Compute the receipt attestation for a completed inference: the
+/// canonical receipt JSON, its hash, and the Secure Enclave signature
+/// over the hash. The signing contract is identical to the v1
+/// `computeResponseAttestation` (DER ECDSA P-256 over SHA-256 of the UTF-8
+/// address bytes) — only what the signed hash covers has grown.
+public func computeReceiptAttestation(
+    identity: (any AttestationSigner)?,
+    receipt: InferenceReceipt
+) -> (receipt: String, address: String, signature: String?) {
+    let json = receipt.canonicalJSON()
+    let address = sha256Hex(Data(json.utf8))
+
+    var signature: String?
+    if let identity {
+        if let sigData = try? identity.sign(Data(address.utf8)) {
+            signature = sigData.base64EncodedString()
+        }
+    }
+    return (json, address, signature)
+}

--- a/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
+++ b/provider-swift/Sources/ProviderCore/Security/SecurityHardening.swift
@@ -351,29 +351,12 @@ public func collectSecurityPosture() -> SecurityPosture {
 }
 
 // MARK: - Response Attestation
-
-/// Compute a SHA-256 hash and optional Secure Enclave signature over an
-/// inference response, for coordinator verification.
-///
-/// The hash covers `requestId:completionTokens:responseBody`.
-public func computeResponseAttestation(
-    identity: (any AttestationSigner)?,
-    requestId: String,
-    completionTokens: UInt64,
-    responseBody: String
-) -> (hash: String, signature: String?) {
-    let signData = "\(requestId):\(completionTokens):\(responseBody)"
-    let responseHash = sha256Hex(Data(signData.utf8))
-
-    var signature: String?
-    if let identity {
-        if let sigData = try? identity.sign(Data(responseHash.utf8)) {
-            signature = sigData.base64EncodedString()
-        }
-    }
-
-    return (responseHash, signature)
-}
+//
+// The v1 response attestation (SHA-256 over "requestId:completionTokens:
+// responseBody", SE-signed) has been superseded by the inference receipt
+// (Security/InferenceReceipt.swift), which keeps the identical signing
+// contract but binds the model weight hash, the exact request bytes, and
+// the response digest. See computeReceiptAttestation.
 
 // MARK: - System Volume Hash
 

--- a/provider-swift/Tests/ProviderCoreTests/ChunkSenderTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ChunkSenderTests.swift
@@ -194,7 +194,8 @@ struct ChunkSenderTests {
             usage: UsageInfo(promptTokens: 0, completionTokens: 0),
             stopSequence: nil,
             seSignature: nil,
-            responseHash: nil))
+            responseHash: nil,
+            receipt: nil))
 
         let events = order.events()
         // The terminal MUST be last: chunks were flushed to the wire first.

--- a/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/CoordinatorClientTests.swift
@@ -292,7 +292,8 @@ private final class RegistrationAttestationSequence: @unchecked Sendable {
             usage: UsageInfo(promptTokens: 10, completionTokens: 20),
             stopSequence: "<END>",
             seSignature: "sig",
-            responseHash: "hash"
+            responseHash: "hash",
+            receipt: #"{"v":2}"#
         ))
     )
     #expect(complete == .inferenceComplete(ProviderMessage.InferenceComplete(
@@ -300,7 +301,8 @@ private final class RegistrationAttestationSequence: @unchecked Sendable {
         usage: UsageInfo(promptTokens: 10, completionTokens: 20),
         stopSequence: "<END>",
         seSignature: "sig",
-        responseHash: "hash"
+        responseHash: "hash",
+        receipt: #"{"v":2}"#
     )))
 
     let lookup = try CoordinatorClientCodec.encodeOutboundMessageString(.prefixCacheLookup(

--- a/provider-swift/Tests/ProviderCoreTests/InferenceReceiptTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/InferenceReceiptTests.swift
@@ -1,0 +1,170 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// Inference receipt canonical form twin tests.
+//
+// The Go coordinator (coordinator/receipt) and this Swift provider must
+// produce byte identical canonical receipt JSON; both the receipt hash and
+// the Secure Enclave signature cover these bytes. The shared golden vectors
+// in fixtures/receipts/receipt_vectors.json (generated independently of both
+// implementations) pin the contract; the Go side runs the same vectors in
+// coordinator/receipt/receipt_test.go.
+
+private struct ReceiptVector: Decodable {
+    struct Fields: Decodable {
+        let completion_tokens: Int
+        let model_id: String
+        let model_weight_hash: String
+        let prompt_tokens: Int
+        let request_id: String
+        let request_sha256: String
+        let response_sha256: String
+        let v: Int
+    }
+    let name: String
+    let receipt: Fields
+    let canonical: String
+    let address: String
+}
+
+private func loadVectors() throws -> [ReceiptVector] {
+    // Tests/ProviderCoreTests/InferenceReceiptTests.swift → repo root
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent() // ProviderCoreTests
+        .deletingLastPathComponent() // Tests
+        .deletingLastPathComponent() // provider-swift
+        .deletingLastPathComponent() // repo root
+    let url = repoRoot
+        .appendingPathComponent("fixtures")
+        .appendingPathComponent("receipts")
+        .appendingPathComponent("receipt_vectors.json")
+    return try JSONDecoder().decode([ReceiptVector].self, from: Data(contentsOf: url))
+}
+
+private func makeReceipt(_ f: ReceiptVector.Fields) -> InferenceReceipt {
+    InferenceReceipt(
+        completionTokens: f.completion_tokens,
+        modelId: f.model_id,
+        modelWeightHash: f.model_weight_hash,
+        promptTokens: f.prompt_tokens,
+        requestId: f.request_id,
+        requestSha256: f.request_sha256,
+        responseSha256: f.response_sha256)
+}
+
+@Test func receiptCanonicalFormMatchesGoldenVectors() throws {
+    let vectors = try loadVectors()
+    #expect(!vectors.isEmpty)
+    for v in vectors {
+        #expect(v.receipt.v == InferenceReceipt.version, "vector \(v.name)")
+        let r = makeReceipt(v.receipt)
+        #expect(r.canonicalJSON() == v.canonical, "canonical drift in vector \(v.name)")
+        #expect(r.address() == v.address, "address drift in vector \(v.name)")
+    }
+}
+
+@Test func receiptAddressChangesWhenAnyFieldChanges() throws {
+    let base = InferenceReceipt(
+        completionTokens: 42,
+        modelId: "mlx-community/gemma-4-26b",
+        modelWeightHash: String(repeating: "ab", count: 32),
+        promptTokens: 17,
+        requestId: "req-0001",
+        requestSha256: String(repeating: "12", count: 32),
+        responseSha256: String(repeating: "34", count: 32))
+    let mutations: [InferenceReceipt] = [
+        InferenceReceipt(
+            completionTokens: 43, modelId: base.modelId,
+            modelWeightHash: base.modelWeightHash, promptTokens: base.promptTokens,
+            requestId: base.requestId, requestSha256: base.requestSha256,
+            responseSha256: base.responseSha256),
+        InferenceReceipt(
+            completionTokens: base.completionTokens, modelId: "other-model",
+            modelWeightHash: base.modelWeightHash, promptTokens: base.promptTokens,
+            requestId: base.requestId, requestSha256: base.requestSha256,
+            responseSha256: base.responseSha256),
+        InferenceReceipt(
+            completionTokens: base.completionTokens, modelId: base.modelId,
+            modelWeightHash: String(repeating: "cd", count: 32), promptTokens: base.promptTokens,
+            requestId: base.requestId, requestSha256: base.requestSha256,
+            responseSha256: base.responseSha256),
+        InferenceReceipt(
+            completionTokens: base.completionTokens, modelId: base.modelId,
+            modelWeightHash: base.modelWeightHash, promptTokens: base.promptTokens,
+            requestId: base.requestId, requestSha256: base.requestSha256,
+            responseSha256: String(repeating: "ee", count: 32)),
+    ]
+    for m in mutations {
+        #expect(m.address() != base.address(), "mutation did not move the address")
+    }
+}
+
+@Test func receiptStringEscapingMatchesGoEncoder() {
+    // Mirrors TestEncodeJSONStringEscaping in coordinator/receipt.
+    let cases: [(String, String)] = [
+        ("plain", "\"plain\""),
+        ("sla/sh", "\"sla/sh\""), // no slash escaping
+        ("qu\"ote", "\"qu\\\"ote\""),
+        ("back\\slash", "\"back\\\\slash\""),
+        ("tab\tnl\n", "\"tab\\tnl\\n\""),
+        ("ctrl\u{01}", "\"ctrl\\u0001\""),
+        ("<html>&", "\"<html>&\""), // no HTML escaping
+        ("unicodé-κ", "\"unicodé-κ\""),
+    ]
+    for (input, want) in cases {
+        #expect(InferenceReceipt.encodeJSONString(input) == want, "escaping drift for \(input)")
+    }
+}
+
+@Test func receiptAttestationSignsTheAddress() throws {
+    // The signature contract must match v1: DER ECDSA over SHA-256 of the
+    // UTF-8 address bytes. Use the software P-256 test signer.
+    let key = try P256TestSigner()
+    let receipt = InferenceReceipt(
+        completionTokens: 1, modelId: "m", modelWeightHash: "",
+        promptTokens: 1, requestId: "r",
+        requestSha256: String(repeating: "00", count: 32),
+        responseSha256: String(repeating: "ff", count: 32))
+    let sealed = computeReceiptAttestation(identity: key, receipt: receipt)
+    #expect(sealed.address == receipt.address())
+    #expect(sealed.receipt == receipt.canonicalJSON())
+    let signature = try #require(sealed.signature)
+    #expect(try key.verify(
+        signatureB64: signature, message: Data(sealed.address.utf8)))
+
+    // Tamper: the signature must not verify over a different address.
+    let forged = InferenceReceipt(
+        completionTokens: 2, modelId: "m", modelWeightHash: "",
+        promptTokens: 1, requestId: "r",
+        requestSha256: String(repeating: "00", count: 32),
+        responseSha256: String(repeating: "ff", count: 32))
+    #expect(!(try key.verify(
+        signatureB64: signature, message: Data(forged.address().utf8))))
+}
+
+/// Software P-256 signer with the same signing shape as the Secure Enclave
+/// identity (DER ECDSA, SHA-256 of the message).
+private struct P256TestSigner: AttestationSigner {
+    let key: P256.Signing.PrivateKey
+
+    init() throws {
+        key = P256.Signing.PrivateKey()
+    }
+
+    func sign(_ data: Data) throws -> Data {
+        try key.signature(for: data).derRepresentation
+    }
+
+    var publicKeyBase64: String {
+        key.publicKey.rawRepresentation.base64EncodedString()
+    }
+
+    func verify(signatureB64: String, message: Data) throws -> Bool {
+        guard let der = Data(base64Encoded: signatureB64) else { return false }
+        let sig = try P256.Signing.ECDSASignature(derRepresentation: der)
+        return key.publicKey.isValidSignature(sig, for: message)
+    }
+}
+


### PR DESCRIPTION
Inference receipts: seal every completed inference into a canonical record binding the model weight hash, the exact decrypted request bytes, and the response digest, signed through the existing attestation channel. `response_hash` becomes the receipt's SHA-256 hash, `se_signature` keeps its existing meaning, and one new optional `receipt` field carries the record. The coordinator cross checks each receipt and serves it with a verdict at public `GET /v1/receipts/{hash}`.

Closes #802

## Why

- `provider-swift/.../SecurityHardening.swift` signed `sha256(requestId:completionTokens:responseBody)`. That hash binds neither the model weights, nor the request bytes, nor any sampling parameter. A provider serving one model at another model's price produces valid attestations today.
- Everything needed to close the gap already exists: providers compute an aggregate weight hash that registration cross checks against the model catalog (`registry.go`), the Secure Enclave signing channel already rides `inference_complete`, and the coordinator holds the exact plaintext it seals for each provider at both encrypt sites.
- Receipts hold digests only, never prompt or response content, so the verdict endpoint can be public without touching the privacy model.

## Behavior: before and after

```mermaid
flowchart LR
  subgraph Before
    A1[consumer request] --> B1[provider runs a model]
    B1 --> C1["se_signature over sha256(requestId:tokens:text)"]
    C1 --> D1[model substitution and parameter tampering undetectable]
  end
  subgraph After
    A2[consumer request] --> B2[provider runs model]
    B2 --> C2["receipt binds weight hash, request digest, response digest; response_hash = receipt hash, SE signed"]
    C2 --> D2["coordinator cross checks 4 bindings; public GET /v1/receipts/{hash}"]
  end
```

Unchanged by design: the signing contract (`se_signature` over `response_hash`) is byte compatible; providers without receipts keep today's path exactly; consumers see the same fields they always saw plus one optional `receipt`; a failed binding never fails the request (logged, counted, visible on the record); no billing, routing, or trust level behavior changes.

## Code: before and after

```mermaid
flowchart LR
  subgraph Before
    S1["InferenceHandler"] --> A1b["computeResponseAttestation\nsha256(requestId:tokens:text)"]
    A1b --> W1["inference_complete: se_signature, response_hash"]
    W1 --> P1["provider.go: copy to pending request"]
    P1 --> C1b["consumer response passthrough"]
  end
  subgraph After
    S2["InferenceHandler\nsha256(decrypted body) + registered weight hash"] --> A2b["InferenceReceipt.swift\ncanonical JSON, hash, SE sign"]
    A2b --> W2["inference_complete: + receipt"]
    W2 --> P2["provider.go: recordReceipt"]
    P2 --> V2["receipt.Verify: hash, dispatched body digest,\nweight hash, signature (coordinator/receipt)"]
    V2 --> E2["receiptCache: GET /v1/receipts/{hash}"]
    P2 --> C2b["consumer response: receipt + response_hash + se_signature"]
  end
```

## Protocol (Go and Swift mirrored)

- `inference_complete` gains one optional field, `receipt` (string): mirrored in `coordinator/protocol/messages.go` and `provider-swift/.../Protocol/Messages.swift` plus the coordinator client codec. Legacy wire shape is unchanged when absent; older coordinators ignore it.
- Canonical receipt form: single line JSON, alphabetical keys, minimal escaping. `receipt.Parse` requires that re encoding reproduces the wire bytes, so each receipt has exactly one byte representation and re serialization forgery is closed. Go and Swift encoders are pinned byte for byte by `fixtures/receipts/receipt_vectors.json`, generated independently of both implementations.
- New public endpoint `GET /v1/receipts/{hash}`: digests, signature, attested public key, and the coordinator's per binding verdict. Checks are paired with `*_checked` flags so sealed sender mode and unattested providers degrade honestly instead of passing silently.
- No release artifact changes, no version bump, no migration.

## Verification

- Coordinator: `go test ./coordinator/...` green on Linux, 25 of 25 packages including the full `api` suite. `go vet` clean.
- `coordinator/receipt`: golden vectors, canonical form strictness, and a tamper matrix (every field mutation, wrong key, malformed signatures, tri state checks).
- `TestIntegration_ReceiptGenuine`: real httptest plus WebSocket loop with a simulated provider signing with its attested P-256 key. The receipt reaches the consumer stream, `response_hash` equals the receipt hash, a third party verifies the signature from public endpoint data alone, and every coordinator check is green.
- `TestIntegration_ReceiptLyingProviderIsFlagged`: a canonically encoded, correctly signed receipt claiming a different request digest and weight hash. `address_match` and `signature_valid` stay true, which is the attack, and the dispatched body digest and registered weight hash cross checks refute it.
- Provider: `swift build --build-tests` compiles the full package including every test target (Swift 6.3, Apple Silicon). Receipt twin tests green: golden vector byte identity with Go, hash movement on any field change, escaping parity, and the signer contract. Protocol and codec round trips carrying the new field green.
- Not run here: the MLX and Metal backed Swift suites (compile verified only; no metallib on the runner used). This repo's own CI covers them.

## Notes for reviewers

- The v1 `computeResponseAttestation` is removed; its signing contract survives unchanged inside `computeReceiptAttestation`.
- The receipt cache is in memory and bounded (`receiptCacheCap`). The receipt travels inline to the consumer, so the endpoint is a lookup convenience, not a custody layer. Durable storage is an easy follow up if wanted.
- On speculative backup dispatch, `DispatchedBodySHA256` follows the same last writer pattern as `SessionPrivKey`; if the two sealed bodies ever differ per provider, a false digest mismatch flag is possible (advisory only, never request failing).
- Follow ups sketched in `docs/architecture/receipts.md` and deliberately out of scope: console receipt display, replay audits on top of direct mode, and the determinism measurement replay verdicts depend on.
- Scope, naming, and wire format are open to maintainer guidance in #802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
