### PR TITLE
fix(coordinator): runtime manifest accepts every active release's metallib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased (2026-09-02) — system profiler
 
+- **Runtime manifest accepts every active release** — `SyncRuntimeManifest`
+  now unions template hashes (including `mlx_metallib`) across ALL active
+  release rows instead of keeping one value per template name. Registering
+  v0.8.16 on 2026-09-03 replaced the v0.8.15 metallib hash in the manifest, so
+  ~1,180 providers still on v0.8.15 failed their next attestation challenge
+  (`provider runtime integrity mismatch in challenge response`, 1,184 times)
+  and the fleet was unroutable for the ~30–40 minute self-update window.
+  Registering a release can no longer deroute the previous release's fleet;
+  deactivating a release remains the way to retire its hashes, a hash no
+  active release ships still fails closed, and `GET /v1/runtime/manifest`
+  lists every accepted hash per template. The post-mutation convergence paths
+  and the `EIGENINFERENCE_KNOWN_TEMPLATE_HASHES` override use the same set
+  semantics.
 - **Per-request profiler** — the coordinator records one prompt-free row per
   dispatched attempt in `request_profiles` (joins `inference_routes` on
   `(request_id, attempt)`): microsecond offsets from middleware entry for every

--- a/coordinator/api/provider_registration_test.go
+++ b/coordinator/api/provider_registration_test.go
@@ -91,7 +91,7 @@ func TestProviderRegistrationBindsProtectedRuntimeClaims(t *testing.T) {
 	)
 	metallibHash := strings.Repeat("a", 64)
 	srv.SetRuntimeManifest(&RuntimeManifest{
-		TemplateHashes: map[string]string{"mlx_metallib": metallibHash},
+		TemplateHashes: map[string]map[string]bool{"mlx_metallib": {metallibHash: true}},
 	})
 	publicKey := testPublicKeyB64()
 	regMsg := &protocol.RegisterMessage{

--- a/coordinator/api/release_policy_failclosed_test.go
+++ b/coordinator/api/release_policy_failclosed_test.go
@@ -381,7 +381,7 @@ func TestReleaseDeactivationReadFailureConvergesPolicyFromCommittedDeactivation(
 
 	// The runtime manifest converged from the retained snapshot: the shared
 	// metallib survives via the remaining 2.1.0 release.
-	if srv.knownRuntimeManifest == nil || srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"] != trHashC {
+	if srv.knownRuntimeManifest == nil || !srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"][trHashC] {
 		t.Fatalf("runtime manifest did not converge with the committed deactivation: %+v", srv.knownRuntimeManifest)
 	}
 
@@ -513,7 +513,7 @@ func TestRegisterReleaseInventoryFailureConvergesPolicyWithCommittedRelease(t *t
 	}
 
 	// The runtime manifest converged with the committed release too.
-	if srv.knownRuntimeManifest == nil || srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"] != trHashC {
+	if srv.knownRuntimeManifest == nil || !srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"][trHashC] {
 		t.Fatalf("runtime manifest did not converge with the committed release: %+v", srv.knownRuntimeManifest)
 	}
 

--- a/coordinator/api/runtime_manifest_test.go
+++ b/coordinator/api/runtime_manifest_test.go
@@ -45,8 +45,8 @@ func TestSyncRuntimeManifestIncludesSwiftMetallibHash(t *testing.T) {
 	if srv.knownRuntimeManifest == nil {
 		t.Fatal("knownRuntimeManifest = nil")
 	}
-	if got := srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"]; got != metallibHash {
-		t.Fatalf("mlx_metallib hash = %q, want %q", got, metallibHash)
+	if accepted := srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"]; !accepted[metallibHash] {
+		t.Fatalf("mlx_metallib accepted hashes = %v, want %q", sortedTemplateHashes(accepted), metallibHash)
 	}
 }
 
@@ -56,7 +56,7 @@ func TestVerifyRuntimeHashesForSwiftRequiresMetallibButNotLegacyRuntime(t *testi
 	srv.SetRuntimeManifest(&RuntimeManifest{
 		PythonHashes:   map[string]bool{"legacy-python": true},
 		RuntimeHashes:  map[string]bool{"legacy-runtime": true},
-		TemplateHashes: map[string]string{"qwen3.5": "legacy-template", "mlx_metallib": metallibHash},
+		TemplateHashes: map[string]map[string]bool{"qwen3.5": {"legacy-template": true}, "mlx_metallib": {metallibHash: true}},
 	})
 
 	ok, mismatches := srv.verifyRuntimeHashesForBackend("mlx-swift", "", "", map[string]string{
@@ -80,13 +80,13 @@ func TestVerifyRuntimeHashesForSwiftRequiresMetallibButNotLegacyRuntime(t *testi
 func TestRuntimeManifestApprovalRequiresExplicitMetallibEntry(t *testing.T) {
 	hash := strings.Repeat("a", 64)
 	if runtimeManifestApprovesMetallib(
-		&RuntimeManifest{TemplateHashes: map[string]string{}},
+		&RuntimeManifest{TemplateHashes: map[string]map[string]bool{}},
 		map[string]string{"mlx_metallib": hash},
 	) {
 		t.Fatal("missing approved mlx_metallib entry was accepted")
 	}
 	if !runtimeManifestApprovesMetallib(
-		&RuntimeManifest{TemplateHashes: map[string]string{"mlx_metallib": hash}},
+		&RuntimeManifest{TemplateHashes: map[string]map[string]bool{"mlx_metallib": {hash: true}}},
 		map[string]string{"mlx_metallib": hash},
 	) {
 		t.Fatal("explicit matching mlx_metallib entry was rejected")
@@ -98,7 +98,7 @@ func TestVerifyRuntimeHashesForLegacyBackendRejected(t *testing.T) {
 	srv.SetRuntimeManifest(&RuntimeManifest{
 		PythonHashes:   map[string]bool{"legacy-python": true},
 		RuntimeHashes:  map[string]bool{"legacy-runtime": true},
-		TemplateHashes: map[string]string{"qwen3.5": "legacy-template", "mlx_metallib": strings.Repeat("a", 64)},
+		TemplateHashes: map[string]map[string]bool{"qwen3.5": {"legacy-template": true}, "mlx_metallib": {strings.Repeat("a", 64): true}},
 	})
 
 	ok, mismatches := srv.verifyRuntimeHashesForBackend("vllm-mlx", "legacy-python", "legacy-runtime", map[string]string{
@@ -112,7 +112,10 @@ func TestVerifyRuntimeHashesForLegacyBackendRejected(t *testing.T) {
 	}
 }
 
-func TestSyncRuntimeManifestUsesLatestReleaseOnly(t *testing.T) {
+// Every active release contributes to every set — template hashes included.
+// The pre-2026-09-03 behaviour ("newest release's template hash wins") is the
+// bug that derouted the fleet on release registration.
+func TestSyncRuntimeManifestUnionsTemplateHashesAcrossActiveReleases(t *testing.T) {
 	srv, st := runtimeManifestTestServer(t)
 
 	if err := st.SetRelease(&store.Release{
@@ -165,11 +168,11 @@ func TestSyncRuntimeManifestUsesLatestReleaseOnly(t *testing.T) {
 	if !manifest.RuntimeHashes["old-runtime"] {
 		t.Fatal("old runtime hash should remain accepted so older providers still pass")
 	}
-	if got := manifest.TemplateHashes["qwen3.5"]; got != "new-template" {
-		t.Fatalf("qwen3.5 template hash = %q, want %q", got, "new-template")
+	if got := manifest.TemplateHashes["qwen3.5"]; len(got) != 2 || !got["new-template"] || !got["old-template"] {
+		t.Fatalf("qwen3.5 accepted hashes = %v, want both old-template and new-template", sortedTemplateHashes(got))
 	}
-	if got := manifest.TemplateHashes["minimax"]; got != "new-minimax-template" {
-		t.Fatalf("minimax template hash = %q, want %q", got, "new-minimax-template")
+	if got := manifest.TemplateHashes["minimax"]; len(got) != 1 || !got["new-minimax-template"] {
+		t.Fatalf("minimax accepted hashes = %v, want %q", sortedTemplateHashes(got), "new-minimax-template")
 	}
 }
 

--- a/coordinator/api/runtime_manifest_union_test.go
+++ b/coordinator/api/runtime_manifest_union_test.go
@@ -1,0 +1,414 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// These tests pin the 2026-09-03 release brownout. Registering provider release
+// v0.8.16 rebuilt the runtime manifest with a SINGLE mlx_metallib value (the
+// newest release overwrote the map entry), so the ~1,180 providers still
+// running v0.8.15 failed their next attestation challenge ("provider runtime
+// integrity mismatch in challenge response — excluding from routing", 1,184
+// times) and the whole fleet was unroutable until every node self-updated on
+// its 30-minute poll. The manifest is now the UNION of every ACTIVE release's
+// hashes per template name, and only deactivating a release removes its values.
+//
+// The hashes echo the incident: 0.8.15 shipped metallib 08c48889…, 0.8.16
+// shipped 4ffbbac4….
+var (
+	unionPreviousMetallib = strings.Repeat("08c48889", 8)
+	unionNewestMetallib   = strings.Repeat("4ffbbac4", 8)
+	unionUnknownMetallib  = strings.Repeat("d", 64)
+)
+
+// unionReleaseRow is a production-shape active release row (family template
+// hashes, empty python/runtime hashes) carrying its own metallib hash.
+func unionReleaseRow(version, binaryHash, metallib string) *store.Release {
+	rel := productionShapeRelease(version, binaryHash)
+	rel.MetallibHash = metallib
+	return rel
+}
+
+// unionFleetProvider registers a routable mlx-swift provider whose last signed
+// runtime identity reported the given metallib — a connected fleet node between
+// challenges. Each provider serves its own model so routability is checked per
+// provider.
+func unionFleetProvider(t *testing.T, reg *registry.Registry, id, model, version, metallib string) *registry.Provider {
+	t.Helper()
+	provider := makeRoutableProvider(t, reg, id, model)
+	provider.Mu().Lock()
+	provider.Version = version
+	provider.MetallibVerified = true
+	provider.TemplateHashes = map[string]string{"mlx_metallib": metallib}
+	provider.Mu().Unlock()
+	return provider
+}
+
+// challengeWithMetallib drives the challenge-response runtime policy the way
+// the attestation handler does (policy application, then capability
+// reconciliation) and returns the policy verdict.
+func challengeWithMetallib(t *testing.T, srv *Server, provider *registry.Provider, metallib string) (policyActive, runtimeOK bool) {
+	t.Helper()
+	resp := &protocol.AttestationResponseMessage{
+		SIPEnabled: trBoolPtr(true), SecureBootEnabled: trBoolPtr(true),
+		TemplateHashes: map[string]string{"mlx_metallib": metallib},
+	}
+	policyActive, runtimeOK, _ = srv.applyChallengeRuntimePolicy(provider, resp)
+	_ = srv.registry.ReconcileAttestedRuntimeCapabilities(provider.ID)
+	return policyActive, runtimeOK
+}
+
+// assertRuntimeApproved checks every manifest-derived routing gate plus actual
+// routability for the provider's model.
+func assertRuntimeApproved(t *testing.T, srv *Server, provider *registry.Provider, model string, want bool, when string) {
+	t.Helper()
+	provider.Mu().Lock()
+	verified, checked, metallib := provider.RuntimeVerified, provider.RuntimeManifestChecked, provider.MetallibVerified
+	provider.Mu().Unlock()
+	if verified != want || checked != want || metallib != want {
+		t.Fatalf("%s: %s runtime policy state = verified:%v checked:%v metallib:%v, want all %v",
+			when, provider.ID, verified, checked, metallib, want)
+	}
+	routed := findRoutableProvider(srv.registry, model)
+	switch {
+	case want && (routed == nil || routed.ID != provider.ID):
+		t.Fatalf("%s: %s must remain routable", when, provider.ID)
+	case !want && routed != nil:
+		t.Fatalf("%s: %s must be excluded from routing, but %s was routed", when, provider.ID, routed.ID)
+	}
+}
+
+// TestRuntimeManifestAcceptsEveryActiveReleaseMetallib: with two active
+// releases shipping different metallibs, a provider on EITHER passes the
+// challenge runtime policy and stays routable, while a metallib no active
+// release ships still fails closed.
+func TestRuntimeManifestAcceptsEveryActiveReleaseMetallib(t *testing.T) {
+	srv, st := runtimeManifestTestServer(t)
+	for _, rel := range []*store.Release{
+		unionReleaseRow("0.8.15", trHashA, unionPreviousMetallib),
+		unionReleaseRow("0.8.16", trHashB, unionNewestMetallib),
+	} {
+		if err := st.SetRelease(rel); err != nil {
+			t.Fatalf("SetRelease(%s): %v", rel.Version, err)
+		}
+	}
+	if err := srv.SyncRuntimeManifest(); err != nil {
+		t.Fatalf("SyncRuntimeManifest: %v", err)
+	}
+	accepted := srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"]
+	if len(accepted) != 2 || !accepted[unionPreviousMetallib] || !accepted[unionNewestMetallib] {
+		t.Fatalf("mlx_metallib accepted set = %v, want both active releases' hashes", sortedTemplateHashes(accepted))
+	}
+
+	cases := []struct {
+		name     string
+		metallib string
+		wantOK   bool
+	}{
+		{"provider still on the previous release", unionPreviousMetallib, true},
+		{"provider already on the newest release", unionNewestMetallib, true},
+		{"provider on a metallib no active release ships", unionUnknownMetallib, false},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := fmt.Sprintf("union-metallib-model-%d", i)
+			provider := unionFleetProvider(t, srv.registry, fmt.Sprintf("union-metallib-provider-%d", i), model, "0.8.15", tc.metallib)
+			active, ok := challengeWithMetallib(t, srv, provider, tc.metallib)
+			if !active {
+				t.Fatal("runtime manifest policy must be active with two active releases")
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("challenge runtimeOK = %v, want %v", ok, tc.wantOK)
+			}
+			assertRuntimeApproved(t, srv, provider, model, tc.wantOK, "after challenge")
+		})
+	}
+}
+
+// TestRuntimeManifestDeactivationRemovesOnlyThatReleaseMetallib: pulling a
+// release (the existing retirement mechanism) removes exactly its metallib from
+// the union. Providers on that binary fail closed both at the live
+// revalidation inside the sync and at their next challenge; providers on the
+// remaining release keep routing.
+func TestRuntimeManifestDeactivationRemovesOnlyThatReleaseMetallib(t *testing.T) {
+	srv, st := runtimeManifestTestServer(t)
+	for _, rel := range []*store.Release{
+		unionReleaseRow("0.8.15", trHashA, unionPreviousMetallib),
+		unionReleaseRow("0.8.16", trHashB, unionNewestMetallib),
+	} {
+		if err := st.SetRelease(rel); err != nil {
+			t.Fatalf("SetRelease(%s): %v", rel.Version, err)
+		}
+	}
+	if err := srv.SyncRuntimeManifest(); err != nil {
+		t.Fatalf("SyncRuntimeManifest: %v", err)
+	}
+
+	const previousModel, newestModel = "deactivation-previous-model", "deactivation-newest-model"
+	previous := unionFleetProvider(t, srv.registry, "deactivation-previous", previousModel, "0.8.15", unionPreviousMetallib)
+	newest := unionFleetProvider(t, srv.registry, "deactivation-newest", newestModel, "0.8.16", unionNewestMetallib)
+	if _, ok := challengeWithMetallib(t, srv, previous, unionPreviousMetallib); !ok {
+		t.Fatal("previous-release provider must pass while its release is active")
+	}
+	if _, ok := challengeWithMetallib(t, srv, newest, unionNewestMetallib); !ok {
+		t.Fatal("newest-release provider must pass while its release is active")
+	}
+	assertRuntimeApproved(t, srv, previous, previousModel, true, "before deactivation")
+	assertRuntimeApproved(t, srv, newest, newestModel, true, "before deactivation")
+
+	if err := st.DeleteRelease("0.8.15", defaultReleasePlatform); err != nil {
+		t.Fatalf("DeleteRelease: %v", err)
+	}
+	if err := srv.SyncRuntimeManifest(); err != nil {
+		t.Fatalf("SyncRuntimeManifest after deactivation: %v", err)
+	}
+	accepted := srv.knownRuntimeManifest.TemplateHashes["mlx_metallib"]
+	if len(accepted) != 1 || !accepted[unionNewestMetallib] {
+		t.Fatalf("mlx_metallib accepted set = %v, want only the remaining active release", sortedTemplateHashes(accepted))
+	}
+
+	// Live revalidation inside the sync deroutes the pulled release's fleet…
+	assertRuntimeApproved(t, srv, previous, previousModel, false, "revalidation after deactivation")
+	assertRuntimeApproved(t, srv, newest, newestModel, true, "revalidation after deactivation")
+	// …and its next challenge fails closed too, while the survivor still passes.
+	if _, ok := challengeWithMetallib(t, srv, previous, unionPreviousMetallib); ok {
+		t.Fatal("deactivated release's metallib must fail the challenge runtime policy")
+	}
+	assertRuntimeApproved(t, srv, previous, previousModel, false, "challenge after deactivation")
+	if _, ok := challengeWithMetallib(t, srv, newest, unionNewestMetallib); !ok {
+		t.Fatal("remaining release's metallib must keep passing the challenge runtime policy")
+	}
+	assertRuntimeApproved(t, srv, newest, newestModel, true, "challenge after deactivation")
+}
+
+// TestRuntimeManifestUnionsPerFamilyTemplateHashes: the per-model-family
+// template keys release rows carry (qwen3.5/trinity/gemma4/minimax) get the
+// same union-and-membership semantics. NOTE: the challenge path
+// (verifyRuntimeHashesForBackend) deliberately scopes verification to
+// mlx_metallib — the family keys are CI fabrications no provider reports
+// (2026-08-31 incident) — so this exercises the manifest and the generic set
+// verifier directly.
+func TestRuntimeManifestUnionsPerFamilyTemplateHashes(t *testing.T) {
+	srv, st := runtimeManifestTestServer(t)
+	qwenOld, qwenNew, qwenUnknown := strings.Repeat("1", 64), strings.Repeat("2", 64), strings.Repeat("3", 64)
+	gemmaShared := strings.Repeat("6", 64)
+
+	older := testRelease("0.8.15", trHashA)
+	older.TemplateHashes = "qwen3.5=" + qwenOld + ",gemma4=" + gemmaShared
+	newer := testRelease("0.8.16", trHashB)
+	newer.TemplateHashes = "qwen3.5=" + qwenNew + ",gemma4=" + gemmaShared
+	for _, rel := range []*store.Release{older, newer} {
+		if err := st.SetRelease(rel); err != nil {
+			t.Fatalf("SetRelease(%s): %v", rel.Version, err)
+		}
+	}
+	if err := srv.SyncRuntimeManifest(); err != nil {
+		t.Fatalf("SyncRuntimeManifest: %v", err)
+	}
+	manifest := srv.knownRuntimeManifest
+	if got := manifest.TemplateHashes["qwen3.5"]; len(got) != 2 || !got[qwenOld] || !got[qwenNew] {
+		t.Fatalf("qwen3.5 accepted set = %v, want both releases' values", sortedTemplateHashes(got))
+	}
+	if got := manifest.TemplateHashes["gemma4"]; len(got) != 1 || !got[gemmaShared] {
+		t.Fatalf("gemma4 accepted set = %v, want the single shared value", sortedTemplateHashes(got))
+	}
+
+	report := func(qwen string) map[string]string {
+		return map[string]string{"qwen3.5": qwen, "gemma4": gemmaShared, "mlx_metallib": trHashC}
+	}
+	cases := []struct {
+		name   string
+		qwen   string
+		wantOK bool
+	}{
+		{"older release's family template", qwenOld, true},
+		{"newer release's family template", qwenNew, true},
+		{"family template no active release ships", qwenUnknown, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, mismatches := srv.verifyRuntimeHashesAgainstManifest(manifest, "", "", report(tc.qwen))
+			if ok != tc.wantOK {
+				t.Fatalf("verify = %v (%+v), want %v", ok, mismatches, tc.wantOK)
+			}
+			if !tc.wantOK && (len(mismatches) != 1 || mismatches[0].Component != "template:qwen3.5") {
+				t.Fatalf("mismatches = %+v, want exactly one qwen3.5 mismatch", mismatches)
+			}
+		})
+	}
+
+	// Deactivating the older release removes only its value.
+	if err := st.DeleteRelease("0.8.15", defaultReleasePlatform); err != nil {
+		t.Fatalf("DeleteRelease: %v", err)
+	}
+	if err := srv.SyncRuntimeManifest(); err != nil {
+		t.Fatalf("SyncRuntimeManifest after deactivation: %v", err)
+	}
+	manifest = srv.knownRuntimeManifest
+	if got := manifest.TemplateHashes["qwen3.5"]; len(got) != 1 || !got[qwenNew] {
+		t.Fatalf("qwen3.5 accepted set after deactivation = %v, want only the newer value", sortedTemplateHashes(got))
+	}
+	if ok, _ := srv.verifyRuntimeHashesAgainstManifest(manifest, "", "", report(qwenOld)); ok {
+		t.Fatal("deactivated release's family template must no longer be accepted")
+	}
+	if ok, mismatches := srv.verifyRuntimeHashesAgainstManifest(manifest, "", "", report(qwenNew)); !ok {
+		t.Fatalf("remaining release's family template must still be accepted: %+v", mismatches)
+	}
+}
+
+// registerReleaseWithMetallibForTest registers a release through the real
+// POST /v1/releases handler (artifact verification against the fake CDN
+// included) with a caller-chosen metallib hash and production-shape family
+// template hashes.
+func registerReleaseWithMetallibForTest(
+	t *testing.T, baseURL, cdnURL string, artifacts *releaseArtifactSet, version, metallib string,
+) {
+	t.Helper()
+	bundle, binaryHash, bundleHash := buildReleaseBundleForTest(t, []byte("provider-"+version))
+	path := "/releases/v" + version + "/darkbloom-bundle-macos-arm64.tar.gz"
+	artifacts.mu.Lock()
+	artifacts.bundles[path] = bundle
+	artifacts.mu.Unlock()
+	payload := map[string]string{
+		"version": version, "platform": defaultReleasePlatform, "backend": "mlx-swift",
+		"binary_hash": binaryHash, "bundle_hash": bundleHash,
+		"metallib_hash": metallib, "url": cdnURL + path,
+		"template_hashes": "qwen3.5=" + strings.Repeat("4", 64) + ",gemma4=" + strings.Repeat("6", 64),
+		"changelog":       "release " + version,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/releases", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer release-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	responseBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("register %s: status=%d body=%s", version, resp.StatusCode, responseBody)
+	}
+}
+
+// publishedMetallibHashes reads the public manifest endpoint's mlx_metallib
+// list (sorted by the server).
+func publishedMetallibHashes(t *testing.T, baseURL string) []string {
+	t.Helper()
+	body := getReleaseBody(t, baseURL+"/v1/runtime/manifest", http.StatusOK)
+	var manifest struct {
+		Configured     bool                `json:"configured"`
+		TemplateHashes map[string][]string `json:"template_hashes"`
+	}
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		t.Fatalf("decode runtime manifest: %v (%s)", err, body)
+	}
+	if !manifest.Configured {
+		t.Fatalf("runtime manifest not configured: %s", body)
+	}
+	return manifest.TemplateHashes["mlx_metallib"]
+}
+
+// TestRegisteringNewerReleaseKeepsPreviousReleaseFleetRuntimeVerified pins the
+// 2026-09-03 incident end to end through the real POST /v1/releases handler:
+// with the fleet connected on v0.8.15, registering v0.8.16 must leave every
+// v0.8.15 provider runtime-verified — immediately (SyncRuntimeManifest's live
+// revalidation) AND at its next attestation challenge — and routable, while a
+// node that already self-updated passes too and an unknown metallib still
+// fails closed. Only an explicit deactivation of v0.8.15 removes its metallib.
+func TestRegisteringNewerReleaseKeepsPreviousReleaseFleetRuntimeVerified(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetReleaseKey("release-key")
+	srv.adminKey = "admin-key"
+	artifacts := &releaseArtifactSet{bundles: make(map[string][]byte)}
+	cdn := httptest.NewServer(http.HandlerFunc(artifacts.handler))
+	defer cdn.Close()
+	srv.SetR2CDNURL(cdn.URL)
+	apiServer := httptest.NewServer(srv.Handler())
+	defer apiServer.Close()
+
+	registerReleaseWithMetallibForTest(t, apiServer.URL, cdn.URL, artifacts, "0.8.15", unionPreviousMetallib)
+	if got := publishedMetallibHashes(t, apiServer.URL); !reflect.DeepEqual(got, []string{unionPreviousMetallib}) {
+		t.Fatalf("published mlx_metallib = %v, want only 0.8.15's", got)
+	}
+
+	// The connected fleet: every node registered and last challenged on 0.8.15.
+	type fleetNode struct {
+		provider *registry.Provider
+		model    string
+	}
+	fleet := make([]fleetNode, 0, 3)
+	for i := 0; i < 3; i++ {
+		model := fmt.Sprintf("fleet-model-%d", i)
+		provider := unionFleetProvider(t, srv.registry, fmt.Sprintf("fleet-node-%d", i), model, "0.8.15", unionPreviousMetallib)
+		if _, ok := challengeWithMetallib(t, srv, provider, unionPreviousMetallib); !ok {
+			t.Fatalf("%s must pass its challenge on the only active release", provider.ID)
+		}
+		assertRuntimeApproved(t, srv, provider, model, true, "before the newer release")
+		fleet = append(fleet, fleetNode{provider, model})
+	}
+
+	// THE incident action: CI registers the next release while the fleet is live.
+	registerReleaseWithMetallibForTest(t, apiServer.URL, cdn.URL, artifacts, "0.8.16", unionNewestMetallib)
+	if got := publishedMetallibHashes(t, apiServer.URL); !reflect.DeepEqual(got, []string{unionPreviousMetallib, unionNewestMetallib}) {
+		t.Fatalf("published mlx_metallib = %v, want the union of both active releases", got)
+	}
+
+	// Live revalidation inside the registration must not deroute anyone…
+	for _, node := range fleet {
+		assertRuntimeApproved(t, srv, node.provider, node.model, true, "immediately after registering the newer release")
+	}
+	// …and neither may the next challenge — the exact point where production
+	// logged 1,184 runtime-integrity mismatches and lost the fleet.
+	for _, node := range fleet {
+		active, ok := challengeWithMetallib(t, srv, node.provider, unionPreviousMetallib)
+		if !active || !ok {
+			t.Fatalf("%s on the previous release failed its post-registration challenge (active=%v ok=%v)",
+				node.provider.ID, active, ok)
+		}
+		assertRuntimeApproved(t, srv, node.provider, node.model, true, "challenge after registering the newer release")
+	}
+
+	// A node that already self-updated passes with the new metallib.
+	updated := unionFleetProvider(t, srv.registry, "fleet-node-updated", "fleet-model-updated", "0.8.16", unionNewestMetallib)
+	if _, ok := challengeWithMetallib(t, srv, updated, unionNewestMetallib); !ok {
+		t.Fatal("provider on the newly registered release must pass its challenge")
+	}
+	assertRuntimeApproved(t, srv, updated, "fleet-model-updated", true, "updated node")
+
+	// Fail-closed is intact: a metallib no active release ships still fails.
+	rogue := unionFleetProvider(t, srv.registry, "fleet-node-rogue", "fleet-model-rogue", "0.8.16", unionUnknownMetallib)
+	if _, ok := challengeWithMetallib(t, srv, rogue, unionUnknownMetallib); ok {
+		t.Fatal("unknown metallib must fail the challenge runtime policy")
+	}
+	assertRuntimeApproved(t, srv, rogue, "fleet-model-rogue", false, "rogue node")
+
+	// Retiring the previous release is an explicit operator action, not a side
+	// effect of registering the next one.
+	deactivateReleaseForCacheTest(t, apiServer.URL, "0.8.15", defaultReleasePlatform)
+	if got := publishedMetallibHashes(t, apiServer.URL); !reflect.DeepEqual(got, []string{unionNewestMetallib}) {
+		t.Fatalf("published mlx_metallib after deactivation = %v, want only 0.8.16's", got)
+	}
+	for _, node := range fleet {
+		assertRuntimeApproved(t, srv, node.provider, node.model, false, "after 0.8.15 was deactivated")
+	}
+	assertRuntimeApproved(t, srv, updated, "fleet-model-updated", true, "after 0.8.15 was deactivated")
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -2064,22 +2064,19 @@ func (s *Server) SyncRuntimeManifest() error {
 	// env var. It is NOT auto-derived from the latest release — pushing a new release
 	// should not instantly knock all existing providers offline.
 
-	manifest := &RuntimeManifest{
-		PythonHashes:   make(map[string]bool),
-		RuntimeHashes:  make(map[string]bool),
-		TemplateHashes: make(map[string]string),
-	}
-
-	// Sort releases ascending by version so newer releases' template hashes
-	// overwrite older ones (templates are keyed by name; binary/runtime hashes
-	// accumulate as a set).
-	sortedReleases := append([]store.Release(nil), releases...)
-	sort.SliceStable(sortedReleases, func(i, j int) bool {
-		return semverGreater(sortedReleases[j].Version, sortedReleases[i].Version)
-	})
-
+	// Every hash — python, runtime, AND each template name including
+	// mlx_metallib — is unioned into a SET across ALL active releases.
+	// Releases overlap in production for the whole self-update window
+	// (providers poll for updates every 30 minutes), so the manifest must
+	// accept the runtime facts of every release a connected provider may
+	// legitimately be running. Template hashes used to be single-valued per
+	// name (newest release wins): registering v0.8.16 replaced the v0.8.15
+	// metallib hash and derouted ~1,180 still-current providers at their next
+	// challenge (2026-09-03 fleet brownout). Deactivating a release is the
+	// mechanism that removes its hashes; iteration order is irrelevant.
+	manifest := NewRuntimeManifest()
 	hasAny := false
-	for _, r := range sortedReleases {
+	for _, r := range releases {
 		if !r.Active {
 			continue
 		}
@@ -2091,15 +2088,8 @@ func (s *Server) SyncRuntimeManifest() error {
 			manifest.RuntimeHashes[r.RuntimeHash] = true
 			hasAny = true
 		}
-		if r.TemplateHashes != "" {
-			// Parse "name=hash,name=hash" format
-			for _, pair := range strings.Split(r.TemplateHashes, ",") {
-				parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
-				if len(parts) == 2 {
-					manifest.TemplateHashes[parts[0]] = parts[1]
-					hasAny = true
-				}
-			}
+		if manifest.addTemplateHashPairs(r.TemplateHashes) {
+			hasAny = true
 		}
 		if r.MetallibHash != "" {
 			normalized, err := normalizeSHA256Hex(r.MetallibHash, "release.metallib_hash")
@@ -2109,8 +2099,7 @@ func (s *Server) SyncRuntimeManifest() error {
 					"platform", r.Platform,
 					"error", err,
 				)
-			} else {
-				manifest.TemplateHashes["mlx_metallib"] = normalized
+			} else if manifest.AddTemplateHash("mlx_metallib", normalized) {
 				hasAny = true
 			}
 		}
@@ -2122,6 +2111,7 @@ func (s *Server) SyncRuntimeManifest() error {
 			"python_hashes", len(manifest.PythonHashes),
 			"runtime_hashes", len(manifest.RuntimeHashes),
 			"template_hashes", len(manifest.TemplateHashes),
+			"template_hash_sets", manifest.templateHashSetSizes(),
 		)
 	} else if len(releases) > 0 {
 		// Explicit empty: releases exist but none have hashes. Clear manifest.
@@ -2146,28 +2136,13 @@ func (s *Server) SyncRuntimeManifest() error {
 // release registration into the runtime manifest when the post-mutation
 // inventory read failed, so a transient store hiccup cannot leave the manifest
 // rejecting the runtime facts of the release that /v1/releases/latest is
-// already distributing. Hash sets are additive, exactly like a full rebuild
-// (which unions every active release); template hashes are overwritten by the
-// new release, matching the rebuild's newest-release-wins ordering for a
-// freshly registered latest release. The next successful sync rebuilds from
-// the exact inventory.
+// already distributing. Every hash set — including each per-template-name
+// set — is additive, exactly like a full rebuild (which unions every active
+// release): the previous release's fleet keeps passing while the newly saved
+// release is accepted too. The next successful sync rebuilds from the exact
+// inventory.
 func (s *Server) convergeRuntimeManifestWithCommittedRelease(release *store.Release, cause error) {
-	merged := &RuntimeManifest{
-		PythonHashes:   make(map[string]bool),
-		RuntimeHashes:  make(map[string]bool),
-		TemplateHashes: make(map[string]string),
-	}
-	if existing := s.knownRuntimeManifest; existing != nil {
-		for hash := range existing.PythonHashes {
-			merged.PythonHashes[hash] = true
-		}
-		for hash := range existing.RuntimeHashes {
-			merged.RuntimeHashes[hash] = true
-		}
-		for name, hash := range existing.TemplateHashes {
-			merged.TemplateHashes[name] = hash
-		}
-	}
+	merged := s.knownRuntimeManifest.clone()
 	contributed := false
 	if release.PythonHash != "" {
 		merged.PythonHashes[release.PythonHash] = true
@@ -2177,18 +2152,12 @@ func (s *Server) convergeRuntimeManifestWithCommittedRelease(release *store.Rele
 		merged.RuntimeHashes[release.RuntimeHash] = true
 		contributed = true
 	}
-	if release.TemplateHashes != "" {
-		for _, pair := range strings.Split(release.TemplateHashes, ",") {
-			parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
-			if len(parts) == 2 {
-				merged.TemplateHashes[parts[0]] = parts[1]
-				contributed = true
-			}
-		}
+	if merged.addTemplateHashPairs(release.TemplateHashes) {
+		contributed = true
 	}
 	if release.MetallibHash != "" {
-		if normalized, err := normalizeSHA256Hex(release.MetallibHash, "release.metallib_hash"); err == nil {
-			merged.TemplateHashes["mlx_metallib"] = normalized
+		if normalized, err := normalizeSHA256Hex(release.MetallibHash, "release.metallib_hash"); err == nil &&
+			merged.AddTemplateHash("mlx_metallib", normalized) {
 			contributed = true
 		}
 	}
@@ -2213,43 +2182,36 @@ func (s *Server) convergeRuntimeManifestWithCommittedRelease(release *store.Rele
 // release's hashes — another active release may share them — so the manifest
 // is rebuilt from the live release trust snapshot, which at this point already
 // excludes the deactivated version/platform (SyncBinaryHashes either succeeded
-// or was converged from the same committed deactivation first). Hash sets are
-// unioned and template hashes applied newest-release-wins, mirroring the full
-// rebuild's ordering. Active releases whose binary hash failed normalization
-// are absent from the snapshot and thus from this approximation; the next
-// successful sync rebuilds from the exact inventory.
+// or was converged from the same committed deactivation first). Every hash
+// set — including each per-template-name set — is the union of the remaining
+// authorized releases, exactly like the full rebuild. Active releases whose
+// binary hash failed normalization are absent from the snapshot and thus from
+// this approximation; the next successful sync rebuilds from the exact
+// inventory.
 func (s *Server) convergeRuntimeManifestWithCommittedDeactivation(version, platform string, cause error) {
-	merged := &RuntimeManifest{
-		PythonHashes:   make(map[string]bool),
-		RuntimeHashes:  make(map[string]bool),
-		TemplateHashes: make(map[string]string),
-	}
+	merged := NewRuntimeManifest()
 	hasAny := false
 	if snapshot := s.releaseTrustPolicy.Load(); snapshot != nil {
-		policies := make([]approvedReleasePolicy, 0, len(snapshot.ByBinaryHash))
-		for _, entries := range snapshot.ByBinaryHash {
-			policies = append(policies, entries...)
-		}
-		sort.SliceStable(policies, func(i, j int) bool {
-			return semverGreater(policies[j].Version, policies[i].Version)
-		})
-		for _, policy := range policies {
-			if policy.PythonHash != "" {
-				merged.PythonHashes[policy.PythonHash] = true
-				hasAny = true
-			}
-			if policy.RuntimeHash != "" {
-				merged.RuntimeHashes[policy.RuntimeHash] = true
-				hasAny = true
-			}
-			for name, hash := range policy.TemplateHashes {
-				merged.TemplateHashes[name] = hash
-				hasAny = true
-			}
-			if policy.MetallibHash != "" {
-				if normalized, err := normalizeSHA256Hex(policy.MetallibHash, "release.metallib_hash"); err == nil {
-					merged.TemplateHashes["mlx_metallib"] = normalized
+		for _, policies := range snapshot.ByBinaryHash {
+			for _, policy := range policies {
+				if policy.PythonHash != "" {
+					merged.PythonHashes[policy.PythonHash] = true
 					hasAny = true
+				}
+				if policy.RuntimeHash != "" {
+					merged.RuntimeHashes[policy.RuntimeHash] = true
+					hasAny = true
+				}
+				for name, hash := range policy.TemplateHashes {
+					if merged.AddTemplateHash(name, hash) {
+						hasAny = true
+					}
+				}
+				if policy.MetallibHash != "" {
+					if normalized, err := normalizeSHA256Hex(policy.MetallibHash, "release.metallib_hash"); err == nil &&
+						merged.AddTemplateHash("mlx_metallib", normalized) {
+						hasAny = true
+					}
 				}
 			}
 		}
@@ -2339,18 +2301,123 @@ func runtimeManifestApprovesMetallib(
 	if manifest == nil {
 		return false
 	}
-	expected := strings.TrimSpace(manifest.TemplateHashes["mlx_metallib"])
-	got := strings.TrimSpace(reported["mlx_metallib"])
-	return expected != "" && got != "" && strings.EqualFold(expected, got)
+	return templateHashAccepted(manifest.TemplateHashes["mlx_metallib"], reported["mlx_metallib"])
 }
 
 // RuntimeManifest holds the set of accepted hashes for provider runtime components.
 // When configured, the coordinator verifies provider-reported hashes against
 // this manifest at registration and during periodic attestation challenges.
+//
+// Every field is a SET: the manifest is the UNION of every ACTIVE release's
+// runtime facts, and a provider passes when its reported value is one of the
+// accepted values for that component. TemplateHashes is a set PER template
+// name (mlx_metallib included). It must never collapse to a single value per
+// name: releases overlap in production for the whole self-update window, and a
+// single-valued mlx_metallib entry derouted ~1,180 providers still running the
+// previous release the moment the next one was registered (2026-09-03).
+// Deactivating a release is the mechanism that removes its values.
 type RuntimeManifest struct {
-	PythonHashes   map[string]bool   `json:"python_hashes"`   // set of accepted Python runtime hashes
-	RuntimeHashes  map[string]bool   `json:"runtime_hashes"`  // set of accepted inference runtime hashes
-	TemplateHashes map[string]string `json:"template_hashes"` // template_name -> expected hash
+	PythonHashes   map[string]bool            `json:"python_hashes"`   // set of accepted Python runtime hashes
+	RuntimeHashes  map[string]bool            `json:"runtime_hashes"`  // set of accepted inference runtime hashes
+	TemplateHashes map[string]map[string]bool `json:"template_hashes"` // template_name -> set of accepted hashes
+}
+
+// NewRuntimeManifest returns an empty manifest with every set allocated.
+func NewRuntimeManifest() *RuntimeManifest {
+	return &RuntimeManifest{
+		PythonHashes:   make(map[string]bool),
+		RuntimeHashes:  make(map[string]bool),
+		TemplateHashes: make(map[string]map[string]bool),
+	}
+}
+
+// AddTemplateHash records value as an accepted hash for template name and
+// reports whether anything was recorded. Values are trimmed and lower-cased so
+// membership is case-insensitive (SHA-256 hex) and identical on the
+// registration, challenge, and revalidation paths; empty names/values are
+// ignored.
+func (m *RuntimeManifest) AddTemplateHash(name, value string) bool {
+	name = strings.TrimSpace(name)
+	value = strings.ToLower(strings.TrimSpace(value))
+	if name == "" || value == "" {
+		return false
+	}
+	if m.TemplateHashes == nil {
+		m.TemplateHashes = make(map[string]map[string]bool)
+	}
+	accepted := m.TemplateHashes[name]
+	if accepted == nil {
+		accepted = make(map[string]bool)
+		m.TemplateHashes[name] = accepted
+	}
+	accepted[value] = true
+	return true
+}
+
+// addTemplateHashPairs unions a release row's "name=hash,name=hash" list into
+// the manifest and reports whether any entry was recorded.
+func (m *RuntimeManifest) addTemplateHashPairs(raw string) bool {
+	added := false
+	for _, pair := range strings.Split(raw, ",") {
+		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(parts) == 2 && m.AddTemplateHash(parts[0], parts[1]) {
+			added = true
+		}
+	}
+	return added
+}
+
+// clone deep-copies the manifest; a nil receiver yields an empty manifest.
+func (m *RuntimeManifest) clone() *RuntimeManifest {
+	out := NewRuntimeManifest()
+	if m == nil {
+		return out
+	}
+	for hash := range m.PythonHashes {
+		out.PythonHashes[hash] = true
+	}
+	for hash := range m.RuntimeHashes {
+		out.RuntimeHashes[hash] = true
+	}
+	for name, accepted := range m.TemplateHashes {
+		for hash := range accepted {
+			out.AddTemplateHash(name, hash)
+		}
+	}
+	return out
+}
+
+// templateHashSetSizes renders "name=count" pairs (sorted by name) for logs,
+// so a sync line shows how many releases' values each template accepts.
+func (m *RuntimeManifest) templateHashSetSizes() string {
+	names := make([]string, 0, len(m.TemplateHashes))
+	for name := range m.TemplateHashes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%s=%d", name, len(m.TemplateHashes[name])))
+	}
+	return strings.Join(parts, ",")
+}
+
+// templateHashAccepted reports whether got is one of the accepted hashes for
+// a template (case-insensitive; empty values never match).
+func templateHashAccepted(accepted map[string]bool, got string) bool {
+	got = strings.ToLower(strings.TrimSpace(got))
+	return got != "" && accepted[got]
+}
+
+// sortedTemplateHashes lists a template's accepted hashes deterministically
+// for diagnostics and the public manifest endpoint.
+func sortedTemplateHashes(accepted map[string]bool) []string {
+	out := make([]string, 0, len(accepted))
+	for hash := range accepted {
+		out = append(out, hash)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // semverGreater returns true when a has higher SemVer precedence than b,
@@ -2410,15 +2477,11 @@ func (s *Server) verifyRuntimeHashesForBackend(backend, pythonHash, runtimeHash 
 	}
 
 	manifest := s.knownRuntimeManifest
-	scoped := &RuntimeManifest{
-		PythonHashes:   map[string]bool{},
-		RuntimeHashes:  map[string]bool{},
-		TemplateHashes: map[string]string{},
-	}
+	scoped := NewRuntimeManifest()
 	scopedReportedTemplates := make(map[string]string)
 
-	if expected := manifest.TemplateHashes["mlx_metallib"]; expected != "" {
-		scoped.TemplateHashes["mlx_metallib"] = expected
+	if accepted := manifest.TemplateHashes["mlx_metallib"]; len(accepted) > 0 {
+		scoped.TemplateHashes["mlx_metallib"] = accepted
 	}
 	if got := templateHashes["mlx_metallib"]; got != "" {
 		scopedReportedTemplates["mlx_metallib"] = got
@@ -2459,9 +2522,15 @@ func (s *Server) verifyRuntimeHashesAgainstManifest(manifest *RuntimeManifest, p
 	requireOneOf("runtime", runtimeHash, manifest.RuntimeHashes)
 
 	if len(manifest.TemplateHashes) > 0 {
-		for name, expected := range manifest.TemplateHashes {
+		// Each template name maps to the SET of hashes accepted across every
+		// active release; the reported value must be one of them.
+		for name, accepted := range manifest.TemplateHashes {
+			if len(accepted) == 0 {
+				continue
+			}
+			expected := "one of " + strings.Join(sortedTemplateHashes(accepted), ",")
 			got, ok := templateHashes[name]
-			if !ok || got == "" {
+			if !ok || strings.TrimSpace(got) == "" {
 				mismatches = append(mismatches, protocol.RuntimeMismatch{
 					Component: "template:" + name,
 					Expected:  expected,
@@ -2469,7 +2538,7 @@ func (s *Server) verifyRuntimeHashesAgainstManifest(manifest *RuntimeManifest, p
 				})
 				continue
 			}
-			if got != expected {
+			if !templateHashAccepted(accepted, got) {
 				mismatches = append(mismatches, protocol.RuntimeMismatch{
 					Component: "template:" + name,
 					Expected:  expected,
@@ -2478,7 +2547,7 @@ func (s *Server) verifyRuntimeHashesAgainstManifest(manifest *RuntimeManifest, p
 			}
 		}
 		for name, got := range templateHashes {
-			if _, ok := manifest.TemplateHashes[name]; !ok {
+			if len(manifest.TemplateHashes[name]) == 0 {
 				mismatches = append(mismatches, protocol.RuntimeMismatch{
 					Component: "template:" + name,
 					Expected:  "template listed in runtime manifest",
@@ -2502,11 +2571,18 @@ func (s *Server) handleRuntimeManifest(w http.ResponseWriter, r *http.Request) {
 	if s.knownRuntimeManifest == nil {
 		resp = map[string]any{"configured": false}
 	} else {
+		// template_hashes is rendered as name -> sorted list of every hash
+		// accepted across the active releases: the manifest is a union, not a
+		// single expected value per template.
+		templates := make(map[string][]string, len(s.knownRuntimeManifest.TemplateHashes))
+		for name, accepted := range s.knownRuntimeManifest.TemplateHashes {
+			templates[name] = sortedTemplateHashes(accepted)
+		}
 		resp = map[string]any{
 			"configured":      true,
 			"python_hashes":   s.knownRuntimeManifest.PythonHashes,
 			"runtime_hashes":  s.knownRuntimeManifest.RuntimeHashes,
-			"template_hashes": s.knownRuntimeManifest.TemplateHashes,
+			"template_hashes": templates,
 		}
 	}
 	body, err := json.Marshal(resp)

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -658,15 +658,13 @@ func main() {
 	// routing (but not disconnected) and receive feedback about mismatches.
 	// Python/runtime hashes are deprecated — only template hashes (e.g. mlx_metallib) are checked.
 	if templateHashes := os.Getenv("EIGENINFERENCE_KNOWN_TEMPLATE_HASHES"); templateHashes != "" {
-		manifest := &api.RuntimeManifest{
-			PythonHashes:   make(map[string]bool),
-			RuntimeHashes:  make(map[string]bool),
-			TemplateHashes: make(map[string]string),
-		}
+		// The manifest is a set per template name: repeating a name
+		// (mlx_metallib=<a>,mlx_metallib=<b>) accepts every listed hash.
+		manifest := api.NewRuntimeManifest()
 		for _, pair := range strings.Split(templateHashes, ",") {
 			parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
 			if len(parts) == 2 {
-				manifest.TemplateHashes[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+				manifest.AddTemplateHash(parts[0], parts[1])
 			}
 		}
 		srv.SetRuntimeManifest(manifest)

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -889,6 +889,16 @@ Provider releases are built and shipped by `.github/workflows/release-swift.yml`
 7. Registers the release with `POST /v1/releases` using `RELEASE_KEY`.
 8. Creates a GitHub release.
 
+Step 7 is safe against a live fleet: the coordinator's runtime manifest is the
+union of every active release row's hashes (one accepted set per template name,
+`mlx_metallib` included), so registering a release never deroutes providers
+still running the previous release. Providers self-update on their 30-minute
+poll; retiring the old release's hashes is a separate, explicit
+`DELETE /v1/admin/releases` (in-use protection applies unless `force=true`).
+The single-valued manifest that registering v0.8.16 tripped on 2026-09-03
+(~1,180 v0.8.15 providers excluded from routing at their next challenge) is a
+regression class pinned by `coordinator/api/runtime_manifest_union_test.go`.
+
 Reference: [`release-swift.yml`](../../.github/workflows/release-swift.yml).
 
 ### Cutting a release

--- a/docs/operations/release-policy-rollout.md
+++ b/docs/operations/release-policy-rollout.md
@@ -53,6 +53,17 @@ provider's reported `mlx_metallib` — nothing else. The gate has two modes via
   because a restarted coordinator has an empty registry (zero evidence) and
   would otherwise 429 the fleet until first challenges complete. Do not set
   the grace below the default for a production flip.
+- Registering a release MUST NOT deroute the fleet running the previous
+  release. The runtime manifest (`SyncRuntimeManifest`) is the UNION of every
+  ACTIVE release row's hashes — one accepted set per template name,
+  `mlx_metallib` included — so providers on v(N-1) and v(N) both pass the
+  challenge runtime policy for the whole self-update window. Deactivating a
+  release (`DELETE /v1/admin/releases`) is the only way to retire its hashes.
+  A manifest gate that keeps a single expected value per key is the
+  2026-09-03 brownout: registering v0.8.16 replaced the v0.8.15 metallib hash
+  and ~1,180 still-current providers were excluded from routing at their next
+  challenge until they self-updated. Regression tests:
+  `coordinator/api/runtime_manifest_union_test.go`.
 
 ## Stage 1 — shadow deployment
 


### PR DESCRIPTION
## Summary
Registering a provider release must never deroute the fleet that is still on the previous release. Tonight it did.

- `SyncRuntimeManifest` (and the two post-commit converge paths) built the runtime manifest by iterating active releases in ascending version order and writing `TemplateHashes["mlx_metallib"] = <hash>` — a single-valued key the newest release overwrote. The same overwrite applied to the per-family `template_hashes` keys.
- The manifest is now the **union** of every active release: `TemplateHashes` is a set per template name, `applyChallengeRuntimePolicy` / `verifyRuntimeHashesAgainstManifest` / `runtimeManifestApprovesMetallib` accept membership, and deactivating a release removes exactly its hashes. Unknown hashes still fail; an empty manifest still means policy withdrawn. Binary hashes already worked this way — this brings the metallib and template gates in line.

## Incident (2026-09-03 21:56Z)
`POST /v1/releases` for v0.8.16 replaced the accepted metallib with 0.8.16's. On their next attestation challenge, every provider still on v0.8.15 failed the runtime-integrity check — 1,184× `provider runtime integrity mismatch in challenge response — excluding from routing` — and the whole fleet became unroutable until each box self-updated on its 30-minute poll. Client success fell from 85 % to ~5 % and recovered over ~40 minutes as adoption reached ~85 %. Every previous release had the same brownout; it was read as slow trust recovery.

## Before / after
```mermaid
flowchart LR
  subgraph Before
    A1[register v0.8.16] --> B1["manifest.mlx_metallib = hash(0.8.16)<br/>(newest overwrites)"]
    B1 --> C1["0.8.15 provider challenge:<br/>hash not in {hash(0.8.16)}"]
    C1 --> D1[excluded from routing<br/>until self-update]
  end
  subgraph After
    A2[register v0.8.16] --> B2["manifest.mlx_metallib = {hash(0.8.15), hash(0.8.16)}<br/>(union of ACTIVE releases)"]
    B2 --> C2["0.8.15 and 0.8.16 providers both pass"]
    D2[deactivate 0.8.15] --> E2["set shrinks to {hash(0.8.16)}<br/>0.8.15 fails at next challenge"]
  end
```

## Tests
- New `coordinator/api/runtime_manifest_union_test.go` (414 lines): either active release's metallib passes the challenge policy and stays routable; deactivation removes exactly that release's hash (fails at live revalidation and at the next challenge, survivor passes); unknown metallib fails; per-family key union; and the incident end-to-end through the real `POST /v1/releases` handler followed by `DELETE /v1/admin/releases`.
- `TestSyncRuntimeManifestUsesLatestReleaseOnly`, which encoded the bug, is now `...UnionsTemplateHashesAcrossActiveReleases`.
- Mutation check: reverting `mlx_metallib` to single-valued fails three of the new tests.
- `gofmt -l coordinator/` clean · `go build ./coordinator/...` · `go vet ./coordinator/api/...` · `go test ./coordinator/api -run 'Runtime|Manifest|Release|Challenge' -race -count=1` ok (one pre-existing `-race` flake in `TestMDMSchedulerQueueRejectedChallengeSettlesDurablyAndReseeds` reproduces on untouched master) · `go test ./coordinator/... -count=1` all ok (`promptcontract` supervisor test flaked once, passed on rerun) · pre-push hook (gofmt + Go tests) passed on push.

## Notes for reviewers
- `GET /v1/runtime/manifest` wire shape: `template_hashes` values are now sorted `[]string` instead of `string`. No in-repo consumer decodes it structurally.
- `RuntimeMismatch.Expected` for template components reads `one of <h1>,<h2>` (display only). `EIGENINFERENCE_KNOWN_TEMPLATE_HASHES` unions repeated names.
- Same-version hash rotation still revokes: Postgres `SetRelease` is `ON CONFLICT (version, platform) DO UPDATE`.
- Same bug class, deliberately out of scope: the per-model weight-hash gate in the challenge handler compares against a single `CatalogWeightHash(model)` and hard-untrusts on mismatch. Re-publishing model weights under a new hash while providers hold the old files would reproduce this shape, more harshly.
- Deploy this coordinator before registering any further provider release (0.8.17 would otherwise brown out the fleet again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jMmfwBw26gaF6qzzoMM4T

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791067690&installation_model_id=21733&pr_number=816&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F816&signature=16443800153a1c8ca4fc52b0153db12399ca324090b2baaf0b12f055958dfce8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->