### PR TITLE
test(provider): gate the destructive-epoch capability test on DEBUG so release test builds compile

### DIFF
--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1065,6 +1065,9 @@ struct SSDPrefixCacheLifecycleTests {
         #expect(try SSDCacheEpochStore(root: dir, binding: binding).current == rotatedEpoch)
     }
 
+    // `holdDestructiveEpochForTesting` exists only under `#if DEBUG` in SSDPrefixCache.swift,
+    // so this test must be gated the same way or `swift test -c release` fails to compile.
+    #if DEBUG
     @Test("capability publication waits for destructive mutation completion")
     func destructiveMutationBracketsCapabilityPublication() async throws {
         let dir = tempDir("epoch-publication-bracket")
@@ -1124,6 +1127,7 @@ struct SSDPrefixCacheLifecycleTests {
         let current = try #require(cache.prefixCacheV2Capability())
         #expect(current.cacheEpoch != original.cacheEpoch)
     }
+    #endif
 
     @Test("reconciliation drops a symlink-replaced indexed file without following it")
     func reconciliationDropsSymlinkReplacement() throws {


### PR DESCRIPTION
## Summary

`swift test -c release` in `provider-swift` does not compile on master:

```
Tests/ProviderCoreTests/SSDPrefixCacheTests.swift:1101:19: error: value of type 'SSDPrefixCache' has no member 'holdDestructiveEpochForTesting'
```

`SSDPrefixCache.holdDestructiveEpochForTesting` is declared under `#if DEBUG` (SSDPrefixCache.swift:2100), but the test `destructiveMutationBracketsCapabilityPublication` calls it unconditionally. Because `scripts/run-mtp-benchmark.py --mode production-performance` runs `swift test -c release --filter GemmaMTPPerformanceLiveTests`, the production-performance MTP benchmark cannot build at master.

This gates that one test on the same `#if DEBUG` as the hook. Debug builds still run it; release test builds compile again.

## Verification

- Before: `swift test -c release --filter ZZZNoSuchTest` fails with the error above.
- After (same command, M5 Max, Xcode 26.6 / Swift 6.3.3): builds, `Test run with 0 tests in 0 suites passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeC8iwU28kLjxCZeD8GcyE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791044518&installation_model_id=21733&pr_number=812&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F812&signature=9daa6218f0809679a08a59eea532d42c5d94c10f26339ec23afc385f9b39eac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->