### PR TITLE
feat(provider): operator-chosen idle-memory policy (Always ready / Free when idle / Custom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ Zero prerequisites and no `sudo`. The installer fetches the latest signed releas
 ### First run
 
 ```bash
-darkbloom start              # background launchd service (interactive model picker)
+darkbloom start              # background launchd service (interactive model picker + memory policy)
 darkbloom start --foreground # run attached to the terminal
+darkbloom idle keep-loaded   # keep models loaded while idle (instant responses); default frees after 60 min
 darkbloom login              # link your account (RFC 8628 device-code flow)
 darkbloom status             # config, hardware, schedule, live trust verdict
 darkbloom doctor             # local diagnostics + coordinator's trust view
@@ -267,7 +268,7 @@ auto_restart = true
 
 [backend]
 enabled_models = []        # empty = advertise all downloaded models
-idle_timeout_mins = 60     # unload an idle model after N minutes (0 = never)
+idle_timeout_mins = 60     # free when idle: unload after N idle minutes, reload on demand (0 = always ready)
 max_model_slots = 3        # max models resident at once
 continuous_batching = true
 

--- a/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
+++ b/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
@@ -4,7 +4,7 @@
 // protect density.
 
 import type { MyProvider } from "../types";
-import { shortModelName } from "./format";
+import { describeIdlePolicy, shortModelName } from "./format";
 
 const CATALOG_LIMIT = 8;
 
@@ -31,12 +31,23 @@ export function ModelsStrip({ provider }: { provider: MyProvider }) {
   const shownCatalog = catalog.slice(0, CATALOG_LIMIT);
   const extraCatalog = catalog.length - shownCatalog.length;
 
+  // The operator's idle-memory policy tells the reader whether an empty
+  // "Loaded" set is by design (sleeping, wakes on demand) or a problem.
+  const idlePolicy = provider.online ? describeIdlePolicy(provider.idle_unload_mins) : undefined;
+  const sleeping =
+    provider.online && warm.length === 0 && catalog.length > 0 && (provider.idle_unload_mins ?? 0) > 0;
+
   if (warm.length === 0 && catalog.length === 0) {
     return <p className="px-4 pb-3 text-xs text-text-tertiary">No models loaded yet.</p>;
   }
 
   return (
     <div className="px-4 pb-3 space-y-2.5">
+      {sleeping && (
+        <p className="text-xs text-text-tertiary" data-testid="models-sleeping">
+          Nothing loaded right now — sleeping until the next request (~10–30 s to reload).
+        </p>
+      )}
       {warm.length > 0 && (
         <div className="space-y-1.5">
           <p className="text-[10px] uppercase tracking-wider text-text-tertiary">Loaded</p>
@@ -84,6 +95,14 @@ export function ModelsStrip({ provider }: { provider: MyProvider }) {
             )}
           </div>
         </div>
+      )}
+
+      {idlePolicy && (
+        <p className="text-[11px] text-text-tertiary" data-testid="idle-policy">
+          <span className="uppercase tracking-wider text-[10px]">Memory when idle</span>
+          {" · "}
+          {idlePolicy}
+        </p>
       )}
     </div>
   );

--- a/console-ui/src/app/providers/dashboard/fixes.ts
+++ b/console-ui/src/app/providers/dashboard/fixes.ts
@@ -107,7 +107,7 @@ const FIX_TABLE: Record<string, FixAction> = {
   backend_idle_shutdown: {
     kind: "guidance",
     label: "No action needed",
-    note: "Model was unloaded after idle; the next request pays a ~10–30s cold start.",
+    note: "Your idle-memory policy freed the model; the next request reloads it (~10–30 s). To keep models resident for instant responses, run `darkbloom idle keep-loaded` on the machine.",
   },
   low_success_rate: {
     kind: "link",

--- a/console-ui/src/app/providers/dashboard/format.ts
+++ b/console-ui/src/app/providers/dashboard/format.ts
@@ -12,4 +12,6 @@ export {
   clampPct,
   formatTps,
   humanizeUptime,
+  formatIdleWindow,
+  describeIdlePolicy,
 } from "@/lib/format";

--- a/console-ui/src/app/providers/dashboard/idle-policy.test.tsx
+++ b/console-ui/src/app/providers/dashboard/idle-policy.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ModelsStrip } from "./ModelsStrip";
+import { describeIdlePolicy, formatIdleWindow } from "./format";
+import { computeWarnings } from "../warnings";
+import { resolveFix } from "./fixes";
+import { makeProvider } from "./testFixtures";
+
+const ctx = {
+  latest_provider_version: "0.6.5",
+  min_provider_version: "0.6.0",
+  heartbeat_timeout_seconds: 90,
+  challenge_max_age_seconds: 360,
+};
+
+const catalog = [{ id: "mlx-community/model-a" }, { id: "mlx-community/model-b" }];
+const POLICY = "idle-policy";
+const SLEEPING = "models-sleeping";
+
+describe("idle-memory policy wording", () => {
+  it("formats the idle window like the CLI does", () => {
+    expect(formatIdleWindow(45)).toBe("45 min");
+    expect(formatIdleWindow(60)).toBe("1 h");
+    expect(formatIdleWindow(90)).toBe("1 h 30 min");
+    expect(formatIdleWindow(120)).toBe("2 h");
+  });
+
+  it("says nothing when the machine has not reported a policy", () => {
+    expect(describeIdlePolicy(undefined)).toBeUndefined();
+    expect(describeIdlePolicy(-1)).toBeUndefined();
+  });
+
+  it("distinguishes always-ready (0) from free-when-idle (N)", () => {
+    expect(describeIdlePolicy(0)).toBe("Always ready — models stay loaded");
+    expect(describeIdlePolicy(60)).toMatch(/Free when idle — unloads after 1 h without requests/);
+    expect(describeIdlePolicy(60)).toMatch(/reloads on demand/);
+  });
+});
+
+describe("ModelsStrip idle-memory policy line", () => {
+  it("shows the policy for an online machine", () => {
+    render(
+      <ModelsStrip
+        provider={makeProvider({ status: "serving", online: true, models: catalog, warm_models: [catalog[0].id], idle_unload_mins: 0 })}
+      />,
+    );
+    expect(screen.getByTestId(POLICY)).toHaveTextContent(/Always ready/);
+    expect(screen.queryByTestId(SLEEPING)).toBeNull();
+  });
+
+  it("hides the policy for an offline machine or an unreported policy", () => {
+    const { unmount } = render(
+      <ModelsStrip provider={makeProvider({ status: "offline", online: false, models: catalog, idle_unload_mins: 60 })} />,
+    );
+    expect(screen.queryByTestId(POLICY)).toBeNull();
+    unmount();
+
+    render(<ModelsStrip provider={makeProvider({ status: "online", online: true, models: catalog, warm_models: [catalog[0].id] })} />);
+    expect(screen.queryByTestId(POLICY)).toBeNull();
+  });
+
+  it("explains an empty Loaded set as sleeping under free-when-idle only", () => {
+    const { unmount } = render(
+      <ModelsStrip provider={makeProvider({ status: "online", online: true, models: catalog, warm_models: [], idle_unload_mins: 60 })} />,
+    );
+    expect(screen.getByTestId(SLEEPING)).toHaveTextContent(/sleeping until the next request/);
+    expect(screen.getByTestId(POLICY)).toHaveTextContent(/unloads after 1 h without requests/);
+    unmount();
+
+    // Always ready with nothing loaded is NOT sleeping — that is a real gap.
+    render(<ModelsStrip provider={makeProvider({ status: "online", online: true, models: catalog, warm_models: [], idle_unload_mins: 0 })} />);
+    expect(screen.queryByTestId(SLEEPING)).toBeNull();
+  });
+});
+
+describe("cold-slot warning under the idle policy", () => {
+  const coldSlots = {
+    backend_capacity: {
+      slots: [{ model: "mlx-community/model-a", state: "idle_shutdown" }],
+    } as never,
+  };
+
+  it("quotes the machine's own idle window when it is known", () => {
+    const p = makeProvider({ status: "online", online: true, idle_unload_mins: 90, ...coldSlots });
+    const w = computeWarnings(p, ctx).find((x) => x.id === "backend_idle_shutdown");
+    expect(w).toBeTruthy();
+    expect(w!.title).toMatch(/reloads on demand/);
+    expect(w!.detail).toMatch(/unloaded after 1 h 30 min without requests/);
+    expect(w!.detail).toMatch(/darkbloom idle keep-loaded/);
+    expect(w!.detail).not.toMatch(/1h of idle/);
+  });
+
+  it("falls back to a generic window for providers that do not report one", () => {
+    const p = makeProvider({ status: "online", online: true, ...coldSlots });
+    const w = computeWarnings(p, ctx).find((x) => x.id === "backend_idle_shutdown");
+    expect(w!.detail).toMatch(/after the idle window/);
+  });
+
+  it("offers keep-loaded as the way to opt out", () => {
+    const fix = resolveFix("backend_idle_shutdown");
+    expect(fix.kind).toBe("guidance");
+    expect(fix.note).toMatch(/darkbloom idle keep-loaded/);
+  });
+});

--- a/console-ui/src/app/providers/setup/page.tsx
+++ b/console-ui/src/app/providers/setup/page.tsx
@@ -126,8 +126,8 @@ const FAQ = [
     answer: "Yes. Configure power management to prevent sleep (pmset -c sleep 0 discsleep 0) and the provider daemon will run as a background service. Note that closing a MacBook lid will put it to sleep regardless of pmset settings.",
   },
   {
-    question: "How does the idle timeout work?",
-    answer: "The vllm-mlx backend process is automatically stopped after 1 hour of no inference requests to free GPU memory. When a new request arrives, the model is lazy-reloaded (10-30 second cold start). This is configurable via the provider config.",
+    question: "Does the provider hold my Mac's memory when nobody is using it?",
+    answer: "That's your call. When you run `darkbloom start` it asks: Always ready keeps models loaded for instant responses (and full base rewards, since a loaded model is what earns them); Free when idle — the default — unloads a model after 60 minutes without requests to give your Mac its memory back, then reloads it on demand when the next request arrives (a ~10–30 s cold start on that first request); Custom lets you pick the number of idle minutes. Change it any time with `darkbloom idle keep-loaded`, `darkbloom idle unload-after <minutes>`, or check it with `darkbloom idle status`; the setting is saved in provider.toml under [backend] idle_timeout_mins.",
   },
 ];
 

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -126,6 +126,10 @@ export interface MyProvider {
 
   system_metrics?: MySystemMetrics;
   backend_capacity?: MyBackendCapacity;
+  /** Idle-memory policy reported in heartbeats: 0 = always ready (models
+   *  stay loaded), N = unloaded after N idle minutes and reloaded on demand.
+   *  Absent for offline machines and providers too old to report it. */
+  idle_unload_mins?: number;
   warm_models?: string[];
   current_model?: string;
   pending_requests: number;

--- a/console-ui/src/app/providers/warnings.ts
+++ b/console-ui/src/app/providers/warnings.ts
@@ -10,6 +10,7 @@
 // rules and FindProviderWithTrust exclusion checks.
 
 import type { MyProvider, MyProvidersResponse } from "./types";
+import { formatIdleWindow } from "@/lib/format";
 
 export type WarningSeverity = "blocking" | "degrading" | "info";
 
@@ -33,6 +34,14 @@ export function semverLess(a: string, b: string): boolean {
     if (av > bv) return false;
   }
   return false;
+}
+
+/** "1 h 30 min without requests" from the machine's reported policy, or a
+ *  generic phrase for providers that do not report one. */
+function idleWindowPhrase(p: MyProvider): string {
+  return p.idle_unload_mins && p.idle_unload_mins > 0
+    ? `${formatIdleWindow(p.idle_unload_mins)} without requests`
+    : "the idle window";
 }
 
 export function computeWarnings(
@@ -212,13 +221,15 @@ export function computeWarnings(
   const idleSlots =
     p.backend_capacity?.slots?.filter((s) => s.state === "idle_shutdown") ?? [];
   if (idleSlots.length > 0) {
+    // Under "Free when idle" a cold slot is the policy working as designed:
+    // say so, with the machine's own window, instead of a bare warning.
     out.push({
       id: "backend_idle_shutdown",
       severity: "degrading",
-      title: "Backend cold (0.1x weight on cold start)",
-      detail: `Backend(s) for ${idleSlots
+      title: "Model unloaded while idle (reloads on demand)",
+      detail: `${idleSlots
         .map((s) => s.model)
-        .join(", ")} were unloaded after 1h of idle. Next request will pay a ~10-30s cold-start penalty.`,
+        .join(", ")} unloaded after ${idleWindowPhrase(p)}. The next request reloads it (~10–30 s), and warm machines are preferred until then. Prefer instant responses? Run \`darkbloom idle keep-loaded\`.`,
     });
   }
 

--- a/console-ui/src/lib/format/time.ts
+++ b/console-ui/src/lib/format/time.ts
@@ -40,6 +40,28 @@ export function formatRelative(iso?: string): string {
 }
 
 /** Seconds -> compact uptime ("3d 4h", "5h 12m", "8m"). */
+/** Idle-unload window in minutes → "45 min" / "1 h" / "1 h 30 min". */
+export function formatIdleWindow(minutes: number): string {
+  const m = Math.max(0, Math.floor(minutes));
+  const hours = Math.floor(m / 60);
+  const rest = m % 60;
+  if (hours === 0) return `${m} min`;
+  if (rest === 0) return `${hours} h`;
+  return `${hours} h ${rest} min`;
+}
+
+/**
+ * Idle-memory policy from the heartbeat's `idle_unload_mins`: 0 keeps models
+ * resident ("always ready"), N frees them after N idle minutes and reloads on
+ * demand. `undefined` when the machine has not reported one (offline or an
+ * older provider) — callers should then say nothing rather than guess.
+ */
+export function describeIdlePolicy(minutes?: number): string | undefined {
+  if (minutes === undefined || minutes === null || minutes < 0) return undefined;
+  if (minutes === 0) return "Always ready — models stay loaded";
+  return `Free when idle — unloads after ${formatIdleWindow(minutes)} without requests, reloads on demand`;
+}
+
 export function humanizeUptime(seconds?: number): string {
   const s = seconds ?? 0;
   if (s <= 0) return "—";

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -91,12 +91,18 @@ type myProvider struct {
 	// Live snapshot (only set when the machine is currently connected)
 	SystemMetrics   *protocol.SystemMetrics   `json:"system_metrics,omitempty"`
 	BackendCapacity *protocol.BackendCapacity `json:"backend_capacity,omitempty"`
-	WarmModels      []string                  `json:"warm_models,omitempty"`
-	CurrentModel    string                    `json:"current_model,omitempty"`
-	PendingRequests int                       `json:"pending_requests"`
-	MaxConcurrency  int                       `json:"max_concurrency"`
-	PrefillTPS      float64                   `json:"prefill_tps,omitempty"`
-	DecodeTPS       float64                   `json:"decode_tps,omitempty"`
+	// IdleUnloadMins is the machine's idle-memory policy as reported in its
+	// heartbeats: 0 = always ready (models stay loaded), N = unloaded after N
+	// idle minutes and reloaded on demand. Omitted for offline machines and
+	// for providers too old to report it. Lets the dashboard render a missing
+	// slot as "sleeping, wakes on demand" instead of a warning.
+	IdleUnloadMins  *int     `json:"idle_unload_mins,omitempty"`
+	WarmModels      []string `json:"warm_models,omitempty"`
+	CurrentModel    string   `json:"current_model,omitempty"`
+	PendingRequests int      `json:"pending_requests"`
+	MaxConcurrency  int      `json:"max_concurrency"`
+	PrefillTPS      float64  `json:"prefill_tps,omitempty"`
+	DecodeTPS       float64  `json:"decode_tps,omitempty"`
 
 	// Reputation
 	Reputation myReputation `json:"reputation"`
@@ -582,6 +588,10 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		if live.BackendCapacity != nil {
 			cap := *live.BackendCapacity
 			mp.BackendCapacity = &cap
+		}
+		if live.IdleUnloadMins != nil {
+			v := *live.IdleUnloadMins
+			mp.IdleUnloadMins = &v
 		}
 		mp.WarmModels = append([]string{}, live.WarmModels...)
 		mp.CurrentModel = live.CurrentModel

--- a/coordinator/api/me_idle_policy_test.go
+++ b/coordinator/api/me_idle_policy_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// The owner's dashboard needs the idle-memory policy to render a missing
+// slot as "sleeping, wakes on demand" (free-when-idle) rather than as a
+// warning. The heartbeat value is surfaced per live machine; 0 (always
+// ready) must not be collapsed into "absent".
+func TestMyProvidersSurfacesIdleUnloadPolicy(t *testing.T) {
+	srv, st := newKeyTestServer(t)
+	seedProviderRecord(t, st, "live-p", "SER-IDLE", "acct-1")
+
+	// A linked, attested live connection — heartbeats persist the live
+	// provider back to the store, so it must carry the owner's account.
+	live := srv.registry.Register("live-p", nil, &protocol.RegisterMessage{})
+	live.SetAttestationResult(&attestation.VerificationResult{SerialNumber: "SER-IDLE"})
+	live.Mu().Lock()
+	live.AccountID = "acct-1"
+	live.Mu().Unlock()
+
+	fetch := func(stage string) map[string]any {
+		t.Helper()
+		r := reqWithUser(http.MethodGet, "/v1/me/providers", "", "acct-1")
+		w := httptest.NewRecorder()
+		srv.handleMyProviders(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+		}
+		var resp struct {
+			Providers []map[string]any `json:"providers"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		for _, p := range resp.Providers {
+			if p["id"] == "live-p" {
+				return p
+			}
+		}
+		t.Fatalf("[%s] live-p missing from response: %s", stage, w.Body.String())
+		return nil
+	}
+
+	// Before any heartbeat reports a policy: omitted, not defaulted.
+	if _, ok := fetch("initial")["idle_unload_mins"]; ok {
+		t.Fatal("idle_unload_mins present before the provider reported one")
+	}
+
+	zero := 0
+	srv.registry.Heartbeat("live-p", &protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", IdleUnloadMins: &zero,
+	})
+	if got := fetch("zero")["idle_unload_mins"]; got != float64(0) {
+		t.Fatalf("idle_unload_mins = %v, want 0 (always ready)", got)
+	}
+
+	sixty := 60
+	srv.registry.Heartbeat("live-p", &protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle", IdleUnloadMins: &sixty,
+	})
+	if got := fetch("sixty")["idle_unload_mins"]; got != float64(60) {
+		t.Fatalf("idle_unload_mins = %v, want 60", got)
+	}
+
+	// A legacy-shaped heartbeat (no field) keeps the last reported policy.
+	srv.registry.Heartbeat("live-p", &protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "idle",
+	})
+	if got := fetch("legacy")["idle_unload_mins"]; got != float64(60) {
+		t.Fatalf("idle_unload_mins after legacy heartbeat = %v, want 60 (sticky)", got)
+	}
+}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -272,6 +272,15 @@ type HeartbeatMessage struct {
 	// registration (see api.handleCodeAttestationResponse).
 	APNsDeviceToken string `json:"apns_device_token,omitempty"` // hex device token from registerForRemoteNotifications
 	APNsEnvironment string `json:"apns_environment,omitempty"`  // "production" | "development" (selects the APNs host)
+
+	// IdleUnloadMins is the operator's idle-memory policy (`[backend]
+	// idle_timeout_mins` on the provider): minutes without requests before the
+	// box unloads a model, or 0 when models stay resident ("always ready").
+	// Pointer so 0 survives omitempty; nil = legacy provider that does not
+	// report the policy. Informational only — it lets the owner's dashboard
+	// tell "unloaded on purpose, wakes on demand" apart from "should be loaded
+	// and isn't". Routing keys on live slot state, never on this field.
+	IdleUnloadMins *int `json:"idle_unload_mins,omitempty"`
 }
 
 // BackendSlotCapacity describes the capacity state of a single backend slot

--- a/coordinator/protocol/messages_idle_unload_test.go
+++ b/coordinator/protocol/messages_idle_unload_test.go
@@ -1,0 +1,44 @@
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// idle_unload_mins: 0 ("always ready") is a real policy and must survive
+// omitempty; only an unreported policy (nil) is absent from the wire.
+func TestHeartbeatIdleUnloadMinsRoundTrip(t *testing.T) {
+	zero := 0
+	msg := HeartbeatMessage{Type: TypeHeartbeat, Status: "idle", IdleUnloadMins: &zero}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"idle_unload_mins":0`) {
+		t.Fatalf("always-ready policy dropped from the wire: %s", data)
+	}
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.IdleUnloadMins == nil || *decoded.IdleUnloadMins != 0 {
+		t.Fatalf("idle_unload_mins = %v, want 0", decoded.IdleUnloadMins)
+	}
+
+	// Legacy provider: key absent → nil, never a defaulted value.
+	var legacy HeartbeatMessage
+	if err := json.Unmarshal([]byte(`{"type":"heartbeat","status":"idle"}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	if legacy.IdleUnloadMins != nil {
+		t.Fatalf("legacy heartbeat decoded idle_unload_mins = %d, want nil", *legacy.IdleUnloadMins)
+	}
+	out, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal legacy: %v", err)
+	}
+	if strings.Contains(string(out), "idle_unload_mins") {
+		t.Fatalf("nil policy must be omitted, got %s", out)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -882,6 +882,14 @@ type Provider struct {
 	// Live system metrics from heartbeats
 	SystemMetrics protocol.SystemMetrics
 
+	// IdleUnloadMins is the provider's reported idle-memory policy (heartbeat
+	// `idle_unload_mins`): 0 = models stay resident, N = unload after N idle
+	// minutes. nil until a heartbeat reports it (legacy providers never do).
+	// Sticky within a connection — the policy is provider config, so a
+	// reporting provider carries it in every heartbeat. Guarded by p.mu.
+	// Surfaced on /v1/me/providers; not a routing input.
+	IdleUnloadMins *int
+
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
 	BackendCapacity *protocol.BackendCapacity
 
@@ -3909,6 +3917,12 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	applyHeartbeatStatsDelta(&p.Stats, p.lastSessionStats, msg.Stats)
 	p.lastSessionStats = mergeHeartbeatSessionStats(p.lastSessionStats, msg.Stats)
 	p.SystemMetrics = systemMetrics
+	// Idle-memory policy: copy so the registry never aliases the decoded
+	// message; ignore nonsense (negative) values from an untrusted provider.
+	if msg.IdleUnloadMins != nil && *msg.IdleUnloadMins >= 0 {
+		v := *msg.IdleUnloadMins
+		p.IdleUnloadMins = &v
+	}
 	// Update backend capacity from heartbeat. A nil report clears prior live
 	// capacity so stale slot state cannot keep influencing routing.
 	p.BackendCapacity = backendCapacity

--- a/coordinator/registry/registry_capacity_test.go
+++ b/coordinator/registry/registry_capacity_test.go
@@ -293,3 +293,46 @@ func TestFindProviderPrefersCrashedLast(t *testing.T) {
 		t.Errorf("expected hot-provider, got %q", found.ID)
 	}
 }
+
+// The idle-memory policy is provider config, reported in every heartbeat by
+// providers that know it and never by legacy ones: 0 must be stored as a real
+// value, negatives are ignored, and a heartbeat without the field keeps the
+// last reported policy rather than clearing it.
+func TestHeartbeatIdleUnloadMinsIsStickyAndValidated(t *testing.T) {
+	reg := New(testLogger())
+	reg.Register("p1", nil, testRegisterMessage())
+
+	policy := func() *int {
+		p := reg.GetProvider("p1")
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return p.IdleUnloadMins
+	}
+
+	reg.Heartbeat("p1", &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle"})
+	if policy() != nil {
+		t.Fatalf("legacy heartbeat set a policy: %d", *policy())
+	}
+
+	zero := 0
+	reg.Heartbeat("p1", &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle", IdleUnloadMins: &zero})
+	if got := policy(); got == nil || *got != 0 {
+		t.Fatalf("always-ready policy = %v, want 0", got)
+	}
+	// Registry owns its copy; mutating the message must not leak in.
+	zero = 99
+	if got := policy(); *got != 0 {
+		t.Fatalf("policy aliased the heartbeat message: %d", *got)
+	}
+
+	negative := -5
+	reg.Heartbeat("p1", &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle", IdleUnloadMins: &negative})
+	if got := policy(); *got != 0 {
+		t.Fatalf("negative policy accepted: %d", *got)
+	}
+
+	reg.Heartbeat("p1", &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle"})
+	if got := policy(); got == nil || *got != 0 {
+		t.Fatalf("field-less heartbeat cleared the policy: %v", got)
+	}
+}

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -29,7 +29,7 @@ darkbloom start [flags]
 | `--coordinator-url <url>` | Override the coordinator WebSocket URL |
 | `--model <id>` | Model to serve; repeatable (skips the interactive picker) |
 | `--all` | Serve all downloaded models |
-| `--idle-timeout <mins>` | Idle timeout before unloading a model |
+| `--idle-timeout <mins>` | Idle-memory policy, saved to `[backend] idle_timeout_mins` (0 = always ready); skips the memory prompt |
 | `--foreground` | Run in the foreground (used by launchd; normally implicit) |
 | `--local` | Run a local OpenAI server only; do not connect to the coordinator |
 | `--local-endpoint` | Serve a local OpenAI endpoint alongside the coordinator |
@@ -41,6 +41,24 @@ Preflight checks for boot security, debugger attachment, and memory run before
 the model picker (`provider-swift/Sources/darkbloom/StartCommand+Preflight.swift:9-27`);
 the Metal requirement is enforced by `Start.prepareServeRuntime`
 (`provider-swift/Sources/darkbloom/StartCommand.swift:128-147`).
+
+After the model picker, an interactive `darkbloom start` asks how the machine
+should treat its memory when nobody is sending requests:
+
+```
+Memory when idle
+  1) Always ready    Keep models loaded (~18 GB while idle). Instant responses,
+                     full base rewards.
+  2) Free when idle  Unload after 60 min without requests; reload on demand
+                     (~10-30 s cold start). Your Mac gets its memory back.
+  3) Custom          Choose the number of idle minutes.
+  Choice [2]:
+```
+
+Enter keeps the policy already in force (`Free when idle` on a fresh install).
+The answer is written to `[backend] idle_timeout_mins` and applies to every
+serve mode; `--model`/`--all`, `--idle-timeout`, non-interactive runs and the
+launchd relaunch never prompt. See [`darkbloom idle`](#darkbloom-idle).
 
 Examples:
 
@@ -60,6 +78,32 @@ darkbloom start --local --port 8080
 # Unified: public fleet + local endpoint
 darkbloom start --local-endpoint --bind 100.x.y.z
 ```
+
+## `darkbloom idle`
+
+Manage the idle-memory policy: whether a model stays loaded while the machine
+receives no requests, or is unloaded to give the memory back and reloaded on
+demand. The single source of truth is `[backend] idle_timeout_mins` in
+`provider.toml` (0 = always ready); `darkbloom start`'s memory prompt and
+`--idle-timeout` write the same key, and the launchd plist never carries it.
+
+```bash
+darkbloom idle status                 # current policy and where it is set (default)
+darkbloom idle keep-loaded            # always ready: models stay loaded
+darkbloom idle unload-after <minutes> # free when idle: unload after N idle minutes (1..10080)
+```
+
+| Policy | `idle_timeout_mins` | Effect |
+|--------|---------------------|--------|
+| Always ready | `0` | Models stay resident; instant responses; the machine stays eligible for base rewards the whole time |
+| Free when idle (default) | `60` | A model with no requests for 60 min is unloaded; the next request reloads it (~10-30 s cold start) |
+| Custom | `N` | Same as above with an `N`-minute window |
+
+Changes are saved with the same locked read-modify-write as `darkbloom beta`
+and take effect after `darkbloom restart`. The provider reports the policy in
+its heartbeat (`idle_unload_mins`) so the dashboard shows an empty slot as
+"sleeping, wakes on demand" rather than as a fault. `--json` prints the policy
+machine-readably.
 
 ## `darkbloom stop`
 
@@ -100,6 +144,9 @@ Output includes:
 - Detected hardware (chip, RAM, GPU cores).
 - Schedule state (active/inactive).
 - Live daemon PID, uptime, trust verdict, and last model-load error.
+- `Memory when idle`: the idle-memory policy in force (`always ready` or
+  `free after N idle`), and any advertised models that are currently not
+  loaded, with the reason (unloaded when idle vs. loads on first request).
 - Per-slot posture: the KV backend each loaded model actually resolved to
   (`paged` / `contiguous`), the selection the config asked for, and whether
   MTP is enabled, active, or enabled-but-inert.

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -89,7 +89,7 @@ auto_restart = true
 
 [backend]
 enabled_models = []
-idle_timeout_mins = 60
+idle_timeout_mins = 60   # free when idle; 0 = always ready (see `darkbloom idle`)
 max_model_slots = 3
 
 [gemma_optimizations]

--- a/docs/provider/quickstart.md
+++ b/docs/provider/quickstart.md
@@ -54,8 +54,10 @@ darkbloom start --local
 
 `darkbloom start` (`provider-swift/Sources/darkbloom/StartCommand.swift`) runs
 preflight checks (SIP, debugger, GPU, memory), offers to link your account if
-you are not logged in, shows an interactive model picker, then installs and
-starts a `launchd` user agent.
+you are not logged in, shows an interactive model picker, asks whether models
+should stay loaded while idle (`Always ready`) or be unloaded after 60 minutes
+without requests and reloaded on demand (`Free when idle`, the default; or a
+custom window), then installs and starts a `launchd` user agent.
 
 ## Link your account
 
@@ -159,8 +161,12 @@ end = "08:00"
   printing the restart boundary
   (`provider-swift/Sources/darkbloom/BetaCommand.swift:201-235`).
 - `backend.enabled_models` — if non-empty, only these models are advertised.
-- `backend.idle_timeout_mins` — minutes of inactivity before an idle model is
-  unloaded (default 60; 0 disables eviction).
+- `backend.idle_timeout_mins` — the idle-memory policy: minutes without
+  requests before a model is unloaded and its memory returned to the Mac
+  (default 60; reloaded on demand with a ~10-30 s cold start), or `0` to keep
+  models loaded for instant responses. `darkbloom start` asks for this
+  interactively; change it later with `darkbloom idle keep-loaded` /
+  `darkbloom idle unload-after <minutes>`.
 - `backend.max_model_slots` — maximum resident models at once (default 3).
 - `config_version` — schema version of this file, written automatically on
   first start after upgrading. It only dates the file, so the provider can

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -111,7 +111,8 @@ extension CoordinatorClient {
             prefixCacheV2Models: prefixCache.protocolVersion == 2
                 ? prefixCache.models : nil,
             prefixCacheStatuses: prefixCache.statuses,
-            prefixCacheDonationOutcomes: prefixCache.donationOutcomes
+            prefixCacheDonationOutcomes: prefixCache.donationOutcomes,
+            idleUnloadMins: config.idleUnloadMins
         )
 
         do {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -108,7 +108,8 @@ public enum CoordinatorClientCodec {
         prefixCacheProtocol: Int? = nil,
         prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
         prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
-        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
+        idleUnloadMins: UInt64? = nil
     ) -> ProviderMessage {
         .heartbeat(ProviderMessage.Heartbeat(
             status: status,
@@ -122,7 +123,8 @@ public enum CoordinatorClientCodec {
             prefixCacheProtocol: prefixCacheProtocol,
             prefixCacheV2Models: prefixCacheV2Models,
             prefixCacheStatuses: prefixCacheStatuses,
-            prefixCacheDonationOutcomes: prefixCacheDonationOutcomes
+            prefixCacheDonationOutcomes: prefixCacheDonationOutcomes,
+            idleUnloadMins: idleUnloadMins
         ))
     }
 

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -158,6 +158,10 @@ public struct CoordinatorClientConfig: Sendable {
     /// nil on headless/no-GUI boxes (no token) — those register un-attested.
     public let apnsDeviceToken: String?
     public let apnsEnvironment: String?
+    /// Idle-memory policy reported in every heartbeat (`idle_unload_mins`):
+    /// `[backend] idle_timeout_mins` — 0 keeps models resident, N unloads
+    /// after N idle minutes. nil omits the field (test/legacy clients).
+    public let idleUnloadMins: UInt64?
 
     public init(
         url: String,
@@ -176,7 +180,8 @@ public struct CoordinatorClientConfig: Sendable {
         runtimeCapabilities: Set<ProviderRuntimeCapability> = [],
         privateOnly: Bool = false,
         apnsDeviceToken: String? = nil,
-        apnsEnvironment: String? = nil
+        apnsEnvironment: String? = nil,
+        idleUnloadMins: UInt64? = nil
     ) {
         self.url = url
         self.hardware = hardware
@@ -195,6 +200,7 @@ public struct CoordinatorClientConfig: Sendable {
         self.privateOnly = privateOnly
         self.apnsDeviceToken = apnsDeviceToken
         self.apnsEnvironment = apnsEnvironment
+        self.idleUnloadMins = idleUnloadMins
     }
 }
 

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -283,6 +283,12 @@ public enum ProviderMessage: Sendable, Equatable {
         public var prefixCacheV2Models: [PrefixCacheV2Capability]?
         public var prefixCacheStatuses: [PrefixCacheModelStatus]?
         public var prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]?
+        /// The operator's idle-memory policy (`[backend] idle_timeout_mins`):
+        /// minutes without requests before this box unloads a model, or 0 when
+        /// models stay resident. Lets the coordinator (and the owner's
+        /// dashboard) tell "unloaded on purpose, wakes on demand" apart from
+        /// "should be loaded and isn't". nil/omitted from older providers.
+        public var idleUnloadMins: UInt64?
 
         public init(
             status: ProviderStatus,
@@ -296,7 +302,8 @@ public enum ProviderMessage: Sendable, Equatable {
             prefixCacheProtocol: Int? = nil,
             prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
             prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
-            prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
+            prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
+            idleUnloadMins: UInt64? = nil
         ) {
             self.status = status
             self.activeModel = activeModel
@@ -310,6 +317,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.prefixCacheV2Models = prefixCacheV2Models
             self.prefixCacheStatuses = prefixCacheStatuses
             self.prefixCacheDonationOutcomes = prefixCacheDonationOutcomes
+            self.idleUnloadMins = idleUnloadMins
         }
     }
 
@@ -848,6 +856,7 @@ extension ProviderMessage: Codable {
         case stats
         case systemMetrics = "system_metrics"
         case backendCapacity = "backend_capacity"
+        case idleUnloadMins = "idle_unload_mins"
         // Common
         case requestId = "request_id"
         // InferenceResponseChunk
@@ -975,6 +984,9 @@ extension ProviderMessage: Codable {
             try container.encodeIfPresent(h.prefixCacheStatuses, forKey: .prefixCacheStatuses)
             try container.encodeIfPresent(
                 h.prefixCacheDonationOutcomes, forKey: .prefixCacheDonationOutcomes)
+            // 0 ("always ready") is a real value and MUST reach the wire; only
+            // nil (policy not reported) is omitted — Go decodes into *int.
+            try container.encodeIfPresent(h.idleUnloadMins, forKey: .idleUnloadMins)
 
         case .inferenceAccepted(let a):
             try container.encode(TypeValue.inferenceAccepted, forKey: .type)
@@ -1211,7 +1223,8 @@ extension ProviderMessage: Codable {
                     [PrefixCacheModelStatus].self, forKey: .prefixCacheStatuses),
                 prefixCacheDonationOutcomes: try container.decodeIfPresent(
                     [PrefixCacheDonationOutcomeCount].self,
-                    forKey: .prefixCacheDonationOutcomes)
+                    forKey: .prefixCacheDonationOutcomes),
+                idleUnloadMins: try container.decodeIfPresent(UInt64.self, forKey: .idleUnloadMins)
             ))
 
         case .inferenceAccepted:

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -156,7 +156,8 @@ extension ProviderLoop {
             runtimeCapabilities: loopConfig.runtimeCapabilities,
             privateOnly: loopConfig.config.coordinator.privateOnly,
             apnsDeviceToken: apnsDeviceToken,
-            apnsEnvironment: apnsDeviceToken != nil ? "production" : nil
+            apnsEnvironment: apnsDeviceToken != nil ? "production" : nil,
+            idleUnloadMins: loopConfig.config.backend.idleTimeoutMins
         )
 
         // 4. Create coordinator client and start connection

--- a/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
+++ b/provider-swift/Sources/ProviderCore/Service/LaunchAgent.swift
@@ -86,7 +86,11 @@ public enum LaunchAgent: Sendable {
     /// - Parameters:
     ///   - coordinatorURL: WebSocket URL for the coordinator (ws:// or wss://).
     ///   - models: Model IDs to serve (passed as --model flags to `serve`).
-    ///   - idleTimeout: Optional idle timeout in minutes (passed as --idle-timeout).
+    ///
+    /// The idle-unload policy is deliberately NOT an argv flag: it lives in
+    /// `[backend] idle_timeout_mins` so `darkbloom idle` + `darkbloom restart`
+    /// can change it without rewriting this plist. (Pre-v0.8.14 plists carried
+    /// `--idle-timeout`; `start --foreground` still parses it as a fallback.)
     /// Options for the unified local OpenAI endpoint (serve the public fleet AND
     /// a local endpoint off the same loaded models). `enabled == false` keeps the
     /// daemon coordinator-only.
@@ -106,7 +110,6 @@ public enum LaunchAgent: Sendable {
     public static func installAndStart(
         coordinatorURL: String,
         models: [String] = [],
-        idleTimeout: UInt64? = nil,
         configPath: URL? = nil,
         localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
     ) throws {
@@ -126,7 +129,6 @@ public enum LaunchAgent: Sendable {
             binaryPath: binaryPath,
             coordinatorURL: coordinatorURL,
             models: models,
-            idleTimeout: idleTimeout,
             configPath: configPath,
             localEndpoint: localEndpoint
         )
@@ -331,7 +333,6 @@ public enum LaunchAgent: Sendable {
         binaryPath: String,
         coordinatorURL: String,
         models: [String],
-        idleTimeout: UInt64?,
         configPath: URL?,
         localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
     ) throws {
@@ -348,7 +349,6 @@ public enum LaunchAgent: Sendable {
             binaryPath: binaryPath,
             coordinatorURL: coordinatorURL,
             models: models,
-            idleTimeout: idleTimeout,
             configPath: configPath,
             localEndpoint: localEndpoint
         )
@@ -375,7 +375,6 @@ public enum LaunchAgent: Sendable {
         binaryPath: String,
         coordinatorURL: String,
         models: [String],
-        idleTimeout: UInt64?,
         configPath: URL?,
         localEndpoint: LocalEndpointOptions = LocalEndpointOptions()
     ) -> [String] {
@@ -391,9 +390,6 @@ public enum LaunchAgent: Sendable {
         }
         for model in models {
             arguments.append(contentsOf: ["--model", model])
-        }
-        if let idleTimeout {
-            arguments.append(contentsOf: ["--idle-timeout", "\(idleTimeout)"])
         }
         if localEndpoint.enabled {
             arguments.append("--local-endpoint")

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -45,6 +45,7 @@ struct Darkbloom: AsyncParsableCommand {
             Report.self,
             AutoUpdate.self,
             Beta.self,
+            Idle.self,
             Fan.self,
             Watchdog.self,
             RuntimeSmoke.self,

--- a/provider-swift/Sources/darkbloom/IdleCommand.swift
+++ b/provider-swift/Sources/darkbloom/IdleCommand.swift
@@ -1,0 +1,300 @@
+// `darkbloom idle` — the operator's idle-memory policy: what the daemon does
+// with a loaded model when no requests arrive. One TOML key
+// (`[backend] idle_timeout_mins`) is the single authority; this command, the
+// `darkbloom start` prompt and `--idle-timeout` are three writers of it.
+import Foundation
+import ArgumentParser
+import ProviderCore
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Pure helpers behind the idle-policy prompt and `darkbloom idle`. No I/O so
+/// the menu, parsing and wording are unit-testable.
+enum IdleUnloadPolicy {
+    /// The shipped default and the "Free when idle" menu option.
+    static let defaultMinutes: UInt64 = 60
+    /// One week. Bounds the daemon's timer arithmetic and catches typos.
+    static let maxMinutes: UInt64 = 7 * 24 * 60
+    /// The `--idle-timeout` value that means "keep loaded".
+    static let alwaysReadyMinutes: UInt64 = 0
+
+    enum MenuChoice: Equatable {
+        case alwaysReady
+        case freeWhenIdle
+        case custom
+    }
+
+    /// Menu item pre-selected for Enter: the operator's CURRENT policy, so a
+    /// repeat `darkbloom start` never silently moves it (0 → 1, 60 → 2,
+    /// anything else → 3).
+    static func defaultChoice(currentMinutes: UInt64) -> MenuChoice {
+        switch currentMinutes {
+        case alwaysReadyMinutes: return .alwaysReady
+        case defaultMinutes: return .freeWhenIdle
+        default: return .custom
+        }
+    }
+
+    static func menuNumber(_ choice: MenuChoice) -> Int {
+        switch choice {
+        case .alwaysReady: return 1
+        case .freeWhenIdle: return 2
+        case .custom: return 3
+        }
+    }
+
+    /// "1"/"2"/"3" → choice; blank → `fallback`; anything else → nil.
+    static func parseChoice(_ input: String, fallback: MenuChoice) -> MenuChoice? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return fallback }
+        switch trimmed {
+        case "1": return .alwaysReady
+        case "2": return .freeWhenIdle
+        case "3": return .custom
+        default: return nil
+        }
+    }
+
+    /// Minutes for the custom prompt / `unload-after`: blank → `fallback`;
+    /// an integer in 1...maxMinutes → itself; anything else → nil.
+    static func parseMinutes(_ input: String, fallback: UInt64) -> UInt64? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return fallback }
+        guard let value = UInt64(trimmed), (1...maxMinutes).contains(value) else { return nil }
+        return value
+    }
+
+    /// Rejects an out-of-range CLI value (`--idle-timeout`, `unload-after`).
+    /// 0 is valid (always ready). Returns the message to print, or nil.
+    static func validate(minutes: UInt64) -> String? {
+        guard minutes <= maxMinutes else {
+            return "idle window must be between 1 and \(maxMinutes) minutes (7 days), or 0 to keep models loaded."
+        }
+        return nil
+    }
+
+    /// "60 min" / "2 h" / "1 h 30 min".
+    static func formatWindow(minutes: UInt64) -> String {
+        if minutes < 60 { return "\(minutes) min" }
+        let hours = minutes / 60
+        let rest = minutes % 60
+        return rest == 0 ? "\(hours) h" : "\(hours) h \(rest) min"
+    }
+
+    /// One-line policy summary for `status`, `idle status` and `start`.
+    static func describe(minutes: UInt64) -> String {
+        if minutes == alwaysReadyMinutes {
+            return "always ready (models stay loaded)"
+        }
+        return "free after \(formatWindow(minutes: minutes)) idle (models reload on demand)"
+    }
+
+    /// The `darkbloom start` menu. `holdsGb` is the resident footprint of the
+    /// selected models (nil when unknown) so the "Always ready" cost is
+    /// concrete.
+    static func menu(holdsGb: Double?, currentMinutes: UInt64) -> String {
+        let holds = holdsGb.map { String(format: " Holds up to ~%.0f GB while idle.", $0) } ?? ""
+        let customNote: String
+        if defaultChoice(currentMinutes: currentMinutes) == .custom {
+            customNote = " (currently \(formatWindow(minutes: currentMinutes)))"
+        } else {
+            customNote = ""
+        }
+        return """
+
+              When there are no requests, how should Darkbloom use your memory?
+
+                1) Always ready     Models stay loaded. Instant responses, first in
+                                    line for routing, base rewards accrue around
+                                    the clock.\(holds)
+                2) Free when idle   Unload after \(defaultMinutes) min without requests; reloaded
+                                    on demand (10–30 s cold start). Your Mac gets
+                                    its memory back between bursts. Base rewards
+                                    pause while unloaded.
+                3) Custom           Same as 2, with your own idle window.\(customNote)
+
+            """
+    }
+}
+
+// MARK: - Persistence (shared by `idle`, `start` prompt and `--idle-timeout`)
+
+/// Read-modify-write `[backend] idle_timeout_mins` and persist it. Returns
+/// the config path written and whether anything changed. Mirrors
+/// `setBetaFeature`: canonical-path resolution, exclusive lock, reload inside
+/// the lock, and key materialization so an absent key that merely decodes to
+/// the requested value is still pinned durably.
+///
+/// Internal (not `private`) so `DarkbloomCLITests` can drive it with temp
+/// config fixtures via `configPath`.
+@discardableResult
+func setIdleUnloadMinutes(
+    _ minutes: UInt64,
+    configPath: String?
+) throws -> (path: URL, changed: Bool) {
+    if let problem = IdleUnloadPolicy.validate(minutes: minutes) {
+        throw ValidationError(problem)
+    }
+
+    let snapshot = try loadRuntimeSnapshot(configPath: configPath)
+    let savePath: URL
+    if configPath != nil {
+        savePath = snapshot.configPath
+    } else {
+        savePath = try ConfigManager.defaultConfigPath()
+    }
+
+    return try withExclusiveConfigLock(at: savePath) {
+        var config: ProviderConfig
+        if FileManager.default.fileExists(atPath: savePath.path) {
+            config = try ConfigManager.load(from: savePath)
+        } else {
+            config = snapshot.config
+        }
+
+        if config.backend.idleTimeoutMins == minutes,
+           let content = try? String(contentsOf: savePath, encoding: .utf8),
+           tomlKeyPresent(content, section: "backend", key: "idle_timeout_mins") {
+            return (savePath, false)
+        }
+
+        config.backend.idleTimeoutMins = minutes
+        try ConfigManager.save(config, to: savePath)
+        return (savePath, true)
+    }
+}
+
+/// Whether the config file at `path` explicitly sets `idle_timeout_mins`.
+/// Used by the launchd `--foreground` child to decide whether a legacy plist's
+/// `--idle-timeout` argv may still fill in the value (TOML wins when present).
+func idleTimeoutPinned(at path: URL) -> Bool {
+    guard let content = try? String(contentsOf: path, encoding: .utf8) else { return false }
+    return tomlKeyPresent(content, section: "backend", key: "idle_timeout_mins")
+}
+
+// MARK: - Command
+
+/// `darkbloom idle status --json`.
+struct IdlePolicyReport: Encodable {
+    /// Minutes without requests before a model is unloaded; 0 = always ready.
+    let idleTimeoutMins: UInt64
+    /// `always_ready` | `free_when_idle`.
+    let policy: String
+    let summary: String
+    /// Whether `[backend] idle_timeout_mins` is written in the TOML (vs. the
+    /// decoded default).
+    let pinned: Bool
+    let configPath: String
+}
+
+struct Idle: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "idle",
+        abstract: "Choose what happens to loaded models when no requests arrive.",
+        discussion: """
+        With no requests for a while the provider can unload its models and give
+        your Mac its memory back; the network reloads them on demand (the first
+        request pays a 10–30 s cold start, and base rewards pause while nothing
+        is loaded). Or keep them loaded around the clock for instant responses,
+        first-in-line routing and uninterrupted base rewards.
+
+        Subcommands:
+          status                   Show the current policy (default).
+          keep-loaded              Models stay loaded while the provider runs.
+          unload-after <minutes>   Unload after N minutes without requests (shipped default: 60).
+
+        The policy is `idle_timeout_mins` under `[backend]` in your provider
+        config. Changes apply after `darkbloom restart`.
+        """,
+        subcommands: [Status.self, KeepLoaded.self, UnloadAfter.self],
+        defaultSubcommand: Status.self
+    )
+}
+
+extension Idle {
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "status",
+            abstract: "Show the current idle-memory policy."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Flag(help: "Emit JSON instead of text.")
+        var json = false
+
+        mutating func run() async throws {
+            let snapshot = try loadRuntimeSnapshot(configOptions: configOptions)
+            let minutes = snapshot.config.backend.idleTimeoutMins
+
+            if json {
+                try printJSON(IdlePolicyReport(
+                    idleTimeoutMins: minutes,
+                    policy: minutes == IdleUnloadPolicy.alwaysReadyMinutes ? "always_ready" : "free_when_idle",
+                    summary: IdleUnloadPolicy.describe(minutes: minutes),
+                    pinned: idleTimeoutPinned(at: snapshot.configPath),
+                    configPath: snapshot.configPath.path))
+                return
+            }
+
+            print("Memory when idle: \(IdleUnloadPolicy.describe(minutes: minutes))")
+            print("  Config:  \(snapshot.configPath.path)")
+            print("  Change:  darkbloom idle keep-loaded")
+            print("           darkbloom idle unload-after <minutes>")
+            print("  Applies after:  darkbloom restart")
+        }
+    }
+
+    struct KeepLoaded: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "keep-loaded",
+            abstract: "Keep models loaded while the provider runs (instant responses; memory stays reserved)."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        mutating func run() async throws {
+            let result = try setIdleUnloadMinutes(
+                IdleUnloadPolicy.alwaysReadyMinutes, configPath: configOptions.config)
+            printIdleOutcome(minutes: IdleUnloadPolicy.alwaysReadyMinutes, result: result)
+        }
+    }
+
+    struct UnloadAfter: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "unload-after",
+            abstract: "Unload models after N minutes without requests; they reload on demand."
+        )
+
+        @OptionGroup var configOptions: ConfigOptions
+
+        @Argument(help: "Minutes without requests before unloading (1–\(IdleUnloadPolicy.maxMinutes)).")
+        var minutes: UInt64
+
+        mutating func validate() throws {
+            guard minutes > 0 else {
+                throw ValidationError("minutes must be at least 1; use `darkbloom idle keep-loaded` to keep models resident.")
+            }
+            if let problem = IdleUnloadPolicy.validate(minutes: minutes) {
+                throw ValidationError(problem)
+            }
+        }
+
+        mutating func run() async throws {
+            let result = try setIdleUnloadMinutes(minutes, configPath: configOptions.config)
+            printIdleOutcome(minutes: minutes, result: result)
+        }
+    }
+}
+
+private func printIdleOutcome(minutes: UInt64, result: (path: URL, changed: Bool)) {
+    let summary = IdleUnloadPolicy.describe(minutes: minutes)
+    if result.changed {
+        print("Memory when idle: \(summary)")
+        print("  Restart to apply:  darkbloom restart")
+    } else {
+        print("Memory when idle is already \(summary).")
+    }
+    print("  Config: \(result.path.path)")
+}

--- a/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Daemon.swift
@@ -51,10 +51,20 @@ extension Start {
             throw ExitCode.failure
         }
 
+        // Idle-memory policy: asked on the same interactive path as the model
+        // picker (never for --model/--all/relaunch), with the CURRENT policy as
+        // the Enter default. `--idle-timeout` already answered it in `run()`.
+        var idleMinutes = config.backend.idleTimeoutMins
+        if model.isEmpty, !all, idleTimeout == nil {
+            idleMinutes = try promptIdleUnloadPolicy(
+                current: idleMinutes,
+                selectedModelIDs: selectedModelIDs,
+                snapshot: snapshot)
+        }
+
         try LaunchAgent.installAndStart(
             coordinatorURL: coordinatorURL,
             models: selectedModelIDs,
-            idleTimeout: idleTimeout ?? (config.backend.idleTimeoutMins > 0 ? config.backend.idleTimeoutMins : nil),
             configPath: configPath,
             localEndpoint: LaunchAgent.LocalEndpointOptions(
                 enabled: localEndpoint, port: port, bind: bind, noAuth: noAuth
@@ -90,6 +100,7 @@ extension Start {
         for id in selectedModelIDs {
             print("    \(id)")
         }
+        print("  Memory:  \(IdleUnloadPolicy.describe(minutes: idleMinutes)) — `darkbloom idle` to change")
         if localEndpoint {
             let shownURL = "http://\(bind == "0.0.0.0" ? "127.0.0.1" : bind):\(port)/v1"
             print("  Local:   \(shownURL) (unified mode — run `darkbloom local` for the API key)")
@@ -102,6 +113,91 @@ extension Start {
         print("  darkbloom stop     Stop the provider")
         print("  darkbloom restart  Restart with the current selection")
         print("  darkbloom status   Check status")
+    }
+
+    // MARK: - Idle-memory policy prompt
+
+    /// Three-way menu (always ready / free after 60 min / custom window). Enter
+    /// keeps the current policy. Persists only when the answer differs from the
+    /// pinned config value, then returns the effective minutes. Non-TTY stdin
+    /// skips the prompt and keeps `current` (scripts never block here).
+    internal func promptIdleUnloadPolicy(
+        current: UInt64,
+        selectedModelIDs: [String],
+        snapshot: RuntimeSnapshot,
+        readInput: () -> String? = { readLine() }
+    ) throws -> UInt64 {
+        guard isatty(STDIN_FILENO) != 0 else { return current }
+
+        // Resident footprint of the selection (upper bound: max_model_slots may
+        // keep fewer resident). Unfiltered scan so a too-big-for-RAM model still
+        // has a size; nil when any selected model is unknown on disk.
+        let allLocal = snapshot.hardware.map { ModelScanner.scanAllModels(hardwareInfo: $0) } ?? []
+        let memoryByID = Dictionary(
+            allLocal.map { ($0.id, $0.estimatedMemoryGb) }, uniquingKeysWith: { first, _ in first })
+        let sizes = selectedModelIDs.compactMap { memoryByID[$0] }
+        let holdsGb: Double? = sizes.count == selectedModelIDs.count && !sizes.isEmpty
+            ? sizes.reduce(0, +) : nil
+
+        print(IdleUnloadPolicy.menu(holdsGb: holdsGb, currentMinutes: current))
+
+        let minutes = Self.resolveIdlePolicyAnswer(
+            current: current,
+            readInput: readInput,
+            emit: { print($0, terminator: "") })
+
+        let result = try setIdleUnloadMinutes(minutes, configPath: configOptions.config)
+        print("  Memory when idle: \(IdleUnloadPolicy.describe(minutes: minutes))"
+            + (result.changed ? " (saved)" : ""))
+        print()
+        return minutes
+    }
+
+    /// The menu dialogue after the menu text is on screen, as a pure function
+    /// of the operator's keystrokes: `readInput` yields one line per prompt
+    /// (nil = EOF), `emit` receives every prompt/complaint. Rules:
+    ///   * blank answer keeps the current policy (Enter = the bracketed default)
+    ///   * 1 → always ready (0), 2 → free after 60 min, 3 → ask for minutes
+    ///   * the custom default is the current window, or 60 when the box is
+    ///     currently always-ready (there is no "current window" to keep)
+    ///   * three bad answers, or EOF, fall back to the default in force
+    static func resolveIdlePolicyAnswer(
+        current: UInt64,
+        readInput: () -> String?,
+        emit: (String) -> Void
+    ) -> UInt64 {
+        let fallback = IdleUnloadPolicy.defaultChoice(currentMinutes: current)
+        var choice: IdleUnloadPolicy.MenuChoice = fallback
+        for attempt in 0..<3 {
+            emit("  Choice [\(IdleUnloadPolicy.menuNumber(fallback))]: ")
+            guard let line = readInput() else { break } // EOF: keep current
+            if let parsed = IdleUnloadPolicy.parseChoice(line, fallback: fallback) {
+                choice = parsed
+                break
+            }
+            if attempt < 2 { emit("  Please enter 1, 2 or 3.\n") }
+        }
+
+        switch choice {
+        case .alwaysReady:
+            return IdleUnloadPolicy.alwaysReadyMinutes
+        case .freeWhenIdle:
+            return IdleUnloadPolicy.defaultMinutes
+        case .custom:
+            let customDefault = current == IdleUnloadPolicy.alwaysReadyMinutes
+                ? IdleUnloadPolicy.defaultMinutes : current
+            for attempt in 0..<3 {
+                emit("  Minutes without requests before unloading [\(customDefault)]: ")
+                guard let line = readInput() else { break }
+                if let parsed = IdleUnloadPolicy.parseMinutes(line, fallback: customDefault) {
+                    return parsed
+                }
+                if attempt < 2 {
+                    emit("  Please enter a whole number of minutes (1–\(IdleUnloadPolicy.maxMinutes)).\n")
+                }
+            }
+            return customDefault
+        }
     }
 
 }

--- a/provider-swift/Sources/darkbloom/StartCommand.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand.swift
@@ -25,7 +25,7 @@ struct Start: AsyncParsableCommand {
     @Flag(help: "Serve all local models (skips interactive picker).")
     var all = false
 
-    @Option(help: "Idle timeout in minutes before unloading the model.")
+    @Option(help: "Minutes without requests before a model is unloaded (0 = keep loaded). Saved to your config; the interactive picker asks this too. See `darkbloom idle`.")
     var idleTimeout: UInt64?
 
     @Flag(inversion: .prefixedNo, help: .hidden)
@@ -78,7 +78,28 @@ struct Start: AsyncParsableCommand {
         let effectiveCoordinator = coordinatorURL ?? snapshot.config.coordinator.url
         var effectiveConfig = snapshot.config
         if let idleTimeout {
-            effectiveConfig.backend.idleTimeoutMins = idleTimeout
+            if let problem = IdleUnloadPolicy.validate(minutes: idleTimeout) {
+                printError("--idle-timeout: \(problem)")
+                throw ExitCode.failure
+            }
+            if foreground {
+                // Plists written before the idle policy moved to TOML baked
+                // `--idle-timeout` into the daemon argv. The TOML key is the
+                // authority now — `darkbloom idle` must win over a stale plist
+                // after `restart` — so the flag only fills in when the config
+                // does not set the key.
+                if !idleTimeoutPinned(at: snapshot.configPath) {
+                    effectiveConfig.backend.idleTimeoutMins = idleTimeout
+                }
+            } else {
+                // Operator-facing: `--idle-timeout` is a writer of the one
+                // authority, so `restart` and later `start`s keep the choice.
+                let result = try setIdleUnloadMinutes(idleTimeout, configPath: configOptions.config)
+                if result.changed {
+                    print("Memory when idle: \(IdleUnloadPolicy.describe(minutes: idleTimeout)) (saved to \(result.path.path))")
+                }
+                effectiveConfig.backend.idleTimeoutMins = idleTimeout
+            }
         }
 
         // These controls are process-start latches in MLX/MLXLM. Project the

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -24,7 +24,7 @@ struct Status: AsyncParsableCommand {
         print("Coordinator: \(config.coordinator.url)")
         print("Backend port: \(config.backend.port)")
         print("Configured model: \(config.backend.model ?? "auto-select")")
-        print("Idle timeout: \(config.backend.idleTimeoutMins == 0 ? "disabled" : "\(config.backend.idleTimeoutMins)m")")
+        print("Memory when idle: \(IdleUnloadPolicy.describe(minutes: config.backend.idleTimeoutMins)) (manage with `darkbloom idle`)")
         print("Beta features: \(betaFeaturesStatus(config)) (manage with `darkbloom beta`)")
         print("Auto-restart: \(autoRestartStatus(config: config))")
 
@@ -116,6 +116,14 @@ struct Status: AsyncParsableCommand {
         }
 
         print("Warm models: \(WarmModelsFormat.warmModelsLine(warmModels: state.warmModels, currentModel: state.currentModel))")
+        if let line = Self.notLoadedLine(
+            advertised: state.advertisedModels,
+            warmModels: state.warmModels,
+            currentModel: state.currentModel,
+            idleTimeoutMins: config.backend.idleTimeoutMins)
+        {
+            print(line)
+        }
         print("\(WarmModelsFormat.mostRecentlyUsedLabel): \(WarmModelsFormat.mostRecentlyUsedLine(currentModel: state.currentModel))")
         print("Requests served: \(state.stats.requestsServed)  |  tokens: \(state.stats.tokensGenerated)")
         if let err = state.lastModelLoadError {
@@ -181,6 +189,28 @@ struct Status: AsyncParsableCommand {
         return "Daemon: running (pid \(state.pid), up \(uptime)) but last update \(ageText) ago "
             + "(expected every ~\(Int(period))s) — snapshot stale, the fields below may be "
             + "out of date"
+    }
+
+    /// Advertised models with no resident engine right now. Under an idle
+    /// policy that is the expected steady state between bursts ("reload on
+    /// demand"), so it is reported as information, not as a fault; under
+    /// "always ready" the same gap means the model has simply not been asked
+    /// for since start. nil when every advertised model is warm (or the daemon
+    /// predates `advertisedModels`).
+    static func notLoadedLine(
+        advertised: [String]?,
+        warmModels: [String],
+        currentModel: String?,
+        idleTimeoutMins: UInt64
+    ) -> String? {
+        guard let advertised else { return nil }
+        var resident = Set(warmModels)
+        if let currentModel, !currentModel.isEmpty { resident.insert(currentModel) }
+        let notLoaded = advertised.filter { !resident.contains($0) }
+        guard !notLoaded.isEmpty else { return nil }
+        let why = idleTimeoutMins == IdleUnloadPolicy.alwaysReadyMinutes
+            ? "loads on first request" : "unloaded when idle; reloads on demand"
+        return "Not loaded (\(why)): \(notLoaded.joined(separator: ", "))"
     }
 
     private func formatUptime(_ seconds: Double) -> String {

--- a/provider-swift/Tests/DarkbloomCLITests/IdleCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/IdleCommandTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import ProviderCore
+import Testing
+
+@testable import darkbloom
+
+/// The idle-memory policy has three writers (`darkbloom idle`, the `start`
+/// prompt, `--idle-timeout`) and one authority (`[backend] idle_timeout_mins`).
+/// These pin the menu semantics — default = the policy in force, 0 = always
+/// ready, custom minutes — and the persistence contract shared with `beta`.
+@Suite("Idle-memory policy")
+struct IdleCommandTests {
+
+    // MARK: - Menu semantics
+
+    @Test("the pre-selected menu item is the policy currently in force")
+    func defaultChoiceTracksCurrentPolicy() {
+        #expect(IdleUnloadPolicy.defaultChoice(currentMinutes: 0) == .alwaysReady)
+        #expect(IdleUnloadPolicy.defaultChoice(currentMinutes: 60) == .freeWhenIdle)
+        #expect(IdleUnloadPolicy.defaultChoice(currentMinutes: 45) == .custom)
+        #expect(IdleUnloadPolicy.menuNumber(.alwaysReady) == 1)
+        #expect(IdleUnloadPolicy.menuNumber(.freeWhenIdle) == 2)
+        #expect(IdleUnloadPolicy.menuNumber(.custom) == 3)
+    }
+
+    @Test("choice parsing: blank keeps the default, digits select, junk is rejected")
+    func parseChoice() {
+        #expect(IdleUnloadPolicy.parseChoice("", fallback: .freeWhenIdle) == .freeWhenIdle)
+        #expect(IdleUnloadPolicy.parseChoice("  \n", fallback: .alwaysReady) == .alwaysReady)
+        #expect(IdleUnloadPolicy.parseChoice("1", fallback: .freeWhenIdle) == .alwaysReady)
+        #expect(IdleUnloadPolicy.parseChoice(" 2 ", fallback: .alwaysReady) == .freeWhenIdle)
+        #expect(IdleUnloadPolicy.parseChoice("3", fallback: .freeWhenIdle) == .custom)
+        #expect(IdleUnloadPolicy.parseChoice("4", fallback: .freeWhenIdle) == nil)
+        #expect(IdleUnloadPolicy.parseChoice("always", fallback: .freeWhenIdle) == nil)
+    }
+
+    @Test("minutes parsing: 1...7 days, blank keeps the default, 0 is not a window")
+    func parseMinutes() {
+        #expect(IdleUnloadPolicy.parseMinutes("", fallback: 60) == 60)
+        #expect(IdleUnloadPolicy.parseMinutes("30", fallback: 60) == 30)
+        #expect(IdleUnloadPolicy.parseMinutes(" 90 ", fallback: 60) == 90)
+        #expect(IdleUnloadPolicy.parseMinutes("0", fallback: 60) == nil)
+        #expect(IdleUnloadPolicy.parseMinutes("-5", fallback: 60) == nil)
+        #expect(IdleUnloadPolicy.parseMinutes("1.5", fallback: 60) == nil)
+        #expect(IdleUnloadPolicy.parseMinutes("\(IdleUnloadPolicy.maxMinutes)", fallback: 60)
+            == IdleUnloadPolicy.maxMinutes)
+        #expect(IdleUnloadPolicy.parseMinutes("\(IdleUnloadPolicy.maxMinutes + 1)", fallback: 60) == nil)
+    }
+
+    @Test("CLI validation accepts 0 and the 7-day ceiling, rejects beyond")
+    func validate() {
+        #expect(IdleUnloadPolicy.validate(minutes: 0) == nil)
+        #expect(IdleUnloadPolicy.validate(minutes: 60) == nil)
+        #expect(IdleUnloadPolicy.validate(minutes: IdleUnloadPolicy.maxMinutes) == nil)
+        let problem = IdleUnloadPolicy.validate(minutes: IdleUnloadPolicy.maxMinutes + 1)
+        #expect(problem?.contains("7 days") == true)
+    }
+
+    @Test("window and policy wording")
+    func wording() {
+        #expect(IdleUnloadPolicy.formatWindow(minutes: 45) == "45 min")
+        #expect(IdleUnloadPolicy.formatWindow(minutes: 60) == "1 h")
+        #expect(IdleUnloadPolicy.formatWindow(minutes: 90) == "1 h 30 min")
+        #expect(IdleUnloadPolicy.formatWindow(minutes: 120) == "2 h")
+        #expect(IdleUnloadPolicy.describe(minutes: 0) == "always ready (models stay loaded)")
+        #expect(IdleUnloadPolicy.describe(minutes: 60)
+            == "free after 1 h idle (models reload on demand)")
+    }
+
+    @Test("the menu names all three options and shows the resident footprint")
+    func menuText() {
+        let menu = IdleUnloadPolicy.menu(holdsGb: 18.2, currentMinutes: 60)
+        #expect(menu.contains("1) Always ready"))
+        #expect(menu.contains("2) Free when idle"))
+        #expect(menu.contains("3) Custom"))
+        #expect(menu.contains("Unload after 60 min"))
+        #expect(menu.contains("~18 GB"))
+        #expect(!menu.contains("currently"))
+
+        // Unknown footprint: no invented number. A custom window in force is
+        // echoed so the operator knows what Enter on 3 would keep.
+        let custom = IdleUnloadPolicy.menu(holdsGb: nil, currentMinutes: 45)
+        #expect(!custom.contains("GB while idle"))
+        #expect(custom.contains("(currently 45 min)"))
+    }
+
+    // MARK: - Prompt dialogue
+
+    /// Scripted keystrokes → chosen minutes. `emit` output is discarded.
+    private func answer(_ lines: [String?], current: UInt64) -> UInt64 {
+        var queue = lines
+        return Start.resolveIdlePolicyAnswer(
+            current: current,
+            readInput: { queue.isEmpty ? nil : queue.removeFirst() },
+            emit: { _ in })
+    }
+
+    @Test("Enter keeps the policy in force")
+    func enterKeepsCurrent() {
+        #expect(answer([""], current: 60) == 60)
+        #expect(answer([""], current: 0) == 0)
+        // A custom window in force: Enter on 3, then Enter on the minutes.
+        #expect(answer(["", ""], current: 45) == 45)
+    }
+
+    @Test("1 → always ready, 2 → free after 60 min")
+    func directChoices() {
+        #expect(answer(["1"], current: 60) == 0)
+        #expect(answer(["2"], current: 0) == 60)
+        #expect(answer(["2"], current: 45) == 60)
+    }
+
+    @Test("3 asks for minutes; its default is the current window, or 60 from always-ready")
+    func customMinutes() {
+        #expect(answer(["3", "45"], current: 60) == 45)
+        #expect(answer(["3", ""], current: 0) == 60)
+        #expect(answer(["3", ""], current: 45) == 45)
+        // Bad minutes are re-asked, then accepted.
+        #expect(answer(["3", "abc", "0", "90"], current: 60) == 90)
+        // Three bad minutes fall back to the custom default.
+        #expect(answer(["3", "x", "y", "z"], current: 45) == 45)
+    }
+
+    @Test("bad menu answers are re-asked; three misses or EOF keep the current policy")
+    func badAnswersAndEOF() {
+        #expect(answer(["9", "x", "1"], current: 60) == 0)
+        #expect(answer(["9", "x", "y"], current: 60) == 60)
+        #expect(answer([nil], current: 45) == 45)
+        #expect(answer([], current: 0) == 0)
+    }
+
+    // MARK: - Persistence (shares the `beta` contract)
+
+    private func makeTempConfig(_ toml: String?) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("idle-cfg-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent("provider.toml")
+        if let toml {
+            try toml.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return url
+    }
+
+    /// Mirrors BetaCommandTests: a non-canonical config path triggers the
+    /// legacy→canonical copy when the canonical file is ABSENT; never plant
+    /// fixtures in the operator's real config.
+    private func withGuardedCanonicalConfig(_ body: () throws -> Void) rethrows {
+        let canonical = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/darkbloom/provider.toml")
+        let existedBefore = FileManager.default.fileExists(atPath: canonical.path)
+        defer {
+            if !existedBefore, FileManager.default.fileExists(atPath: canonical.path) {
+                try? FileManager.default.removeItem(at: canonical)
+            }
+        }
+        try body()
+    }
+
+    @Test("keep-loaded pins idle_timeout_mins = 0 under [backend]")
+    func keepLoadedPersistsZero() throws {
+        let url = try makeTempConfig("""
+            [provider]
+            name = "idle-test"
+            """)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        try withGuardedCanonicalConfig {
+            let result = try setIdleUnloadMinutes(0, configPath: url.path)
+            #expect(result.changed)
+            #expect(result.path == url)
+        }
+        let written = try String(contentsOf: url, encoding: .utf8)
+        #expect(tomlKeyPresent(written, section: "backend", key: "idle_timeout_mins"))
+        #expect(written.contains("idle_timeout_mins = 0"))
+        #expect(try ConfigManager.load(from: url).backend.idleTimeoutMins == 0)
+        #expect(idleTimeoutPinned(at: url))
+    }
+
+    @Test("the default value is still materialized when the key is absent")
+    func defaultIsMaterialized() throws {
+        let url = try makeTempConfig("""
+            [provider]
+            name = "idle-test"
+            """)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        #expect(!idleTimeoutPinned(at: url))
+
+        try withGuardedCanonicalConfig {
+            // Decodes to 60 already, but "Free when idle" must be pinned so a
+            // future default flip cannot silently move this provider.
+            let first = try setIdleUnloadMinutes(60, configPath: url.path)
+            #expect(first.changed)
+            // Now pinned at the requested value: a true no-op, no rewrite.
+            let pinned = try String(contentsOf: url, encoding: .utf8)
+            let second = try setIdleUnloadMinutes(60, configPath: url.path)
+            #expect(second.changed == false)
+            let after = try String(contentsOf: url, encoding: .utf8)
+            #expect(after == pinned)
+        }
+        #expect(idleTimeoutPinned(at: url))
+    }
+
+    @Test("a custom window round-trips and replaces the previous value")
+    func customWindowRoundTrips() throws {
+        let url = try makeTempConfig("""
+            [backend]
+            idle_timeout_mins = 60
+            """)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        try withGuardedCanonicalConfig {
+            let result = try setIdleUnloadMinutes(45, configPath: url.path)
+            #expect(result.changed)
+        }
+        let config = try ConfigManager.load(from: url)
+        #expect(config.backend.idleTimeoutMins == 45)
+        let written = try String(contentsOf: url, encoding: .utf8)
+        #expect(!written.contains("idle_timeout_mins = 60"))
+    }
+
+    @Test("an out-of-range window is refused before anything is written")
+    func outOfRangeIsRefused() throws {
+        let url = try makeTempConfig("""
+            [backend]
+            idle_timeout_mins = 60
+            """)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let before = try String(contentsOf: url, encoding: .utf8)
+
+        withGuardedCanonicalConfig {
+            #expect(throws: (any Error).self) {
+                try setIdleUnloadMinutes(IdleUnloadPolicy.maxMinutes + 1, configPath: url.path)
+            }
+        }
+        #expect(try String(contentsOf: url, encoding: .utf8) == before)
+    }
+
+    @Test("`idle unload-after 0` is rejected in favour of keep-loaded")
+    func unloadAfterZeroIsRejected() {
+        #expect(throws: (any Error).self) {
+            _ = try Idle.UnloadAfter.parse(["0"])
+        }
+        #expect(throws: Never.self) {
+            _ = try Idle.UnloadAfter.parse(["45"])
+        }
+    }
+
+    // MARK: - status
+
+    @Test("status lists advertised-but-unloaded models with the policy's reason")
+    func statusNotLoadedLine() {
+        #expect(Status.notLoadedLine(
+            advertised: nil, warmModels: [], currentModel: nil, idleTimeoutMins: 60) == nil)
+        #expect(Status.notLoadedLine(
+            advertised: ["a", "b"], warmModels: ["a"], currentModel: "b", idleTimeoutMins: 60) == nil)
+
+        #expect(Status.notLoadedLine(
+            advertised: ["a", "b"], warmModels: ["a"], currentModel: nil, idleTimeoutMins: 60)
+            == "Not loaded (unloaded when idle; reloads on demand): b")
+        #expect(Status.notLoadedLine(
+            advertised: ["a", "b"], warmModels: [], currentModel: nil, idleTimeoutMins: 0)
+            == "Not loaded (loads on first request): a, b")
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/HeartbeatIdlePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/HeartbeatIdlePolicyTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+/// `idle_unload_mins` tells the coordinator (and the owner's dashboard) whether
+/// a missing slot is "unloaded on purpose, wakes on demand" or "should be
+/// loaded and isn't". Zero is the always-ready policy and MUST reach the wire;
+/// only an unreported policy (nil) is omitted, so legacy heartbeats decode
+/// unchanged.
+@Suite("Heartbeat idle_unload_mins")
+struct HeartbeatIdlePolicyTests {
+
+    private func encodedObject(idleUnloadMins: UInt64?) throws -> [String: Any] {
+        let message = CoordinatorClientCodec.heartbeatMessage(
+            status: .idle,
+            activeModel: nil,
+            warmModels: [],
+            stats: ProviderStats(requestsServed: 0, tokensGenerated: 0),
+            systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal),
+            backendCapacity: nil,
+            idleUnloadMins: idleUnloadMins)
+        let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    @Test("always-ready (0) is encoded, not dropped as empty")
+    func zeroReachesTheWire() throws {
+        let object = try encodedObject(idleUnloadMins: 0)
+        #expect(object["idle_unload_mins"] as? Int == 0)
+    }
+
+    @Test("a window is encoded in minutes")
+    func windowIsEncoded() throws {
+        let object = try encodedObject(idleUnloadMins: 60)
+        #expect(object["idle_unload_mins"] as? Int == 60)
+    }
+
+    @Test("an unreported policy keeps the legacy wire shape")
+    func nilIsOmitted() throws {
+        let object = try encodedObject(idleUnloadMins: nil)
+        #expect(object["idle_unload_mins"] == nil)
+    }
+
+    @Test("the field round-trips through the provider-message decoder")
+    func roundTrip() throws {
+        let message = CoordinatorClientCodec.heartbeatMessage(
+            status: .serving,
+            activeModel: "model-a",
+            warmModels: ["model-a"],
+            stats: ProviderStats(requestsServed: 1, tokensGenerated: 10),
+            systemMetrics: SystemMetrics(memoryPressure: 0.1, cpuUsage: 0.2, thermalState: .nominal),
+            backendCapacity: nil,
+            idleUnloadMins: 45)
+        let data = try ProviderProtocolCodec.encodeProviderMessage(message)
+        let decoded = try JSONDecoder().decode(ProviderMessage.self, from: data)
+        guard case .heartbeat(let heartbeat) = decoded else {
+            Issue.record("expected a heartbeat, got \(decoded)")
+            return
+        }
+        #expect(heartbeat.idleUnloadMins == 45)
+
+        // Legacy heartbeat without the key: nil, never a defaulted 0 or 60.
+        let legacy = Data("""
+            {"type":"heartbeat","status":"idle","stats":{"requests_served":0,"tokens_generated":0},\
+            "system_metrics":{"memory_pressure":0,"cpu_usage":0,"thermal_state":"nominal"}}
+            """.utf8)
+        guard case .heartbeat(let old) = try JSONDecoder().decode(ProviderMessage.self, from: legacy) else {
+            Issue.record("expected a heartbeat")
+            return
+        }
+        #expect(old.idleUnloadMins == nil)
+    }
+
+    @Test("the client config carries the policy into every heartbeat")
+    func clientConfigCarriesPolicy() {
+        let hardware = HardwareInfo(
+            machineModel: "Mac16,5",
+            chipName: "Apple M4 Max",
+            chipFamily: .m4,
+            chipTier: .max,
+            memoryGb: 128,
+            memoryAvailableGb: 124,
+            cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40,
+            memoryBandwidthGbs: 546)
+        let config = CoordinatorClientConfig(
+            url: "wss://example.invalid/ws/provider",
+            hardware: hardware,
+            models: [],
+            backendName: "mlx-swift",
+            idleUnloadMins: 0)
+        #expect(config.idleUnloadMins == 0)
+
+        let unset = CoordinatorClientConfig(
+            url: "wss://example.invalid/ws/provider",
+            hardware: hardware,
+            models: [],
+            backendName: "mlx-swift")
+        #expect(unset.idleUnloadMins == nil)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/LaunchAgentRestartTests.swift
@@ -311,7 +311,6 @@ struct LaunchAgentServicePlistTests {
             binaryPath: "/usr/local/bin/darkbloom",
             coordinatorURL: "wss://api.darkbloom.dev/ws/provider",
             models: ["org/model"],
-            idleTimeout: 15,
             configPath: URL(fileURLWithPath: "/tmp/custom provider.toml")
         )
         let flagIndex = try #require(arguments.firstIndex(of: "--config"))
@@ -323,9 +322,21 @@ struct LaunchAgentServicePlistTests {
             binaryPath: "/usr/local/bin/darkbloom",
             coordinatorURL: "wss://api.darkbloom.dev/ws/provider",
             models: [],
-            idleTimeout: nil,
             configPath: nil
         )
         #expect(!arguments.contains("--config"))
+    }
+
+    @Test func idlePolicyIsNeverBakedIntoTheServiceArgv() {
+        // `[backend] idle_timeout_mins` is the single authority: `darkbloom idle`
+        // + `darkbloom restart` must be able to change the policy without a
+        // plist rewrite, so the daemon argv carries no `--idle-timeout`.
+        let arguments = LaunchAgent.serviceProgramArguments(
+            binaryPath: "/usr/local/bin/darkbloom",
+            coordinatorURL: "wss://api.darkbloom.dev/ws/provider",
+            models: ["org/model"],
+            configPath: nil
+        )
+        #expect(!arguments.contains("--idle-timeout"))
     }
 }


### PR DESCRIPTION
## Summary

Providers had an idle-unload timeout (60 min) they were never asked about, so both "my model vanished" and "why is my RAM still full" were surprises. This makes the policy an explicit operator choice with a single source of truth, and teaches the coordinator/dashboard to tell "unloaded on purpose, wakes on demand" apart from "should be loaded and isn't".

## Operator experience

**`darkbloom start`** (interactive path only) asks after the model picker:

```
When there are no requests, how should Darkbloom use your memory?

  1) Always ready     Models stay loaded. Instant responses, first in line
                      for routing, base rewards accrue around the clock.
                      Holds up to ~18 GB while idle.
  2) Free when idle   Unload after 60 min without requests; reloaded on
                      demand (10–30 s cold start). Your Mac gets its memory
                      back between bursts. Base rewards pause while unloaded.
  3) Custom           Same as 2, with your own idle window.

Choice [2]:
```

- **Default is 2 (Free when idle)**; Enter keeps whatever policy is already in force, so a repeat `start` never silently moves it.
- `--model` / `--all`, `--idle-timeout`, non-TTY stdin and the launchd `--foreground` relaunch never prompt.

**New `darkbloom idle` command**

```
darkbloom idle status [--json]        # current policy (default subcommand)
darkbloom idle keep-loaded            # always ready (idle_timeout_mins = 0)
darkbloom idle unload-after <minutes> # free when idle, 1..10080
```

Mirrors `darkbloom beta`: locked read-modify-write of the TOML, key materialised even when it matches the default, "restart to apply".

**`darkbloom status`** prints `Memory when idle: …` and lists advertised-but-unloaded models with the reason (unloaded when idle vs. loads on first request).

## Single source of truth

`[backend] idle_timeout_mins` (0 = always ready). `--idle-timeout` now persists there too. The launchd plist **no longer bakes `--idle-timeout` into argv** — a legacy plist still works as a fallback until the TOML key is pinned, so `darkbloom idle …` + `darkbloom restart` always wins over a stale plist.

## Coordinator / dashboard

- Heartbeat carries `idle_unload_mins` (`*int`: 0 preserved on the wire, omitted by legacy providers). Registry stores it per live provider — sticky within a connection, negatives ignored — and `/v1/me/providers` surfaces it.
- Dashboard shows the policy on each machine card; an empty *Loaded* set renders as "sleeping, wakes on demand" **only** under free-when-idle (under always-ready it remains a real gap). The cold-slot warning and its fix quote the machine's own window and point at `darkbloom idle keep-loaded`.
- Setup FAQ rewritten — it still described the old vllm-mlx process.

## Docs

`docs/provider/cli-reference.md` (start flag, new `idle` section, status), `quickstart.md`, `installation.md`, `README.md`.

## Verification

- **Swift**: build green; 77 tests / 8 suites pass — new `IdleCommandTests` (menu semantics, prompt dialogue as a pure function, TOML persistence/pinning, CLI validation, status line) and `HeartbeatIdlePolicyTests` (0 reaches the wire, nil omitted, round trip); `LaunchAgentRestartTests` now asserts argv never carries `--idle-timeout`. Hermetic CLI smoke of every `idle` subcommand incl. `--json` and the `0` / `99999` rejections.
- **Go**: `gofmt`/`vet` clean; `./protocol ./registry ./api` pass — new protocol round-trip, registry sticky/validated policy, and `/v1/me/providers` surfacing tests.
- **UI**: new `idle-policy.test.tsx` + neighbouring suites pass (16/16); ESLint 0 errors on touched files. The three `tsc` errors and the `warnings.ts` cognitive-complexity warning are pre-existing on `master`.

## Notes for reviewers

- Based on `4c78503f5`, one commit behind `master` (#809 system profiler). No overlapping files with that commit; merges cleanly. Happy to rebase if preferred.
- No behaviour change for existing providers until they next run an interactive `darkbloom start` (they keep 60 min) — no fleet-wide flip on upgrade.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791062810&installation_model_id=21733&pr_number=813&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F813&signature=93e449479059ca215f395206a91f41c5d16dd5eaca01c952460ef206dea75d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
