### PR TITLE
fix(coordinator,console-ui): provider card Decode always read "— tok/s"; show catalog display names

### DIFF
--- a/console-ui/__tests__/provider-dashboard-aggregate.test.ts
+++ b/console-ui/__tests__/provider-dashboard-aggregate.test.ts
@@ -3,10 +3,9 @@ import {
   buildAttentionGroups,
   deriveFleetVerdict,
   capacitySegments,
-  fleetMaxDecodeTps,
-  fleetDecodeTps,
   onlineCount,
 } from "@/app/providers/dashboard/aggregate";
+import { fleetMaxDecodeTps } from "@/app/providers/dashboard/throughput";
 import { baseProvider, ctx } from "./provider-dashboard-fixtures";
 
 describe("buildAttentionGroups", () => {
@@ -101,14 +100,13 @@ describe("capacitySegments", () => {
 });
 
 describe("fleet throughput + online helpers", () => {
-  it("computes max/sum decode tps with guards", () => {
+  it("computes max decode tps with guards", () => {
     const providers = [
       baseProvider({ decode_tps: 40 }),
       baseProvider({ id: "x", decode_tps: 90 }),
       baseProvider({ id: "y", decode_tps: undefined }),
     ];
     expect(fleetMaxDecodeTps(providers)).toBe(90);
-    expect(fleetDecodeTps(providers)).toBe(130);
     expect(fleetMaxDecodeTps([])).toBe(0);
   });
 

--- a/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
+++ b/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
@@ -5,7 +5,7 @@
 
 import type { MyBackendCapacity } from "../types";
 import { abbreviateNumber, clampPct, formatTps } from "./format";
-import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
+import { modelDisplayName, type ModelNames } from "./modelNames";
 import { MeterBar } from "./gauges/MeterBar";
 
 const STATE_TAG: Record<string, string> = {
@@ -24,7 +24,7 @@ function MiniStat({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function BackendSlotsPanel({ cap, names = NO_MODEL_NAMES }: { cap: MyBackendCapacity; names?: ModelNames }) {
+export function BackendSlotsPanel({ cap, names }: { cap: MyBackendCapacity; names: ModelNames }) {
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-3 gap-2.5">

--- a/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
+++ b/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
@@ -1,9 +1,10 @@
 // Backend detail (inside the "Backend slots" accordion): GPU memory mini-stats
 // plus a per-model slot table. The token-budget bar (active / max potential) is
-// the literal headroom the coordinator admits new requests against.
+// the literal headroom the coordinator admits new requests against; each slot's
+// measured decode tok/s is the per-model view of the card's headline Decode line.
 
 import type { MyBackendCapacity } from "../types";
-import { abbreviateNumber, clampPct, shortModelName } from "./format";
+import { abbreviateNumber, clampPct, formatTps, shortModelName } from "./format";
 import { MeterBar } from "./gauges/MeterBar";
 
 const STATE_TAG: Record<string, string> = {
@@ -50,6 +51,7 @@ export function BackendSlotsPanel({ cap }: { cap: MyBackendCapacity }) {
                     </span>
                     <span className="text-[11px] font-mono text-text-tertiary">
                       {s.num_running} run · {s.num_waiting} wait
+                      {(s.observed_decode_tps ?? 0) > 0 && ` · ${formatTps(s.observed_decode_tps)} tok/s`}
                     </span>
                   </div>
                 </div>

--- a/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
+++ b/console-ui/src/app/providers/dashboard/BackendSlotsPanel.tsx
@@ -4,7 +4,8 @@
 // measured decode tok/s is the per-model view of the card's headline Decode line.
 
 import type { MyBackendCapacity } from "../types";
-import { abbreviateNumber, clampPct, formatTps, shortModelName } from "./format";
+import { abbreviateNumber, clampPct, formatTps } from "./format";
+import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
 import { MeterBar } from "./gauges/MeterBar";
 
 const STATE_TAG: Record<string, string> = {
@@ -23,7 +24,7 @@ function MiniStat({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function BackendSlotsPanel({ cap }: { cap: MyBackendCapacity }) {
+export function BackendSlotsPanel({ cap, names = NO_MODEL_NAMES }: { cap: MyBackendCapacity; names?: ModelNames }) {
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-3 gap-2.5">
@@ -40,7 +41,9 @@ export function BackendSlotsPanel({ cap }: { cap: MyBackendCapacity }) {
             return (
               <div key={s.model} className="rounded-lg bg-bg-tertiary/40 px-3 py-2 space-y-1.5">
                 <div className="flex items-center justify-between gap-2">
-                  <span className="text-xs font-mono text-text-secondary truncate">{shortModelName(s.model)}</span>
+                  <span className="text-xs font-mono text-text-secondary truncate" title={s.model}>
+                    {modelDisplayName(s.model, names)}
+                  </span>
                   <div className="flex items-center gap-2 shrink-0">
                     <span
                       className={`px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase ${

--- a/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
@@ -2,21 +2,14 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { CardVitals } from "./CardVitals";
-import { makeProvider } from "./testFixtures";
-import { modelNamesFrom } from "./modelNames";
-import type { MyBackendCapacity, MyBackendSlot, MyProvider } from "../types";
-
-const ACTIVE = "qwen-27b";
-const MOE = "qwen-35b-a3b";
-
-function slot(model: string, overrides: Partial<MyBackendSlot> = {}): MyBackendSlot {
-  return { model, state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, ...overrides };
-}
+import { makeModelNames, makeProvider, makeSlot, MOE_ID, MOE_NAME, QWEN27_ID } from "./testFixtures";
+import { NO_MODEL_NAMES } from "./modelNames";
+import type { MyBackendCapacity, MyProvider } from "../types";
 
 const cap: MyBackendCapacity = {
   slots: [
-    slot(MOE, { observed_decode_tps: 92 }),
-    slot(ACTIVE, { state: "running", num_running: 1, active_tokens: 512, observed_decode_tps: 31.5, observed_prefill_tps: 1400 }),
+    makeSlot(MOE_ID, { observed_decode_tps: 92 }),
+    makeSlot(QWEN27_ID, { state: "running", num_running: 1, active_tokens: 512, observed_decode_tps: 31.5, observed_prefill_tps: 1400 }),
   ],
   gpu_memory_active_gb: 38.1,
   gpu_memory_peak_gb: 40,
@@ -24,11 +17,17 @@ const cap: MyBackendCapacity = {
   total_memory_gb: 64,
 };
 
+/** The active 27B slot has served nothing yet; the MoE slot has. */
+const swappedInCap: MyBackendCapacity = {
+  ...cap,
+  slots: [makeSlot(MOE_ID, { observed_decode_tps: 92 }), makeSlot(QWEN27_ID, { state: "running", num_running: 1 })],
+};
+
 function liveProvider(overrides: Partial<MyProvider> = {}): MyProvider {
   return makeProvider({
     status: "serving",
     online: true,
-    current_model: ACTIVE,
+    current_model: QWEN27_ID,
     system_metrics: { memory_pressure: 0.62, cpu_usage: 0.09, thermal_state: "nominal" },
     backend_capacity: cap,
     pending_requests: 1,
@@ -39,7 +38,7 @@ function liveProvider(overrides: Partial<MyProvider> = {}): MyProvider {
 
 describe("CardVitals decode line", () => {
   it("renders the active model's measured decode and prefill rates without attribution", () => {
-    render(<CardVitals provider={liveProvider({ decode_tps: 31.5, prefill_tps: 1400 })} fleetMaxDecodeTps={92} />);
+    render(<CardVitals provider={liveProvider({ decode_tps: 31.5, prefill_tps: 1400 })} fleetMaxDecodeTps={92} names={NO_MODEL_NAMES} />);
     expect(screen.getByText("31.5")).toBeInTheDocument();
     expect(screen.getByText("prefill 1400")).toBeInTheDocument();
     expect(screen.getByLabelText("Decode 31.5 tokens per second")).toBeInTheDocument();
@@ -47,35 +46,29 @@ describe("CardVitals decode line", () => {
   });
 
   it("renders the same figure when decode_tps is absent from the payload", () => {
-    render(<CardVitals provider={liveProvider()} fleetMaxDecodeTps={92} />);
+    render(<CardVitals provider={liveProvider()} fleetMaxDecodeTps={92} names={NO_MODEL_NAMES} />);
     expect(screen.getByText("31.5")).toBeInTheDocument();
     expect(screen.getByText("prefill 1400")).toBeInTheDocument();
   });
 
   it("names the stand-in model when the active slot has not been measured yet", () => {
-    const swappedIn = liveProvider({
-      decode_tps: 92,
-      backend_capacity: { ...cap, slots: [slot(MOE, { observed_decode_tps: 92 }), slot(ACTIVE, { state: "running", num_running: 1 })] },
-    });
-    render(<CardVitals provider={swappedIn} fleetMaxDecodeTps={92} />);
+    render(<CardVitals provider={liveProvider({ decode_tps: 92, backend_capacity: swappedInCap })} fleetMaxDecodeTps={92} names={NO_MODEL_NAMES} />);
     expect(screen.getByText("92.0")).toBeInTheDocument();
-    expect(screen.getByText(`on ${MOE}`)).toBeInTheDocument();
+    expect(screen.getByText(`on ${MOE_ID}`)).toBeInTheDocument();
   });
 
   it("uses the catalog display name for the stand-in model, raw id in the tooltip", () => {
-    const swappedIn = liveProvider({
-      backend_capacity: { ...cap, slots: [slot(MOE, { observed_decode_tps: 92 }), slot(ACTIVE, { state: "running", num_running: 1 })] },
-    });
-    const names = modelNamesFrom({ model_display_names: { [MOE]: "Qwen 3.6 35B A3B" } });
-    render(<CardVitals provider={swappedIn} fleetMaxDecodeTps={92} names={names} />);
-    const label = screen.getByText("on Qwen 3.6 35B A3B");
+    render(<CardVitals provider={liveProvider({ backend_capacity: swappedInCap })} fleetMaxDecodeTps={92} names={makeModelNames()} />);
+    const label = screen.getByText(`on ${MOE_NAME}`);
     expect(label).toBeInTheDocument();
-    expect(label.getAttribute("title")).toContain(MOE);
+    expect(label.getAttribute("title")).toContain(MOE_ID);
   });
 
   it("renders an explicit blank, not a zero, for an unmeasured machine", () => {
-    const unmeasured = liveProvider({ backend_capacity: { ...cap, slots: [slot(MOE), slot(ACTIVE, { state: "running", num_running: 1 })] } });
-    render(<CardVitals provider={unmeasured} fleetMaxDecodeTps={0} />);
+    const unmeasured = liveProvider({
+      backend_capacity: { ...cap, slots: [makeSlot(MOE_ID), makeSlot(QWEN27_ID, { state: "running", num_running: 1 })] },
+    });
+    render(<CardVitals provider={unmeasured} fleetMaxDecodeTps={0} names={NO_MODEL_NAMES} />);
     expect(screen.getByText("—")).toBeInTheDocument();
     expect(screen.queryByText(/^prefill/)).toBeNull();
     expect(screen.queryByText(/^on /)).toBeNull();

--- a/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { CardVitals } from "./CardVitals";
 import { makeProvider } from "./testFixtures";
+import { modelNamesFrom } from "./modelNames";
 import type { MyBackendCapacity, MyBackendSlot, MyProvider } from "../types";
 
 const ACTIVE = "qwen-27b";
@@ -59,6 +60,17 @@ describe("CardVitals decode line", () => {
     render(<CardVitals provider={swappedIn} fleetMaxDecodeTps={92} />);
     expect(screen.getByText("92.0")).toBeInTheDocument();
     expect(screen.getByText(`on ${MOE}`)).toBeInTheDocument();
+  });
+
+  it("uses the catalog display name for the stand-in model, raw id in the tooltip", () => {
+    const swappedIn = liveProvider({
+      backend_capacity: { ...cap, slots: [slot(MOE, { observed_decode_tps: 92 }), slot(ACTIVE, { state: "running", num_running: 1 })] },
+    });
+    const names = modelNamesFrom({ model_display_names: { [MOE]: "Qwen 3.6 35B A3B" } });
+    render(<CardVitals provider={swappedIn} fleetMaxDecodeTps={92} names={names} />);
+    const label = screen.getByText("on Qwen 3.6 35B A3B");
+    expect(label).toBeInTheDocument();
+    expect(label.getAttribute("title")).toContain(MOE);
   });
 
   it("renders an explicit blank, not a zero, for an unmeasured machine", () => {

--- a/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
@@ -3,12 +3,19 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { CardVitals } from "./CardVitals";
 import { makeProvider } from "./testFixtures";
-import type { MyBackendCapacity, MyProvider } from "../types";
+import type { MyBackendCapacity, MyBackendSlot, MyProvider } from "../types";
+
+const ACTIVE = "qwen-27b";
+const MOE = "qwen-35b-a3b";
+
+function slot(model: string, overrides: Partial<MyBackendSlot> = {}): MyBackendSlot {
+  return { model, state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, ...overrides };
+}
 
 const cap: MyBackendCapacity = {
   slots: [
-    { model: "qwen-35b-a3b", state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, observed_decode_tps: 92 },
-    { model: "qwen-27b", state: "running", num_running: 1, num_waiting: 0, active_tokens: 512, max_tokens_potential: 8192, observed_decode_tps: 31.5, observed_prefill_tps: 1400 },
+    slot(MOE, { observed_decode_tps: 92 }),
+    slot(ACTIVE, { state: "running", num_running: 1, active_tokens: 512, observed_decode_tps: 31.5, observed_prefill_tps: 1400 }),
   ],
   gpu_memory_active_gb: 38.1,
   gpu_memory_peak_gb: 40,
@@ -20,7 +27,7 @@ function liveProvider(overrides: Partial<MyProvider> = {}): MyProvider {
   return makeProvider({
     status: "serving",
     online: true,
-    current_model: "qwen-27b",
+    current_model: ACTIVE,
     system_metrics: { memory_pressure: 0.62, cpu_usage: 0.09, thermal_state: "nominal" },
     backend_capacity: cap,
     pending_requests: 1,
@@ -30,25 +37,35 @@ function liveProvider(overrides: Partial<MyProvider> = {}): MyProvider {
 }
 
 describe("CardVitals decode line", () => {
-  it("renders the coordinator-resolved decode and prefill rates", () => {
+  it("renders the active model's measured decode and prefill rates without attribution", () => {
     render(<CardVitals provider={liveProvider({ decode_tps: 31.5, prefill_tps: 1400 })} fleetMaxDecodeTps={92} />);
     expect(screen.getByText("31.5")).toBeInTheDocument();
     expect(screen.getByText("prefill 1400")).toBeInTheDocument();
     expect(screen.getByLabelText("Decode 31.5 tokens per second")).toBeInTheDocument();
+    expect(screen.queryByText(/^on /)).toBeNull();
   });
 
-  it("renders the active slot's EWMA when decode_tps is absent from the payload", () => {
+  it("renders the same figure when decode_tps is absent from the payload", () => {
     render(<CardVitals provider={liveProvider()} fleetMaxDecodeTps={92} />);
     expect(screen.getByText("31.5")).toBeInTheDocument();
     expect(screen.getByText("prefill 1400")).toBeInTheDocument();
   });
 
-  it("renders an explicit blank, not a zero, for an unmeasured machine", () => {
-    const unmeasured = liveProvider({
-      backend_capacity: { ...cap, slots: cap.slots.map((s) => ({ ...s, observed_decode_tps: undefined, observed_prefill_tps: undefined })) },
+  it("names the stand-in model when the active slot has not been measured yet", () => {
+    const swappedIn = liveProvider({
+      decode_tps: 92,
+      backend_capacity: { ...cap, slots: [slot(MOE, { observed_decode_tps: 92 }), slot(ACTIVE, { state: "running", num_running: 1 })] },
     });
+    render(<CardVitals provider={swappedIn} fleetMaxDecodeTps={92} />);
+    expect(screen.getByText("92.0")).toBeInTheDocument();
+    expect(screen.getByText(`on ${MOE}`)).toBeInTheDocument();
+  });
+
+  it("renders an explicit blank, not a zero, for an unmeasured machine", () => {
+    const unmeasured = liveProvider({ backend_capacity: { ...cap, slots: [slot(MOE), slot(ACTIVE, { state: "running", num_running: 1 })] } });
     render(<CardVitals provider={unmeasured} fleetMaxDecodeTps={0} />);
     expect(screen.getByText("—")).toBeInTheDocument();
     expect(screen.queryByText(/^prefill/)).toBeNull();
+    expect(screen.queryByText(/^on /)).toBeNull();
   });
 });

--- a/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CardVitals } from "./CardVitals";
+import { makeProvider } from "./testFixtures";
+import type { MyBackendCapacity, MyProvider } from "../types";
+
+const cap: MyBackendCapacity = {
+  slots: [
+    { model: "qwen-35b-a3b", state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, observed_decode_tps: 92 },
+    { model: "qwen-27b", state: "running", num_running: 1, num_waiting: 0, active_tokens: 512, max_tokens_potential: 8192, observed_decode_tps: 31.5, observed_prefill_tps: 1400 },
+  ],
+  gpu_memory_active_gb: 38.1,
+  gpu_memory_peak_gb: 40,
+  gpu_memory_cache_gb: 1.6,
+  total_memory_gb: 64,
+};
+
+function liveProvider(overrides: Partial<MyProvider> = {}): MyProvider {
+  return makeProvider({
+    status: "serving",
+    online: true,
+    current_model: "qwen-27b",
+    system_metrics: { memory_pressure: 0.62, cpu_usage: 0.09, thermal_state: "nominal" },
+    backend_capacity: cap,
+    pending_requests: 1,
+    max_concurrency: 24,
+    ...overrides,
+  });
+}
+
+describe("CardVitals decode line", () => {
+  it("renders the coordinator-resolved decode and prefill rates", () => {
+    render(<CardVitals provider={liveProvider({ decode_tps: 31.5, prefill_tps: 1400 })} fleetMaxDecodeTps={92} />);
+    expect(screen.getByText("31.5")).toBeInTheDocument();
+    expect(screen.getByText("prefill 1400")).toBeInTheDocument();
+    expect(screen.getByLabelText("Decode 31.5 tokens per second")).toBeInTheDocument();
+  });
+
+  it("renders the active slot's EWMA when decode_tps is absent from the payload", () => {
+    render(<CardVitals provider={liveProvider()} fleetMaxDecodeTps={92} />);
+    expect(screen.getByText("31.5")).toBeInTheDocument();
+    expect(screen.getByText("prefill 1400")).toBeInTheDocument();
+  });
+
+  it("renders an explicit blank, not a zero, for an unmeasured machine", () => {
+    const unmeasured = liveProvider({
+      backend_capacity: { ...cap, slots: cap.slots.map((s) => ({ ...s, observed_decode_tps: undefined, observed_prefill_tps: undefined })) },
+    });
+    render(<CardVitals provider={unmeasured} fleetMaxDecodeTps={0} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText(/^prefill/)).toBeNull();
+  });
+});

--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -5,7 +5,7 @@
 
 import type { MyProvider } from "../types";
 import { clampPct, formatTps, pct } from "./format";
-import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
+import { modelDisplayName, type ModelNames } from "./modelNames";
 import { resolveThroughput } from "./throughput";
 import { MeterBar, StackedBar, pressureColor, cpuColor } from "./gauges/MeterBar";
 import { ThermalPips } from "./gauges/ThermalPips";
@@ -34,11 +34,11 @@ function Vital({
 export function CardVitals({
   provider,
   fleetMaxDecodeTps,
-  names = NO_MODEL_NAMES,
+  names,
 }: {
   provider: MyProvider;
   fleetMaxDecodeTps: number;
-  names?: ModelNames;
+  names: ModelNames;
 }) {
   const sm = provider.system_metrics;
   const cap = provider.backend_capacity;

--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -4,7 +4,7 @@
 // snapshot shows an honest line, never a wall of misleading zeros.
 
 import type { MyProvider } from "../types";
-import { clampPct, formatTps, pct } from "./format";
+import { clampPct, formatTps, pct, shortModelName } from "./format";
 import { resolveThroughput } from "./throughput";
 import { MeterBar, StackedBar, pressureColor, cpuColor } from "./gauges/MeterBar";
 import { ThermalPips } from "./gauges/ThermalPips";
@@ -48,7 +48,7 @@ export function CardVitals({
     return <p className="px-4 py-3 text-xs text-text-tertiary">{msg}</p>;
   }
 
-  const { decode, prefill } = resolveThroughput(provider);
+  const { decode, prefill, decodeFallbackModel } = resolveThroughput(provider);
   const decodePct = fleetMaxDecodeTps > 0 ? (decode / fleetMaxDecodeTps) * 100 : 0;
 
   return (
@@ -95,6 +95,14 @@ export function CardVitals({
           {formatTps(decode)}
           <span className="text-text-tertiary"> tok/s</span>
         </span>
+        {decodeFallbackModel && (
+          <span
+            className="text-[11px] font-mono text-text-tertiary shrink-0 truncate max-w-[9rem]"
+            title={`Measured on ${decodeFallbackModel}; the active model has not served a request yet`}
+          >
+            on {shortModelName(decodeFallbackModel)}
+          </span>
+        )}
         {prefill > 0 && (
           <span className="text-[11px] font-mono text-text-tertiary shrink-0 hidden sm:inline">
             prefill {formatTps(prefill)}

--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -4,7 +4,8 @@
 // snapshot shows an honest line, never a wall of misleading zeros.
 
 import type { MyProvider } from "../types";
-import { clampPct, formatTps, pct, shortModelName } from "./format";
+import { clampPct, formatTps, pct } from "./format";
+import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
 import { resolveThroughput } from "./throughput";
 import { MeterBar, StackedBar, pressureColor, cpuColor } from "./gauges/MeterBar";
 import { ThermalPips } from "./gauges/ThermalPips";
@@ -33,9 +34,11 @@ function Vital({
 export function CardVitals({
   provider,
   fleetMaxDecodeTps,
+  names = NO_MODEL_NAMES,
 }: {
   provider: MyProvider;
   fleetMaxDecodeTps: number;
+  names?: ModelNames;
 }) {
   const sm = provider.system_metrics;
   const cap = provider.backend_capacity;
@@ -100,7 +103,7 @@ export function CardVitals({
             className="text-[11px] font-mono text-text-tertiary shrink-0 truncate max-w-[9rem]"
             title={`Measured on ${decodeFallbackModel}; the active model has not served a request yet`}
           >
-            on {shortModelName(decodeFallbackModel)}
+            on {modelDisplayName(decodeFallbackModel, names)}
           </span>
         )}
         {prefill > 0 && (

--- a/console-ui/src/app/providers/dashboard/CardVitals.tsx
+++ b/console-ui/src/app/providers/dashboard/CardVitals.tsx
@@ -5,6 +5,7 @@
 
 import type { MyProvider } from "../types";
 import { clampPct, formatTps, pct } from "./format";
+import { resolveThroughput } from "./throughput";
 import { MeterBar, StackedBar, pressureColor, cpuColor } from "./gauges/MeterBar";
 import { ThermalPips } from "./gauges/ThermalPips";
 import { ConcurrencyDots } from "./gauges/ConcurrencyDots";
@@ -47,8 +48,7 @@ export function CardVitals({
     return <p className="px-4 py-3 text-xs text-text-tertiary">{msg}</p>;
   }
 
-  const decode = provider.decode_tps ?? 0;
-  const prefill = provider.prefill_tps ?? 0;
+  const { decode, prefill } = resolveThroughput(provider);
   const decodePct = fleetMaxDecodeTps > 0 ? (decode / fleetMaxDecodeTps) * 100 : 0;
 
   return (

--- a/console-ui/src/app/providers/dashboard/MachineCard.test.tsx
+++ b/console-ui/src/app/providers/dashboard/MachineCard.test.tsx
@@ -2,7 +2,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MachineCard } from "./MachineCard";
-import { makeProvider } from "./testFixtures";
+import { makeModelNames, makeProvider, makeSlot, MOE_ID, MOE_NAME, QWEN27_ID, QWEN27_NAME } from "./testFixtures";
+import { NO_MODEL_NAMES } from "./modelNames";
 import type { RoutingCtx } from "./routing";
 
 // The Remove button has its own behavioral test; here we only assert MachineCard
@@ -22,12 +23,12 @@ const AFFORDANCE = "remove-affordance";
 
 describe("MachineCard remove gating", () => {
   it("shows the Remove affordance for an offline machine", () => {
-    render(<MachineCard provider={makeProvider({ status: "offline" })} ctx={ctx} fleetMaxDecodeTps={100} />);
+    render(<MachineCard provider={makeProvider({ status: "offline" })} ctx={ctx} fleetMaxDecodeTps={100} names={NO_MODEL_NAMES} />);
     expect(screen.getByTestId(AFFORDANCE)).toBeInTheDocument();
   });
 
   it("shows the Remove affordance for a never-seen machine", () => {
-    render(<MachineCard provider={makeProvider({ status: "never_seen" })} ctx={ctx} fleetMaxDecodeTps={100} />);
+    render(<MachineCard provider={makeProvider({ status: "never_seen" })} ctx={ctx} fleetMaxDecodeTps={100} names={NO_MODEL_NAMES} />);
     expect(screen.getByTestId(AFFORDANCE)).toBeInTheDocument();
   });
 
@@ -37,8 +38,33 @@ describe("MachineCard remove gating", () => {
         provider={makeProvider({ status: "serving", online: true })}
         ctx={ctx}
         fleetMaxDecodeTps={100}
+        names={NO_MODEL_NAMES}
       />
     );
     expect(screen.queryByTestId(AFFORDANCE)).toBeNull();
+  });
+});
+
+describe("MachineCard model labels", () => {
+  it("shows catalog display names on the loaded chips, catalog chips, and decode stand-in label", () => {
+    const provider = makeProvider({
+      status: "serving",
+      online: true,
+      current_model: QWEN27_ID,
+      warm_models: [QWEN27_ID, MOE_ID],
+      models: [{ id: QWEN27_ID }, { id: MOE_ID }],
+      system_metrics: { memory_pressure: 0.62, cpu_usage: 0.09, thermal_state: "nominal" },
+      backend_capacity: {
+        slots: [makeSlot(MOE_ID, { observed_decode_tps: 88.4 }), makeSlot(QWEN27_ID, { state: "running", num_running: 1 })],
+        gpu_memory_active_gb: 38.1,
+        gpu_memory_peak_gb: 40,
+        gpu_memory_cache_gb: 1.6,
+        total_memory_gb: 64,
+      },
+    });
+    render(<MachineCard provider={provider} ctx={ctx} fleetMaxDecodeTps={88.4} names={makeModelNames()} />);
+    expect(screen.getAllByText(QWEN27_NAME).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(`on ${MOE_NAME}`)).toBeInTheDocument();
+    expect(screen.queryByText("Qwen3.8-27B-4bit-mtp")).toBeNull();
   });
 });

--- a/console-ui/src/app/providers/dashboard/MachineCard.tsx
+++ b/console-ui/src/app/providers/dashboard/MachineCard.tsx
@@ -17,17 +17,21 @@ import { BackendSlotsPanel } from "./BackendSlotsPanel";
 import { AttestationPanel } from "./AttestationPanel";
 import { ExpandSection } from "./gauges/ExpandSection";
 import { RemoveMachineButton } from "./RemoveMachineButton";
+import { NO_MODEL_NAMES, type ModelNames } from "./modelNames";
 
 export function MachineCard({
   provider,
   ctx,
   fleetMaxDecodeTps,
   onRemoved,
+  names = NO_MODEL_NAMES,
 }: {
   provider: MyProvider;
   ctx: RoutingCtx;
   fleetMaxDecodeTps: number;
   onRemoved?: () => void;
+  /** Catalog display names for the model chips, slot rows, and decode label. */
+  names?: ModelNames;
 }) {
   // Compute this machine's warnings once and derive everything (rail color,
   // hero verdict, the top reason to surface) from the shared routing module so
@@ -85,15 +89,15 @@ export function MachineCard({
 
       {/* Always-visible body: live vitals, models, then earnings */}
       <div className={dimmed ? "opacity-70" : ""}>
-        <CardVitals provider={provider} fleetMaxDecodeTps={fleetMaxDecodeTps} />
-        <ModelsStrip provider={provider} />
+        <CardVitals provider={provider} fleetMaxDecodeTps={fleetMaxDecodeTps} names={names} />
+        <ModelsStrip provider={provider} names={names} />
         <CardEarningsRow provider={provider} />
       </div>
 
       {/* Progressive disclosure: deep detail stays collapsed by default */}
       {provider.backend_capacity && (
         <ExpandSection label="Backend slots" icon={Zap} right={`${provider.backend_capacity.slots.length} model${provider.backend_capacity.slots.length === 1 ? "" : "s"}`}>
-          <BackendSlotsPanel cap={provider.backend_capacity} />
+          <BackendSlotsPanel cap={provider.backend_capacity} names={names} />
         </ExpandSection>
       )}
 

--- a/console-ui/src/app/providers/dashboard/MachineCard.tsx
+++ b/console-ui/src/app/providers/dashboard/MachineCard.tsx
@@ -17,21 +17,21 @@ import { BackendSlotsPanel } from "./BackendSlotsPanel";
 import { AttestationPanel } from "./AttestationPanel";
 import { ExpandSection } from "./gauges/ExpandSection";
 import { RemoveMachineButton } from "./RemoveMachineButton";
-import { NO_MODEL_NAMES, type ModelNames } from "./modelNames";
+import type { ModelNames } from "./modelNames";
 
 export function MachineCard({
   provider,
   ctx,
   fleetMaxDecodeTps,
   onRemoved,
-  names = NO_MODEL_NAMES,
+  names,
 }: {
   provider: MyProvider;
   ctx: RoutingCtx;
   fleetMaxDecodeTps: number;
   onRemoved?: () => void;
   /** Catalog display names for the model chips, slot rows, and decode label. */
-  names?: ModelNames;
+  names: ModelNames;
 }) {
   // Compute this machine's warnings once and derive everything (rail color,
   // hero verdict, the top reason to surface) from the shared routing module so

--- a/console-ui/src/app/providers/dashboard/MachineGrid.tsx
+++ b/console-ui/src/app/providers/dashboard/MachineGrid.tsx
@@ -8,6 +8,7 @@ import type { MyProvider } from "../types";
 import { routingFor, type RoutingCtx, type RoutingState } from "./routing";
 import { MachineCard } from "./MachineCard";
 import { FleetControls, type Density, type SortMode } from "./FleetControls";
+import type { ModelNames } from "./modelNames";
 
 const STATE_RANK: Record<RoutingState, number> = {
   blocked: 0,
@@ -21,11 +22,13 @@ export function MachineGrid({
   ctx,
   fleetMaxDecodeTps,
   onRemoved,
+  names,
 }: {
   providers: MyProvider[];
   ctx: RoutingCtx;
   fleetMaxDecodeTps: number;
   onRemoved?: () => void;
+  names: ModelNames;
 }) {
   const [sort, setSort] = useState<SortMode>("attention");
   const [density, setDensity] = useState<Density>("grid");
@@ -61,6 +64,7 @@ export function MachineGrid({
             ctx={ctx}
             fleetMaxDecodeTps={fleetMaxDecodeTps}
             onRemoved={onRemoved}
+            names={names}
           />
         ))}
       </div>

--- a/console-ui/src/app/providers/dashboard/ModelsStrip.test.tsx
+++ b/console-ui/src/app/providers/dashboard/ModelsStrip.test.tsx
@@ -3,22 +3,17 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ModelsStrip } from "./ModelsStrip";
 import { BackendSlotsPanel } from "./BackendSlotsPanel";
-import { makeProvider } from "./testFixtures";
-import { modelNamesFrom } from "./modelNames";
+import { makeModelNames, makeProvider, makeSlot, MOE_ID, MOE_NAME, QWEN27_ID, QWEN27_NAME } from "./testFixtures";
+import { NO_MODEL_NAMES } from "./modelNames";
 import type { MyBackendCapacity } from "../types";
 
-const QWEN27 = "EigenLabs/Qwen3.8-27B-4bit-mtp";
-const MOE = "qwen3.6-35b-a3b-vl-mtp-mxfp8";
 const LOCAL = "EigenLabs/local-experiment-4bit";
-const QWEN27_NAME = "Qwen 3.8 27B";
-const MOE_NAME = "Qwen 3.6 35B A3B";
-
-const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME, [MOE]: MOE_NAME } });
+const names = makeModelNames();
 
 const cap: MyBackendCapacity = {
   slots: [
-    { model: MOE, state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, observed_decode_tps: 88.4 },
-    { model: QWEN27, state: "running", num_running: 1, num_waiting: 0, active_tokens: 512, max_tokens_potential: 8192 },
+    makeSlot(MOE_ID, { observed_decode_tps: 88.4 }),
+    makeSlot(QWEN27_ID, { state: "running", num_running: 1, active_tokens: 512 }),
   ],
   gpu_memory_active_gb: 38.1,
   gpu_memory_peak_gb: 40,
@@ -29,10 +24,10 @@ const cap: MyBackendCapacity = {
 const provider = makeProvider({
   status: "serving",
   online: true,
-  current_model: QWEN27,
-  warm_models: [QWEN27, MOE],
+  current_model: QWEN27_ID,
+  warm_models: [QWEN27_ID, MOE_ID],
   backend_capacity: cap,
-  models: [{ id: QWEN27 }, { id: MOE }, { id: LOCAL }],
+  models: [{ id: QWEN27_ID }, { id: MOE_ID }, { id: LOCAL }],
 });
 
 describe("ModelsStrip display names", () => {
@@ -41,7 +36,7 @@ describe("ModelsStrip display names", () => {
     // Loaded + catalog chips both carry the display name.
     expect(screen.getAllByText(QWEN27_NAME)).toHaveLength(2);
     expect(screen.getAllByText(MOE_NAME)).toHaveLength(2);
-    expect(screen.getAllByTitle(QWEN27)).toHaveLength(2);
+    expect(screen.getAllByTitle(QWEN27_ID)).toHaveLength(2);
     expect(screen.queryByText("Qwen3.8-27B-4bit-mtp")).toBeNull();
   });
 
@@ -51,8 +46,8 @@ describe("ModelsStrip display names", () => {
     expect(screen.getByTitle(LOCAL)).toBeInTheDocument();
   });
 
-  it("renders short raw ids when no names are supplied (older coordinator)", () => {
-    render(<ModelsStrip provider={provider} />);
+  it("renders short raw ids when the coordinator sent no names", () => {
+    render(<ModelsStrip provider={provider} names={NO_MODEL_NAMES} />);
     expect(screen.getAllByText("Qwen3.8-27B-4bit-mtp")).toHaveLength(2);
     expect(screen.queryByText(QWEN27_NAME)).toBeNull();
   });
@@ -63,7 +58,7 @@ describe("BackendSlotsPanel display names", () => {
     render(<BackendSlotsPanel cap={cap} names={names} />);
     expect(screen.getByText(MOE_NAME)).toBeInTheDocument();
     expect(screen.getByText(QWEN27_NAME)).toBeInTheDocument();
-    expect(screen.getByTitle(MOE)).toBeInTheDocument();
+    expect(screen.getByTitle(MOE_ID)).toBeInTheDocument();
     expect(screen.getByText("0 run · 0 wait · 88.4 tok/s")).toBeInTheDocument();
   });
 });

--- a/console-ui/src/app/providers/dashboard/ModelsStrip.test.tsx
+++ b/console-ui/src/app/providers/dashboard/ModelsStrip.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ModelsStrip } from "./ModelsStrip";
+import { BackendSlotsPanel } from "./BackendSlotsPanel";
+import { makeProvider } from "./testFixtures";
+import { modelNamesFrom } from "./modelNames";
+import type { MyBackendCapacity } from "../types";
+
+const QWEN27 = "EigenLabs/Qwen3.8-27B-4bit-mtp";
+const MOE = "qwen3.6-35b-a3b-vl-mtp-mxfp8";
+const LOCAL = "EigenLabs/local-experiment-4bit";
+const QWEN27_NAME = "Qwen 3.8 27B";
+const MOE_NAME = "Qwen 3.6 35B A3B";
+
+const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME, [MOE]: MOE_NAME } });
+
+const cap: MyBackendCapacity = {
+  slots: [
+    { model: MOE, state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, observed_decode_tps: 88.4 },
+    { model: QWEN27, state: "running", num_running: 1, num_waiting: 0, active_tokens: 512, max_tokens_potential: 8192 },
+  ],
+  gpu_memory_active_gb: 38.1,
+  gpu_memory_peak_gb: 40,
+  gpu_memory_cache_gb: 1.6,
+  total_memory_gb: 64,
+};
+
+const provider = makeProvider({
+  status: "serving",
+  online: true,
+  current_model: QWEN27,
+  warm_models: [QWEN27, MOE],
+  backend_capacity: cap,
+  models: [{ id: QWEN27 }, { id: MOE }, { id: LOCAL }],
+});
+
+describe("ModelsStrip display names", () => {
+  it("labels loaded and catalog chips with catalog display names, raw id on hover", () => {
+    render(<ModelsStrip provider={provider} names={names} />);
+    // Loaded + catalog chips both carry the display name.
+    expect(screen.getAllByText(QWEN27_NAME)).toHaveLength(2);
+    expect(screen.getAllByText(MOE_NAME)).toHaveLength(2);
+    expect(screen.getAllByTitle(QWEN27)).toHaveLength(2);
+    expect(screen.queryByText("Qwen3.8-27B-4bit-mtp")).toBeNull();
+  });
+
+  it("falls back to the short raw id for a model the catalog has no name for", () => {
+    render(<ModelsStrip provider={provider} names={names} />);
+    expect(screen.getByText("local-experiment-4bit")).toBeInTheDocument();
+    expect(screen.getByTitle(LOCAL)).toBeInTheDocument();
+  });
+
+  it("renders short raw ids when no names are supplied (older coordinator)", () => {
+    render(<ModelsStrip provider={provider} />);
+    expect(screen.getAllByText("Qwen3.8-27B-4bit-mtp")).toHaveLength(2);
+    expect(screen.queryByText(QWEN27_NAME)).toBeNull();
+  });
+});
+
+describe("BackendSlotsPanel display names", () => {
+  it("labels slot rows with display names and keeps the raw id on hover", () => {
+    render(<BackendSlotsPanel cap={cap} names={names} />);
+    expect(screen.getByText(MOE_NAME)).toBeInTheDocument();
+    expect(screen.getByText(QWEN27_NAME)).toBeInTheDocument();
+    expect(screen.getByTitle(MOE)).toBeInTheDocument();
+    expect(screen.getByText("0 run · 0 wait · 88.4 tok/s")).toBeInTheDocument();
+  });
+});

--- a/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
+++ b/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
@@ -1,10 +1,10 @@
 // Models on a machine: the loaded/warm set (active one highlighted, with
 // cold/crashed/reloading tags pulled from backend slot state) and the catalog
-// it's approved to serve. Mono pills; catalog collapses past a threshold to
-// protect density.
+// it's approved to serve. Mono pills showing catalog display names (raw build
+// id on hover); catalog collapses past a threshold to protect density.
 
 import type { MyProvider } from "../types";
-import { shortModelName } from "./format";
+import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
 
 const CATALOG_LIMIT = 8;
 
@@ -14,7 +14,7 @@ const SLOT_TAG: Record<string, { label: string; cls: string }> = {
   reloading: { label: "reloading", cls: "bg-blue/15 text-blue" },
 };
 
-export function ModelsStrip({ provider }: { provider: MyProvider }) {
+export function ModelsStrip({ provider, names = NO_MODEL_NAMES }: { provider: MyProvider; names?: ModelNames }) {
   // Prefer the reported warm set; fall back to the single current model.
   const warm = provider.warm_models?.length
     ? provider.warm_models
@@ -47,12 +47,13 @@ export function ModelsStrip({ provider }: { provider: MyProvider }) {
               return (
                 <span
                   key={m}
+                  title={m}
                   className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-xs font-mono ${
                     active ? "bg-accent-brand/15 text-accent-brand" : "bg-bg-tertiary text-text-secondary"
                   }`}
                 >
                   {active && <span className="w-1.5 h-1.5 rounded-full bg-accent-green animate-pulse" />}
-                  {shortModelName(m)}
+                  {modelDisplayName(m, names)}
                   {active && <span className="opacity-70">active</span>}
                   {tag && (
                     <span className={`px-1 rounded text-[10px] font-semibold uppercase ${tag.cls}`} title={`backend ${slotState.get(m)}`}>
@@ -73,8 +74,8 @@ export function ModelsStrip({ provider }: { provider: MyProvider }) {
           </p>
           <div className="flex flex-wrap gap-1.5">
             {shownCatalog.map((m) => (
-              <span key={m.id} className="px-2 py-0.5 rounded-md bg-bg-tertiary/70 text-xs font-mono text-text-tertiary">
-                {shortModelName(m.id)}
+              <span key={m.id} title={m.id} className="px-2 py-0.5 rounded-md bg-bg-tertiary/70 text-xs font-mono text-text-tertiary">
+                {modelDisplayName(m.id, names)}
               </span>
             ))}
             {extraCatalog > 0 && (

--- a/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
+++ b/console-ui/src/app/providers/dashboard/ModelsStrip.tsx
@@ -4,7 +4,7 @@
 // id on hover); catalog collapses past a threshold to protect density.
 
 import type { MyProvider } from "../types";
-import { modelDisplayName, NO_MODEL_NAMES, type ModelNames } from "./modelNames";
+import { modelDisplayName, type ModelNames } from "./modelNames";
 
 const CATALOG_LIMIT = 8;
 
@@ -14,7 +14,7 @@ const SLOT_TAG: Record<string, { label: string; cls: string }> = {
   reloading: { label: "reloading", cls: "bg-blue/15 text-blue" },
 };
 
-export function ModelsStrip({ provider, names = NO_MODEL_NAMES }: { provider: MyProvider; names?: ModelNames }) {
+export function ModelsStrip({ provider, names }: { provider: MyProvider; names: ModelNames }) {
   // Prefer the reported warm set; fall back to the single current model.
   const warm = provider.warm_models?.length
     ? provider.warm_models

--- a/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
+++ b/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
@@ -8,12 +8,8 @@
 import { useMemo } from "react";
 import { useFleetData } from "./useFleetData";
 import { semverLess } from "../warnings";
-import {
-  buildAttentionGroups,
-  deriveFleetVerdict,
-  fleetMaxDecodeTps,
-  onlineCount,
-} from "./aggregate";
+import { buildAttentionGroups, deriveFleetVerdict, onlineCount } from "./aggregate";
+import { fleetMaxDecodeTps } from "./throughput";
 import { DashboardHeader } from "./DashboardHeader";
 import { FleetHealthStrip } from "./FleetHealthStrip";
 import { AttentionFeed } from "./AttentionFeed";

--- a/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
+++ b/console-ui/src/app/providers/dashboard/ProviderDashboard.tsx
@@ -10,6 +10,7 @@ import { useFleetData } from "./useFleetData";
 import { semverLess } from "../warnings";
 import { buildAttentionGroups, deriveFleetVerdict, onlineCount } from "./aggregate";
 import { fleetMaxDecodeTps } from "./throughput";
+import { modelNamesFrom } from "./modelNames";
 import { DashboardHeader } from "./DashboardHeader";
 import { FleetHealthStrip } from "./FleetHealthStrip";
 import { AttentionFeed } from "./AttentionFeed";
@@ -35,6 +36,7 @@ export function ProviderDashboard() {
   } = useFleetData();
 
   const providers = useMemo(() => providersResp?.providers ?? [], [providersResp]);
+  const modelNames = useMemo(() => modelNamesFrom(providersResp), [providersResp]);
 
   const verdict = useMemo(() => deriveFleetVerdict(providers, ctx), [providers, ctx]);
   const groups = useMemo(() => buildAttentionGroups(providers, ctx), [providers, ctx]);
@@ -81,7 +83,7 @@ export function ProviderDashboard() {
       />
       <FleetHealthStrip verdict={verdict} summary={summary} />
       <AttentionFeed groups={groups} />
-      <MachineGrid providers={providers} ctx={ctx} fleetMaxDecodeTps={maxDecode} onRemoved={refetch} />
+      <MachineGrid providers={providers} ctx={ctx} fleetMaxDecodeTps={maxDecode} onRemoved={refetch} names={modelNames} />
       <TrustFooter hardwareCount={hardwareCount} total={providers.length} />
     </Shell>
   );

--- a/console-ui/src/app/providers/dashboard/aggregate.ts
+++ b/console-ui/src/app/providers/dashboard/aggregate.ts
@@ -138,24 +138,6 @@ export function capacitySegments(counts: FleetCounts) {
     .filter((s) => s.count > 0);
 }
 
-/** Largest decode TPS across the fleet — used to scale per-card TPS bars. */
-export function fleetMaxDecodeTps(providers: MyProvider[]): number {
-  let max = 0;
-  for (const p of providers) {
-    if (typeof p.decode_tps === "number" && p.decode_tps > max) max = p.decode_tps;
-  }
-  return max;
-}
-
-/** Aggregate live decode throughput across connected machines. */
-export function fleetDecodeTps(providers: MyProvider[]): number {
-  let sum = 0;
-  for (const p of providers) {
-    if (typeof p.decode_tps === "number" && Number.isFinite(p.decode_tps)) sum += p.decode_tps;
-  }
-  return sum;
-}
-
 /** Count machines that are currently connected (online or serving). */
 export function onlineCount(providers: MyProvider[]): number {
   return providers.filter((p) => p.status === "online" || p.status === "serving").length;

--- a/console-ui/src/app/providers/dashboard/modelNames.test.ts
+++ b/console-ui/src/app/providers/dashboard/modelNames.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { modelDisplayName, modelNamesFrom, NO_MODEL_NAMES } from "./modelNames";
+
+const QWEN27 = "EigenLabs/Qwen3.8-27B-4bit-mtp";
+const MOE = "qwen3.6-35b-a3b-vl-mtp-mxfp8";
+const QWEN27_NAME = "Qwen 3.8 27B";
+
+describe("modelNamesFrom", () => {
+  it("indexes the response map", () => {
+    const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME, [MOE]: "Qwen 3.6 35B A3B" } });
+    expect(names.get(QWEN27)).toBe(QWEN27_NAME);
+    expect(names.size).toBe(2);
+  });
+
+  it("is empty for an older coordinator that omits the key, or no response yet", () => {
+    expect(modelNamesFrom({}).size).toBe(0);
+    expect(modelNamesFrom(null).size).toBe(0);
+    expect(modelNamesFrom(undefined).size).toBe(0);
+  });
+});
+
+describe("modelDisplayName", () => {
+  const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME } });
+
+  it("returns the catalog display name for a known build id", () => {
+    expect(modelDisplayName(QWEN27, names)).toBe(QWEN27_NAME);
+  });
+
+  it("falls back to the id without its org prefix for unknown ids", () => {
+    expect(modelDisplayName("EigenLabs/local-experiment-4bit", names)).toBe("local-experiment-4bit");
+    expect(modelDisplayName(MOE, NO_MODEL_NAMES)).toBe(MOE);
+  });
+});

--- a/console-ui/src/app/providers/dashboard/modelNames.test.ts
+++ b/console-ui/src/app/providers/dashboard/modelNames.test.ts
@@ -1,14 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { modelDisplayName, modelNamesFrom, NO_MODEL_NAMES } from "./modelNames";
-
-const QWEN27 = "EigenLabs/Qwen3.8-27B-4bit-mtp";
-const MOE = "qwen3.6-35b-a3b-vl-mtp-mxfp8";
-const QWEN27_NAME = "Qwen 3.8 27B";
+import { makeModelNames, MOE_ID, QWEN27_ID, QWEN27_NAME } from "./testFixtures";
 
 describe("modelNamesFrom", () => {
   it("indexes the response map", () => {
-    const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME, [MOE]: "Qwen 3.6 35B A3B" } });
-    expect(names.get(QWEN27)).toBe(QWEN27_NAME);
+    const names = makeModelNames();
+    expect(names.get(QWEN27_ID)).toBe(QWEN27_NAME);
     expect(names.size).toBe(2);
   });
 
@@ -20,14 +17,14 @@ describe("modelNamesFrom", () => {
 });
 
 describe("modelDisplayName", () => {
-  const names = modelNamesFrom({ model_display_names: { [QWEN27]: QWEN27_NAME } });
+  const names = makeModelNames();
 
   it("returns the catalog display name for a known build id", () => {
-    expect(modelDisplayName(QWEN27, names)).toBe(QWEN27_NAME);
+    expect(modelDisplayName(QWEN27_ID, names)).toBe(QWEN27_NAME);
   });
 
   it("falls back to the id without its org prefix for unknown ids", () => {
     expect(modelDisplayName("EigenLabs/local-experiment-4bit", names)).toBe("local-experiment-4bit");
-    expect(modelDisplayName(MOE, NO_MODEL_NAMES)).toBe(MOE);
+    expect(modelDisplayName(MOE_ID, NO_MODEL_NAMES)).toBe(MOE_ID);
   });
 });

--- a/console-ui/src/app/providers/dashboard/modelNames.ts
+++ b/console-ui/src/app/providers/dashboard/modelNames.ts
@@ -1,11 +1,10 @@
-// Human-readable model names for the dashboard. The coordinator ships the
-// catalog's id -> display-name map on /v1/me/providers (model_display_names,
-// keyed by the raw build id providers advertise, e.g.
-// "EigenLabs/Qwen3.8-27B-4bit-mtp" -> "Qwen 3.8 27B"). Built once per response
-// into a Map so every chip, slot row, and label resolves in O(1); anything the
-// catalog has no name for (off-catalog local models, older coordinators) falls
-// back to the id minus its org prefix, and render sites keep the raw id in the
-// hover title so it is always one hover away.
+// Human-readable model names for the dashboard, from the coordinator's
+// model_display_names on /v1/me/providers (raw build id -> catalog display
+// name, e.g. "EigenLabs/Qwen3.8-27B-4bit-mtp" -> "Qwen 3.8 27B"; builds that
+// share a name arrive already disambiguated, "Gemma 4 26B (4bit)"). Ids the
+// catalog has no name for — off-catalog local models, older coordinators —
+// fall back to the id without its org prefix, and render sites keep the raw id
+// in the hover title.
 
 import type { MyProvidersResponse } from "../types";
 import { shortModelName } from "./format";

--- a/console-ui/src/app/providers/dashboard/modelNames.ts
+++ b/console-ui/src/app/providers/dashboard/modelNames.ts
@@ -1,0 +1,25 @@
+// Human-readable model names for the dashboard. The coordinator ships the
+// catalog's id -> display-name map on /v1/me/providers (model_display_names,
+// keyed by the raw build id providers advertise, e.g.
+// "EigenLabs/Qwen3.8-27B-4bit-mtp" -> "Qwen 3.8 27B"). Built once per response
+// into a Map so every chip, slot row, and label resolves in O(1); anything the
+// catalog has no name for (off-catalog local models, older coordinators) falls
+// back to the id minus its org prefix, and render sites keep the raw id in the
+// hover title so it is always one hover away.
+
+import type { MyProvidersResponse } from "../types";
+import { shortModelName } from "./format";
+
+export type ModelNames = ReadonlyMap<string, string>;
+
+export const NO_MODEL_NAMES: ModelNames = new Map();
+
+/** Index a fleet response's display names; an absent map yields an empty index. */
+export function modelNamesFrom(resp: Pick<MyProvidersResponse, "model_display_names"> | null | undefined): ModelNames {
+  return new Map(Object.entries(resp?.model_display_names ?? {}));
+}
+
+/** The catalog display name for a model id, else the id without its org prefix. */
+export function modelDisplayName(id: string, names: ModelNames): string {
+  return names.get(id) || shortModelName(id);
+}

--- a/console-ui/src/app/providers/dashboard/testFixtures.ts
+++ b/console-ui/src/app/providers/dashboard/testFixtures.ts
@@ -1,7 +1,24 @@
 // Shared test fixtures for the provider dashboard. Builds a fully-populated
-// MyProvider so individual tests only override the few fields they exercise.
+// MyProvider so individual tests only override the few fields they exercise,
+// plus the catalog ids/names the model-label tests share.
 
-import type { MyProvider, MyReputation } from "../types";
+import type { MyBackendSlot, MyProvider, MyReputation } from "../types";
+import { modelNamesFrom, type ModelNames } from "./modelNames";
+
+/** Raw catalog build ids as providers advertise them. */
+export const QWEN27_ID = "EigenLabs/Qwen3.8-27B-4bit-mtp";
+export const MOE_ID = "qwen3.6-35b-a3b-vl-mtp-mxfp8";
+export const QWEN27_NAME = "Qwen 3.8 27B";
+export const MOE_NAME = "Qwen 3.6 35B A3B";
+
+/** Display names for the two fixture builds, as /v1/me/providers ships them. */
+export function makeModelNames(): ModelNames {
+  return modelNamesFrom({ model_display_names: { [QWEN27_ID]: QWEN27_NAME, [MOE_ID]: MOE_NAME } });
+}
+
+export function makeSlot(model: string, overrides: Partial<MyBackendSlot> = {}): MyBackendSlot {
+  return { model, state: "idle", num_running: 0, num_waiting: 0, active_tokens: 0, max_tokens_potential: 8192, ...overrides };
+}
 
 export function makeReputation(overrides: Partial<MyReputation> = {}): MyReputation {
   return {

--- a/console-ui/src/app/providers/dashboard/throughput.test.ts
+++ b/console-ui/src/app/providers/dashboard/throughput.test.ts
@@ -3,6 +3,10 @@ import { fleetMaxDecodeTps, resolveThroughput } from "./throughput";
 import { makeProvider } from "./testFixtures";
 import type { MyBackendCapacity, MyBackendSlot } from "../types";
 
+const ACTIVE = "qwen-27b";
+const MOE = "qwen-35b-a3b";
+const GEMMA = "gemma-26b";
+
 function slot(model: string, decode?: number, prefill?: number): MyBackendSlot {
   return {
     model,
@@ -21,62 +25,75 @@ function capacity(slots: MyBackendSlot[]): MyBackendCapacity {
 }
 
 describe("resolveThroughput", () => {
-  it("prefers the coordinator-resolved decode_tps / prefill_tps", () => {
+  it("reads the active model's slot EWMA, unattributed, over a faster co-resident slot", () => {
     const p = makeProvider({
       decode_tps: 31.5,
       prefill_tps: 1400,
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-35b-a3b", 92, 3100), slot("qwen-27b", 31.5, 1400)]),
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(MOE, 92, 3100), slot(ACTIVE, 31.5, 1400)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 1400 });
+    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 1400, decodeFallbackModel: undefined });
   });
 
-  it("falls back to the active model's slot EWMA when the coordinator omitted decode_tps", () => {
+  it("gives the same answer when an older coordinator omitted decode_tps", () => {
     const p = makeProvider({
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-35b-a3b", 92, 3100), slot("qwen-27b", 31.5, 1400)]),
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(MOE, 92, 3100), slot(ACTIVE, 31.5, 1400)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 1400 });
+    expect(resolveThroughput(p)).toMatchObject({ decode: 31.5, prefill: 1400 });
   });
 
-  it("uses the fastest measured co-resident slot when the active model is unmeasured", () => {
+  it("stands in the fastest measured co-resident slot, attributed, when the active model is unmeasured", () => {
     const p = makeProvider({
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-27b"), slot("gemma-26b", 44, 900), slot("qwen-35b-a3b", 92, 3100)]),
+      decode_tps: 92,
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(ACTIVE), slot(GEMMA, 44, 900), slot(MOE, 92, 3100)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 92, prefill: 3100 });
+    expect(resolveThroughput(p)).toEqual({ decode: 92, prefill: 3100, decodeFallbackModel: MOE });
+  });
+
+  it("attributes the stand-in when no model is active at all", () => {
+    const p = makeProvider({ backend_capacity: capacity([slot(GEMMA, 44, 900), slot(ACTIVE, 31.5, 1400)]) });
+    expect(resolveThroughput(p)).toEqual({ decode: 44, prefill: 1400, decodeFallbackModel: GEMMA });
   });
 
   it("resolves decode and prefill independently", () => {
     const p = makeProvider({
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-27b", 31.5), slot("gemma-26b", 44, 900)]),
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(ACTIVE, 31.5), slot(GEMMA, 44, 900)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 900 });
+    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 900, decodeFallbackModel: undefined });
+  });
+
+  it("falls back to the coordinator's decode_tps / prefill_tps for a provider without slot EWMAs", () => {
+    const legacy = makeProvider({ decode_tps: 60, prefill_tps: 700, current_model: ACTIVE, backend_capacity: capacity([slot(ACTIVE)]) });
+    expect(resolveThroughput(legacy)).toEqual({ decode: 60, prefill: 700, decodeFallbackModel: undefined });
+    const noCapacity = makeProvider({ decode_tps: 60, prefill_tps: 700 });
+    expect(resolveThroughput(noCapacity)).toEqual({ decode: 60, prefill: 700, decodeFallbackModel: undefined });
   });
 
   it("reports 0 (unmeasured) for a connected machine that has not served yet", () => {
     const p = makeProvider({
       status: "online",
       online: true,
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-27b"), slot("qwen-35b-a3b")]),
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(ACTIVE), slot(MOE)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0 });
+    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0, decodeFallbackModel: undefined });
   });
 
   it("reports 0 for an offline machine with no live snapshot", () => {
-    expect(resolveThroughput(makeProvider({ status: "offline" }))).toEqual({ decode: 0, prefill: 0 });
+    expect(resolveThroughput(makeProvider({ status: "offline" }))).toMatchObject({ decode: 0, prefill: 0 });
   });
 
   it("ignores non-finite and non-positive wire values", () => {
     const p = makeProvider({
       decode_tps: Number.NaN,
       prefill_tps: -5,
-      current_model: "qwen-27b",
-      backend_capacity: capacity([slot("qwen-27b", Number.POSITIVE_INFINITY, 0)]),
+      current_model: ACTIVE,
+      backend_capacity: capacity([slot(ACTIVE, Number.POSITIVE_INFINITY, 0)]),
     });
-    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0 });
+    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0, decodeFallbackModel: undefined });
   });
 });
 

--- a/console-ui/src/app/providers/dashboard/throughput.test.ts
+++ b/console-ui/src/app/providers/dashboard/throughput.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { fleetMaxDecodeTps, resolveThroughput } from "./throughput";
+import { makeProvider } from "./testFixtures";
+import type { MyBackendCapacity, MyBackendSlot } from "../types";
+
+function slot(model: string, decode?: number, prefill?: number): MyBackendSlot {
+  return {
+    model,
+    state: "running",
+    num_running: 0,
+    num_waiting: 0,
+    active_tokens: 0,
+    max_tokens_potential: 8192,
+    observed_decode_tps: decode,
+    observed_prefill_tps: prefill,
+  };
+}
+
+function capacity(slots: MyBackendSlot[]): MyBackendCapacity {
+  return { slots, gpu_memory_active_gb: 38.1, gpu_memory_peak_gb: 40, gpu_memory_cache_gb: 1.6, total_memory_gb: 64 };
+}
+
+describe("resolveThroughput", () => {
+  it("prefers the coordinator-resolved decode_tps / prefill_tps", () => {
+    const p = makeProvider({
+      decode_tps: 31.5,
+      prefill_tps: 1400,
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-35b-a3b", 92, 3100), slot("qwen-27b", 31.5, 1400)]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 1400 });
+  });
+
+  it("falls back to the active model's slot EWMA when the coordinator omitted decode_tps", () => {
+    const p = makeProvider({
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-35b-a3b", 92, 3100), slot("qwen-27b", 31.5, 1400)]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 1400 });
+  });
+
+  it("uses the fastest measured co-resident slot when the active model is unmeasured", () => {
+    const p = makeProvider({
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-27b"), slot("gemma-26b", 44, 900), slot("qwen-35b-a3b", 92, 3100)]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 92, prefill: 3100 });
+  });
+
+  it("resolves decode and prefill independently", () => {
+    const p = makeProvider({
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-27b", 31.5), slot("gemma-26b", 44, 900)]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 31.5, prefill: 900 });
+  });
+
+  it("reports 0 (unmeasured) for a connected machine that has not served yet", () => {
+    const p = makeProvider({
+      status: "online",
+      online: true,
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-27b"), slot("qwen-35b-a3b")]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0 });
+  });
+
+  it("reports 0 for an offline machine with no live snapshot", () => {
+    expect(resolveThroughput(makeProvider({ status: "offline" }))).toEqual({ decode: 0, prefill: 0 });
+  });
+
+  it("ignores non-finite and non-positive wire values", () => {
+    const p = makeProvider({
+      decode_tps: Number.NaN,
+      prefill_tps: -5,
+      current_model: "qwen-27b",
+      backend_capacity: capacity([slot("qwen-27b", Number.POSITIVE_INFINITY, 0)]),
+    });
+    expect(resolveThroughput(p)).toEqual({ decode: 0, prefill: 0 });
+  });
+});
+
+describe("fleetMaxDecodeTps", () => {
+  it("scales by the fastest resolved machine, whichever source it came from", () => {
+    const fleet = [
+      makeProvider({ id: "a", decode_tps: 31.5 }),
+      makeProvider({ id: "b", current_model: "m", backend_capacity: capacity([slot("m", 92)]) }),
+      makeProvider({ id: "c", status: "offline" }),
+    ];
+    expect(fleetMaxDecodeTps(fleet)).toBe(92);
+  });
+
+  it("is 0 for an unmeasured fleet", () => {
+    expect(fleetMaxDecodeTps([makeProvider(), makeProvider({ id: "b" })])).toBe(0);
+  });
+});

--- a/console-ui/src/app/providers/dashboard/throughput.ts
+++ b/console-ui/src/app/providers/dashboard/throughput.ts
@@ -2,42 +2,68 @@
 // line and the fleet-wide bar scale. Pure, so the card, the fleet max, and the
 // tests all read one definition.
 //
-// The coordinator resolves `decode_tps` / `prefill_tps` from the heartbeat's
-// per-slot EWMAs (registry.MeasuredThroughputLocked) and that value wins when
-// present. The slot fallback below applies the same precedence client-side so a
-// console deployed ahead of the coordinator still shows real numbers instead of
-// "—": active model's slot first, then the fastest measured co-resident slot.
-// A value of 0 means unmeasured and renders as an explicit blank.
+// Slot EWMAs are the raw measurement: retained by the provider across idle
+// time (smoothed over recent requests, not decaying), so a value means
+// "recently measured", not "decoding at this instant". Precedence mirrors the
+// coordinator's registry.MeasuredThroughputLocked, which fills decode_tps /
+// prefill_tps from the same slots: the active model's slot first, then the
+// fastest measured co-resident slot (reported with its model so the card can
+// say whose number it is), then the coordinator's value itself — which for a
+// current provider is identical, and for a legacy provider without slot
+// EWMAs is its registration benchmark. Resolving from slots first keeps the
+// attribution and gives the same answer whichever side deploys first. 0 means
+// unmeasured and renders as an explicit blank.
 
 import type { MyBackendSlot, MyProvider } from "../types";
 
 export interface Throughput {
   decode: number;
   prefill: number;
+  /**
+   * Model whose slot supplied `decode` when it is NOT the active model — the
+   * active slot has no measurement yet (just swapped in, pre-warmed) and a
+   * co-resident slot stands in. Undefined when the figure is the active
+   * model's own, or when nothing is measured.
+   */
+  decodeFallbackModel?: string;
 }
 
 function positive(v: number | undefined): number {
   return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 0;
 }
 
-function slotThroughput(slots: MyBackendSlot[] | undefined, currentModel: string | undefined): Throughput {
-  const out: Throughput = { decode: 0, prefill: 0 };
-  if (!slots?.length) return out;
-  let bestDecode = 0;
-  let bestPrefill = 0;
+/** The slot with the largest positive reading, or undefined when none has one. */
+function fastestSlot(slots: MyBackendSlot[], read: (s: MyBackendSlot) => number | undefined): MyBackendSlot | undefined {
+  let best: MyBackendSlot | undefined;
+  let bestValue = 0;
   for (const s of slots) {
-    const decode = positive(s.observed_decode_tps);
-    const prefill = positive(s.observed_prefill_tps);
-    if (currentModel && s.model === currentModel) {
-      out.decode = decode;
-      out.prefill = prefill;
-      continue;
+    const v = positive(read(s));
+    if (v > bestValue) {
+      bestValue = v;
+      best = s;
     }
-    if (decode > bestDecode) bestDecode = decode;
-    if (prefill > bestPrefill) bestPrefill = prefill;
   }
-  if (out.decode <= 0) out.decode = bestDecode;
-  if (out.prefill <= 0) out.prefill = bestPrefill;
+  return best;
+}
+
+function slotThroughput(slots: MyBackendSlot[] | undefined, currentModel: string | undefined): Throughput {
+  if (!slots?.length) return { decode: 0, prefill: 0 };
+  const active = currentModel ? slots.find((s) => s.model === currentModel) : undefined;
+  const others = slots.filter((s) => s !== active);
+  const out: Throughput = {
+    decode: positive(active?.observed_decode_tps),
+    prefill: positive(active?.observed_prefill_tps),
+  };
+  if (out.decode <= 0) {
+    const standIn = fastestSlot(others, (s) => s.observed_decode_tps);
+    if (standIn) {
+      out.decode = positive(standIn.observed_decode_tps);
+      out.decodeFallbackModel = standIn.model;
+    }
+  }
+  if (out.prefill <= 0) {
+    out.prefill = positive(fastestSlot(others, (s) => s.observed_prefill_tps)?.observed_prefill_tps);
+  }
   return out;
 }
 
@@ -45,8 +71,9 @@ function slotThroughput(slots: MyBackendSlot[] | undefined, currentModel: string
 export function resolveThroughput(provider: MyProvider): Throughput {
   const fromSlots = slotThroughput(provider.backend_capacity?.slots, provider.current_model);
   return {
-    decode: positive(provider.decode_tps) || fromSlots.decode,
-    prefill: positive(provider.prefill_tps) || fromSlots.prefill,
+    decode: fromSlots.decode || positive(provider.decode_tps),
+    prefill: fromSlots.prefill || positive(provider.prefill_tps),
+    decodeFallbackModel: fromSlots.decodeFallbackModel,
   };
 }
 

--- a/console-ui/src/app/providers/dashboard/throughput.ts
+++ b/console-ui/src/app/providers/dashboard/throughput.ts
@@ -1,0 +1,61 @@
+// Measured throughput for one machine — the number behind the card's "Decode"
+// line and the fleet-wide bar scale. Pure, so the card, the fleet max, and the
+// tests all read one definition.
+//
+// The coordinator resolves `decode_tps` / `prefill_tps` from the heartbeat's
+// per-slot EWMAs (registry.MeasuredThroughputLocked) and that value wins when
+// present. The slot fallback below applies the same precedence client-side so a
+// console deployed ahead of the coordinator still shows real numbers instead of
+// "—": active model's slot first, then the fastest measured co-resident slot.
+// A value of 0 means unmeasured and renders as an explicit blank.
+
+import type { MyBackendSlot, MyProvider } from "../types";
+
+export interface Throughput {
+  decode: number;
+  prefill: number;
+}
+
+function positive(v: number | undefined): number {
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : 0;
+}
+
+function slotThroughput(slots: MyBackendSlot[] | undefined, currentModel: string | undefined): Throughput {
+  const out: Throughput = { decode: 0, prefill: 0 };
+  if (!slots?.length) return out;
+  let bestDecode = 0;
+  let bestPrefill = 0;
+  for (const s of slots) {
+    const decode = positive(s.observed_decode_tps);
+    const prefill = positive(s.observed_prefill_tps);
+    if (currentModel && s.model === currentModel) {
+      out.decode = decode;
+      out.prefill = prefill;
+      continue;
+    }
+    if (decode > bestDecode) bestDecode = decode;
+    if (prefill > bestPrefill) bestPrefill = prefill;
+  }
+  if (out.decode <= 0) out.decode = bestDecode;
+  if (out.prefill <= 0) out.prefill = bestPrefill;
+  return out;
+}
+
+/** Resolve a machine's measured decode/prefill tok/s (0 = unmeasured). */
+export function resolveThroughput(provider: MyProvider): Throughput {
+  const fromSlots = slotThroughput(provider.backend_capacity?.slots, provider.current_model);
+  return {
+    decode: positive(provider.decode_tps) || fromSlots.decode,
+    prefill: positive(provider.prefill_tps) || fromSlots.prefill,
+  };
+}
+
+/** Largest measured decode TPS across the fleet — scales the per-card bars. */
+export function fleetMaxDecodeTps(providers: MyProvider[]): number {
+  let max = 0;
+  for (const p of providers) {
+    const { decode } = resolveThroughput(p);
+    if (decode > max) max = decode;
+  }
+  return max;
+}

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -36,8 +36,9 @@ export interface MyBackendSlot {
   active_tokens: number;
   max_tokens_potential: number;
   // Measured provider telemetry, mirrored from the Go BackendSlotCapacity wire
-  // type. Both are `omitempty` server-side (omitted when zero/unmeasured), so
+  // type. All are `omitempty` server-side (omitted when zero/unmeasured), so
   // they are optional here.
+  observed_decode_tps?: number; // EWMA of measured per-request decode TPS for this slot's model
   observed_prefill_tps?: number; // EWMA of measured prefill TPS (admission→first token)
   model_load_time_ms?: number; // measured cold-start load time (ms) for this slot's model
   // Per-slot KV-cache backend the provider's engine was actually built with,
@@ -130,6 +131,9 @@ export interface MyProvider {
   current_model?: string;
   pending_requests: number;
   max_concurrency: number;
+  // Measured throughput resolved server-side from the heartbeat's per-slot
+  // EWMAs (active model first). Omitted when the machine has not served a
+  // request yet. Read through dashboard/throughput.ts, never directly.
   prefill_tps?: number;
   decode_tps?: number;
 

--- a/console-ui/src/app/providers/types.ts
+++ b/console-ui/src/app/providers/types.ts
@@ -154,6 +154,10 @@ export interface MyProvidersResponse {
   min_provider_version: string;
   heartbeat_timeout_seconds: number;
   challenge_max_age_seconds: number;
+  // Raw catalog model id -> published display name ("Qwen 3.8 27B"). Ids
+  // without a published name are absent. Optional only because coordinators
+  // predating the key omit it; read through dashboard/modelNames.ts.
+  model_display_names?: Record<string, string>;
 }
 
 export interface MyFleetCounts {

--- a/console-ui/src/app/stats/ProviderNodeDetail.tsx
+++ b/console-ui/src/app/stats/ProviderNodeDetail.tsx
@@ -114,7 +114,7 @@ export function ProviderNodeDetail({ provider }: { provider: ProviderStats | nul
             <p className="mt-1 font-mono text-sm font-semibold text-text-primary">{formatCompact(provider.tokens_generated)}</p>
           </div>
           <div>
-            <p className="text-[9px] font-mono uppercase text-text-tertiary">Reported speed</p>
+            <p className="text-[9px] font-mono uppercase text-text-tertiary">Measured decode</p>
             <p className="mt-1 font-mono text-sm font-semibold text-text-primary">{provider.decode_tps > 0 ? `${Math.round(provider.decode_tps)} tok/s` : "—"}</p>
           </div>
         </div>

--- a/console-ui/src/app/stats/page.tsx
+++ b/console-ui/src/app/stats/page.tsx
@@ -818,8 +818,7 @@ function ProviderGeography({ stats }: { stats: PlatformStats }) {
   const certificateProviders = stats.providers.filter(
     (provider) => provider.certificate_available || provider.mda_verified,
   ).length;
-  const networkDecodeTPS = stats.providers.reduce((sum, provider) => sum + provider.decode_tps, 0);
-  const networkTPS = stats.network_capacity_tps || networkDecodeTPS;
+  const networkTPS = stats.network_capacity_tps;
   const unknownProviderLabel = unknown === 1 ? "provider" : "providers";
   const emptyLocationMessage = unknown > 0
     ? `${unknown} ${unknownProviderLabel} online without a resolved location`

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -555,9 +555,8 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		}
 		mp.LifetimeRequestsServed = live.Stats.RequestsServed
 		mp.LifetimeTokensGenerated = live.Stats.TokensGenerated
-		// Measured throughput: the heartbeat's per-slot EWMA, not the
-		// registration benchmark alone — current providers never send the
-		// latter, which left decode_tps permanently omitted.
+		// Measured per-slot EWMA; the registration benchmark is only a legacy
+		// fallback inside the resolver.
 		tp := live.MeasuredThroughputLocked()
 		mp.PrefillTPS = tp.PrefillTPS
 		mp.DecodeTPS = tp.DecodeTPS

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -118,6 +118,11 @@ type myProvidersResponse struct {
 	MinProviderVersion    string       `json:"min_provider_version"`
 	HeartbeatTimeoutSec   int          `json:"heartbeat_timeout_seconds"`
 	ChallengeMaxAgeSec    int          `json:"challenge_max_age_seconds"`
+	// ModelDisplayNames maps every active catalog model ID to its published
+	// human-readable name, so the dashboard can label loaded/catalog/slot
+	// models without a second fetch. IDs without a published name are absent;
+	// the UI falls back to the raw ID.
+	ModelDisplayNames map[string]string `json:"model_display_names"`
 }
 
 // myFleetCounts aggregates machine counts by status for the dashboard header.
@@ -343,6 +348,7 @@ func (s *Server) handleMyProviders(w http.ResponseWriter, r *http.Request) {
 		MinProviderVersion:    s.minProviderVersion,
 		HeartbeatTimeoutSec:   90,
 		ChallengeMaxAgeSec:    int((6 * time.Minute).Seconds()),
+		ModelDisplayNames:     s.registry.CatalogDisplayNames(),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/coordinator/api/me_handlers.go
+++ b/coordinator/api/me_handlers.go
@@ -555,8 +555,12 @@ func buildMyProvider(rec *store.ProviderRecord, live *registry.Provider) myProvi
 		}
 		mp.LifetimeRequestsServed = live.Stats.RequestsServed
 		mp.LifetimeTokensGenerated = live.Stats.TokensGenerated
-		mp.PrefillTPS = live.PrefillTPS
-		mp.DecodeTPS = live.DecodeTPS
+		// Measured throughput: the heartbeat's per-slot EWMA, not the
+		// registration benchmark alone — current providers never send the
+		// latter, which left decode_tps permanently omitted.
+		tp := live.MeasuredThroughputLocked()
+		mp.PrefillTPS = tp.PrefillTPS
+		mp.DecodeTPS = tp.DecodeTPS
 
 		if live.AttestationResult != nil {
 			ar := live.AttestationResult

--- a/coordinator/api/me_model_names_test.go
+++ b/coordinator/api/me_model_names_test.go
@@ -69,9 +69,9 @@ func TestMyProvidersModelDisplayNames(t *testing.T) {
 	}
 }
 
-// TestMyProvidersModelDisplayNamesAlwaysObject: consoles index into the map
-// unconditionally, so a coordinator without a catalog must still send {} — never
-// null and never a missing key.
+// TestMyProvidersModelDisplayNamesAlwaysObject pins the response contract: the
+// key is always an object — never null, never missing — so an empty catalog and
+// an unnamed model look the same to a client (no entry → raw-id fallback).
 func TestMyProvidersModelDisplayNamesAlwaysObject(t *testing.T) {
 	srv, _ := newKeyTestServer(t)
 	w := httptest.NewRecorder()

--- a/coordinator/api/me_model_names_test.go
+++ b/coordinator/api/me_model_names_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// seedActiveCatalogModel registers a model in the DB-backed registry with a
+// promoted version so SyncModelCatalog publishes it to the live catalog.
+func seedActiveCatalogModel(t *testing.T, st *store.MemoryStore, id, displayName string) {
+	t.Helper()
+	entry := &store.ModelRegistryEntry{ID: id, DisplayName: displayName, Status: "active"}
+	version := &store.ModelVersion{ModelID: id, Version: "v1", R2Prefix: modelR2Prefix(id, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 9_000_000_000, FileCount: 1, Status: "ready"}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := st.SetModelVersion(entry, version, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PromoteModelVersion(id, "v1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type myProvidersNamesResp struct {
+	Providers         []struct{ ID string } `json:"providers"`
+	ModelDisplayNames map[string]string     `json:"model_display_names"`
+}
+
+// TestMyProvidersModelDisplayNames pins the dashboard's name source: the
+// published catalog display names ride on /v1/me/providers, keyed by the raw
+// build ID the provider advertises, so chips can show "Qwen 3.8 27B" instead of
+// "EigenLabs/Qwen3.8-27B-4bit-mtp". A row whose display name merely repeats its
+// ID is omitted so the UI applies its own raw-ID fallback.
+func TestMyProvidersModelDisplayNames(t *testing.T) {
+	srv, st := newKeyTestServer(t)
+	const qwen27, moe, unnamed = "EigenLabs/Qwen3.8-27B-4bit-mtp", "qwen3.6-35b-a3b-vl-mtp-mxfp8", "gpt-oss-20b"
+	seedActiveCatalogModel(t, st, qwen27, "Qwen 3.8 27B")
+	seedActiveCatalogModel(t, st, moe, "Qwen 3.6 35B A3B")
+	seedActiveCatalogModel(t, st, unnamed, unnamed)
+	srv.SyncModelCatalog()
+
+	p := srv.registry.Register("p-live", nil, &protocol.RegisterMessage{
+		Models: []protocol.ModelInfo{{ID: qwen27, WeightHash: testHash}, {ID: moe, WeightHash: testHash}},
+	})
+	p.Mu().Lock()
+	p.AccountID = "acct-1"
+	p.Mu().Unlock()
+
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, reqWithUser(http.MethodGet, "/v1/me/providers", "", "acct-1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp myProvidersNamesResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1: %s", len(resp.Providers), w.Body.String())
+	}
+	want := map[string]string{qwen27: "Qwen 3.8 27B", moe: "Qwen 3.6 35B A3B"}
+	if !reflect.DeepEqual(resp.ModelDisplayNames, want) {
+		t.Fatalf("model_display_names = %v, want %v", resp.ModelDisplayNames, want)
+	}
+}
+
+// TestMyProvidersModelDisplayNamesAlwaysObject: consoles index into the map
+// unconditionally, so a coordinator without a catalog must still send {} — never
+// null and never a missing key.
+func TestMyProvidersModelDisplayNamesAlwaysObject(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, reqWithUser(http.MethodGet, "/v1/me/providers", "", "acct-1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(raw["model_display_names"]) != "{}" {
+		t.Fatalf("model_display_names = %s, want {}", raw["model_display_names"])
+	}
+}

--- a/coordinator/api/me_throughput_test.go
+++ b/coordinator/api/me_throughput_test.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// heartbeatTwoSlotProvider registers an account-owned live provider and drives
+// ONE real heartbeat with two loaded slots — the active 27B measured slower
+// than a co-resident MoE — so the tests exercise the ingest path
+// (canonicalization, clamping) rather than hand-setting registry state.
+// Registration deliberately carries no decode_tps/prefill_tps benchmark: that
+// is what every current Swift provider sends.
+func heartbeatTwoSlotProvider(t *testing.T, srv *Server, id, accountID string, measured bool) *registry.Provider {
+	t.Helper()
+	const active, other = "qwen3.8-27b-4bit-mtp", "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+	p := srv.registry.Register(id, nil, &protocol.RegisterMessage{
+		Hardware: protocol.Hardware{ChipName: "Apple M5 Max", ChipFamily: "M5", ChipTier: "Max", GPUCores: 40, MemoryGB: 64},
+		Models:   []protocol.ModelInfo{{ID: active}, {ID: other}},
+	})
+	if p == nil {
+		t.Fatalf("provider %q did not register", id)
+	}
+	p.Mu().Lock()
+	p.AccountID = accountID
+	p.TrustLevel = registry.TrustHardware
+	p.Attested = true
+	p.Mu().Unlock()
+
+	slots := []protocol.BackendSlotCapacity{
+		{Model: other, State: "idle", NumRunning: 0},
+		{Model: active, State: "running", NumRunning: 1},
+	}
+	if measured {
+		slots[0].ObservedDecodeTPS, slots[0].ObservedPrefillTPS = 92.0, 3100
+		slots[1].ObservedDecodeTPS, slots[1].ObservedPrefillTPS = 31.5, 1400
+	}
+	activeModel := active
+	srv.registry.Heartbeat(id, &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "serving",
+		ActiveModel: &activeModel,
+		WarmModels:  []string{active, other},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB:     64,
+			GPUMemoryActiveGB: 38.1,
+			Slots:             slots,
+		},
+	})
+	return p
+}
+
+type myProvidersThroughputResp struct {
+	Providers []struct {
+		ID         string   `json:"id"`
+		DecodeTPS  *float64 `json:"decode_tps"`
+		PrefillTPS *float64 `json:"prefill_tps"`
+	} `json:"providers"`
+}
+
+func getMyProviders(t *testing.T, srv *Server, accountID string) (myProvidersThroughputResp, string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	srv.handleMyProviders(w, reqWithUser(http.MethodGet, "/v1/me/providers", "", accountID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp myProvidersThroughputResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1: %s", len(resp.Providers), w.Body.String())
+	}
+	return resp, w.Body.String()
+}
+
+// TestMyProvidersThroughputFromHeartbeatSlots is the regression for the
+// dashboard's permanently blank "Decode — tok/s": decode_tps/prefill_tps must
+// come from the heartbeat's per-slot EWMA (active model first), not from the
+// registration benchmark the Swift provider never sends.
+func TestMyProvidersThroughputFromHeartbeatSlots(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	heartbeatTwoSlotProvider(t, srv, "p-live", "acct-1", true)
+
+	resp, body := getMyProviders(t, srv, "acct-1")
+	got := resp.Providers[0]
+	if got.DecodeTPS == nil || *got.DecodeTPS != 31.5 {
+		t.Fatalf("decode_tps = %v, want 31.5 (active slot EWMA): %s", got.DecodeTPS, body)
+	}
+	if got.PrefillTPS == nil || *got.PrefillTPS != 1400 {
+		t.Fatalf("prefill_tps = %v, want 1400 (active slot EWMA): %s", got.PrefillTPS, body)
+	}
+}
+
+// TestMyProvidersThroughputOmittedWhenUnmeasured pins the honest-blank
+// contract: a connected machine that has not served a request omits both keys
+// (omitempty) so the UI renders "—" rather than a fabricated zero or a
+// bandwidth heuristic.
+func TestMyProvidersThroughputOmittedWhenUnmeasured(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	heartbeatTwoSlotProvider(t, srv, "p-live", "acct-1", false)
+
+	resp, body := getMyProviders(t, srv, "acct-1")
+	if resp.Providers[0].DecodeTPS != nil || resp.Providers[0].PrefillTPS != nil {
+		t.Fatalf("unmeasured provider reported throughput: %s", body)
+	}
+	if strings.Contains(body, `"decode_tps"`) || strings.Contains(body, `"prefill_tps"`) {
+		t.Fatalf("unmeasured provider emitted throughput keys: %s", body)
+	}
+}
+
+// TestStatsDecodeTPSFromHeartbeatSlots covers the public /v1/stats per-provider
+// decode_tps, which shared the same dead registration-benchmark source.
+func TestStatsDecodeTPSFromHeartbeatSlots(t *testing.T) {
+	srv, _ := newKeyTestServer(t)
+	heartbeatTwoSlotProvider(t, srv, "p-live", "acct-1", true)
+
+	rr := httptest.NewRecorder()
+	srv.handleStats(rr, httptest.NewRequest(http.MethodGet, "/v1/stats", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Providers []struct {
+			ID        string  `json:"id"`
+			DecodeTPS float64 `json:"decode_tps"`
+		} `json:"providers"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1: %s", len(body.Providers), rr.Body.String())
+	}
+	if body.Providers[0].DecodeTPS != 31.5 {
+		t.Fatalf("stats decode_tps = %v, want 31.5 (active slot EWMA)", body.Providers[0].DecodeTPS)
+	}
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1183,11 +1183,12 @@ func (s *Server) SyncModelCatalog() {
 			continue
 		}
 		entries = append(entries, registry.CatalogEntry{
-			ID:          row.ID,
-			DisplayName: row.DisplayName,
-			WeightHash:  row.ActiveVersion.AggregateSHA256,
-			SizeGB:      float64(row.ActiveVersion.TotalSizeBytes) / 1e9,
-			MinRAMGB:    row.MinRAMGB,
+			ID:           row.ID,
+			DisplayName:  row.DisplayName,
+			Quantization: row.Quantization,
+			WeightHash:   row.ActiveVersion.AggregateSHA256,
+			SizeGB:       float64(row.ActiveVersion.TotalSizeBytes) / 1e9,
+			MinRAMGB:     row.MinRAMGB,
 			RequiredProviderCapabilities: append(
 				[]string{}, row.RequiredProviderCapabilities...),
 		})

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -1183,10 +1183,11 @@ func (s *Server) SyncModelCatalog() {
 			continue
 		}
 		entries = append(entries, registry.CatalogEntry{
-			ID:         row.ID,
-			WeightHash: row.ActiveVersion.AggregateSHA256,
-			SizeGB:     float64(row.ActiveVersion.TotalSizeBytes) / 1e9,
-			MinRAMGB:   row.MinRAMGB,
+			ID:          row.ID,
+			DisplayName: row.DisplayName,
+			WeightHash:  row.ActiveVersion.AggregateSHA256,
+			SizeGB:      float64(row.ActiveVersion.TotalSizeBytes) / 1e9,
+			MinRAMGB:    row.MinRAMGB,
 			RequiredProviderCapabilities: append(
 				[]string{}, row.RequiredProviderCapabilities...),
 		})

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -132,6 +132,10 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		if last := p.GetLastChallengeVerified(); !last.IsZero() {
 			lastChallengeVerified = last.UTC().Format(time.RFC3339)
 		}
+		// Heartbeat state (slots, active model) is written under p.mu.
+		p.Mu().Lock()
+		decodeTPS := p.MeasuredThroughputLocked().DecodeTPS
+		p.Mu().Unlock()
 
 		prov := map[string]any{
 			"id":                             p.ID,
@@ -145,7 +149,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 			"memory_bandwidth_gbs":           p.Hardware.MemoryBandwidthGBs,
 			"status":                         status,
 			"trust_level":                    string(p.TrustLevel),
-			"decode_tps":                     p.DecodeTPS,
+			"decode_tps":                     decodeTPS,
 			"requests_served":                p.Stats.RequestsServed,
 			"tokens_generated":               p.Stats.TokensGenerated,
 			"cancellations_received":         p.Stats.CancellationsReceived,

--- a/coordinator/api/stats.go
+++ b/coordinator/api/stats.go
@@ -128,14 +128,16 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		modelSnapshot := publicProviderModels[p.ID]
 		provModels := modelSnapshot.Models
 
-		lastChallengeVerified := ""
-		if last := p.GetLastChallengeVerified(); !last.IsZero() {
-			lastChallengeVerified = last.UTC().Format(time.RFC3339)
-		}
-		// Heartbeat state (slots, active model) is written under p.mu.
+		// Challenge time and heartbeat state (slots, active model) are written
+		// under p.mu; read both in one acquisition.
 		p.Mu().Lock()
+		last := p.LastChallengeVerified
 		decodeTPS := p.MeasuredThroughputLocked().DecodeTPS
 		p.Mu().Unlock()
+		lastChallengeVerified := ""
+		if !last.IsZero() {
+			lastChallengeVerified = last.UTC().Format(time.RFC3339)
+		}
 
 		prov := map[string]any{
 			"id":                             p.ID,

--- a/coordinator/registry/catalog_display_names.go
+++ b/coordinator/registry/catalog_display_names.go
@@ -1,18 +1,55 @@
 package registry
 
+import "strings"
+
 // CatalogDisplayNames returns model ID → human-readable name for every active
-// catalog entry that carries one. Entries whose display name is empty or just
-// repeats the ID are left out so callers fall back to their own rendering of
-// the raw ID rather than echoing it. Thread-safe; returns a fresh map.
+// catalog entry that carries one. Names are trimmed; an entry whose name is
+// empty or just repeats its ID is left out so callers fall back to their own
+// rendering of the raw ID. Builds that share one name (a rollout alias's
+// desired and previous builds are both "Gemma 4 26B") are told apart by their
+// catalog quantization — "Gemma 4 26B (4bit)" / "Gemma 4 26B (8bit)"; a build
+// the quantization cannot separate either is left out rather than labelled
+// identically to another. Thread-safe; returns a fresh map.
 func (r *Registry) CatalogDisplayNames() map[string]string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	names := make(map[string]string, len(r.modelCatalog))
+	byName := make(map[string][]string, len(r.modelCatalog))
 	for id, entry := range r.modelCatalog {
-		if entry.DisplayName == "" || entry.DisplayName == id {
+		name := strings.TrimSpace(entry.DisplayName)
+		if name == "" || name == id {
 			continue
 		}
-		names[id] = entry.DisplayName
+		byName[name] = append(byName[name], id)
+	}
+	names := make(map[string]string, len(r.modelCatalog))
+	for name, ids := range byName {
+		if len(ids) == 1 {
+			names[ids[0]] = name
+			continue
+		}
+		for id, label := range labelsByQuantization(name, ids, r.modelCatalog) {
+			names[id] = label
+		}
 	}
 	return names
+}
+
+// labelsByQuantization labels same-named builds "<name> (<quantization>)".
+// Only builds whose quantization is non-empty and unique within the group get
+// a label; the others are omitted.
+func labelsByQuantization(name string, ids []string, catalog map[string]CatalogEntry) map[string]string {
+	quantCount := make(map[string]int, len(ids))
+	for _, id := range ids {
+		if q := strings.TrimSpace(catalog[id].Quantization); q != "" {
+			quantCount[q]++
+		}
+	}
+	labels := make(map[string]string, len(ids))
+	for _, id := range ids {
+		q := strings.TrimSpace(catalog[id].Quantization)
+		if q != "" && quantCount[q] == 1 {
+			labels[id] = name + " (" + q + ")"
+		}
+	}
+	return labels
 }

--- a/coordinator/registry/catalog_display_names.go
+++ b/coordinator/registry/catalog_display_names.go
@@ -1,0 +1,18 @@
+package registry
+
+// CatalogDisplayNames returns model ID → human-readable name for every active
+// catalog entry that carries one. Entries whose display name is empty or just
+// repeats the ID are left out so callers fall back to their own rendering of
+// the raw ID rather than echoing it. Thread-safe; returns a fresh map.
+func (r *Registry) CatalogDisplayNames() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make(map[string]string, len(r.modelCatalog))
+	for id, entry := range r.modelCatalog {
+		if entry.DisplayName == "" || entry.DisplayName == id {
+			continue
+		}
+		names[id] = entry.DisplayName
+	}
+	return names
+}

--- a/coordinator/registry/catalog_display_names_test.go
+++ b/coordinator/registry/catalog_display_names_test.go
@@ -15,14 +15,28 @@ func TestCatalogDisplayNames(t *testing.T) {
 	}
 
 	r.SetModelCatalog([]CatalogEntry{
-		{ID: "EigenLabs/Qwen3.8-27B-4bit-mtp", DisplayName: "Qwen 3.8 27B"},
-		{ID: "qwen3.6-35b-a3b-vl-mtp-mxfp8", DisplayName: "Qwen 3.6 35B A3B"},
-		{ID: "gpt-oss-20b", DisplayName: "gpt-oss-20b"}, // name repeats the id: not a display name
-		{ID: "local-experiment"}, // none published
+		{ID: "EigenLabs/Qwen3.8-27B-4bit-mtp", DisplayName: "Qwen 3.8 27B", Quantization: "fp4"},
+		{ID: "qwen3.6-35b-a3b-vl-mtp-mxfp8", DisplayName: "  Qwen 3.6 35B A3B  "}, // trimmed
+		{ID: "gpt-oss-20b", DisplayName: "gpt-oss-20b"},                           // repeats the id: not a display name
+		{ID: "local-experiment"},               // none published
+		{ID: "blank-name", DisplayName: "   "}, // whitespace is none
+		// A rollout alias's desired + previous builds share the public name;
+		// quantization tells them apart.
+		{ID: "gemma-4-26b-qat-4bit", DisplayName: "Gemma 4 26B", Quantization: "4bit"},
+		{ID: "gemma-4-26b", DisplayName: "Gemma 4 26B", Quantization: "8bit"},
+		// Same name AND same quantization (or none): no honest label exists.
+		{ID: "llama-x-a", DisplayName: "Llama X", Quantization: "4bit"},
+		{ID: "llama-x-b", DisplayName: "Llama X", Quantization: "4bit"},
+		{ID: "llama-x-c", DisplayName: "Llama X", Quantization: "8bit"},
+		{ID: "mistral-y-a", DisplayName: "Mistral Y"},
+		{ID: "mistral-y-b", DisplayName: "Mistral Y"},
 	})
 	want := map[string]string{
 		"EigenLabs/Qwen3.8-27B-4bit-mtp": "Qwen 3.8 27B",
 		"qwen3.6-35b-a3b-vl-mtp-mxfp8":   "Qwen 3.6 35B A3B",
+		"gemma-4-26b-qat-4bit":           "Gemma 4 26B (4bit)",
+		"gemma-4-26b":                    "Gemma 4 26B (8bit)",
+		"llama-x-c":                      "Llama X (8bit)",
 	}
 	got := r.CatalogDisplayNames()
 	if !reflect.DeepEqual(got, want) {

--- a/coordinator/registry/catalog_display_names_test.go
+++ b/coordinator/registry/catalog_display_names_test.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+)
+
+func TestCatalogDisplayNames(t *testing.T) {
+	r := New(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	if got := r.CatalogDisplayNames(); len(got) != 0 {
+		t.Fatalf("no catalog: got %v, want empty", got)
+	}
+
+	r.SetModelCatalog([]CatalogEntry{
+		{ID: "EigenLabs/Qwen3.8-27B-4bit-mtp", DisplayName: "Qwen 3.8 27B"},
+		{ID: "qwen3.6-35b-a3b-vl-mtp-mxfp8", DisplayName: "Qwen 3.6 35B A3B"},
+		{ID: "gpt-oss-20b", DisplayName: "gpt-oss-20b"}, // name repeats the id: not a display name
+		{ID: "local-experiment"}, // none published
+	})
+	want := map[string]string{
+		"EigenLabs/Qwen3.8-27B-4bit-mtp": "Qwen 3.8 27B",
+		"qwen3.6-35b-a3b-vl-mtp-mxfp8":   "Qwen 3.6 35B A3B",
+	}
+	got := r.CatalogDisplayNames()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CatalogDisplayNames() = %v, want %v", got, want)
+	}
+
+	// The returned map is a copy: mutating it must not touch the catalog.
+	got["gpt-oss-20b"] = "GPT-OSS 20B"
+	if again := r.CatalogDisplayNames(); !reflect.DeepEqual(again, want) {
+		t.Fatalf("catalog mutated through returned map: %v", again)
+	}
+
+	r.SetModelCatalog(nil)
+	if got := r.CatalogDisplayNames(); len(got) != 0 {
+		t.Fatalf("catalog disabled: got %v, want empty", got)
+	}
+}

--- a/coordinator/registry/measured_throughput.go
+++ b/coordinator/registry/measured_throughput.go
@@ -1,0 +1,63 @@
+package registry
+
+// MeasuredThroughput is the decode/prefill tok/s a machine has actually been
+// measured at — the number a dashboard shows next to "Decode". It is distinct
+// from the scheduler's routing estimate (resolvedModelTPSLocked), which falls
+// back to a sqrt(memory-bandwidth) heuristic so every provider has a rankable
+// cost; a display must never print that placeholder as a measurement.
+//
+// Zero means "not measured yet" (a freshly connected box that has not served
+// a request), and callers render it as an explicit blank.
+type MeasuredThroughput struct {
+	DecodeTPS  float64
+	PrefillTPS float64
+}
+
+// MeasuredThroughputLocked resolves the machine's measured throughput from the
+// live heartbeat state. Caller must hold p.mu.
+//
+// Precedence, per axis (decode and prefill resolve independently):
+//
+//  1. The heartbeat EWMA of the slot serving CurrentModel — the model the
+//     machine is decoding right now.
+//  2. The largest EWMA across the other loaded slots — the box has been
+//     measured, just not yet on the active model (e.g. it was just swapped in).
+//  3. The registration-time benchmark (PrefillTPS / DecodeTPS). Current Swift
+//     providers never send it; legacy providers did.
+//  4. Zero: unmeasured.
+func (p *Provider) MeasuredThroughputLocked() MeasuredThroughput {
+	out := MeasuredThroughput{}
+	if p.BackendCapacity != nil {
+		var bestDecode, bestPrefill float64
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model == p.CurrentModel {
+				if slot.ObservedDecodeTPS > 0 {
+					out.DecodeTPS = slot.ObservedDecodeTPS
+				}
+				if slot.ObservedPrefillTPS > 0 {
+					out.PrefillTPS = slot.ObservedPrefillTPS
+				}
+				continue
+			}
+			if slot.ObservedDecodeTPS > bestDecode {
+				bestDecode = slot.ObservedDecodeTPS
+			}
+			if slot.ObservedPrefillTPS > bestPrefill {
+				bestPrefill = slot.ObservedPrefillTPS
+			}
+		}
+		if out.DecodeTPS <= 0 {
+			out.DecodeTPS = bestDecode
+		}
+		if out.PrefillTPS <= 0 {
+			out.PrefillTPS = bestPrefill
+		}
+	}
+	if out.DecodeTPS <= 0 && p.DecodeTPS > 0 {
+		out.DecodeTPS = p.DecodeTPS
+	}
+	if out.PrefillTPS <= 0 && p.PrefillTPS > 0 {
+		out.PrefillTPS = p.PrefillTPS
+	}
+	return out
+}

--- a/coordinator/registry/measured_throughput.go
+++ b/coordinator/registry/measured_throughput.go
@@ -16,10 +16,13 @@ type MeasuredThroughput struct {
 // MeasuredThroughputLocked resolves the machine's measured throughput from the
 // live heartbeat state. Caller must hold p.mu.
 //
-// Precedence, per axis (decode and prefill resolve independently):
+// Slot EWMAs are retained by the provider across idle time (they smooth recent
+// requests; they do not decay), so a value is "recently measured", not
+// "decoding at this instant". Precedence, per axis (decode and prefill resolve
+// independently):
 //
-//  1. The heartbeat EWMA of the slot serving CurrentModel — the model the
-//     machine is decoding right now.
+//  1. The EWMA of the slot holding CurrentModel — the active (most recently
+//     used) loaded model.
 //  2. The largest EWMA across the other loaded slots — the box has been
 //     measured, just not yet on the active model (e.g. it was just swapped in).
 //  3. The registration-time benchmark (PrefillTPS / DecodeTPS). Current Swift

--- a/coordinator/registry/measured_throughput_test.go
+++ b/coordinator/registry/measured_throughput_test.go
@@ -1,0 +1,111 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestMeasuredThroughputLocked(t *testing.T) {
+	slot := func(model string, decode, prefill float64) protocol.BackendSlotCapacity {
+		return protocol.BackendSlotCapacity{Model: model, State: "running", ObservedDecodeTPS: decode, ObservedPrefillTPS: prefill}
+	}
+	cases := []struct {
+		name string
+		p    *Provider
+		want MeasuredThroughput
+	}{
+		{
+			name: "no heartbeat, no benchmark: unmeasured",
+			p:    &Provider{},
+			want: MeasuredThroughput{},
+		},
+		{
+			name: "active model slot EWMA wins over a faster co-resident slot",
+			p: &Provider{
+				CurrentModel: "qwen-27b",
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("qwen-35b-a3b", 92.0, 3100),
+					slot("qwen-27b", 31.5, 1400),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 31.5, PrefillTPS: 1400},
+		},
+		{
+			name: "active model unmeasured: fall back to the best measured slot",
+			p: &Provider{
+				CurrentModel: "qwen-27b",
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("qwen-27b", 0, 0),
+					slot("gemma-26b", 44.0, 900),
+					slot("qwen-35b-a3b", 92.0, 3100),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 92.0, PrefillTPS: 3100},
+		},
+		{
+			name: "axes resolve independently: active decode, other slot prefill",
+			p: &Provider{
+				CurrentModel: "qwen-27b",
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("qwen-27b", 31.5, 0),
+					slot("gemma-26b", 44.0, 900),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 31.5, PrefillTPS: 900},
+		},
+		{
+			name: "no active model: best measured slot",
+			p: &Provider{
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("gemma-26b", 44.0, 900),
+					slot("qwen-27b", 31.5, 1400),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 44.0, PrefillTPS: 1400},
+		},
+		{
+			name: "slots present but all unmeasured: registration benchmark",
+			p: &Provider{
+				DecodeTPS:    60,
+				PrefillTPS:   700,
+				CurrentModel: "qwen-27b",
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("qwen-27b", 0, 0),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 60, PrefillTPS: 700},
+		},
+		{
+			name: "legacy provider without backend capacity: registration benchmark",
+			p:    &Provider{DecodeTPS: 60, PrefillTPS: 700},
+			want: MeasuredThroughput{DecodeTPS: 60, PrefillTPS: 700},
+		},
+		{
+			name: "heartbeat EWMA beats a stale registration benchmark",
+			p: &Provider{
+				DecodeTPS:    60,
+				CurrentModel: "qwen-27b",
+				BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{
+					slot("qwen-27b", 31.5, 0),
+				}},
+			},
+			want: MeasuredThroughput{DecodeTPS: 31.5},
+		},
+		{
+			name: "memory bandwidth alone is never reported as a measurement",
+			p:    &Provider{Hardware: protocol.Hardware{MemoryBandwidthGBs: 400}},
+			want: MeasuredThroughput{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.p.mu.Lock()
+			got := tc.p.MeasuredThroughputLocked()
+			tc.p.mu.Unlock()
+			if got != tc.want {
+				t.Fatalf("MeasuredThroughputLocked() = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2524,7 +2524,11 @@ func TruncHash(h string) string {
 
 // CatalogEntry holds metadata about an active model in the catalog.
 type CatalogEntry struct {
-	ID                           string
+	ID string
+	// DisplayName is the operator-published human-readable name ("Qwen 3.8
+	// 27B"); empty when the catalog row has none. Presentation only — never
+	// consulted by routing.
+	DisplayName                  string
 	WeightHash                   string  // expected SHA-256 weight fingerprint (empty = not enforced)
 	SizeGB                       float64 // disk/GPU footprint of the model weights (zero = unknown, gate disabled)
 	RequiredProviderCapabilities []string

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -2526,9 +2526,11 @@ func TruncHash(h string) string {
 type CatalogEntry struct {
 	ID string
 	// DisplayName is the operator-published human-readable name ("Qwen 3.8
-	// 27B"); empty when the catalog row has none. Presentation only — never
-	// consulted by routing.
+	// 27B"); empty when the catalog row has none. Quantization ("4bit", "fp8")
+	// tells apart builds that share a DisplayName. Both are presentation only —
+	// never consulted by routing.
 	DisplayName                  string
+	Quantization                 string
 	WeightHash                   string  // expected SHA-256 weight fingerprint (empty = not enforced)
 	SizeGB                       float64 // disk/GPU footprint of the model weights (zero = unknown, gate disabled)
 	RequiredProviderCapabilities []string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two provider-dashboard card fixes from #providers.

**1. DECODE always rendered `— tok/s`.** `/v1/me/providers` fills `decode_tps` / `prefill_tps` from `Provider.DecodeTPS` / `PrefillTPS` — the registration-time benchmark fields the Swift provider never sends (`CoordinatorClientCodec.registrationMessage` leaves `decodeTps` nil) — so both were `0`, `omitempty` dropped them, and `formatTps(0)` printed the dash. The measured number already arrives in every heartbeat as `backend_capacity.slots[].observed_decode_tps` / `observed_prefill_tps` (per-model EWMA, α = 0.3, retained across idle); nothing surfaced it. `/v1/stats` per-provider `decode_tps` (stats page node detail) had the same dead source.
- `registry.(*Provider).MeasuredThroughputLocked()` — active model's slot EWMA → fastest measured co-resident slot → registration benchmark → 0 (unmeasured, stays omitted). Deliberately never the scheduler's `sqrt(memory_bandwidth)` routing placeholder: a display must not print a heuristic as a measurement. `/v1/me/providers` and `/v1/stats` read it (`/v1/stats` reads challenge time + throughput under one `p.mu` hold).
- Console: `dashboard/throughput.ts` resolves the Decode line with the same precedence from the slots (so it can say **whose** number it is) and falls back to `decode_tps` / `prefill_tps` for providers without slot EWMAs — identical result to the coordinator's field for every current provider, correct whichever side deploys first. When the active model's slot is unmeasured (just swapped in / pre-warmed) the card shows the stand-in slot's rate **labelled with its model**. `fleetMaxDecodeTps` (bar scale) uses the same resolver; the Backend slots panel shows each slot's own tok/s; `observed_decode_tps` added to the `MyBackendSlot` mirror.
- Stats page: the `Σ decode_tps` fallback for `network_capacity_tps` is removed (the coordinator always emits `network_capacity_tps`; the fallback could only fire with zero routable providers, where it would now count non-routable nodes' retained EWMAs). Node-detail label `Reported speed` → `Measured decode`.

**2. Raw build ids → catalog display names.** Loaded/Catalog chips, Backend-slots rows, and the decode stand-in label showed `EigenLabs/Qwen3.8-27B-4bit-mtp`-style ids. The DB-backed registry already publishes a display name per build ("Qwen 3.8 27B", "Qwen 3.6 35B A3B", "Gemma 4 26B", …).
- `registry.CatalogEntry` snapshots `DisplayName` + `Quantization` in `SyncModelCatalog`; `Registry.CatalogDisplayNames()` (in-memory, `r.mu.RLock`) returns id → name, omitting rows whose name is empty/whitespace or merely repeats the id. Builds that share a name — a rollout alias's desired and previous builds are both "Gemma 4 26B" and one machine can hold both — are told apart by quantization: `Gemma 4 26B (4bit)` / `Gemma 4 26B (8bit)`; a build the quantization cannot separate either is omitted rather than labelled identically to another. `/v1/me/providers` adds `model_display_names` (always an object) keyed by the raw id providers advertise, so warm/current/slot/catalog models all resolve from one map with no second fetch.
- Console: `dashboard/modelNames.ts` indexes it once per response into a `Map`; `modelDisplayName(id, names)` → name or the previous `shortModelName(id)` fallback (off-catalog local models, older coordinators). `names` is a **required** prop `ProviderDashboard → MachineGrid → MachineCard → ModelsStrip / CardVitals / BackendSlotsPanel` (a dropped prop cannot silently revert a card to raw ids); the raw id stays one hover away in `title`.

## Screenshots

Real `MachineCard` rendered with the console's built CSS from the **actual `/v1/me/providers` JSON** the handler emits after one real `registry.Heartbeat` against a real `SyncModelCatalog` (headless Chrome).

Active model measured (27B at 31.5 tok/s; the idle MoE's 88.4 does not leak into the headline), display names everywhere, per-slot rates in the expanded Backend slots panel:

[Provider card after: DECODE 31.5 tok/s, prefill 1420, Loaded/Catalog chips and slot rows show Qwen 3.8 27B, Qwen 3.6 35B A3B, Gemma 4 26B, GPT-OSS 20B](https://cursor.com/agents/bc-50b37aae-2677-5ac2-a4c8-d2006d96b448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprovider_card_display_names_after.png)

Active model just swapped in and unmeasured — the co-resident slot stands in and is named:

[Provider card with the active model unmeasured: DECODE 88.4 tok/s on Qwen 3.6 35B A3B, prefill 2960](https://cursor.com/agents/bc-50b37aae-2677-5ac2-a4c8-d2006d96b448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprovider_card_display_names_stand_in_after.png)

## Before / after

### Behavior

```mermaid
flowchart LR
  subgraph Before
    HB1[heartbeat: slots[].observed_decode_tps = 31.5] --> REG1[Provider.BackendCapacity]
    RG1[registration: decode_tps omitted] --> D1[Provider.DecodeTPS = 0]
    D1 --> ME1["/v1/me/providers: decode_tps omitted, no names"]
    D1 --> ST1["/v1/stats: decode_tps = 0"]
    REG1 -. never read for display .-> ME1
    ME1 --> UI1["card: DECODE — tok/s · chips: EigenLabs/Qwen3.8-27B-4bit-mtp"]
  end
  subgraph After
    HB2[heartbeat: slots[].observed_decode_tps = 31.5] --> REG2[Provider.BackendCapacity]
    RG2[registration: decode_tps omitted] --> D2[Provider.DecodeTPS = 0]
    REG2 --> MT[MeasuredThroughputLocked: active slot → best slot → benchmark → 0]
    D2 --> MT
    CAT[DB model registry: display_name, quantization] --> SYNC[SyncModelCatalog → CatalogEntry]
    SYNC --> NAMES["CatalogDisplayNames(): id → name, same-name builds get (quant)"]
    MT --> ME2["/v1/me/providers: decode_tps = 31.5, prefill_tps = 1400, model_display_names"]
    NAMES --> ME2
    MT --> ST2["/v1/stats: decode_tps = 31.5"]
    ME2 --> RT[resolveThroughput + modelDisplayName]
    RT --> UI2["active measured: DECODE 31.5 tok/s · chips: Qwen 3.8 27B active, Qwen 3.6 35B A3B"]
    RT --> UI3["active unmeasured: DECODE 88.4 tok/s on Qwen 3.6 35B A3B"]
    RT --> UI4["nothing measured: DECODE — tok/s · unknown id: short raw id"]
  end
```

### Code

```mermaid
flowchart TD
  subgraph Before
    B1[api.buildMyProvider] -->|"mp.DecodeTPS = live.DecodeTPS"| B2[registration benchmark, always 0]
    B3[api.handleStats] -->|"decode_tps: p.DecodeTPS"| B2
    B4[CardVitals] -->|"provider.decode_tps ?? 0"| B5[formatTps → —]
    B6[ModelsStrip / BackendSlotsPanel] -->|"shortModelName(id)"| B7[raw build id]
    B8[stats/page.tsx] -->|"network_capacity_tps || Σ decode_tps"| B9[network TPS]
  end
  subgraph After
    A1[api.buildMyProvider] --> A0["registry.(*Provider).MeasuredThroughputLocked()"]
    A3[api.handleStats] -->|"one p.Mu() hold"| A0
    A0 --> A0a[CurrentModel slot EWMA] --> A0b[best other slot EWMA] --> A0c[DecodeTPS / PrefillTPS benchmark] --> A0d[0]
    S1[api.SyncModelCatalog] -->|DisplayName, Quantization| S2[registry.CatalogEntry] --> S3["Registry.CatalogDisplayNames() → labelsByQuantization"] --> S4["handleMyProviders: model_display_names"]
    A4[CardVitals] --> A7[throughput.resolveThroughput]
    A6[throughput.fleetMaxDecodeTps] --> A7
    A7 --> A9["slots: current_model → fastestSlot(others) + decodeFallbackModel"] --> A8[formatTps → 31.5 / 88.4 on model]
    A9 -. no slot EWMA .-> A10["decode_tps / prefill_tps (legacy benchmark)"] --> A8
    S4 --> N1["modelNames.modelNamesFrom → Map"] --> N2[ProviderDashboard → MachineGrid → MachineCard names prop, required]
    N2 --> N3["ModelsStrip / CardVitals / BackendSlotsPanel: modelDisplayName(id, names), title=raw id"]
    A13[stats/page.tsx] -->|network_capacity_tps| A14[network TPS]
  end
```

## Linked issue

Reported in Slack (#providers); no tracked issue.

## Test plan

- [x] `cd coordinator && gofmt -l api registry && go vet ./api/ ./registry/ && go build ./... && go test ./api/ ./registry/ ./protocol/ -count=1` — green. New: `TestMeasuredThroughputLocked` (9 precedence cases incl. "bandwidth is never a measurement"), `TestMyProvidersThroughputFromHeartbeatSlots`, `TestMyProvidersThroughputOmittedWhenUnmeasured`, `TestStatsDecodeTPSFromHeartbeatSlots` (all drive a **real** `registry.Heartbeat` and the real handlers; both HTTP tests fail on `master`), `TestCatalogDisplayNames` (trim, id-echo, whitespace, same-name builds split by quantization, unsplittable builds omitted, copy semantics), `TestMyProvidersModelDisplayNames` (real memory store rows → `SyncModelCatalog` → handler), `TestMyProvidersModelDisplayNamesAlwaysObject`.
- [x] `cd console-ui && npm test` — 61 files / 528 tests green. New: `throughput.test.ts`, `CardVitals.test.tsx` (measured, absent `decode_tps`, stand-in label incl. display name + raw-id tooltip, explicit `—`), `modelNames.test.ts`, `ModelsStrip.test.tsx` (display names on loaded + catalog chips and slot rows, raw id in `title`, short-raw-id fallback, no-names fallback), `MachineCard.test.tsx` card-level display-name assertion.
- [x] `npx eslint src/` — 0 errors, no new warnings on changed files; `npm run build` — green.
- [x] Pixel check: both screenshots above are the real component + built CSS + real handler JSON.
- [x] Two independent reviews on each increment (correctness/locking; end-to-end chain/regressions); should-fix items (same-name builds, required `names` prop) and nits folded in.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [x] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] Yes — described above and matching side updated. No WebSocket protocol change. HTTP: `/v1/me/providers` gains `model_display_names` (object, always present; console treats it as optional for older coordinators); `decode_tps` / `prefill_tps` and `/v1/stats` `decode_tps` keep their keys and types and now carry the measured value instead of a permanently-zero field.

## Notes for reviewers

- Slot EWMAs are **retained** (smoothed over recent requests, no decay), so a figure means "recently measured", not "decoding this instant" — `CurrentModel` is the most recently used loaded model. Decode and prefill resolve independently.
- `MeasuredThroughputLocked` intentionally does not share the scheduler's `resolvedModelTPSLocked` chain: that one ends in `sqrt(memory_bandwidth)` so routing always has a rankable cost. `~20 tok/s` for an M-series Max would be a lie on a dashboard.
- Display names come from the registry's in-memory catalog snapshot (no DB read on the dashboard poll). On today's prod catalog the only same-name pair is `gemma-4-26b` (8bit) / `gemma-4-26b-qat-4bit` (4bit) → `Gemma 4 26B (8bit)` / `Gemma 4 26B (4bit)`.
- Warning `detail` strings (`warnings.ts`, e.g. "Backend(s) for X report a crashed state") intentionally keep raw ids — operational text matched against CLI/log output. The earnings table (`/providers/earnings`) still shows raw ids; separate data source, follow-up.
- Unused `aggregate.fleetDecodeTps` (no app consumer, only a test) is removed rather than rewired.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://darkbloom.slack.com/archives/C0B0CAQC8P5/p1788476187212289?thread_ts=1788476187.212289&cid=C0B0CAQC8P5)

<div><a href="https://cursor.com/agents/bc-50b37aae-2677-5ac2-a4c8-d2006d96b448?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b37aae-2677-5ac2-a4c8-d2006d96b448&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073060&installation_model_id=21733&pr_number=817&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F817&signature=7445f753b3ae146d095862520a2def7b68c5c1a1a9e2fea671d5bb62a65b4171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->