### PR TITLE
feat(models): surface required provider capabilities in CLI catalog and console

### DIFF
--- a/console-ui/__tests__/api.test.ts
+++ b/console-ui/__tests__/api.test.ts
@@ -254,6 +254,25 @@ describe("fetchModels", () => {
     expect(m.supported_sampling_parameters).toContain("temperature");
   });
 
+  it("surfaces required_provider_capabilities from the top level or metadata", async () => {
+    client.fetch.mockResolvedValueOnce(jsonResponse({
+      data: [
+        // Public catalog path: top-level, as /api/models emits it.
+        { id: "qwen3.8-27b", object: "model", required_provider_capabilities: ["apple_m5", "mlx_nax"], metadata: {} },
+        // Forward-compat: where the keyed /v1/models path would carry it.
+        { id: "vendor/meta-only", object: "model", metadata: { required_provider_capabilities: ["mlx_nax"] } },
+        { id: "gemma-4-26b", object: "model", metadata: {} },
+      ],
+    }));
+
+    const result = await fetchModels();
+    const byID = new Map(result.map((m) => [m.id, m]));
+
+    expect(byID.get("qwen3.8-27b")?.required_provider_capabilities).toEqual(["apple_m5", "mlx_nax"]);
+    expect(byID.get("vendor/meta-only")?.required_provider_capabilities).toEqual(["mlx_nax"]);
+    expect(byID.get("gemma-4-26b")?.required_provider_capabilities).toBeUndefined();
+  });
+
   it("throws on non-ok response", async () => {
     client.fetch.mockResolvedValueOnce(jsonResponse({}, 503));
     await expect(fetchModels()).rejects.toThrow("Failed to fetch models: 503");

--- a/console-ui/__tests__/pages.test.tsx
+++ b/console-ui/__tests__/pages.test.tsx
@@ -395,3 +395,38 @@ describe("ProvidersPage", () => {
     expect(screen.getAllByText("darkbloom start").length).toBeGreaterThan(0);
   });
 });
+
+// =========================================================================
+// Models page
+// =========================================================================
+
+describe("ModelsPage", () => {
+  it("shows the provider hardware requirement badge only on gated models", async () => {
+    const api = await import("@/lib/api");
+    vi.mocked(api.fetchModels).mockResolvedValueOnce([
+      {
+        id: "qwen3.8-27b",
+        object: "model",
+        display_name: "Qwen 3.8 27B",
+        required_provider_capabilities: ["apple_m5", "mlx_nax"],
+      },
+      {
+        id: "gemma-4-26b",
+        object: "model",
+        display_name: "Gemma 4 26B",
+        required_provider_capabilities: [],
+      },
+    ]);
+    const ModelsPage = (await import("@/app/models/page")).default;
+    render(<ModelsPage />);
+
+    const badge = await screen.findByText("Apple M5 + NAX runtime only");
+    expect(badge).toHaveAttribute(
+      "title",
+      "Served only by providers with: Apple M5, NAX runtime"
+    );
+    // The ungated card renders no requirement pill.
+    expect(screen.getAllByText(/ only$/)).toHaveLength(1);
+    expect(screen.getByText("gemma-4-26b")).toBeInTheDocument();
+  });
+});

--- a/console-ui/src/app/api/models/route.test.ts
+++ b/console-ui/src/app/api/models/route.test.ts
@@ -1,0 +1,120 @@
+// Exercises the real GET handler against a throwaway in-process HTTP server
+// standing in for the coordinator (live-isolated: no mocks of the route, no
+// network beyond loopback).
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+const QWEN_BUILD = "EigenLabs/Qwen3.8-27B-4bit-mtp";
+const QWEN_ALIAS = "qwen3.8-27b";
+
+const catalogFixture = {
+  models: [
+    {
+      id: QWEN_BUILD,
+      display_name: "Qwen 3.8 27B (4-bit, MTP)",
+      model_type: "text",
+      size_gb: 27,
+      required_provider_capabilities: ["apple_m5", "mlx_nax"],
+      metadata: {},
+    },
+    {
+      id: "gemma-4-26b",
+      display_name: "Gemma 4 26B",
+      model_type: "text",
+      size_gb: 26,
+      required_provider_capabilities: [],
+      metadata: {},
+    },
+    {
+      // Malformed upstream value: only the string entries may reach the UI.
+      id: "vendor/odd",
+      display_name: "Odd",
+      model_type: "text",
+      size_gb: 1,
+      required_provider_capabilities: ["apple_m5", 7, null],
+      metadata: {},
+    },
+    {
+      // Legacy row without the field at all.
+      id: "vendor/legacy",
+      display_name: "Legacy",
+      model_type: "text",
+      size_gb: 1,
+      metadata: {},
+    },
+  ],
+  aliases: [
+    {
+      id: QWEN_ALIAS,
+      display_name: "Qwen 3.8 27B",
+      desired_build: QWEN_BUILD,
+      primary_build: QWEN_BUILD,
+    },
+  ],
+};
+
+let server: Server;
+let previousCoordinatorUrl: string | undefined;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const path = new URL(req.url ?? "/", "http://localhost").pathname;
+    if (path === "/v1/models/catalog") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(catalogFixture));
+      return;
+    }
+    if (path === "/v1/models/capacity") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ models: [] }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  previousCoordinatorUrl = process.env.NEXT_PUBLIC_COORDINATOR_URL;
+  process.env.NEXT_PUBLIC_COORDINATOR_URL = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  if (previousCoordinatorUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_COORDINATOR_URL;
+  } else {
+    process.env.NEXT_PUBLIC_COORDINATOR_URL = previousCoordinatorUrl;
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+async function fetchPublicCatalog() {
+  const res = await GET(new NextRequest("http://localhost/api/models"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { data: Array<Record<string, unknown>> };
+  return new Map(body.data.map((row) => [row.id as string, row]));
+}
+
+describe("GET /api/models (public catalog)", () => {
+  it("passes required_provider_capabilities through to the public alias row", async () => {
+    const rows = await fetchPublicCatalog();
+    // The concrete build is hidden behind its alias; the alias inherits the gate.
+    expect(rows.has(QWEN_BUILD)).toBe(false);
+    expect(rows.get(QWEN_ALIAS)?.required_provider_capabilities).toEqual(["apple_m5", "mlx_nax"]);
+  });
+
+  it("emits an empty array for ungated and legacy rows", async () => {
+    const rows = await fetchPublicCatalog();
+    expect(rows.get("gemma-4-26b")?.required_provider_capabilities).toEqual([]);
+    expect(rows.get("vendor/legacy")?.required_provider_capabilities).toEqual([]);
+  });
+
+  it("drops non-string entries from a malformed upstream value", async () => {
+    const rows = await fetchPublicCatalog();
+    expect(rows.get("vendor/odd")?.required_provider_capabilities).toEqual(["apple_m5"]);
+  });
+});

--- a/console-ui/src/app/api/models/route.ts
+++ b/console-ui/src/app/api/models/route.ts
@@ -47,6 +47,9 @@ function toModelEntry(model: JsonRecord, capacity?: JsonRecord) {
     output_modalities: model.output_modalities,
     supported_features: model.supported_features,
     supported_sampling_parameters: model.supported_sampling_parameters,
+    // Provider hardware gate (e.g. Apple M5 + NAX only). The catalog emits it
+    // top-level; sanitized to strings so a malformed value cannot reach the UI.
+    required_provider_capabilities: asStringArray(model.required_provider_capabilities),
     metadata: {
       ...metadata,
       model_type: model.model_type ?? metadata.model_type,

--- a/console-ui/src/app/models/page.tsx
+++ b/console-ui/src/app/models/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { TopBar } from "@/components/TopBar";
 import { fetchModels, fetchPricing, type Model, type PricingResponse } from "@/lib/api";
+import { providerRequirementBadge, providerRequirementTitle } from "@/lib/provider-capabilities";
 import {
   Cpu,
   Shield,
@@ -139,6 +140,8 @@ export default function ModelsPage() {
                 const org = model.id.includes("/")
                   ? model.id.split("/")[0]
                   : undefined;
+                const requirementBadge = providerRequirementBadge(model.required_provider_capabilities);
+                const requirementTitle = providerRequirementTitle(model.required_provider_capabilities);
 
                 return (
                   <div
@@ -187,6 +190,14 @@ export default function ModelsPage() {
                           {formatContextLength(model.context_length ?? model.max_context_length)} ctx
                         </span>
                       ) : null}
+                      {requirementBadge && (
+                        <span
+                          title={requirementTitle ?? undefined}
+                          className="px-2 py-0.5 rounded bg-accent-amber-dim/30 text-xs font-mono text-accent-amber border border-accent-amber/20"
+                        >
+                          {requirementBadge}
+                        </span>
+                      )}
                     </div>
 
                     {/* Pricing */}

--- a/console-ui/src/lib/api/models.ts
+++ b/console-ui/src/lib/api/models.ts
@@ -31,6 +31,11 @@ export async function fetchModels(): Promise<Model[]> {
       architecture: m.architecture ?? meta.architecture,
       family: m.family ?? meta.family,
       capabilities: m.capabilities ?? meta.capabilities,
+      // Top-level on the public catalog path. The keyed path proxies
+      // /v1/models, which does not carry this field yet; the metadata fallback
+      // is where it would land once the coordinator's ModelMetadata adds it.
+      required_provider_capabilities:
+        m.required_provider_capabilities ?? meta.required_provider_capabilities,
       // OpenRouter provider schema fields.
       name: m.name ?? meta.display_name,
       hugging_face_id: m.hugging_face_id ?? m.id,

--- a/console-ui/src/lib/api/types.ts
+++ b/console-ui/src/lib/api/types.ts
@@ -27,6 +27,10 @@ export interface Model {
   architecture?: string;
   family?: string;
   capabilities?: string[];
+  // Provider hardware/runtime the model needs (e.g. ["apple_m5", "mlx_nax"]).
+  // Empty or absent means any provider can serve it. Label mapping lives in
+  // lib/provider-capabilities.ts.
+  required_provider_capabilities?: string[];
   // OpenRouter provider schema fields (from the enriched /v1/models endpoint).
   name?: string;
   hugging_face_id?: string;

--- a/console-ui/src/lib/provider-capabilities.test.ts
+++ b/console-ui/src/lib/provider-capabilities.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  providerCapabilityLabel,
+  providerCapabilityLabels,
+  providerRequirementBadge,
+  providerRequirementTitle,
+} from "./provider-capabilities";
+
+describe("providerCapabilityLabel", () => {
+  it("maps the known capabilities", () => {
+    expect(providerCapabilityLabel("apple_m5")).toBe("Apple M5");
+    expect(providerCapabilityLabel("mlx_nax")).toBe("NAX runtime");
+  });
+
+  it("falls back to the raw id for unknown values", () => {
+    expect(providerCapabilityLabel("future_runtime")).toBe("future_runtime");
+  });
+});
+
+describe("providerCapabilityLabels", () => {
+  it("orders by wire id, de-duplicates, and drops blanks", () => {
+    expect(providerCapabilityLabels(["mlx_nax", "apple_m5", "mlx_nax", "", "  "])).toEqual([
+      "Apple M5",
+      "NAX runtime",
+    ]);
+  });
+
+  it("returns nothing for absent, null, empty, or non-array input", () => {
+    expect(providerCapabilityLabels(undefined)).toEqual([]);
+    expect(providerCapabilityLabels(null)).toEqual([]);
+    expect(providerCapabilityLabels([])).toEqual([]);
+    expect(providerCapabilityLabels("apple_m5" as unknown as string[])).toEqual([]);
+  });
+});
+
+describe("providerRequirementBadge", () => {
+  it("renders a single requirement", () => {
+    expect(providerRequirementBadge(["apple_m5"])).toBe("Apple M5 only");
+  });
+
+  it("joins several requirements in wire-id order", () => {
+    expect(providerRequirementBadge(["mlx_nax", "apple_m5"])).toBe("Apple M5 + NAX runtime only");
+  });
+
+  it("keeps unknown ids visible", () => {
+    expect(providerRequirementBadge(["future_runtime"])).toBe("future_runtime only");
+  });
+
+  it("is null when there is nothing to show (including the API's empty array)", () => {
+    expect(providerRequirementBadge([])).toBeNull();
+    expect(providerRequirementBadge(undefined)).toBeNull();
+    expect(providerRequirementBadge(null)).toBeNull();
+  });
+});
+
+describe("providerRequirementTitle", () => {
+  it("spells out the full requirement", () => {
+    expect(providerRequirementTitle(["apple_m5", "mlx_nax"])).toBe(
+      "Served only by providers with: Apple M5, NAX runtime",
+    );
+  });
+
+  it("is null when there is nothing to show", () => {
+    expect(providerRequirementTitle([])).toBeNull();
+  });
+});

--- a/console-ui/src/lib/provider-capabilities.ts
+++ b/console-ui/src/lib/provider-capabilities.ts
@@ -1,0 +1,44 @@
+// Display names for a model's `required_provider_capabilities` — the provider
+// hardware/runtime a model can only be served on. Mirrors the provider CLI's
+// `ProviderCapabilityLabels` (provider-swift/.../ModelRequirementDisplay.swift);
+// keep the two label tables in sync. Unknown values render as their raw id so
+// a newer catalog still shows something truthful.
+
+const CAPABILITY_LABELS = new Map<string, string>([
+  ["apple_m5", "Apple M5"],
+  ["mlx_nax", "NAX runtime"],
+]);
+
+export function providerCapabilityLabel(capability: string): string {
+  return CAPABILITY_LABELS.get(capability) ?? capability;
+}
+
+/**
+ * Labels in stable wire-id order, de-duplicated, blanks dropped. Empty when
+ * the model has no provider requirement.
+ */
+export function providerCapabilityLabels(capabilities?: string[] | null): string[] {
+  if (!Array.isArray(capabilities)) return [];
+  const ids = new Set<string>();
+  for (const value of capabilities) {
+    if (typeof value === "string" && value.trim()) ids.add(value.trim());
+  }
+  return [...ids].sort().map(providerCapabilityLabel);
+}
+
+/**
+ * Compact badge text for a model card, e.g. "Apple M5 only" or
+ * "Apple M5 + NAX runtime only". Null when there is nothing to show.
+ */
+export function providerRequirementBadge(capabilities?: string[] | null): string | null {
+  const labels = providerCapabilityLabels(capabilities);
+  if (labels.length === 0) return null;
+  return `${labels.join(" + ")} only`;
+}
+
+/** Longer tooltip copy for the badge. Null when there is nothing to show. */
+export function providerRequirementTitle(capabilities?: string[] | null): string | null {
+  const labels = providerCapabilityLabels(capabilities);
+  if (labels.length === 0) return null;
+  return `Served only by providers with: ${labels.join(", ")}`;
+}

--- a/provider-swift/Sources/ProviderCore/Models/ModelRequirementDisplay.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelRequirementDisplay.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Human-readable names for provider runtime capabilities. Unknown values
+/// (future capabilities this binary predates) render as their raw wire id so
+/// an operator still sees exactly what the catalog asked for.
+public enum ProviderCapabilityLabels {
+    public static func label(for capability: ProviderRuntimeCapability) -> String {
+        switch capability {
+        case .appleM5: return "Apple M5"
+        case .mlxNAX: return "NAX runtime"
+        default: return capability.rawValue
+        }
+    }
+
+    /// Labels in stable wire-id order, so output does not depend on set
+    /// iteration order.
+    public static func labels(_ capabilities: Set<ProviderRuntimeCapability>) -> [String] {
+        capabilities.sorted().map(label(for:))
+    }
+}
+
+/// Pure, hardware-free formatting for the "requires:" / "not eligible" lines
+/// that `darkbloom models catalog` prints under a model. The daemon already
+/// enforces these requirements silently (`advertisedModels` drops ineligible
+/// models); these lines are the operator-facing explanation.
+public enum ModelRequirementLine {
+    /// `requires: Apple M5, NAX runtime`, or nil when nothing is required.
+    public static func requires(_ required: Set<ProviderRuntimeCapability>) -> String? {
+        guard !required.isEmpty else { return nil }
+        return "requires: \(ProviderCapabilityLabels.labels(required).joined(separator: ", "))"
+    }
+
+    /// `not eligible on this machine (missing: apple_m5, mlx_nax)`, or nil when
+    /// nothing is missing. Uses raw ids so the line matches the download error.
+    public static func ineligible(missing: Set<ProviderRuntimeCapability>) -> String? {
+        guard !missing.isEmpty else { return nil }
+        let ids = missing.sorted().map(\.rawValue).joined(separator: ", ")
+        return "not eligible on this machine (missing: \(ids))"
+    }
+
+    public static let hardwareUnknown = "eligibility unknown (hardware detection unavailable)"
+
+    /// Every line to print under a catalog entry. Empty when the model has no
+    /// requirement. `available == nil` means hardware detection failed, which
+    /// must not be reported as "not eligible".
+    ///
+    /// Goes through `ModelRuntimeRequirements.evaluate` so the embedded
+    /// exact-id rule is honoured even when the catalog field is absent.
+    public static func lines(
+        modelID: String,
+        catalogRequirements: [ProviderRuntimeCapability]?,
+        available: Set<ProviderRuntimeCapability>?
+    ) -> [String] {
+        let eligibility = ModelRuntimeRequirements.evaluate(
+            modelID: modelID,
+            catalogRequirements: catalogRequirements,
+            available: available ?? [])
+        guard let requiresLine = requires(eligibility.required) else { return [] }
+
+        var lines = [requiresLine]
+        if available == nil {
+            lines.append(hardwareUnknown)
+        } else if let verdict = ineligible(missing: eligibility.missing) {
+            lines.append(verdict)
+        }
+        return lines
+    }
+}

--- a/provider-swift/Sources/darkbloom/ModelsCommand.swift
+++ b/provider-swift/Sources/darkbloom/ModelsCommand.swift
@@ -133,6 +133,19 @@ extension Models {
             } else {
                 localModels = []
             }
+            // Bind the metallib and run the GPU diagnostic only when some entry
+            // is gated: `catalog` is the default `models` subcommand and the
+            // verdict is never printed otherwise. nil when hardware detection
+            // failed, so the lines say "unknown" rather than wrongly reporting
+            // every gated model ineligible.
+            let anyGated = entries.contains {
+                !ModelRuntimeRequirements.requiredCapabilities(
+                    for: $0.id, catalogRequirements: $0.requiredProviderCapabilities
+                ).isEmpty
+            }
+            let runtimeCapabilities: Set<ProviderRuntimeCapability>? = anyGated
+                ? snapshot.hardware.map { ProviderRuntimeCapabilityDetector.detectLive(hardware: $0) }
+                : nil
             let downloadedIDs = Set(localModels.map(\.id))
             let catalogIDs = Set(entries.map(\.id))
 
@@ -147,6 +160,14 @@ extension Models {
                     let mark = downloadedIDs.contains(entry.id) ? "✓" : " "
                     let mem = entry.minRamGb.map { " (≥ \($0) GB RAM)" } ?? ""
                     print("  \(mark) \(entry.displayName)  [\(entry.id)]  ~\(String(format: "%.1f", entry.sizeGb)) GB\(mem)")
+                    // Same gate `start` applies silently; here it is explained.
+                    for line in ModelRequirementLine.lines(
+                        modelID: entry.id,
+                        catalogRequirements: entry.requiredProviderCapabilities,
+                        available: runtimeCapabilities
+                    ) {
+                        print("      \(line)")
+                    }
                 }
             }
 

--- a/provider-swift/Tests/ProviderCoreTests/ModelRequirementDisplayTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelRequirementDisplayTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+private let qwen38ID = ModelRuntimeRequirements.qwen38ConcreteModelID
+private let qwen38Caps: Set<ProviderRuntimeCapability> = [.appleM5, .mlxNAX]
+
+@Suite("Provider capability labels")
+struct ProviderCapabilityLabelsTests {
+    @Test("known capabilities map to operator-facing names")
+    func knownLabels() {
+        #expect(ProviderCapabilityLabels.label(for: .appleM5) == "Apple M5")
+        #expect(ProviderCapabilityLabels.label(for: .mlxNAX) == "NAX runtime")
+    }
+
+    @Test("unknown capabilities fall back to the raw wire id")
+    func unknownLabel() {
+        let future = ProviderRuntimeCapability(rawValue: "future_runtime")
+        #expect(ProviderCapabilityLabels.label(for: future) == "future_runtime")
+    }
+
+    @Test("labels are ordered by wire id and de-duplicated")
+    func labelsOrdering() {
+        #expect(
+            ProviderCapabilityLabels.labels([.mlxNAX, .appleM5, .mlxNAX])
+                == ["Apple M5", "NAX runtime"])
+        #expect(ProviderCapabilityLabels.labels([]).isEmpty)
+    }
+}
+
+@Suite("Model requirement lines")
+struct ModelRequirementLineTests {
+    @Test("requires line lists labels in wire-id order and is nil when empty")
+    func requiresLine() {
+        #expect(ModelRequirementLine.requires(qwen38Caps) == "requires: Apple M5, NAX runtime")
+        #expect(ModelRequirementLine.requires([.mlxNAX]) == "requires: NAX runtime")
+        #expect(ModelRequirementLine.requires([]) == nil)
+    }
+
+    @Test("ineligible line uses raw ids like the download error and is nil when nothing is missing")
+    func ineligibleLine() {
+        #expect(
+            ModelRequirementLine.ineligible(missing: qwen38Caps)
+                == "not eligible on this machine (missing: apple_m5, mlx_nax)")
+        #expect(
+            ModelRequirementLine.ineligible(missing: [.mlxNAX])
+                == "not eligible on this machine (missing: mlx_nax)")
+        #expect(ModelRequirementLine.ineligible(missing: []) == nil)
+    }
+
+    @Test("models without requirements print nothing")
+    func noRequirement() {
+        #expect(ModelRequirementLine.lines(
+            modelID: "unrelated/model", catalogRequirements: nil, available: []).isEmpty)
+        #expect(ModelRequirementLine.lines(
+            modelID: "unrelated/model", catalogRequirements: [], available: nil).isEmpty)
+    }
+
+    @Test("catalog requirement on an M4-class box explains the missing capabilities")
+    func catalogRequirementIneligible() {
+        let lines = ModelRequirementLine.lines(
+            modelID: "vendor/future-model",
+            catalogRequirements: [.mlxNAX, .appleM5],
+            available: [.mlxNAX])
+        #expect(lines == [
+            "requires: Apple M5, NAX runtime",
+            "not eligible on this machine (missing: apple_m5)",
+        ])
+    }
+
+    @Test("an eligible machine sees only the requires line")
+    func catalogRequirementEligible() {
+        let lines = ModelRequirementLine.lines(
+            modelID: "vendor/future-model",
+            catalogRequirements: [.appleM5, .mlxNAX],
+            available: qwen38Caps)
+        #expect(lines == ["requires: Apple M5, NAX runtime"])
+    }
+
+    @Test("embedded exact-id rule surfaces even when the catalog carries no requirement")
+    func embeddedRuleWithoutCatalogField() {
+        for modelID in ModelRuntimeRequirements.qwen38ConcreteModelIDs {
+            let lines = ModelRequirementLine.lines(
+                modelID: modelID, catalogRequirements: nil, available: [])
+            #expect(lines == [
+                "requires: Apple M5, NAX runtime",
+                "not eligible on this machine (missing: apple_m5, mlx_nax)",
+            ], "\(modelID)")
+        }
+    }
+
+    @Test("embedded rule unions with catalog requirements and unknown values keep their raw id")
+    func embeddedRuleUnionsWithCatalog() {
+        let future = ProviderRuntimeCapability(rawValue: "future_runtime")
+        let lines = ModelRequirementLine.lines(
+            modelID: qwen38ID, catalogRequirements: [future], available: qwen38Caps)
+        // Ordered by wire id (apple_m5 < future_runtime < mlx_nax), not by label.
+        #expect(lines == [
+            "requires: Apple M5, future_runtime, NAX runtime",
+            "not eligible on this machine (missing: future_runtime)",
+        ])
+    }
+
+    @Test("failed hardware detection reports unknown, never ineligible")
+    func hardwareUnknown() {
+        let lines = ModelRequirementLine.lines(
+            modelID: qwen38ID, catalogRequirements: nil, available: nil)
+        #expect(lines == [
+            "requires: Apple M5, NAX runtime",
+            ModelRequirementLine.hardwareUnknown,
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

The catalog carries `required_provider_capabilities` per model (today `apple_m5`, `mlx_nax`) and the provider already enforces it silently: `advertisedModels()` drops ineligible models at `start`, and only `darkbloom models download` says anything ("permanently ineligible on this provider: missing runtime capabilities [...]"). The first gated model is Qwen 3.8 27B (`EigenLabs/Qwen3.8-27B-4bit-mtp`, Apple M5 + NAX runtime only), so operators on M1–M4 currently see no explanation and console users see no hint.

This PR surfaces the requirement in the two places people look:

- **Provider CLI** — `darkbloom models catalog` prints, under each gated entry, `requires: Apple M5, NAX runtime` and, when this machine lacks any of them, `not eligible on this machine (missing: apple_m5, mlx_nax)`. The verdict goes through `ModelRuntimeRequirements.evaluate(...)` so the embedded exact-id rule is honoured (it unions with the catalog field). If hardware detection failed it prints `eligibility unknown (hardware detection unavailable)` rather than a false "not eligible". Label mapping + line formatting live in a new pure, MLX-free helper (`ProviderCapabilityLabels`, `ModelRequirementLine`) in ProviderCore. The metallib bind + GPU diagnostic (`detectLive`) only runs when some catalog entry is gated — `catalog` is the default `models` subcommand, so an ungated catalog costs nothing extra — and never on the `--json` path, whose output is unchanged.
- **Console UI** — `required_provider_capabilities` is passed through `/api/models` (`toModelEntry`, sanitized to strings) and `fetchModels`, typed on `Model`, and rendered on the model card as a compact amber pill (`Apple M5 + NAX runtime only`) with a tooltip. Alias rows inherit the field from their primary build, so the public Qwen 3.8 alias shows it. Labels come from a tiny `src/lib/provider-capabilities.ts` mirroring the Swift table; unknown ids render as their raw value on both sides.

## Before / After — behaviour

```mermaid
flowchart LR
  subgraph Before
    O1[Operator on M1–M4<br/>darkbloom models catalog] --> C1[entry: name, id, size, RAM only]
    O1 --> S1[darkbloom start<br/>silently drops the model]
    O1 --> D1[models download<br/>fails: permanently ineligible]
    U1[Console user opens /models] --> K1[card: no hardware hint]
  end
  subgraph After
    O2[Operator<br/>darkbloom models catalog] --> C2[entry + requires: Apple M5, NAX runtime]
    C2 --> V2{hardware detected?}
    V2 -- missing caps --> N2[not eligible on this machine<br/>missing: apple_m5, mlx_nax]
    V2 -- all present --> E2[requires line only]
    V2 -- detection failed --> H2[eligibility unknown]
    U2[Console user opens /models] --> K2[card: amber pill<br/>Apple M5 + NAX runtime only]
  end
```

## Before / After — code

```mermaid
flowchart LR
  subgraph Before
    A1[Models.Catalog.run] --> B1[print name / id / size / RAM]
    R1[api/models route<br/>toModelEntry] --> F1[fetchModels] --> P1[models/page.tsx pills]
    R1 -. drops required_provider_capabilities .-> F1
  end
  subgraph After
    A2[Models.Catalog.run] --> Q2{any entry gated?}
    Q2 -- no --> B1x[print as before]
    Q2 -- yes --> D2[ProviderRuntimeCapabilityDetector.detectLive]
    D2 --> L2[ModelRequirementLine.lines]
    L2 --> E2[ModelRuntimeRequirements.evaluate<br/>catalog ∪ embedded rule]
    L2 --> G2[ProviderCapabilityLabels]
    L2 --> B2[print requires / not eligible / unknown]
    R2[toModelEntry<br/>+ required_provider_capabilities] --> F2[fetchModels<br/>flattens field] --> H2[provider-capabilities.ts<br/>badge + title] --> P2[models/page.tsx<br/>amber pill]
  end
```

## Test plan

- `cd provider-swift && swift build --product darkbloom` — ok
- `swift test --filter "ModelRequirementLineTests|ProviderCapabilityLabelsTests"` — 11 tests in 2 suites passed (label mapping incl. unknown ids, wire-id ordering, requires/ineligible lines, embedded Qwen 3.8 rule with no catalog field, catalog ∪ embedded union, hardware-unknown path)
- `cd console-ui && npm test` — 59 files / 518 tests passed (new: `src/lib/provider-capabilities.test.ts`; `src/app/api/models/route.test.ts` drives the real `GET` handler against an in-process loopback HTTP server standing in for the coordinator, incl. alias inheritance and a malformed upstream value; a `fetchModels` case in `__tests__/api.test.ts`; a `ModelsPage` render in `__tests__/pages.test.tsx` asserting the badge reaches the DOM only on the gated card)
- `npx eslint src/` — 0 errors; `npm run build` — ok
- Manual: `.build/debug/darkbloom models catalog` on this machine — output unchanged because the current catalog has no gated model yet

## Not in this PR

- **Keyed console sessions.** When an inference API key is stored, `fetchModels` sends `x-api-key` and `/api/models` proxies the coordinator's `/v1/models` verbatim; that response does not carry `required_provider_capabilities` yet, so the badge shows on the public catalog path only. Adding the field to the coordinator's `ModelMetadata` is a small follow-up (the `fetchModels` metadata fallback is already in place for it); left out to keep this PR free of coordinator changes.
- `darkbloom status` and `darkbloom models list` do not hide ineligible models (they call `advertisedModels` without runtime capabilities), so there was nothing to annotate there. The silent drop happens at `darkbloom start` (`StartCommand+Modes.swift`); a one-line "skipped for hardware" note there is a follow-up.
- `models download` error text still uses raw capability ids (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxThXGrq5VyXfUzcahTVw6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791066175&installation_model_id=21733&pr_number=815&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F815&signature=fc2d0a2c331bede6a1bf055f201f1709c1ef61dcd00b5aefaffa32b2114a88f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->