### PR TITLE
fix: allow fractional seconds in model manifest timestamps (resolves #673)

### DIFF
--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
@@ -126,7 +126,9 @@ public struct ModelCatalogClient: Sendable {
 
     static let manifestDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        decoder.dateDecodingStrategy = .formatted(formatter)
         return decoder
     }()
 


### PR DESCRIPTION
This changes the JSONDecoder's dateDecodingStrategy from .iso8601 to a custom ISO8601DateFormatter with fractional seconds enabled, allowing decoding of timestamps like `2026-05-25T22:46:27.580497Z`. Fixes issue where model download fails to decode manifest due to microsecond fractions in `created_at` field.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791064374&installation_model_id=21733&pr_number=814&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F814&signature=698c4bde3b8ee09412d3ac4887b516e31bb67acdf801248031ae55bb8c1f1d2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->