### PR TITLE
perf(registry): index scans and coalesce swap planning safely (Tier 2 B)

### DIFF
--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -430,6 +430,7 @@ func TestMergeProviderModelsDoesNotDropSiblingForUnrelatedSharedAlias(t *testing
 		protocol.ModelInfo{ID: shared, ModelType: "gemma"},
 		protocol.ModelInfo{ID: other, ModelType: "gemma"},
 	)
+	p.syncModelIndexLocked()
 	p.mu.Unlock()
 	makeProviderRoutable(p)
 	reg.SetModelCatalog([]CatalogEntry{{ID: oldA}, {ID: shared}, {ID: other}})

--- a/coordinator/registry/cache_receipts_v2_test.go
+++ b/coordinator/registry/cache_receipts_v2_test.go
@@ -237,7 +237,7 @@ func TestPrefixCacheV2CapabilityEpochChangeClearsEvidence(t *testing.T) {
 			"model": oldCapability,
 		},
 	}
-	registry.providers[provider.ID] = provider
+	insertTestProvider(registry, provider)
 	prompt := protocol.PrefixCacheAnchor{
 		ChainHash:  strings.Repeat("c", 64),
 		TokenCount: int(promptcontract.BlockSize),

--- a/coordinator/registry/cache_routing_exact_test.go
+++ b/coordinator/registry/cache_routing_exact_test.go
@@ -64,9 +64,7 @@ func exactTestRegistry(t *testing.T) (*Registry, *Provider, protocol.PrefixCache
 		PrefixCacheProtocol: 2,
 		PrefixCacheV2Models: map[string]protocol.PrefixCacheV2Capability{"model": capability},
 	}
-	r.mu.Lock()
-	r.providers[provider.ID] = provider
-	r.mu.Unlock()
+	insertTestProvider(r, provider)
 	return r, provider, capability
 }
 
@@ -76,6 +74,7 @@ func TestExactRoutingHintRevalidatesCapabilityBeforeDiscount(t *testing.T) {
 	provider.Models = []protocol.ModelInfo{{
 		ID: "model", WeightHash: capability.ModelAggregateHash,
 	}}
+	r.modelIndex.sync(provider)
 	revision := provider.prefixCacheRevision
 	provider.mu.Unlock()
 	hint := cacheRoutingHint{
@@ -296,9 +295,7 @@ func TestExactV2SpeculativeAttemptsKeepWinnerAndLoserProofsIsolated(t *testing.T
 			"model": capabilityB,
 		},
 	}
-	r.mu.Lock()
-	r.providers[providerB.ID] = providerB
-	r.mu.Unlock()
+	insertTestProvider(r, providerB)
 
 	prompt := exactTestAnchor(2, "c")
 	final := exactTestAnchor(3, "d")
@@ -459,9 +456,7 @@ func TestExactRoutingV1ProviderRemainsColdBaseline(t *testing.T) {
 
 func TestExactRoutingMixedV1V2FleetFallsBackToV1Inference(t *testing.T) {
 	r, original, capability := exactTestRegistry(t)
-	r.mu.Lock()
-	delete(r.providers, original.ID)
-	r.mu.Unlock()
+	removeTestProvider(r, original.ID)
 	v1 := makeSchedulerProvider(t, r, "mixed-v1", "model", 100)
 	v2 := makeSchedulerProvider(t, r, "mixed-v2", "model", 100)
 	v1.mu.Lock()
@@ -565,9 +560,7 @@ func TestLegacyCacheBustKeyLengthMatchesSizingContract(t *testing.T) {
 
 func TestExactV2LongestHolderChangesMultiProviderSelection(t *testing.T) {
 	r, _, capability := exactTestRegistry(t)
-	r.mu.Lock()
-	delete(r.providers, "provider-a")
-	r.mu.Unlock()
+	removeTestProvider(r, "provider-a")
 	cached := makeSchedulerProvider(t, r, "cached", "model", 100)
 	cold := makeSchedulerProvider(t, r, "cold", "model", 100)
 	for _, provider := range []*Provider{cached, cold} {

--- a/coordinator/registry/cache_routing_hint_skip_test.go
+++ b/coordinator/registry/cache_routing_hint_skip_test.go
@@ -1,0 +1,78 @@
+package registry
+
+import "testing"
+
+// TestScanProviderReservationSkipsHintsExactlyWhenTrackerWould pins the
+// predicate scanProviderReservation uses to skip the capability walk against
+// cacheRoutingTracker.hints' own early return: hints are produced (a non-nil
+// map, possibly empty) only when the tracker exists, cache routing is ON, the
+// request carries a plan, and a route key is configured; in every other state
+// the walk is skipped and the request carries nil hints — exactly what the
+// former unconditional walk + hints() call produced.
+func TestScanProviderReservationSkipsHintsExactlyWhenTrackerWould(t *testing.T) {
+	plan := exactTestPlan(exactTestAnchor(1, "c"))
+	newPR := func(with bool) *PendingRequest {
+		pr := &PendingRequest{RequestID: "hint-skip", Model: "model", RequestedMaxTokens: 16}
+		if with {
+			pr.CachePlan = plan
+		}
+		return pr
+	}
+
+	t.Run("mode off", func(t *testing.T) {
+		r := New(testLogger())
+		pr := newPR(true)
+		r.scanProviderReservation("model", pr)
+		if pr.cacheRoutingHints != nil {
+			t.Fatal("cache routing off must leave hints nil")
+		}
+		if pr.CacheSelectionMode != "" {
+			t.Fatalf("selection mode = %q, want empty when off", pr.CacheSelectionMode)
+		}
+	})
+
+	t.Run("on without plan", func(t *testing.T) {
+		r, _, _ := exactTestRegistry(t)
+		pr := newPR(false)
+		r.scanProviderReservation("model", pr)
+		if pr.cacheRoutingHints != nil {
+			t.Fatal("a request without a cache plan must get no hints")
+		}
+	})
+
+	t.Run("on with plan", func(t *testing.T) {
+		r, _, _ := exactTestRegistry(t)
+		pr := newPR(true)
+		r.scanProviderReservation("model", pr)
+		if pr.cacheRoutingHints == nil {
+			t.Fatal("tracker on + plan + route key must compute hints (non-nil map)")
+		}
+		if pr.CacheSelectionMode != "active" {
+			t.Fatalf("selection mode = %q, want active", pr.CacheSelectionMode)
+		}
+	})
+
+	t.Run("on with plan but no route key", func(t *testing.T) {
+		r, _, _ := exactTestRegistry(t)
+		r.mu.Lock()
+		r.cacheRouteKeys.route = nil
+		r.mu.Unlock()
+		pr := newPR(true)
+		r.scanProviderReservation("model", pr)
+		if pr.cacheRoutingHints != nil {
+			t.Fatal("no route key must leave hints nil (hints() would return nil)")
+		}
+	})
+
+	t.Run("on with plan but nil tracker", func(t *testing.T) {
+		r, _, _ := exactTestRegistry(t)
+		r.mu.Lock()
+		r.cacheRouting = nil
+		r.mu.Unlock()
+		pr := newPR(true)
+		r.scanProviderReservation("model", pr) // must not panic
+		if pr.cacheRoutingHints != nil {
+			t.Fatal("nil tracker must leave hints nil")
+		}
+	})
+}

--- a/coordinator/registry/cache_routing_hints.go
+++ b/coordinator/registry/cache_routing_hints.go
@@ -8,11 +8,13 @@ func (r *Registry) prefixCacheV2CapabilitiesForModel(
 	model string,
 ) map[string]cacheRoutingCapability {
 	r.mu.RLock()
-	providers := make([]*Provider, 0, len(r.providers))
+	// Per-model index: a v2 capability is keyed by the model the provider
+	// advertises, and the discount only ever applies to a candidate that
+	// passed the advertisement gate, so a capability for a model the provider
+	// does not advertise could never influence selection — pruning the walk to
+	// advertisers changes no hint that matters (model_index.go).
+	providers := r.providersForModelLocked(model)
 	tracker := r.cacheRouting
-	for _, provider := range r.providers {
-		providers = append(providers, provider)
-	}
 	r.mu.RUnlock()
 	out := make(map[string]cacheRoutingCapability)
 	for _, provider := range providers {

--- a/coordinator/registry/candidate_arena.go
+++ b/coordinator/registry/candidate_arena.go
@@ -1,0 +1,48 @@
+package registry
+
+// candidate_arena.go — chunked storage for the routing scan's candidates.
+//
+// scanCandidatesLocked used to heap-allocate one routingCandidate per
+// eligible provider (~250 per request at fleet scale, each carrying a ~600
+// byte snapshot that had already been copied twice on the way in). An arena
+// hands out slots from chunks of candidateArenaChunk candidates, so the scan
+// performs one allocation per chunk and every snapshot is written in place.
+//
+// Pointer stability: a chunk is never grown or moved once handed out, so
+// pointers into it (the candidate pool, the winner, the DispatchPlan's
+// retained alternates) stay valid for as long as they are referenced — the
+// GC keeps the whole chunk alive with them. The scan pool's "immutable value
+// snapshots" contract is unchanged: nothing writes a slot after it is
+// appended to the pool.
+
+// candidateArenaChunk is the number of candidates per chunk. 32 × ~650 bytes
+// keeps a chunk around 20 KiB (below the large-object threshold) while a
+// fleet-scale scan of ~250 candidates needs ~8 allocations.
+const candidateArenaChunk = 32
+
+// candidateArena is a bump allocator over chunks of routingCandidate. The
+// zero value is ready to use; it is single-goroutine (one per scan).
+type candidateArena struct {
+	chunk []routingCandidate
+}
+
+// next returns a zeroed slot. The slot belongs to the caller until release
+// hands it back or the caller keeps it (appends it to the pool).
+func (a *candidateArena) next() *routingCandidate {
+	if len(a.chunk) == cap(a.chunk) {
+		a.chunk = make([]routingCandidate, 0, candidateArenaChunk)
+	}
+	a.chunk = a.chunk[:len(a.chunk)+1]
+	c := &a.chunk[len(a.chunk)-1]
+	*c = routingCandidate{}
+	return c
+}
+
+// release hands back the slot most recently returned by next so the next
+// call reuses it (a provider rejected after its snapshot was built). Any
+// other pointer is ignored — a kept slot is never reclaimed.
+func (a *candidateArena) release(c *routingCandidate) {
+	if n := len(a.chunk); n > 0 && &a.chunk[n-1] == c {
+		a.chunk = a.chunk[:n-1]
+	}
+}

--- a/coordinator/registry/candidate_arena_test.go
+++ b/coordinator/registry/candidate_arena_test.go
@@ -1,0 +1,111 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestCandidateArenaPointersStayValidAcrossChunks pins the arena's only
+// hard guarantee: a slot handed out and kept is never moved, so pointers
+// taken across many chunk boundaries keep reading the value written into them.
+func TestCandidateArenaPointersStayValidAcrossChunks(t *testing.T) {
+	var arena candidateArena
+	const n = 5*candidateArenaChunk + 3
+	kept := make([]*routingCandidate, 0, n)
+	for i := 0; i < n; i++ {
+		c := arena.next()
+		if c.costMs != 0 || c.provider != nil || c.snapshot.model != "" {
+			t.Fatalf("slot %d not zeroed: %+v", i, c)
+		}
+		c.costMs = float64(i)
+		c.snapshot.model = fmt.Sprintf("m-%d", i)
+		kept = append(kept, c)
+	}
+	for i, c := range kept {
+		if c.costMs != float64(i) || c.snapshot.model != fmt.Sprintf("m-%d", i) {
+			t.Fatalf("slot %d was overwritten or moved: %+v", i, c)
+		}
+	}
+	for i := 1; i < len(kept); i++ {
+		if kept[i] == kept[i-1] {
+			t.Fatalf("slots %d and %d alias", i-1, i)
+		}
+	}
+}
+
+// TestCandidateArenaReleaseReusesAndZeroes pins the rejection path: the most
+// recently handed-out slot is reused (no new chunk) and comes back zeroed;
+// releasing anything else is a no-op so a kept slot is never reclaimed.
+func TestCandidateArenaReleaseReusesAndZeroes(t *testing.T) {
+	var arena candidateArena
+	a := arena.next()
+	a.costMs = 42
+	arena.release(a)
+	b := arena.next()
+	if b != a {
+		t.Fatal("release did not hand the slot back for reuse")
+	}
+	if b.costMs != 0 {
+		t.Fatalf("reused slot not zeroed: costMs=%v", b.costMs)
+	}
+	b.costMs = 7
+	c := arena.next()
+	arena.release(b) // not the most recent slot: must be ignored
+	if arena.next() == b {
+		t.Fatal("releasing a kept (non-latest) slot reclaimed it")
+	}
+	if b.costMs != 7 {
+		t.Fatal("kept slot was disturbed")
+	}
+	_ = c
+}
+
+// TestScanPoolCandidatesAreIndependentValues pins the scan-level contract the
+// arena must preserve: every pool entry's snapshot belongs to its own
+// provider, entries never alias, and a second scan does not disturb the first
+// scan's retained candidates (the DispatchPlan keeps them).
+func TestScanPoolCandidatesAreIndependentValues(t *testing.T) {
+	reg := New(testLogger())
+	const model = "arena-model"
+	for i := 0; i < 3*candidateArenaChunk+5; i++ {
+		makeSchedulerProvider(t, reg, fmt.Sprintf("p-%03d", i), model, 50+float64(i%9))
+	}
+	scan := func() candidateScan {
+		pr := &PendingRequest{RequestID: "arena", Model: model, RequestedMaxTokens: 16}
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		return reg.scanCandidatesLocked(model, pr, false)
+	}
+	first := scan()
+	if len(first.pool) != 3*candidateArenaChunk+5 {
+		t.Fatalf("pool size = %d, want %d", len(first.pool), 3*candidateArenaChunk+5)
+	}
+	seen := make(map[*routingCandidate]struct{}, len(first.pool))
+	providers := make(map[string]struct{}, len(first.pool))
+	for _, c := range first.pool {
+		if _, dup := seen[c]; dup {
+			t.Fatal("pool entries alias the same arena slot")
+		}
+		seen[c] = struct{}{}
+		if c.provider == nil || c.snapshot.provider != c.provider || c.snapshot.model != model {
+			t.Fatalf("candidate/snapshot mismatch: %+v", c)
+		}
+		if _, dup := providers[c.provider.ID]; dup {
+			t.Fatalf("provider %s appears twice in the pool", c.provider.ID)
+		}
+		providers[c.provider.ID] = struct{}{}
+	}
+	costs := make(map[*routingCandidate]float64, len(first.pool))
+	for _, c := range first.pool {
+		costs[c] = c.costMs
+	}
+	second := scan()
+	if len(second.pool) != len(first.pool) {
+		t.Fatalf("second scan pool size = %d, want %d", len(second.pool), len(first.pool))
+	}
+	for _, c := range first.pool {
+		if c.costMs != costs[c] {
+			t.Fatal("a second scan mutated the first scan's retained candidates")
+		}
+	}
+}

--- a/coordinator/registry/concurrency_cap.go
+++ b/coordinator/registry/concurrency_cap.go
@@ -110,7 +110,7 @@ var qualityCapOvercommitByModel map[string]float64
 // rate. Nested rather than flat-with-a-composite-key because the flat form
 // forced soloTPSSeedForClass to BUILD "model@class" on every probe — and that
 // probe runs once per candidate provider per request inside
-// snapshotProviderLocked, under both r.mu and p.mu, ~94 times on a full fleet.
+// snapshotProviderIntoLockedEx, under both r.mu and p.mu, ~94 times on a full fleet.
 // Two map reads allocate nothing; one string concatenation allocates every
 // time.
 //
@@ -319,7 +319,7 @@ func soloSeedFleetFallbacks(seed map[string]float64) map[string]float64 {
 // "Unknown|Unknown", so it matches no class-qualified entry and takes (2) or
 // (3). Both are floors, never the fast class's rate.
 // HOT PATH: once per candidate provider per request, inside
-// snapshotProviderLocked under both r.mu and p.mu. Every lookup here is a map
+// snapshotProviderIntoLockedEx under both r.mu and p.mu. Every lookup here is a map
 // read against an already-lowered key; nothing is concatenated and nothing is
 // allocated when the strings are already lower-case ASCII (strings.ToLower
 // returns its argument unchanged in that case, which is the common one — the

--- a/coordinator/registry/concurrency_cap_test.go
+++ b/coordinator/registry/concurrency_cap_test.go
@@ -308,7 +308,7 @@ func TestQualityCapAppliedAtAdmitRecheck(t *testing.T) {
 		defer reg.mu.RUnlock()
 		p.mu.Lock()
 		defer p.mu.Unlock()
-		return reg.providerCanAdmitLockedEx(p, gemmaBuild, RequestTraits{}, false, false)
+		return reg.providerCanAdmitLockedEx(p, gemmaBuild, RequestTraits{}, false, false, time.Now())
 	}
 
 	// Under the cap (1 in flight, cap 2) → admit re-check passes.

--- a/coordinator/registry/dedicated_models_test.go
+++ b/coordinator/registry/dedicated_models_test.go
@@ -115,6 +115,7 @@ func TestProviderDedicatedToPatternLocked(t *testing.T) {
 	empty := makeSchedulerProvider(t, reg, "empty", gemmaBuild, 80)
 	empty.mu.Lock()
 	empty.Models = nil
+	empty.syncModelIndexLocked()
 	empty.mu.Unlock()
 	if check(empty) {
 		t.Fatal("provider advertising nothing must NOT be dedicated")

--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -336,7 +336,7 @@ func (r *Registry) ReserveProviderWithPlan(model string, pr *PendingRequest, exc
 //   - identity: r.providers[id] must still be the exact retained *Provider
 //     (a reconnect registers a new object under the same ID — its slot state,
 //     trust, and capacity are a stranger's; see Register/Disconnect);
-//   - snapshotProviderLocked → providerPassesRoutingGatesLocked (every
+//   - snapshotProviderIntoLockedEx → providerPassesRoutingGatesLocked (every
 //     structural/privacy/cooldown/trait gate);
 //   - buildCandidateWithReason (slot state, concurrency headroom, thermal,
 //     hardware fit, freeMemoryAdmits — including the in-flight pending debit
@@ -405,6 +405,8 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	tryReserve := func(entry planEntry) (*Provider, RoutingDecision, bool) {
 		id := entry.view.ProviderID
 		p := entry.provider
+		// One clock read per revalidated entry (snapshot, cost, admit, claim).
+		now := time.Now()
 		skip := func(reason PlanSkipReason) {
 			skips = append(skips, PlanSkip{ProviderID: id, Reason: reason})
 		}
@@ -420,12 +422,12 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 			return nil, RoutingDecision{}, false
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-		snap, ok := r.snapshotProviderLocked(p, model, pr.Traits, relaxTrust)
+		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, false, now)
 		if !ok {
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
-		candidate, _, ok := r.buildCandidateWithReason(snap, pr)
+		candidate, _, ok := r.buildCandidateWithReason(snap, pr, now)
 		if !ok {
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
@@ -436,10 +438,10 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 		}
 
 		// Final admit + reservation under p.mu — the same commit sequence as
-		// reserveProvider (snapshotProviderLocked released p.mu, so the admit
+		// reserveProvider (snapshotProviderIntoLockedEx released p.mu, so the admit
 		// re-check closes the snapshot→reserve gap, including the vision gate).
 		p.mu.Lock()
-		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false) ||
+		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false, now) ||
 			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
@@ -449,7 +451,7 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 		p.addPendingLocked(pr)
 		// Half-open capacity probe claim: identical to the primary reservation
 		// path (the r.mu write lock held across this loop serializes claims).
-		r.claimCapacityProbeLocked(p.ID, model, time.Now())
+		r.claimCapacityProbeLocked(p.ID, model, now)
 		if p.Status != StatusUntrusted && p.Status != StatusOffline {
 			p.Status = StatusServing
 		}

--- a/coordinator/registry/eviction_grace_test.go
+++ b/coordinator/registry/eviction_grace_test.go
@@ -1,8 +1,12 @@
 package registry
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 func providerPresent(r *Registry, id string) bool {
@@ -77,4 +81,157 @@ func TestDurationStats(t *testing.T) {
 		t.Fatalf("median %v out of range", med)
 	}
 	_ = p90
+}
+
+func evictStrikesSnapshot(r *Registry) map[string]int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]int, len(r.evictStrikes))
+	for id, n := range r.evictStrikes {
+		out[id] = n
+	}
+	return out
+}
+
+// TestEvictStaleReapsExactlyTheStaleSet is the behavioral pin for the
+// read-lock scan: a mixed fleet must lose exactly its two-strike stale
+// providers, a provider that goes stale one sweep later must survive with a
+// single strike, and recovery must clear the strike.
+func TestEvictStaleReapsExactlyTheStaleSet(t *testing.T) {
+	r := New(testLogger())
+	const model = aliasQAT
+	var ids []string
+	for i := 0; i < 30; i++ {
+		id := fmt.Sprintf("p%02d", i)
+		registerProviderWithModel(r, id, model)
+		ids = append(ids, id)
+	}
+	setHeartbeatAge := func(id string, age time.Duration) {
+		p := r.GetProvider(id)
+		p.mu.Lock()
+		p.LastHeartbeat = time.Now().Add(-age)
+		p.mu.Unlock()
+	}
+	stale := map[string]bool{}
+	for i, id := range ids {
+		if i%3 == 0 {
+			stale[id] = true
+			setHeartbeatAge(id, 5*time.Minute)
+		}
+	}
+	timeout := 90 * time.Second
+
+	if before := evictStrikesSnapshot(r); len(before) != 0 {
+		t.Fatalf("fresh registry carries strikes: %v", before)
+	}
+	r.evictStale(timeout) // strike 1 — grace for everyone
+	for _, id := range ids {
+		if !providerPresent(r, id) {
+			t.Fatalf("%s evicted on the first stale sweep", id)
+		}
+	}
+	strikes := evictStrikesSnapshot(r)
+	if len(strikes) != len(stale) {
+		t.Fatalf("strikes after sweep 1 = %v, want exactly the %d stale providers", strikes, len(stale))
+	}
+	for id := range stale {
+		if strikes[id] != 1 {
+			t.Fatalf("strike for %s = %d, want 1", id, strikes[id])
+		}
+	}
+
+	late := "p01" // goes stale only now: one strike, must survive sweep 2
+	setHeartbeatAge(late, 5*time.Minute)
+	r.evictStale(timeout) // strike 2 for the original set — reaped
+	for _, id := range ids {
+		present := providerPresent(r, id)
+		if stale[id] && present {
+			t.Fatalf("%s survived two consecutive stale sweeps", id)
+		}
+		if !stale[id] && !present {
+			t.Fatalf("%s evicted despite being fresh (or late by one sweep)", id)
+		}
+	}
+	if strikes := evictStrikesSnapshot(r); len(strikes) != 1 || strikes[late] != 1 {
+		t.Fatalf("strikes after sweep 2 = %v, want {%s:1}", strikes, late)
+	}
+
+	setHeartbeatAge(late, 0) // recovered
+	r.evictStale(timeout)
+	if !providerPresent(r, late) {
+		t.Fatalf("%s evicted after recovering", late)
+	}
+	if strikes := evictStrikesSnapshot(r); len(strikes) != 0 {
+		t.Fatalf("strikes after recovery = %v, want none", strikes)
+	}
+	if r.ProviderCount() != len(ids)-len(stale) {
+		t.Fatalf("fleet = %d, want %d", r.ProviderCount(), len(ids)-len(stale))
+	}
+}
+
+// TestEvictStaleConcurrentWithHeartbeats runs sweeps against a fleet that is
+// heartbeating, being listed, AND churning (extra providers registered and
+// disconnected, which mutate r.providers under the write lock) concurrently.
+// Under -race this proves the read-lock scan introduces no data race with the
+// writers of LastHeartbeat, the other read-lock walks, or the map writers —
+// dropping the RLock around the scan fails this test.
+func TestEvictStaleConcurrentWithHeartbeats(t *testing.T) {
+	r := New(testLogger())
+	const model = aliasQAT
+	var ids []string
+	for i := 0; i < 40; i++ {
+		id := fmt.Sprintf("hb%02d", i)
+		p := registerProviderWithModel(r, id, model)
+		makeProviderRoutable(p)
+		ids = append(ids, id)
+	}
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for n := 0; ; n++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				r.Heartbeat(ids[(n*7+w)%len(ids)], &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle"})
+				if n%16 == 0 {
+					_ = r.ListModels()
+					_ = r.PublicProviderModels()
+				}
+			}
+		}(w)
+	}
+	// Churn: register and disconnect extra providers for the whole run so the
+	// provider map is written while the sweep iterates it. Every iteration
+	// ends with the disconnect, so the fleet is back to ids when it stops.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := 0; ; n++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			id := fmt.Sprintf("churn%03d", n%50)
+			registerProviderWithModel(r, id, model)
+			r.Disconnect(id)
+		}
+	}()
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		r.evictStale(90 * time.Second)
+	}
+	close(stop)
+	wg.Wait()
+	if r.ProviderCount() != len(ids) {
+		t.Fatalf("fleet = %d after concurrent no-evict sweeps, want %d", r.ProviderCount(), len(ids))
+	}
+	if strikes := evictStrikesSnapshot(r); len(strikes) != 0 {
+		t.Fatalf("fresh fleet carries strikes: %v", strikes)
+	}
 }

--- a/coordinator/registry/eviction_revalidation_test.go
+++ b/coordinator/registry/eviction_revalidation_test.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// The sweep summary is emitted after its read scan and before any removals,
+// providing a deterministic barrier without adding hooks to the registry.
+type evictionBarrierHandler struct {
+	slog.Handler
+	afterScan func()
+}
+
+func (h evictionBarrierHandler) Handle(ctx context.Context, record slog.Record) error {
+	if record.Message == "eviction sweep" {
+		h.afterScan()
+	}
+	return h.Handler.Handle(ctx, record)
+}
+
+func TestEvictStaleRevalidatesRecoveryAndSessionIdentity(t *testing.T) {
+	for _, replacement := range []bool{false, true} {
+		name := "heartbeat-recovery"
+		if replacement {
+			name = "replacement-with-same-id"
+		}
+		t.Run(name, func(t *testing.T) {
+			scanned, resume := make(chan struct{}), make(chan struct{})
+			release := sync.OnceFunc(func() { close(resume) })
+			defer release()
+			armed := false
+			logger := slog.New(evictionBarrierHandler{
+				Handler: slog.NewTextHandler(io.Discard, nil),
+				afterScan: func() {
+					if armed {
+						close(scanned)
+						<-resume
+					}
+				},
+			})
+			r := New(logger)
+			p := registerProviderWithModel(r, "eviction-revalidate", aliasQAT)
+			oldHeartbeat := time.Now().Add(-5 * time.Minute)
+			p.mu.Lock()
+			p.LastHeartbeat = oldHeartbeat
+			p.mu.Unlock()
+			const timeout = 90 * time.Second
+			r.evictStale(timeout) // First strike.
+			armed = true
+			done := make(chan struct{})
+			go func() {
+				r.evictStale(timeout) // Second strike; pause before removal.
+				close(done)
+			}()
+			select {
+			case <-scanned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("second stale scan did not reach the eviction barrier")
+			}
+
+			want := p
+			if replacement {
+				r.Disconnect(p.ID)
+				want = registerProviderWithModel(r, p.ID, aliasQAT)
+				// Keep the replacement stale too, so preserving it proves the
+				// identity check independently of the freshness check.
+				want.mu.Lock()
+				want.LastHeartbeat = oldHeartbeat
+				want.mu.Unlock()
+			} else {
+				r.Heartbeat(p.ID, &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle"})
+			}
+			release()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("eviction did not finish after releasing the barrier")
+			}
+			if got := r.GetProvider(p.ID); got != want {
+				t.Fatal("a stale scan disconnected the recovered or replacement session")
+			}
+			if r.ProviderCount() != 1 {
+				t.Fatalf("provider count = %d, want 1", r.ProviderCount())
+			}
+			assertModelIndexConsistent(t, r)
+		})
+	}
+}

--- a/coordinator/registry/fleet_aggregate_equivalence_test.go
+++ b/coordinator/registry/fleet_aggregate_equivalence_test.go
@@ -1,0 +1,417 @@
+package registry
+
+// Behavioral-equivalence tests for the allocation-free rewrites of the fleet
+// aggregation walks. Each rewritten function is checked against a VERBATIM
+// copy of its pre-rewrite body (the oracle) on randomized mixed fleets that
+// toggle every provider-level gate and model-level filter independently, then
+// again after every kind of mutation the registry sees in production
+// (heartbeat status changes, trust changes, catalog hot swaps, disconnects,
+// fresh registrations). The oracles are frozen on purpose: a future change to
+// the live function that alters output on ANY fleet shape fails here.
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// referenceListModels is ListModels exactly as it stood before the
+// allocation-free rewrite (baseline commit 37d0f181c).
+func referenceListModels(r *Registry) []AggregateModel {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	type modelAgg struct {
+		modelType     string
+		quantization  string
+		count         int
+		attestedCount int
+		highestTrust  TrustLevel
+		secureEnclave bool
+		sipEnabled    bool
+		secureBoot    bool
+	}
+
+	agg := make(map[string]*modelAgg)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		status := p.Status
+		trust := p.TrustLevel
+		attested := p.Attested
+		attestResult := p.AttestationResult
+		privateReady := r.providerSupportsPrivateTextLocked(p)
+		privateOnly := p.PrivateOnly
+		models := make([]protocol.ModelInfo, 0, len(p.Models))
+		for _, model := range p.Models {
+			if r.providerModelAllowedByCatalogLocked(p, model) {
+				models = append(models, model)
+			}
+		}
+		p.mu.Unlock()
+
+		if status == StatusOffline || status == StatusUntrusted {
+			continue
+		}
+		if privateOnly {
+			continue
+		}
+		if !r.trustMeetsMinimum(trust) || !privateReady {
+			continue
+		}
+		for _, m := range models {
+			k := m.ID
+			a, ok := agg[k]
+			if !ok {
+				a = &modelAgg{
+					modelType:    m.ModelType,
+					quantization: m.Quantization,
+					highestTrust: TrustNone,
+				}
+				agg[k] = a
+			}
+			a.count++
+			if trustRank(trust) > trustRank(a.highestTrust) {
+				a.highestTrust = trust
+			}
+			if attested && attestResult != nil {
+				a.attestedCount++
+				a.secureEnclave = a.secureEnclave || attestResult.SecureEnclaveAvailable
+				a.sipEnabled = a.sipEnabled || attestResult.SIPEnabled
+				a.secureBoot = a.secureBoot || attestResult.SecureBootEnabled
+			}
+		}
+	}
+
+	models := make([]AggregateModel, 0, len(agg))
+	for k, a := range agg {
+		am := AggregateModel{
+			ID:                k,
+			ModelType:         a.modelType,
+			Quantization:      a.quantization,
+			Providers:         a.count,
+			AttestedProviders: a.attestedCount,
+			TrustLevel:        a.highestTrust,
+		}
+		if a.attestedCount > 0 {
+			am.Attestation = &AttestationSummary{
+				SecureEnclave: a.secureEnclave,
+				SIPEnabled:    a.sipEnabled,
+				SecureBoot:    a.secureBoot,
+			}
+		}
+		models = append(models, am)
+	}
+	return models
+}
+
+// referencePublicProviderModels is PublicProviderModels exactly as it stood
+// before the single-backing-array rewrite (baseline commit 37d0f181c).
+func referencePublicProviderModels(r *Registry) map[string]PublicProviderModelSnapshot {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make(map[string]PublicProviderModelSnapshot, len(r.providers))
+	for id, p := range r.providers {
+		p.mu.Lock()
+		snapshot := PublicProviderModelSnapshot{
+			Models: make([]string, 0, len(p.Models)),
+		}
+		for _, model := range p.Models {
+			if r.providerModelAllowedByCatalogLocked(p, model) {
+				snapshot.Models = append(snapshot.Models, model.ID)
+			}
+		}
+		if p.CurrentModel != "" &&
+			r.providerServesCatalogModelLocked(p, p.CurrentModel) {
+			snapshot.CurrentModel = p.CurrentModel
+		}
+		p.mu.Unlock()
+		out[id] = snapshot
+	}
+	return out
+}
+
+const equivCatalogModels = 6
+
+func equivModelID(i int) string {
+	return fmt.Sprintf("mlx-community/equiv-model-%02d-4bit", i)
+}
+
+func equivCatalog() []CatalogEntry {
+	catalog := make([]CatalogEntry, 0, equivCatalogModels)
+	for m := 0; m < equivCatalogModels; m++ {
+		entry := CatalogEntry{ID: equivModelID(m), SizeGB: 8, MinRAMGB: 16}
+		if m%2 == 0 {
+			// Half the catalog pins a weight hash, so a mismatching
+			// advertisement is filtered while a hashless one is not.
+			entry.WeightHash = fmt.Sprintf("hash-%02d", m)
+		}
+		catalog = append(catalog, entry)
+	}
+	return catalog
+}
+
+// equivRandomInventory draws an advertised inventory that exercises every
+// model-level filter: catalog hit/miss, pinned-hash match/mismatch/absent,
+// off-catalog entries, varied metadata, and duplicate advertisements.
+func equivRandomInventory(rng *rand.Rand) []protocol.ModelInfo {
+	var models []protocol.ModelInfo
+	for m := 0; m < equivCatalogModels; m++ {
+		if rng.Intn(2) == 0 {
+			continue
+		}
+		info := protocol.ModelInfo{ID: equivModelID(m), ModelType: "chat", Quantization: "4bit"}
+		switch rng.Intn(3) {
+		case 0:
+			info.WeightHash = fmt.Sprintf("hash-%02d", m) // matches a pinned entry
+		case 1:
+			info.WeightHash = "hash-mismatch" // filtered on pinned entries only
+		}
+		// Metadata varies BY MODEL, never per provider: ListModels (before and
+		// after the rewrite) takes ModelType/Quantization from whichever
+		// eligible provider map iteration visits first, so two providers
+		// disagreeing on a shared ID would make the oracle comparison flake on
+		// a pre-existing non-determinism rather than on the rewrite.
+		if m%3 == 0 {
+			info.ModelType = "vision"
+			info.Quantization = "8bit"
+		}
+		models = append(models, info)
+	}
+	if rng.Intn(3) == 0 {
+		models = append(models, protocol.ModelInfo{ID: "local/off-catalog", ModelType: "chat"})
+	}
+	if rng.Intn(5) == 0 && len(models) > 0 {
+		models = append(models, models[0]) // duplicate advertisement counts twice
+	}
+	return models
+}
+
+// equivRandomizeProvider toggles every provider-level gate the aggregations
+// consult (status, private-only, trust floor, private-text readiness,
+// attestation presence and flags, current model) independently at random.
+func equivRandomizeProvider(rng *rand.Rand, p *Provider) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	switch rng.Intn(5) {
+	case 0:
+		p.Status = StatusOffline
+	case 1:
+		p.Status = StatusUntrusted
+	case 2:
+		p.Status = StatusServing
+	default:
+		p.Status = StatusOnline
+	}
+	p.PrivateOnly = rng.Intn(6) == 0
+	switch rng.Intn(4) {
+	case 0:
+		p.TrustLevel = TrustNone
+	case 1:
+		p.TrustLevel = TrustSelfSigned
+	default:
+		p.TrustLevel = TrustHardware
+	}
+	p.RuntimeVerified = rng.Intn(5) != 0
+	p.RuntimeManifestChecked = rng.Intn(5) != 0
+	p.ChallengeVerifiedSIP = rng.Intn(5) != 0
+	p.LastChallengeVerified = time.Now()
+	p.Attested = false
+	p.AttestationResult = nil
+	switch rng.Intn(4) {
+	case 0, 1:
+		p.Attested = true
+		p.AttestationResult = &attestation.VerificationResult{
+			Valid:                  true,
+			SecureEnclaveAvailable: rng.Intn(2) == 0,
+			SIPEnabled:             rng.Intn(2) == 0,
+			SecureBootEnabled:      rng.Intn(2) == 0,
+		}
+	case 2:
+		p.Attested = true // flag without a result must not count as attested
+	}
+	if rng.Intn(4) == 0 {
+		p.PrivacyCapabilities = nil
+	}
+	switch rng.Intn(4) {
+	case 0:
+		if len(p.Models) > 0 {
+			p.CurrentModel = p.Models[rng.Intn(len(p.Models))].ID
+		}
+	case 1:
+		p.CurrentModel = "local/off-catalog"
+	case 2:
+		p.CurrentModel = "never/advertised"
+	default:
+		p.CurrentModel = ""
+	}
+}
+
+func equivRegister(reg *Registry, rng *rand.Rand, id string) *Provider {
+	msg := testRegisterMessage()
+	msg.Models = equivRandomInventory(rng)
+	p := reg.Register(id, nil, msg)
+	equivRandomizeProvider(rng, p)
+	return p
+}
+
+func sortAggregateModels(models []AggregateModel) []AggregateModel {
+	sort.Slice(models, func(i, j int) bool { return models[i].ID < models[j].ID })
+	return models
+}
+
+// assertAggregatesMatchReference compares both live walks with their oracles.
+// Output order of ListModels is map-random on both sides, so it is sorted.
+func assertAggregatesMatchReference(t *testing.T, reg *Registry, step string) {
+	t.Helper()
+	got := sortAggregateModels(reg.ListModels())
+	want := sortAggregateModels(referenceListModels(reg))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s: ListModels diverged from the pre-rewrite oracle\n got: %+v\nwant: %+v", step, got, want)
+	}
+	gotP := reg.PublicProviderModels()
+	wantP := referencePublicProviderModels(reg)
+	if !reflect.DeepEqual(gotP, wantP) {
+		t.Fatalf("%s: PublicProviderModels diverged from the pre-rewrite oracle\n got: %+v\nwant: %+v", step, gotP, wantP)
+	}
+	for id, snap := range gotP {
+		// /v1/stats serializes Models straight to JSON: [] must never become null.
+		if snap.Models == nil {
+			t.Fatalf("%s: provider %s has a nil Models view (stats JSON would emit null)", step, id)
+		}
+		if cap(snap.Models) != len(snap.Models) {
+			t.Fatalf("%s: provider %s view has spare capacity %d > len %d (a consumer append could alias a neighbour)",
+				step, id, cap(snap.Models), len(snap.Models))
+		}
+	}
+}
+
+// TestFleetAggregatesMatchReferenceAcrossMutations drives randomized fleets
+// through every mutation class and checks both rewrites against their oracles
+// after each one.
+func TestFleetAggregatesMatchReferenceAcrossMutations(t *testing.T) {
+	for seed := int64(1); seed <= 6; seed++ {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(seed))
+			reg := New(testLogger())
+			reg.SetModelCatalog(equivCatalog())
+
+			var ids []string
+			for i := 0; i < 60; i++ {
+				id := fmt.Sprintf("equiv-%03d", i)
+				equivRegister(reg, rng, id)
+				ids = append(ids, id)
+			}
+			assertAggregatesMatchReference(t, reg, "initial")
+
+			// Heartbeat-driven status changes (idle/serving) with and without
+			// capacity, on a random third of the fleet.
+			for _, id := range ids {
+				if rng.Intn(3) != 0 {
+					continue
+				}
+				status := "idle"
+				if rng.Intn(2) == 0 {
+					status = "serving"
+				}
+				hb := &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: status}
+				if rng.Intn(2) == 0 {
+					active := equivModelID(rng.Intn(equivCatalogModels))
+					hb.ActiveModel = &active
+					hb.WarmModels = []string{active}
+				}
+				reg.Heartbeat(id, hb)
+			}
+			assertAggregatesMatchReference(t, reg, "after heartbeats")
+
+			// Trust / attestation churn on a random half.
+			for _, id := range ids {
+				if rng.Intn(2) != 0 {
+					continue
+				}
+				equivRandomizeProvider(rng, reg.GetProvider(id))
+			}
+			assertAggregatesMatchReference(t, reg, "after trust churn")
+
+			// Catalog hot swaps: shrink, re-pin hashes, then disable filtering.
+			catalog := equivCatalog()
+			reg.SetModelCatalog(catalog[1:4])
+			assertAggregatesMatchReference(t, reg, "after catalog shrink")
+			for i := range catalog {
+				catalog[i].WeightHash = "hash-mismatch"
+			}
+			reg.SetModelCatalog(catalog)
+			assertAggregatesMatchReference(t, reg, "after catalog re-pin")
+			reg.SetModelCatalog(nil)
+			assertAggregatesMatchReference(t, reg, "after catalog disabled")
+			reg.SetModelCatalog(equivCatalog())
+
+			// Disconnect a third, register replacements.
+			for i, id := range ids {
+				if i%3 == 0 {
+					reg.Disconnect(id)
+				}
+			}
+			assertAggregatesMatchReference(t, reg, "after disconnects")
+			for i := 0; i < 15; i++ {
+				equivRegister(reg, rng, fmt.Sprintf("equiv-new-%03d", i))
+			}
+			assertAggregatesMatchReference(t, reg, "after re-registrations")
+
+			// Empty fleet.
+			for _, id := range reg.ProviderIDs() {
+				reg.Disconnect(id)
+			}
+			assertAggregatesMatchReference(t, reg, "empty fleet")
+			if got := reg.ListModels(); len(got) != 0 {
+				t.Fatalf("empty fleet listed %d models", len(got))
+			}
+		})
+	}
+}
+
+// TestPublicProviderModelsViewsDoNotAlias pins the shared-backing-array
+// contract: appending to one provider's view must never change another's.
+func TestPublicProviderModelsViewsDoNotAlias(t *testing.T) {
+	reg := New(testLogger())
+	reg.SetModelCatalog(equivCatalog())
+	for i := 0; i < 5; i++ {
+		msg := testRegisterMessage()
+		msg.Models = []protocol.ModelInfo{
+			{ID: equivModelID(1), ModelType: "chat"},
+			{ID: equivModelID(3), ModelType: "chat"},
+		}
+		reg.Register(fmt.Sprintf("alias-%d", i), nil, msg)
+	}
+	// One provider with nothing eligible: its view must be an empty, non-nil
+	// slice even though it sits between populated neighbours in the array.
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: "local/off-catalog"}}
+	reg.Register("alias-empty", nil, msg)
+
+	snap := reg.PublicProviderModels()
+	before := make(map[string][]string, len(snap))
+	for id, s := range snap {
+		// Non-nil copy even when empty, so DeepEqual compares contents only.
+		before[id] = append(make([]string, 0, len(s.Models)), s.Models...)
+	}
+	if got := snap["alias-empty"].Models; got == nil || len(got) != 0 {
+		t.Fatalf("empty provider view = %#v, want non-nil empty slice", got)
+	}
+	for id, s := range snap {
+		grown := append(s.Models, "consumer/appended")
+		if len(grown) != len(s.Models)+1 {
+			t.Fatalf("append on %s did not grow the view", id)
+		}
+	}
+	for id, s := range snap {
+		if !reflect.DeepEqual(s.Models, before[id]) {
+			t.Fatalf("view for %s changed after appending to a neighbour: %v -> %v", id, before[id], s.Models)
+		}
+	}
+}

--- a/coordinator/registry/fleet_sample.go
+++ b/coordinator/registry/fleet_sample.go
@@ -23,8 +23,8 @@ import (
 //  3. Per provider, phase B takes r.mu.RLock briefly for the registry-side
 //     state that lives in maps under r.mu (breaker, ejection, cooldowns, clamp,
 //     effective cap, catalog membership) and for the eligibility verdict, which
-//     deliberately reuses the routing gate itself (snapshotProviderReasonLockedEx
-//     + buildCandidateGateLocked — the single source of routing eligibility).
+//     deliberately reuses the routing gate itself (snapshotProviderIntoLockedEx
+//     + buildCandidateInto — the single source of routing eligibility).
 //     p.mu is taken inside that RLock where needed (r.mu → p.mu is the
 //     established order). A provider that disconnected between 1 and 3 is
 //     dropped rather than sampled from stale registry state.
@@ -266,7 +266,7 @@ func (r *Registry) appendProviderSample(rows []store.FleetSnapshotRow, p *Provid
 	for i := range scratch {
 		row := &rows[start+i]
 		raw := scratch[i].rawModel
-		row.EligibilityReason = r.slotEligibilityReasonLocked(p, raw, probe)
+		row.EligibilityReason = r.slotEligibilityReasonLocked(p, raw, probe, now)
 		row.Model = r.fleetSnapshotModelLocked(raw)
 	}
 	return rows
@@ -288,16 +288,19 @@ func (r *Registry) fleetSnapshotModelLocked(raw string) string {
 }
 
 // slotEligibilityReasonLocked evaluates the FULL routing eligibility of
-// (p, model) for a plain text probe — the same providerRoutingGateReasonLockedEx
-// + buildCandidateGateLocked pipeline the dispatch scan runs — and returns the
+// (p, model) for a plain text probe — the same snapshotProviderIntoLockedEx
+// + buildCandidateInto pipeline the dispatch scan runs — and returns the
 // first failing GateReason name or "eligible". Caller holds r.mu (read) and
 // must NOT hold p.mu (the snapshot helper takes it).
-func (r *Registry) slotEligibilityReasonLocked(p *Provider, model string, probe *PendingRequest) string {
-	snap, ok, reason := r.snapshotProviderReasonLockedEx(p, model, probe.Traits, false, false)
+func (r *Registry) slotEligibilityReasonLocked(p *Provider, model string, probe *PendingRequest, now time.Time) string {
+	// One stack-resident candidate: the arena variants fill the snapshot in
+	// place and return the closed GateReason the dispatch scan would tally.
+	var c routingCandidate
+	ok, reason := r.snapshotProviderIntoLockedEx(&c.snapshot, p, model, probe.Traits, false, false, now)
 	if !ok {
 		return reason.String()
 	}
-	if _, _, gateReason, built := r.buildCandidateGateLocked(snap, probe); !built {
+	if _, gateReason, built := r.buildCandidateInto(&c, probe, now); !built {
 		return gateReason.String()
 	}
 	return EligibilityReasonEligible

--- a/coordinator/registry/fleet_scale_aggregate_bench_test.go
+++ b/coordinator/registry/fleet_scale_aggregate_bench_test.go
@@ -1,0 +1,423 @@
+package registry
+
+// Fleet-scale benchmarks for the periodic and aggregate paths: everything that
+// walks the whole fleet OUTSIDE the routing scan (metrics gauges, the public
+// /v1/models and /v1/stats aggregations, the eviction sweep, the warm-pool
+// planning tick, the per-heartbeat model-swap planner) plus the per-heartbeat
+// BackendCapacitySnapshot deep copy. Same 1,260-provider fixture as
+// fleet_scale_bench_test.go so the two families are directly comparable:
+//
+//	go test ./registry/ -run '^$' -bench 'FleetAgg|FleetTick|BackendCapacitySnapshot' -benchmem
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// BenchmarkFleetAggSnapshot is the /metrics FleetSnapshot gauge summary.
+func BenchmarkFleetAggSnapshot(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if f.reg.Snapshot().Connected == 0 {
+			b.Fatal("empty snapshot")
+		}
+	}
+}
+
+// BenchmarkFleetAggPublicProviderModels is the capability-filtered per-provider
+// model view behind /v1/stats and /v1/providers/attestation.
+func BenchmarkFleetAggPublicProviderModels(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.PublicProviderModels()) == 0 {
+			b.Fatal("no providers")
+		}
+	}
+}
+
+// BenchmarkFleetAggListProviders is the base-rewards settlement snapshot.
+func BenchmarkFleetAggListProviders(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.ListProviders()) == 0 {
+			b.Fatal("no providers")
+		}
+	}
+}
+
+// BenchmarkFleetAggRoutableProviderIDsForBuild is the rollout-progress gate.
+func BenchmarkFleetAggRoutableProviderIDsForBuild(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.RoutableProviderIDsForBuild(model)) == 0 {
+			b.Fatal("no routable providers")
+		}
+	}
+}
+
+// BenchmarkFleetAggOwnedModels is the self-route /v1/models view for one
+// account owning a handful of boxes inside a large public fleet.
+func BenchmarkFleetAggOwnedModels(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	const account = "acct-bench"
+	for i, id := range f.ids {
+		if i%100 != 0 {
+			continue
+		}
+		p := f.reg.GetProvider(id)
+		p.mu.Lock()
+		p.AccountID = account
+		p.mu.Unlock()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.OwnedModels(account)) == 0 {
+			b.Fatal("no owned models")
+		}
+	}
+}
+
+// BenchmarkFleetAggCodeAttestationCoverage is the 15s DD gauge + /v1/stats count.
+func BenchmarkFleetAggCodeAttestationCoverage(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, online := f.reg.CodeAttestationCoverage(); online == 0 {
+			b.Fatal("no online providers")
+		}
+	}
+}
+
+// BenchmarkFleetAggCountProvidersWithCurrentApplicationEvidence is the
+// release-policy shadow-mode acceptance counter (/v1/stats).
+func BenchmarkFleetAggCountProvidersWithCurrentApplicationEvidence(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, connected := f.reg.CountProvidersWithCurrentApplicationEvidence(); connected == 0 {
+			b.Fatal("no connected providers")
+		}
+	}
+}
+
+// BenchmarkFleetAggApplicationEvidenceModelCoverage is the per-model
+// release-policy coverage table (/v1/stats).
+func BenchmarkFleetAggApplicationEvidenceModelCoverage(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.ApplicationEvidenceModelCoverage()) == 0 {
+			b.Fatal("no coverage rows")
+		}
+	}
+}
+
+// BenchmarkFleetTickEvictStale is the eviction sweep (every timeout/3) in its
+// steady state: every provider fresh, nothing to evict. The timeout is far
+// larger than any benchmark run so the fixture never ages into a strike.
+func BenchmarkFleetTickEvictStale(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.reg.evictStale(24 * time.Hour)
+	}
+	b.StopTimer()
+	if f.reg.ProviderCount() != benchFleetProviders {
+		b.Fatalf("fleet shrank to %d during a no-evict sweep", f.reg.ProviderCount())
+	}
+}
+
+// BenchmarkFleetTickEvictStaleStriking is the sweep with a third of the fleet
+// stale on its FIRST strike each time (the strike map is reset between
+// iterations so nothing is ever reaped). This is the write path: strikes are
+// carried across sweeps.
+func BenchmarkFleetTickEvictStaleStriking(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	stale := time.Now().Add(-48 * time.Hour)
+	for i, id := range f.ids {
+		if i%3 != 0 {
+			continue
+		}
+		p := f.reg.GetProvider(id)
+		p.mu.Lock()
+		p.LastHeartbeat = stale
+		p.mu.Unlock()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.reg.evictStale(24 * time.Hour)
+		b.StopTimer()
+		f.reg.mu.Lock()
+		f.reg.evictStrikes = make(map[string]int)
+		f.reg.mu.Unlock()
+		b.StartTimer()
+	}
+	b.StopTimer()
+	if f.reg.ProviderCount() != benchFleetProviders {
+		b.Fatalf("fleet shrank to %d during a first-strike sweep", f.reg.ProviderCount())
+	}
+}
+
+// BenchmarkFleetTickWarmPoolFleetSnapshot is the fleet walk inside every
+// warm-pool controller tick (30s + hot-path triggers).
+func BenchmarkFleetTickWarmPoolFleetSnapshot(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.warmPoolFleetSnapshot(time.Now())) == 0 {
+			b.Fatal("no models")
+		}
+	}
+}
+
+// BenchmarkFleetTickWarmPoolPlanObserveOnly is one full observe-only planning
+// pass (fleet snapshot + Little's Law targets), invoked without the controller
+// goroutine.
+func BenchmarkFleetTickWarmPoolPlanObserveOnly(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	c := newWarmPoolController(f.reg, WarmPoolConfig{
+		Enabled:                    true,
+		ObserveOnly:                true,
+		Interval:                   30 * time.Second,
+		DecodeFloorTPS:             12,
+		FallbackQualityConcurrency: 4,
+		AssumedPromptTokens:        800,
+		AssumedCompletionTokens:    400,
+	})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(c.planObserveOnly(time.Now(), nil)) == 0 {
+			b.Fatal("no snapshots")
+		}
+	}
+}
+
+// BenchmarkFleetTickTriggerModelSwapsWarmQueued is the per-heartbeat swap
+// planner while a request is queued for a model that IS warm somewhere: the
+// planner walks providers until it finds the first warm one.
+func BenchmarkFleetTickTriggerModelSwapsWarmQueued(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	f.reg.loadModelSender = func(string, string) error { return nil }
+	if err := f.reg.Queue().Enqueue(&QueuedRequest{RequestID: "bench-queued-warm", Model: f.models[0]}); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.reg.TriggerModelSwaps()
+	}
+}
+
+// BenchmarkFleetTickTriggerModelSwapsUnservableQueued is the planner's worst
+// case, reached on EVERY heartbeat while a request is queued for a catalog
+// model no connected provider can serve: both the warm scan and the
+// cold-candidate scan walk the entire fleet and find nothing.
+func BenchmarkFleetTickTriggerModelSwapsUnservableQueued(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	f.reg.loadModelSender = func(string, string) error { return nil }
+	catalog := make([]CatalogEntry, 0, benchFleetModels+1)
+	for m := 0; m < benchFleetModels; m++ {
+		catalog = append(catalog, CatalogEntry{ID: benchFleetModelID(m), SizeGB: 16 + float64(m), MinRAMGB: 32})
+	}
+	unservable := benchFleetModelID(benchFleetModels)
+	catalog = append(catalog, CatalogEntry{ID: unservable, SizeGB: 40, MinRAMGB: 32})
+	f.reg.SetModelCatalog(catalog)
+	if err := f.reg.Queue().Enqueue(&QueuedRequest{RequestID: "bench-queued-cold", Model: unservable}); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.reg.TriggerModelSwaps()
+	}
+}
+
+// benchThreeSlotHeartbeat is a realistic current-provider heartbeat: three
+// resident slots, paged KV backend on each, and MLX cache reclaimer telemetry.
+func benchThreeSlotHeartbeat(models []string) *protocol.HeartbeatMessage {
+	slots := make([]protocol.BackendSlotCapacity, 0, 3)
+	for i, m := range models[:3] {
+		kv := "paged"
+		slots = append(slots, protocol.BackendSlotCapacity{
+			Model:                 m,
+			State:                 "running",
+			NumRunning:            i,
+			MaxConcurrency:        8,
+			ActiveTokens:          int64(i) * 900,
+			MaxTokensPotential:    int64(i) * 1400,
+			ObservedDecodeTPS:     20 + float64(i),
+			ObservedPrefillTPS:    900,
+			ActiveTokenBudgetUsed: int64(i) * 1400,
+			ActiveTokenBudgetMax:  120000,
+			KVBytesPerToken:       98304,
+			KVBackend:             &kv,
+			StepsExecuted:         int64(1000 + i),
+			Admits:                int64(50 + i),
+			FirstTokensEmitted:    int64(50 + i),
+		})
+	}
+	active := models[0]
+	free := 30.0
+	return &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "idle",
+		ActiveModel: &active,
+		WarmModels:  models[:3],
+		BackendCapacity: &protocol.BackendCapacity{
+			Slots:             slots,
+			GPUMemoryActiveGB: 48,
+			GPUMemoryPeakGB:   52,
+			GPUMemoryCacheGB:  3,
+			TotalMemoryGB:     128,
+			FreeForLoadGB:     &free,
+			MLXCacheReclaimer: &protocol.MLXCacheReclaimerTelemetry{
+				CacheLimitBytes:       8 << 30,
+				SweepSignals:          120,
+				Reclaims:              12,
+				ReclaimedBytes:        3 << 30,
+				LastReclaimedBytes:    256 << 20,
+				LastReclaimDurationMS: 14,
+			},
+		},
+	}
+}
+
+// benchRegisterThreeSlotProvider registers one provider advertising three
+// catalog models with the three-slot heartbeat applied.
+func benchRegisterThreeSlotProvider(tb testing.TB, reg *Registry, id string, models []string) *Provider {
+	tb.Helper()
+	infos := make([]protocol.ModelInfo, 0, 3)
+	for _, m := range models[:3] {
+		infos = append(infos, protocol.ModelInfo{ID: m, ModelType: "chat", Quantization: "4bit"})
+	}
+	msg := &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{ChipFamily: "M3", ChipTier: "Max", MemoryGB: 128},
+		Models:                  infos,
+		Backend:                 BackendMLXSwift,
+		Version:                 "0.8.15",
+		PublicKey:               benchFleetPublicKey,
+		EncryptedResponseChunks: true,
+	}
+	p := reg.Register(id, nil, msg)
+	makeProviderRoutable(p)
+	reg.Heartbeat(id, benchThreeSlotHeartbeat(models))
+	return p
+}
+
+// BenchmarkBackendCapacitySnapshot is the per-heartbeat detached copy the API
+// heartbeat branch takes for telemetry (three slots, KV backend pointers,
+// reclaimer telemetry present).
+func BenchmarkBackendCapacitySnapshot(b *testing.B) {
+	f := buildBenchFleet(b, 8, benchFleetModels)
+	p := benchRegisterThreeSlotProvider(b, f.reg, fmt.Sprintf("bench-%04d", benchFleetProviders), f.models)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if snap := p.BackendCapacitySnapshot(); snap == nil || len(snap.Slots) != 3 {
+			b.Fatal("unexpected snapshot")
+		}
+	}
+}
+
+// benchQueueColdAdvertised extends the fleet with one more catalog model that
+// a handful of extra providers advertise but hold in a crashed slot (so it is
+// neither warm nor reservable anywhere), queues one request for it, and
+// returns one of those providers plus a heartbeat that keeps the slot crashed.
+// This is the congestion shape: a request waits for a model the fleet
+// advertises but cannot currently serve.
+func benchQueueColdAdvertised(b *testing.B, f *benchFleet, extra int) (providerID string, hb *protocol.HeartbeatMessage, cold string) {
+	b.Helper()
+	f.reg.loadModelSender = func(string, string) error { return nil }
+	catalog := make([]CatalogEntry, 0, benchFleetModels+1)
+	for m := 0; m < benchFleetModels; m++ {
+		catalog = append(catalog, CatalogEntry{ID: benchFleetModelID(m), SizeGB: 16 + float64(m), MinRAMGB: 32})
+	}
+	cold = benchFleetModelID(benchFleetModels)
+	catalog = append(catalog, CatalogEntry{ID: cold, SizeGB: 40, MinRAMGB: 32})
+	f.reg.SetModelCatalog(catalog)
+
+	crashedHeartbeat := func() *protocol.HeartbeatMessage {
+		active := cold
+		return &protocol.HeartbeatMessage{
+			Type:        protocol.TypeHeartbeat,
+			Status:      "idle",
+			ActiveModel: &active,
+			BackendCapacity: &protocol.BackendCapacity{
+				Slots:         []protocol.BackendSlotCapacity{{Model: cold, State: "crashed"}},
+				TotalMemoryGB: 128,
+			},
+		}
+	}
+	for i := 0; i < extra; i++ {
+		id := fmt.Sprintf("bench-cold-%03d", i)
+		if providerID == "" {
+			providerID = id
+		}
+		msg := &protocol.RegisterMessage{
+			Type:                    protocol.TypeRegister,
+			Hardware:                protocol.Hardware{ChipFamily: "M3", ChipTier: "Max", MemoryGB: 128},
+			Models:                  []protocol.ModelInfo{{ID: cold, ModelType: "chat", Quantization: "4bit"}},
+			Backend:                 BackendMLXSwift,
+			Version:                 "0.8.15",
+			PublicKey:               benchFleetPublicKey,
+			EncryptedResponseChunks: true,
+		}
+		p := f.reg.Register(id, nil, msg)
+		makeProviderRoutable(p)
+		f.reg.Heartbeat(id, crashedHeartbeat())
+	}
+	if err := f.reg.Queue().Enqueue(&QueuedRequest{RequestID: "bench-queued-cold-advertised", Model: cold}); err != nil {
+		b.Fatal(err)
+	}
+	return providerID, crashedHeartbeat(), cold
+}
+
+// BenchmarkFleetTickHeartbeatQueuedColdAdvertised is the FULL registry
+// heartbeat ingest while a request is queued for a model the heartbeating
+// provider advertises but cannot serve: every such heartbeat pops the request,
+// runs a reservation scan across the fleet, requeues it, and then runs the
+// model-swap planner (registry.go: drainQueuedRequestsForModels +
+// TriggerModelSwaps at the tail of Heartbeat). Compare with
+// BenchmarkFleetHeartbeat (~0.5 µs) for the same ingest with an empty queue.
+func BenchmarkFleetTickHeartbeatQueuedColdAdvertised(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	providerID, hb, cold := benchQueueColdAdvertised(b, f, 12)
+	requeues := 0
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.reg.Heartbeat(providerID, hb)
+		if f.reg.Queue().QueueSize(cold) == 0 {
+			// The drain terminally failed or assigned the request; put a fresh
+			// one back so every iteration measures the congested shape.
+			b.StopTimer()
+			requeues++
+			if err := f.reg.Queue().Enqueue(&QueuedRequest{RequestID: fmt.Sprintf("bench-queued-cold-advertised-%d", i), Model: cold}); err != nil {
+				b.Fatal(err)
+			}
+			b.StartTimer()
+		}
+	}
+	b.ReportMetric(float64(requeues)/float64(b.N), "requeues/op")
+}

--- a/coordinator/registry/fleet_scale_bench_test.go
+++ b/coordinator/registry/fleet_scale_bench_test.go
@@ -1,0 +1,294 @@
+package registry
+
+// Fleet-scale routing benchmarks.
+//
+// The 2026-09-01 congestion collapse (PR #799) was a CPU cliff: every request
+// walked ~1,260 providers, and the failure path re-walked them up to 64 times.
+// These benchmarks reproduce that fleet shape in-process so a scheduler change
+// can be measured (ns/op, allocs/op, pprof) instead of argued about:
+//
+//	go test ./registry/ -run '^$' -bench 'Fleet' -benchmem
+//	go test ./registry/ -run '^$' -bench 'FleetReserveProviderEx$' -cpuprofile /tmp/fleet.prof
+//	go tool pprof -top -nodecount=40 registry.test /tmp/fleet.prof
+//
+// The fleet is deliberately heterogeneous: providers advertise one to three of
+// benchFleetModels, half of them have the requested model resident, every
+// provider carries a live BackendCapacity heartbeat (token budgets, observed
+// TPS, running/waiting counts) and a few in-flight pending requests, and the
+// catalog is populated so the catalog gates take their real path. Nothing here
+// depends on a store, a WebSocket, or Postgres.
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	benchFleetProviders = 1260
+	benchFleetModels    = 15
+	// benchFleetPublicKey is a syntactically valid base64 X25519 key so the
+	// private-text gate passes; it is never used for real encryption here.
+	benchFleetPublicKey = "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw="
+)
+
+type benchFleet struct {
+	reg    *Registry
+	models []string
+	ids    []string
+}
+
+func benchFleetModelID(i int) string {
+	return fmt.Sprintf("mlx-community/bench-model-%02d-4bit", i)
+}
+
+// buildBenchFleet registers providers synthetic providers. Provider i
+// advertises model i%models always, model (i+1)%models when i is even, and
+// model (i+2)%models when i%3 == 0, so each model has ~3× providers/models
+// advertisers and the scan sees a realistic mix of "advertises the model" and
+// "does not". The primary model is resident (warm) on even providers only.
+func buildBenchFleet(tb testing.TB, providers, models int) *benchFleet {
+	tb.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := New(logger)
+
+	f := &benchFleet{reg: reg}
+	catalog := make([]CatalogEntry, 0, models)
+	for m := 0; m < models; m++ {
+		id := benchFleetModelID(m)
+		f.models = append(f.models, id)
+		catalog = append(catalog, CatalogEntry{ID: id, SizeGB: 16 + float64(m), MinRAMGB: 32})
+	}
+	reg.SetModelCatalog(catalog)
+
+	for i := 0; i < providers; i++ {
+		id := fmt.Sprintf("bench-%04d", i)
+		f.ids = append(f.ids, id)
+		advertised := []string{f.models[i%models]}
+		if i%2 == 0 {
+			advertised = append(advertised, f.models[(i+1)%models])
+		}
+		if i%3 == 0 {
+			advertised = append(advertised, f.models[(i+2)%models])
+		}
+		infos := make([]protocol.ModelInfo, 0, len(advertised))
+		for _, m := range advertised {
+			infos = append(infos, protocol.ModelInfo{ID: m, ModelType: "chat", Quantization: "4bit"})
+		}
+		msg := &protocol.RegisterMessage{
+			Type: protocol.TypeRegister,
+			Hardware: protocol.Hardware{
+				MachineModel:       "Mac15,8",
+				ChipName:           "Apple M3 Max",
+				ChipFamily:         "M3",
+				ChipTier:           "Max",
+				MemoryGB:           64 + 32*(i%3),
+				MemoryAvailableGB:  60,
+				MemoryBandwidthGBs: 400,
+				CPUCores:           protocol.CPUCores{Total: 16, Performance: 12, Efficiency: 4},
+				GPUCores:           40,
+			},
+			Models:                  infos,
+			Backend:                 BackendMLXSwift,
+			Version:                 "0.8.15",
+			DecodeTPS:               20 + float64(i%25),
+			PublicKey:               benchFleetPublicKey,
+			EncryptedResponseChunks: true,
+			PrivacyCapabilities: &protocol.PrivacyCapabilities{
+				TextBackendInprocess:    true,
+				TextProxyDisabled:       true,
+				PythonRuntimeLocked:     true,
+				DangerousModulesBlocked: true,
+				SIPEnabled:              true,
+				AntiDebugEnabled:        true,
+				CoreDumpsDisabled:       true,
+				EnvScrubbed:             true,
+			},
+		}
+		p := reg.Register(id, nil, msg)
+		makeProviderRoutable(p)
+
+		// One realistic heartbeat per provider: the primary model resident on
+		// even providers, the others cold; live token budgets and observed rates.
+		reg.Heartbeat(id, benchHeartbeat(i, advertised))
+
+		// A few in-flight requests so pending accounting is exercised.
+		for k := 0; k < i%4; k++ {
+			p.AddPending(&PendingRequest{
+				RequestID:             fmt.Sprintf("%s-pending-%d", id, k),
+				Model:                 advertised[k%len(advertised)],
+				EstimatedPromptTokens: 800,
+				RequestedMaxTokens:    512,
+			})
+		}
+	}
+	return f
+}
+
+func benchHeartbeat(i int, advertised []string) *protocol.HeartbeatMessage {
+	var slots []protocol.BackendSlotCapacity
+	if i%2 == 0 {
+		running := i % 3
+		slots = append(slots, protocol.BackendSlotCapacity{
+			Model:                 advertised[0],
+			State:                 "running",
+			NumRunning:            running,
+			NumWaiting:            i % 2,
+			MaxConcurrency:        8,
+			ActiveTokens:          int64(running) * 900,
+			MaxTokensPotential:    int64(running) * 1400,
+			ObservedDecodeTPS:     18 + float64(i%20),
+			ObservedPrefillTPS:    900 + float64(i%300),
+			ActiveTokenBudgetUsed: int64(running) * 1400,
+			ActiveTokenBudgetMax:  120000,
+			QueuedTokenBudget:     int64(i%2) * 1400,
+			KVBytesPerToken:       98304,
+		})
+	}
+	active := advertised[0]
+	free := 30.0
+	return &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "idle",
+		ActiveModel: &active,
+		WarmModels:  advertised[:1],
+		SystemMetrics: protocol.SystemMetrics{
+			MemoryPressure: 0.2 + 0.01*float64(i%30),
+			CPUUsage:       0.1 + 0.01*float64(i%40),
+			ThermalState:   "nominal",
+		},
+		BackendCapacity: &protocol.BackendCapacity{
+			Slots:             slots,
+			GPUMemoryActiveGB: 18,
+			GPUMemoryPeakGB:   22,
+			GPUMemoryCacheGB:  2,
+			TotalMemoryGB:     float64(64 + 32*(i%3)),
+			FreeForLoadGB:     &free,
+		},
+	}
+}
+
+func benchPendingRequest(model string, n int) *PendingRequest {
+	return &PendingRequest{
+		RequestID:             fmt.Sprintf("bench-req-%d", n),
+		Model:                 model,
+		EstimatedPromptTokens: 600,
+		RequestedMaxTokens:    512,
+		FirstContentBudgetMS:  10_000,
+		FirstContentDeadline:  time.Now().Add(10 * time.Second),
+	}
+}
+
+// TestFleetScaleBenchFixture pins the fixture itself: the benchmark must be
+// measuring a fleet that actually routes, or its numbers are meaningless.
+func TestFleetScaleBenchFixture(t *testing.T) {
+	f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+
+	candidates, capacityRejections, tooLarge := f.reg.QuickCapacityCheckForRequest(model, 600, 512, RequestTraits{}, false)
+	if candidates == 0 {
+		t.Fatalf("fixture has no routable candidates for %s (capacity=%d tooLarge=%d)", model, capacityRejections, tooLarge)
+	}
+	// Providers advertising model 0: i%15==0 (84) + even i with (i+1)%15==0 (42)
+	// + i%3==0 with (i+2)%15==0 (28) — a few hundred, never the whole fleet.
+	if candidates > benchFleetProviders/2 {
+		t.Fatalf("fixture is too homogeneous: %d/%d providers route %s", candidates, benchFleetProviders, model)
+	}
+
+	pr := benchPendingRequest(model, 0)
+	p, decision := f.reg.ReserveProviderEx(model, pr)
+	if p == nil {
+		t.Fatalf("fixture cannot reserve a provider: %+v", decision)
+	}
+	if got := p.RemovePending(pr.RequestID); got != pr {
+		t.Fatalf("pending request not released from %s", p.ID)
+	}
+	t.Logf("fixture: %d providers, %d models, %d candidates for %s (capacity rejections %d)",
+		benchFleetProviders, benchFleetModels, candidates, model, capacityRejections)
+}
+
+// BenchmarkFleetReserveProviderEx is the dispatch-path reservation: shared scan
+// + serialized commit + release, one request at a time.
+func BenchmarkFleetReserveProviderEx(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pr := benchPendingRequest(model, i)
+		p, _ := f.reg.ReserveProviderEx(model, pr)
+		if p == nil {
+			b.Fatal("no provider reserved")
+		}
+		p.RemovePending(pr.RequestID)
+	}
+}
+
+// BenchmarkFleetReserveProviderExParallel runs reservations from GOMAXPROCS
+// goroutines to expose lock contention between the shared scan and the commit
+// section.
+func BenchmarkFleetReserveProviderExParallel(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			model := f.models[n%len(f.models)]
+			pr := benchPendingRequest(model, n)
+			p, _ := f.reg.ReserveProviderEx(model, pr)
+			if p == nil {
+				b.Fatal("no provider reserved")
+			}
+			p.RemovePending(pr.RequestID)
+			n++
+		}
+	})
+}
+
+// BenchmarkFleetQuickCapacityCheck is the consumer preflight (runs once per
+// request before dispatch, and again per failover attempt).
+func BenchmarkFleetQuickCapacityCheck(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		candidates, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false)
+		if candidates == 0 {
+			b.Fatal("no candidates")
+		}
+	}
+}
+
+// BenchmarkFleetHeartbeat is the ingest path: ~1,260 providers × one baseline
+// heartbeat every 5s is ~250 applications/s in production.
+func BenchmarkFleetHeartbeat(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	msgs := make([]*protocol.HeartbeatMessage, len(f.ids))
+	for i := range f.ids {
+		msgs[i] = benchHeartbeat(i, []string{f.models[i%benchFleetModels]})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		idx := i % len(f.ids)
+		f.reg.Heartbeat(f.ids[idx], msgs[idx])
+	}
+}
+
+// BenchmarkFleetListModels is the /v1/models aggregation over the whole fleet.
+func BenchmarkFleetListModels(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if len(f.reg.ListModels()) == 0 {
+			b.Fatal("no models")
+		}
+	}
+}

--- a/coordinator/registry/fleet_scale_servability_bench_test.go
+++ b/coordinator/registry/fleet_scale_servability_bench_test.go
@@ -1,0 +1,26 @@
+package registry
+
+// Fleet-scale benchmark for the servability gate — the THIRD full-fleet walk
+// every public request pays (api/servability_gate.go → PredictServable) before
+// the QuickCapacityCheck preflight and the reservation scan. Shares the
+// fixture in fleet_scale_bench_test.go so all three walks are measured on the
+// same 1,260-provider / 15-model fleet:
+//
+//	go test ./registry/ -run '^$' -bench 'Fleet' -benchmem
+
+import "testing"
+
+// BenchmarkFleetPredictServable is the structural prompt-size gate: one walk
+// per request, per-provider snapshot + structural budget.
+func BenchmarkFleetPredictServable(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		verdict := f.reg.PredictServable(model, 600, 600, 512, 128_000, RequestTraits{}, false)
+		if !verdict.Servable || verdict.ProviderCount == 0 {
+			b.Fatalf("fixture is not servable: %+v", verdict)
+		}
+	}
+}

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -1,8 +1,6 @@
 package registry
 
 import (
-	"os"
-	"strings"
 	"time"
 )
 
@@ -72,16 +70,16 @@ type capacityStreak struct {
 	last time.Time
 }
 
-// healthEjectionEnabled is the LIVE kill switch (read at evaluation time so it
-// toggles without a coordinator restart). Default ON; EIGENINFERENCE_HEALTH_EJECTION
-// set to off/0/false/no disables both gating and recording.
+// healthEjectionEnabled is the kill switch. Default ON;
+// EIGENINFERENCE_HEALTH_EJECTION set to off/0/false/no disables both gating and
+// recording. The value is read from the environment ONCE at process start
+// (health_ejection_switch.go): a process's environment cannot change underneath
+// it, so the former per-call os.Getenv + ToLower/TrimSpace — evaluated once per
+// provider per routing scan — never actually toggled anything live; it only
+// cost ~3% of the fleet-scale scan. Tests flip it through
+// setHealthEjectionEnabledForTest.
 func healthEjectionEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("EIGENINFERENCE_HEALTH_EJECTION"))) {
-	case "off", "0", "false", "no":
-		return false
-	default:
-		return true
-	}
+	return healthEjectionSwitch.Load()
 }
 
 // stableProviderIdentityLocked derives a provider's stable identity (precedence:
@@ -208,11 +206,11 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 		return
 	}
 
-	// Dispatch-load cooldowns: composite "key:modelID" string keys.
-	prefix := oldKey + ":"
+	// Dispatch-load cooldowns: struct keys per (fault key, model).
 	for k, expiry := range r.dispatchLoadCooldowns {
-		if strings.HasPrefix(k, prefix) {
-			nk := newKey + ":" + k[len(prefix):]
+		if k.FaultKey == oldKey {
+			nk := k
+			nk.FaultKey = newKey
 			if cur, ok := r.dispatchLoadCooldowns[nk]; !ok || expiry.After(cur) {
 				r.dispatchLoadCooldowns[nk] = expiry
 			}

--- a/coordinator/registry/health_ejection_switch.go
+++ b/coordinator/registry/health_ejection_switch.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// health_ejection_switch.go — the process-wide health-ejection kill switch.
+//
+// EIGENINFERENCE_HEALTH_EJECTION is parsed exactly once at package init and
+// cached in an atomic so the routing gate (providerPassesRoutingGatesLockedEx,
+// once per provider per scan) reads a single atomic load instead of
+// os.Getenv + ToLower + TrimSpace. A running process cannot observe a change
+// to its own environment, so this is behavior-identical to the former per-call
+// read; the only writer after init is the test hook
+// setHealthEjectionEnabledForTest (health_ejection_switch_test.go).
+
+// healthEjectionEnvKey is the kill-switch variable; off/0/false/no disable.
+const healthEjectionEnvKey = "EIGENINFERENCE_HEALTH_EJECTION"
+
+var healthEjectionSwitch = func() *atomic.Bool {
+	var b atomic.Bool
+	b.Store(parseHealthEjectionEnv(os.Getenv(healthEjectionEnvKey)))
+	return &b
+}()
+
+// parseHealthEjectionEnv maps the raw environment value to the switch state:
+// off/0/false/no (case-insensitive, whitespace-trimmed) disable; anything
+// else — including unset — enables.
+func parseHealthEjectionEnv(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "off", "0", "false", "no":
+		return false
+	default:
+		return true
+	}
+}

--- a/coordinator/registry/health_ejection_switch_test.go
+++ b/coordinator/registry/health_ejection_switch_test.go
@@ -1,0 +1,100 @@
+package registry
+
+import "testing"
+
+// setHealthEjectionEnabledForTest flips the cached kill switch for the
+// duration of a test and restores the previous state on cleanup. It replaces
+// t.Setenv(healthEjectionEnvKey, ...) — which has no effect after init — as
+// the way tests exercise the disabled path. Lives in a _test.go file so the
+// production package never links the testing tree.
+func setHealthEjectionEnabledForTest(t testing.TB, enabled bool) {
+	t.Helper()
+	prev := healthEjectionSwitch.Swap(enabled)
+	t.Cleanup(func() { healthEjectionSwitch.Store(prev) })
+}
+
+func TestParseHealthEjectionEnv(t *testing.T) {
+	cases := map[string]bool{
+		"":        true,
+		"on":      true,
+		"ON":      true,
+		"1":       true,
+		"true":    true,
+		"yes":     true,
+		"garbage": true,
+		"off":     false,
+		" OFF ":   false,
+		"0":       false,
+		"false":   false,
+		"False":   false,
+		"no":      false,
+		"\tno\n":  false,
+	}
+	for raw, want := range cases {
+		if got := parseHealthEjectionEnv(raw); got != want {
+			t.Errorf("parseHealthEjectionEnv(%q) = %v, want %v", raw, got, want)
+		}
+	}
+}
+
+// TestHealthEjectionSwitchHookRestores pins the test hook contract: the flip
+// is visible through healthEjectionEnabled immediately, and the previous state
+// comes back when the (sub)test finishes so tests cannot leak the kill switch
+// into each other.
+func TestHealthEjectionSwitchHookRestores(t *testing.T) {
+	before := healthEjectionEnabled()
+	t.Run("flip", func(t *testing.T) {
+		setHealthEjectionEnabledForTest(t, !before)
+		if healthEjectionEnabled() != !before {
+			t.Fatalf("hook did not flip the switch")
+		}
+		// The gate consults the cached switch, not the environment: setting the
+		// variable here must have no effect.
+		if before {
+			t.Setenv(healthEjectionEnvKey, "on")
+		} else {
+			t.Setenv(healthEjectionEnvKey, "off")
+		}
+		if healthEjectionEnabled() != !before {
+			t.Fatalf("environment change leaked into the cached switch")
+		}
+	})
+	if healthEjectionEnabled() != before {
+		t.Fatalf("hook did not restore the switch after the subtest")
+	}
+}
+
+// TestHealthEjectionSwitchGatesRouting proves the routing gate honors the
+// cached switch: an ejected identity is derouted while the switch is on and
+// routable again once it is off (recording is disabled too, so a fresh
+// registry with the switch off never ejects — see TestHealthEjection_KillSwitch).
+func TestHealthEjectionSwitchGatesRouting(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	reg := New(testLogger())
+	const model, serial = "switch-model", "SER-SWITCH"
+	attestSchedulerProvider(t, reg, "sess-1", model, serial, 100)
+	sid := "serial:" + serial
+	for i := 0; i < healthEjectionConsecTrip+1; i++ {
+		reg.RecordProviderServeOutcome(sid, false, 500, "boom")
+	}
+	if !reg.HealthEjectionOpen(sid) {
+		t.Fatal("precondition: identity ejected")
+	}
+	// The scan (not the preflight, which fails open on breaker-class gates)
+	// is where the ejection gate bites; breakerRejected is its tally.
+	scan := func() candidateScan {
+		pr := &PendingRequest{RequestID: "switch", Model: model, RequestedMaxTokens: 16}
+		reg.mu.RLock()
+		defer reg.mu.RUnlock()
+		return reg.scanCandidatesLocked(model, pr, false)
+	}
+	if got := scan(); got.candidateCount != 0 || got.breakerRejected != 1 {
+		t.Fatalf("switch on: candidates=%d breakerRejected=%d, want 0/1",
+			got.candidateCount, got.breakerRejected)
+	}
+	setHealthEjectionEnabledForTest(t, false)
+	if got := scan(); got.candidateCount != 1 || got.breakerRejected != 0 {
+		t.Fatalf("switch off: candidates=%d breakerRejected=%d, want 1/0",
+			got.candidateCount, got.breakerRejected)
+	}
+}

--- a/coordinator/registry/health_ejection_test.go
+++ b/coordinator/registry/health_ejection_test.go
@@ -178,7 +178,7 @@ func TestHealthEjection_SurvivesSessionChurn(t *testing.T) {
 }
 
 func TestHealthEjection_KillSwitch(t *testing.T) {
-	t.Setenv("EIGENINFERENCE_HEALTH_EJECTION", "off")
+	setHealthEjectionEnabledForTest(t, false)
 	reg := New(testLogger())
 	const sid = "serial:OFF"
 	for i := 0; i < healthEjectionConsecTrip+5; i++ {

--- a/coordinator/registry/helpers_shared_test.go
+++ b/coordinator/registry/helpers_shared_test.go
@@ -24,6 +24,7 @@ func addAdvertisedModel(p *Provider, modelID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.Models = append(p.Models, protocol.ModelInfo{ID: modelID, ModelType: "chat", Quantization: "4bit"})
+	p.syncModelIndexLocked()
 }
 
 func testLogger() *slog.Logger {

--- a/coordinator/registry/model_index.go
+++ b/coordinator/registry/model_index.go
@@ -1,0 +1,169 @@
+package registry
+
+import (
+	"sync"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// model_index.go — the per-model provider index.
+//
+// Every fleet walk that serves one request (the reservation scan, the
+// capacity preflight, the servability gate, the cache-capability snapshot and
+// the alias routability probe) used to iterate ALL of r.providers and take
+// p.mu on each, even though ~90% of a 1,260-provider fleet does not advertise
+// the requested model and fails the very first gate. The index maps an
+// advertised model id to the providers advertising it, so those walks visit
+// only providers that could possibly pass. It prunes NOTHING else: every
+// eligibility gate still runs per visited provider exactly as before, and the
+// index is keyed purely on advertisement (p.Models), not on catalog, trust,
+// status or capacity — so owner self-route to an off-catalog model, dedicated
+// families, aliases and every other rule keep working unchanged.
+//
+// Invariant (pinned by TestModelIndexMatchesBruteForceAfterEveryMutation):
+//
+//	index[model] == { p ∈ r.providers : model ∈ ids(p.Models) }
+//
+// Locking. p.Models is written under p.mu, sometimes WITHOUT r.mu
+// (MergeProviderModels), so an r.mu-guarded index cannot be kept in step.
+// The index has its own mutex, which is always the innermost lock:
+//
+//   - writers hold p.mu (and maybe r.mu) and take ix.mu briefly (sync);
+//   - readers hold r.mu and take ix.mu only to COPY the provider list
+//     (providersForModelLocked); they release it before touching any p.mu.
+//
+// Nothing ever waits for another lock while holding ix.mu, so it cannot take
+// part in a cycle. Readers additionally re-check r.providers membership so a
+// stale entry could never route to a removed session, and Disconnect sets
+// modelIndexDetached under p.mu so a models_update racing the disconnect
+// cannot re-insert the session. Heartbeat re-syncs as a backstop against any
+// future p.Models writer that forgets to.
+
+// providerModelIndex maps advertised model id → session id → provider. The
+// zero value is ready to use (test registries are built as bare literals).
+type providerModelIndex struct {
+	mu      sync.RWMutex
+	byModel map[string]map[string]*Provider
+}
+
+// sync brings the index in line with p.Models (or removes p entirely once it
+// is detached). Caller holds p.mu. Allocation-free when nothing changed.
+func (ix *providerModelIndex) sync(p *Provider) {
+	var want []string
+	if !p.modelIndexDetached {
+		if modelIndexIDsMatch(p.modelIndexIDs, p.Models) {
+			return
+		}
+		want = make([]string, 0, len(p.Models))
+		for _, m := range p.Models {
+			want = append(want, m.ID)
+		}
+	} else if len(p.modelIndexIDs) == 0 {
+		return
+	}
+	ix.mu.Lock()
+	for _, id := range p.modelIndexIDs {
+		if set := ix.byModel[id]; set != nil && set[p.ID] == p {
+			delete(set, p.ID)
+			if len(set) == 0 {
+				delete(ix.byModel, id)
+			}
+		}
+	}
+	if len(want) > 0 {
+		if ix.byModel == nil {
+			ix.byModel = make(map[string]map[string]*Provider)
+		}
+		for _, id := range want {
+			set := ix.byModel[id]
+			if set == nil {
+				set = make(map[string]*Provider)
+				ix.byModel[id] = set
+			}
+			set[p.ID] = p
+		}
+	}
+	ix.mu.Unlock()
+	p.modelIndexIDs = want
+}
+
+// providersFor appends every indexed provider for model to buf (in map
+// order, i.e. randomized like the former range over r.providers) and returns
+// it. The copy is what lets callers take p.mu afterwards without holding ix.mu.
+func (ix *providerModelIndex) providersFor(model string, buf []*Provider) []*Provider {
+	ix.mu.RLock()
+	defer ix.mu.RUnlock()
+	set := ix.byModel[model]
+	if cap(buf)-len(buf) < len(set) {
+		grown := make([]*Provider, len(buf), len(buf)+len(set))
+		copy(grown, buf)
+		buf = grown
+	}
+	for _, p := range set {
+		buf = append(buf, p)
+	}
+	return buf
+}
+
+// count reports how many providers are indexed for model (tests, sizing).
+func (ix *providerModelIndex) count(model string) int {
+	ix.mu.RLock()
+	defer ix.mu.RUnlock()
+	return len(ix.byModel[model])
+}
+
+// modelIndexIDsMatch reports whether the indexed id list equals the model
+// list's ids, element for element (order-sensitive: a reorder simply resyncs).
+func modelIndexIDsMatch(ids []string, models []protocol.ModelInfo) bool {
+	if len(ids) != len(models) {
+		return false
+	}
+	for i := range ids {
+		if ids[i] != models[i].ID {
+			return false
+		}
+	}
+	return true
+}
+
+// syncModelIndexLocked re-syncs this provider's index entries from p.Models.
+// Every p.Models writer calls it before releasing p.mu; Heartbeat calls it as
+// a backstop. No-op for providers that were never registered (p.registry nil).
+// Caller holds p.mu.
+func (p *Provider) syncModelIndexLocked() {
+	if p.registry == nil {
+		return
+	}
+	p.registry.modelIndex.sync(p)
+}
+
+// detachModelIndexLocked removes the provider from the index for good: after
+// this, sync can only ever remove. Called by Disconnect. Caller holds p.mu.
+func (p *Provider) detachModelIndexLocked(r *Registry) {
+	p.modelIndexDetached = true
+	r.modelIndex.sync(p)
+}
+
+// providersForModelLocked returns the live providers advertising model — the
+// candidate set every per-request fleet walk iterates. Entries are re-checked
+// against r.providers so a stale index entry can never surface a removed
+// session. With modelIndexDisabled (tests only) it returns every provider, so
+// the walks can be proven identical with and without the index. Caller holds
+// r.mu (either mode) and NO p.mu.
+func (r *Registry) providersForModelLocked(model string) []*Provider {
+	if r.modelIndexDisabled {
+		out := make([]*Provider, 0, len(r.providers))
+		for _, p := range r.providers {
+			out = append(out, p)
+		}
+		return out
+	}
+	providers := r.modelIndex.providersFor(model, nil)
+	live := providers[:0]
+	for _, p := range providers {
+		if r.providers[p.ID] == p {
+			live = append(live, p)
+		}
+	}
+	return live
+}

--- a/coordinator/registry/model_index_test.go
+++ b/coordinator/registry/model_index_test.go
@@ -1,0 +1,360 @@
+package registry
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func modelIndexRegister(t *testing.T, r *Registry, id string, models ...string) *Provider {
+	t.Helper()
+	msg := testRegisterMessage()
+	msg.Models = msg.Models[:0]
+	for _, m := range models {
+		msg.Models = append(msg.Models, protocol.ModelInfo{ID: m, ModelType: "chat", Quantization: "4bit"})
+	}
+	p := r.Register(id, nil, msg)
+	makeProviderRoutable(p)
+	return p
+}
+
+// TestModelIndexMatchesBruteForceAfterEveryMutation drives every p.Models /
+// r.providers mutation path the registry has and checks the index invariant
+// after each one: register, models_update add, weight-hash refresh, alias
+// hard-swap drop, catalog change, untrust/recover, disconnect, a
+// models_update racing a disconnect, and the heartbeat backstop.
+func TestModelIndexMatchesBruteForceAfterEveryMutation(t *testing.T) {
+	r := New(testLogger())
+	r.SetModelCatalog(nil)
+	assertModelIndexConsistent(t, r)
+
+	p1 := modelIndexRegister(t, r, "p1", "model-a", "model-b")
+	assertModelIndexConsistent(t, r)
+	p2 := modelIndexRegister(t, r, "p2", "model-b")
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-b") != 2 || r.modelIndex.count("model-a") != 1 {
+		t.Fatalf("unexpected counts after register: a=%d b=%d", r.modelIndex.count("model-a"), r.modelIndex.count("model-b"))
+	}
+
+	// models_update: add.
+	r.MergeProviderModels("p1", []protocol.ModelInfo{{ID: "model-c", ModelType: "chat"}})
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-c") != 1 {
+		t.Fatal("merge-added model not indexed")
+	}
+
+	// Weight-hash refresh: ids unchanged.
+	r.UpdateModelWeightHashes("p1", map[string]string{"model-a": "hash-a"})
+	assertModelIndexConsistent(t, r)
+
+	// Alias hard-swap: updating to the desired build drops the previous one.
+	r.SetModelAliases(map[string]AliasTarget{"alias": {Desired: "model-d", Previous: "model-a"}})
+	r.MergeProviderModels("p1", []protocol.ModelInfo{{ID: "model-d", ModelType: "chat"}})
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-a") != 0 || r.modelIndex.count("model-d") != 1 {
+		t.Fatalf("hard-swap not reflected: a=%d d=%d", r.modelIndex.count("model-a"), r.modelIndex.count("model-d"))
+	}
+
+	// Catalog change touches no advertisement.
+	r.SetModelCatalog([]CatalogEntry{{ID: "model-b"}, {ID: "model-c"}})
+	assertModelIndexConsistent(t, r)
+
+	// Untrust / recover: status is not advertisement; index unchanged.
+	r.markUntrusted("p1", true)
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-b") != 2 {
+		t.Fatal("untrust must not remove advertisement from the index")
+	}
+
+	// Disconnect removes every entry.
+	r.Disconnect("p2")
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-b") != 1 {
+		t.Fatalf("disconnected provider still indexed: %d", r.modelIndex.count("model-b"))
+	}
+
+	// A models_update that raced the disconnect (it already held the
+	// *Provider) must not re-insert the dead session.
+	p2.mu.Lock()
+	p2.Models = append(p2.Models, protocol.ModelInfo{ID: "model-b"}, protocol.ModelInfo{ID: "model-z"})
+	r.modelIndex.sync(p2)
+	p2.mu.Unlock()
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-z") != 0 {
+		t.Fatal("detached provider was re-inserted by a racing sync")
+	}
+
+	// Heartbeat backstop: a writer that forgets to sync is corrected on the
+	// next heartbeat.
+	p1.mu.Lock()
+	p1.Models = append(p1.Models, protocol.ModelInfo{ID: "model-e", ModelType: "chat"})
+	p1.mu.Unlock()
+	if r.modelIndex.count("model-e") != 0 {
+		t.Fatal("precondition: unsynced write must not be visible yet")
+	}
+	r.Heartbeat("p1", &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: "idle"})
+	assertModelIndexConsistent(t, r)
+	if r.modelIndex.count("model-e") != 1 {
+		t.Fatal("heartbeat did not resync the index")
+	}
+
+	// Index reads never allocate when the advertisement is unchanged.
+	p1.mu.Lock()
+	allocs := testing.AllocsPerRun(100, func() { r.modelIndex.sync(p1) })
+	p1.mu.Unlock()
+	if allocs != 0 {
+		t.Fatalf("no-op sync allocated %v", allocs)
+	}
+}
+
+type walkOutcome struct {
+	pool        []string
+	count       int
+	capacity    int
+	tooLarge    int
+	vision      int
+	ttft        int
+	bestTTFT    float64
+	quick       [3]int
+	quickTTFT   int64
+	quickHas    bool
+	servable    ServabilityVerdict
+	aliasRoute  bool
+	aliasStruct bool
+	aliasBuild  bool
+	cacheCaps   []string
+}
+
+func runWalks(r *Registry, model string, pr *PendingRequest, traits RequestTraits, vision bool) walkOutcome {
+	var out walkOutcome
+	r.mu.RLock()
+	scan := r.scanCandidatesLocked(model, pr, false)
+	out.aliasRoute = r.anyProviderCanServeAliasWithTraitsLocked(model, nil, pr.OwnerAccountID, pr.SelfRouteOnly, pr.PreferOwner, pr.FirstContentDeadline, traits, false)
+	out.aliasStruct = r.anyProviderCanServeAliasWithTraitsLocked(model, nil, pr.OwnerAccountID, pr.SelfRouteOnly, pr.PreferOwner, pr.FirstContentDeadline, traits, true)
+	out.aliasBuild = r.anyProviderCanRouteBuildLocked(model)
+	r.mu.RUnlock()
+	for _, c := range scan.pool {
+		out.pool = append(out.pool, c.provider.ID)
+	}
+	sort.Strings(out.pool)
+	out.count, out.capacity, out.tooLarge = scan.candidateCount, scan.capacityRejections, scan.tooLargeRejections
+	out.vision, out.ttft, out.bestTTFT = scan.visionRejections, scan.ttftRejections, scan.bestTTFTMs
+	c, cap_, tl, ttft, has := r.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, traits, vision)
+	out.quick, out.quickTTFT, out.quickHas = [3]int{c, cap_, tl}, int64(ttft), has
+	out.servable = r.PredictServable(model, 600, 600, 512, 128_000, traits, vision)
+	for id := range r.prefixCacheV2CapabilitiesForModel(model) {
+		out.cacheCaps = append(out.cacheCaps, id)
+	}
+	sort.Strings(out.cacheCaps)
+	return out
+}
+
+// TestRoutingWalksIdenticalWithAndWithoutModelIndex runs every indexed walk
+// over the fleet-scale fixture with the index on and off (brute-force over
+// r.providers) for several request shapes and models, and requires identical
+// eligible pools (as ID sets — near-tie spread randomizes the winner either
+// way) and identical rejection tallies / verdicts.
+func TestRoutingWalksIdenticalWithAndWithoutModelIndex(t *testing.T) {
+	f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+	shapes := []struct {
+		name   string
+		traits RequestTraits
+		vision bool
+		ttftMs float64
+	}{
+		{name: "plain"},
+		{name: "tools", traits: RequestTraits{HasTools: true}},
+		{name: "vision", vision: true},
+		{name: "ttft-ceiling", ttftMs: 5_000},
+	}
+	for _, model := range []string{f.models[0], f.models[7], f.models[14], "not-a-model"} {
+		for _, shape := range shapes {
+			pr := benchPendingRequest(model, 0)
+			pr.Traits, pr.RequiresVision, pr.MaxTTFTMs = shape.traits, shape.vision, shape.ttftMs
+			f.reg.modelIndexDisabled = false
+			withIndex := runWalks(f.reg, model, pr, shape.traits, shape.vision)
+			f.reg.modelIndexDisabled = true
+			brute := runWalks(f.reg, model, pr, shape.traits, shape.vision)
+			f.reg.modelIndexDisabled = false
+			if !reflect.DeepEqual(withIndex, brute) {
+				t.Fatalf("%s/%s: walks differ\n index: %+v\n brute: %+v", model, shape.name, withIndex, brute)
+			}
+			if model != "not-a-model" && withIndex.count == 0 && shape.name == "plain" {
+				t.Fatalf("%s: fixture produced no candidates", model)
+			}
+		}
+	}
+	assertModelIndexConsistent(t, f.reg)
+}
+
+// benchProviderAdvertises reports whether bench provider i advertises model
+// (mirrors buildBenchFleet's advertisement rule).
+func benchProviderAdvertises(f *benchFleet, i int, model string) bool {
+	if f.models[i%benchFleetModels] == model {
+		return true
+	}
+	if i%2 == 0 && f.models[(i+1)%benchFleetModels] == model {
+		return true
+	}
+	return i%3 == 0 && f.models[(i+2)%benchFleetModels] == model
+}
+
+// TestRoutingWalksIdenticalWithFaultStateWithAndWithoutIndex adds fault
+// state the plain fixture lacks — a breaker-open NON-advertiser, a
+// health-ejected NON-advertiser and a capacity-cooled ADVERTISER — and pins
+// that the eligible pool, capacityRejections and every exposed
+// RoutingDecision tally are identical with and without the index, and that a
+// reservation succeeds from the same pool either way.
+//
+// The ONE intentional difference is scanCandidateScan.breakerRejected: the
+// brute-force walk counts the two breaker/ejected providers even though they
+// do not advertise the model, the indexed walk never visits them. That count
+// is behavior-neutral: shouldBypassBreakerFailOpen only fires when the pool is
+// empty AND no capacity/TTFT rejection exists, and the pass-2 rescan it
+// triggers can only rescue an ADVERTISER rejected solely by breaker/ejection —
+// which counts itself in both walks. The field is not part of RoutingDecision.
+func TestRoutingWalksIdenticalWithFaultStateWithAndWithoutIndex(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+	model := f.models[0]
+
+	// Two non-advertisers of model: one breaker-open, one health-ejected.
+	var breakerID, ejectedID, cooledID string
+	for i, id := range f.ids {
+		if !benchProviderAdvertises(f, i, model) {
+			if breakerID == "" {
+				breakerID = id
+			} else if ejectedID == "" {
+				ejectedID = id
+			}
+		} else if cooledID == "" {
+			cooledID = id
+		}
+		if breakerID != "" && ejectedID != "" && cooledID != "" {
+			break
+		}
+	}
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		f.reg.RecordProviderOutcome(breakerID, false, 500, "internal error")
+	}
+	if !f.reg.ProviderBreakerOpen(breakerID) {
+		t.Fatal("precondition: breaker open")
+	}
+	f.reg.mu.RLock()
+	ejectedP := f.reg.providers[ejectedID]
+	f.reg.mu.RUnlock()
+	ejectedP.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-EJECT"})
+	const sid = "serial:SER-EJECT"
+	for i := 0; i < healthEjectionConsecTrip+1; i++ {
+		f.reg.RecordProviderServeOutcome(sid, false, 500, "boom")
+	}
+	if !f.reg.HealthEjectionOpen(sid) {
+		t.Fatal("precondition: identity ejected")
+	}
+	for i := 0; i < f.reg.capacityCooldownCfg.Threshold+1; i++ {
+		f.reg.RecordCapacityReject(cooledID, model)
+	}
+	f.reg.mu.RLock()
+	cooled := f.reg.capacityCooldownActiveLocked(cooledID, model, benchPendingRequest(model, 0).FirstContentDeadline)
+	f.reg.mu.RUnlock()
+	if !cooled {
+		t.Fatal("precondition: advertiser capacity-cooled")
+	}
+
+	pr := benchPendingRequest(model, 0)
+	scanWith := func(disabled bool) (candidateScan, walkOutcome) {
+		f.reg.modelIndexDisabled = disabled
+		defer func() { f.reg.modelIndexDisabled = false }()
+		f.reg.mu.RLock()
+		scan := f.reg.scanCandidatesLocked(model, pr, false)
+		f.reg.mu.RUnlock()
+		return scan, runWalks(f.reg, model, pr, RequestTraits{}, false)
+	}
+	scanIdx, walkIdx := scanWith(false)
+	scanBrute, walkBrute := scanWith(true)
+	if !reflect.DeepEqual(walkIdx, walkBrute) {
+		t.Fatalf("walks differ under fault state\n index: %+v\n brute: %+v", walkIdx, walkBrute)
+	}
+	if walkIdx.capacity == 0 {
+		t.Fatal("the capacity-cooled advertiser must be counted as a capacity rejection")
+	}
+	for _, c := range scanIdx.pool {
+		if c.provider.ID == cooledID || c.provider.ID == breakerID || c.provider.ID == ejectedID {
+			t.Fatalf("faulted provider %s in the eligible pool", c.provider.ID)
+		}
+	}
+	// The documented, behavior-neutral difference.
+	if scanIdx.breakerRejected != 0 {
+		t.Fatalf("indexed walk counted %d breaker rejections from non-advertisers", scanIdx.breakerRejected)
+	}
+	if scanBrute.breakerRejected != 2 {
+		t.Fatalf("brute-force walk breakerRejected = %d, want 2 (breaker-open + ejected non-advertisers)", scanBrute.breakerRejected)
+	}
+
+	// Reservation: the same exposed RoutingDecision tallies and a winner from
+	// the same pool either way (the winner itself is near-tie randomized).
+	poolIDs := map[string]struct{}{}
+	for _, id := range walkIdx.pool {
+		poolIDs[id] = struct{}{}
+	}
+	reserve := func(disabled bool) (*Provider, RoutingDecision) {
+		f.reg.modelIndexDisabled = disabled
+		defer func() { f.reg.modelIndexDisabled = false }()
+		req := benchPendingRequest(model, 1)
+		p, d := f.reg.ReserveProviderEx(model, req)
+		if p != nil {
+			p.RemovePending(req.RequestID)
+		}
+		return p, d
+	}
+	pIdx, dIdx := reserve(false)
+	pBrute, dBrute := reserve(true)
+	if pIdx == nil || pBrute == nil {
+		t.Fatal("reservation must succeed with and without the index")
+	}
+	if _, ok := poolIDs[pIdx.ID]; !ok {
+		t.Fatalf("indexed winner %s not in the eligible pool", pIdx.ID)
+	}
+	if _, ok := poolIDs[pBrute.ID]; !ok {
+		t.Fatalf("brute-force winner %s not in the eligible pool", pBrute.ID)
+	}
+	tallies := func(d RoutingDecision) [6]float64 {
+		return [6]float64{float64(d.CandidateCount), float64(d.CapacityRejections),
+			float64(d.ModelTooLargeRejections), float64(d.VisionRejections),
+			float64(d.TTFTRejections), d.BestTTFTMs}
+	}
+	if tallies(dIdx) != tallies(dBrute) {
+		t.Fatalf("RoutingDecision tallies differ\n index: %+v\n brute: %+v", dIdx, dBrute)
+	}
+	assertModelIndexConsistent(t, f.reg)
+}
+
+// TestModelIndexOffCatalogSelfRouteStillRoutes pins that the index is keyed on
+// advertisement, not catalog: an owner's off-catalog local model (absent from
+// the catalog) routes through the index exactly as through the full walk.
+func TestModelIndexOffCatalogSelfRouteStillRoutes(t *testing.T) {
+	r := New(testLogger())
+	r.SetModelCatalog([]CatalogEntry{{ID: "catalog-model"}})
+	const local = "owner/local-model"
+	mine := makeSchedulerProvider(t, r, "mine", local, 100)
+	mine.mu.Lock()
+	mine.AccountID = "acct"
+	mine.mu.Unlock()
+	pr := &PendingRequest{RequestID: "self", Model: local, RequestedMaxTokens: 16,
+		OwnerAccountID: "acct", SelfRouteOnly: true}
+	p, decision := r.ReserveProviderEx(local, pr)
+	if p == nil {
+		t.Fatalf("owner self-route to an off-catalog model failed through the index: %+v", decision)
+	}
+	p.RemovePending(pr.RequestID)
+	// Public routing to the same off-catalog model is still refused (catalog
+	// gate), proving the index pruned nothing the gates would have allowed.
+	pub := &PendingRequest{RequestID: "pub", Model: local, RequestedMaxTokens: 16}
+	if p, _ := r.ReserveProviderEx(local, pub); p != nil {
+		t.Fatal("public request routed to an off-catalog model")
+	}
+	assertModelIndexConsistent(t, r)
+}

--- a/coordinator/registry/model_index_test_helpers_test.go
+++ b/coordinator/registry/model_index_test_helpers_test.go
@@ -1,0 +1,84 @@
+package registry
+
+import "testing"
+
+// Test-only registry mutators that keep the per-model provider index in step
+// with r.providers / p.Models for providers built by hand (not through
+// Register). Production writers sync the index themselves (model_index.go);
+// a test that mutates p.Models on a REGISTERED provider calls
+// p.syncModelIndexLocked() before releasing p.mu.
+
+// insertTestProvider publishes a hand-built provider and indexes its
+// advertised models.
+func insertTestProvider(r *Registry, p *Provider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	r.providers[p.ID] = p
+	r.modelIndex.sync(p)
+}
+
+// removeTestProvider deletes a provider the way Disconnect does as far as the
+// index is concerned (detach, then remove from r.providers).
+func removeTestProvider(r *Registry, id string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if p := r.providers[id]; p != nil {
+		p.mu.Lock()
+		p.detachModelIndexLocked(r)
+		p.mu.Unlock()
+	}
+	delete(r.providers, id)
+}
+
+// assertModelIndexConsistent checks the index invariant against a brute-force
+// walk of r.providers:
+//
+//	index[model] == { p ∈ r.providers : model ∈ ids(p.Models) }
+//
+// plus each live provider's own diff baseline (modelIndexIDs == ids(p.Models)).
+func assertModelIndexConsistent(t testing.TB, r *Registry) {
+	t.Helper()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	expected := make(map[string]map[string]*Provider)
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if p.modelIndexDetached {
+			t.Errorf("live provider %s is marked detached", p.ID)
+		}
+		if !modelIndexIDsMatch(p.modelIndexIDs, p.Models) {
+			t.Errorf("provider %s baseline %v does not match models %v", p.ID, p.modelIndexIDs, p.Models)
+		}
+		for _, m := range p.Models {
+			set := expected[m.ID]
+			if set == nil {
+				set = make(map[string]*Provider)
+				expected[m.ID] = set
+			}
+			set[p.ID] = p
+		}
+		p.mu.Unlock()
+	}
+	r.modelIndex.mu.RLock()
+	defer r.modelIndex.mu.RUnlock()
+	got := r.modelIndex.byModel
+	for model, want := range expected {
+		have := got[model]
+		if len(have) != len(want) {
+			t.Errorf("index[%s] has %d providers, brute force %d", model, len(have), len(want))
+			continue
+		}
+		for id, p := range want {
+			if have[id] != p {
+				t.Errorf("index[%s] missing/mismatched provider %s", model, id)
+			}
+		}
+	}
+	for model, have := range got {
+		if _, ok := expected[model]; !ok {
+			t.Errorf("index has stale model %s with %d providers", model, len(have))
+		}
+	}
+}

--- a/coordinator/registry/model_swap_coalesce.go
+++ b/coordinator/registry/model_swap_coalesce.go
@@ -1,0 +1,140 @@
+package registry
+
+import (
+	"sync"
+	"time"
+)
+
+// model_swap_coalesce.go — fleet-wide coalescing of heartbeat-triggered
+// model-swap planning.
+//
+// Heartbeat used to call TriggerModelSwaps on EVERY heartbeat while the
+// request queue was non-empty. The planner walks the fleet per queued model
+// (warm scan + cold-candidate scan), so with one queued model no provider
+// could serve, every one of ~250 heartbeats/s paid the whole plan (~80 µs at
+// 1,260 providers) — ~9% of a core per queued model, in exactly the
+// congested regime the 2026-09-01 collapse lived in. The plan's inputs (the
+// queued-model set and the fleet's warm/cold state) change on the order of
+// seconds, so N heartbeats inside a short window need one plan, not N.
+//
+// Coalesced is not dropped. A heartbeat the window refuses may be the one
+// that made a cold provider loadable (free_for_load_gb grew, a slot reported
+// room to reload), and in a small or synchronized fleet the next heartbeat
+// can be seconds away — event heartbeats routinely land within a few ms of
+// the baseline one. The first refused heartbeat of a window therefore arms
+// ONE trailing plan for the window's end, so a state change waits at most
+// modelSwapPlanInterval for the planner, never for the next heartbeat. The
+// trailing plan claims the gate like any other, so the bound of one plan per
+// window still holds.
+//
+// The queue DRAIN is deliberately NOT coalesced: it is per-heartbeat and
+// per-provider (only the heartbeating provider's advertised models), so a
+// heartbeat that makes a queued model servable still hands the request over
+// immediately — and with the per-model provider index its reservation scan is
+// cheap (BenchmarkFleetTickHeartbeatQueuedColdAdvertised).
+
+// modelSwapPlanInterval is the minimum spacing between heartbeat-triggered
+// swap plans, fleet-wide. 250 ms keeps a newly-queued cold model's load_model
+// within a quarter second of the next heartbeat (heartbeats arrive every ~4
+// ms at fleet scale) while bounding planner CPU to ≤ 4 plans/s regardless of
+// fleet size or queue depth. The explicit TriggerModelSwaps entry point
+// (api cold-dispatch kick, tests) stays immediate and is not subject to this
+// gate. Deliberately a constant, not an env knob.
+const modelSwapPlanInterval = 250 * time.Millisecond
+
+// modelSwapPlanGate is the fleet-wide rate limiter. The zero value is ready.
+type modelSwapPlanGate struct {
+	mu       sync.Mutex
+	last     time.Time
+	runs     int  // plans admitted (tests)
+	trailing bool // a trailing plan is armed for the end of the current window
+	// afterFunc schedules the trailing plan; nil means time.AfterFunc. Tests
+	// inject a capturing stub so the trailing plan fires deterministically.
+	afterFunc func(d time.Duration, f func())
+	// now supplies the timer callback clock; nil means time.Now.
+	now func() time.Time
+}
+
+// claim reports whether a plan may run at now, and records it if so. When it
+// refuses, wait is the time left until the window reopens.
+func (g *modelSwapPlanGate) claim(now time.Time) (ok bool, wait time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if !g.last.IsZero() {
+		if elapsed := now.Sub(g.last); elapsed < modelSwapPlanInterval {
+			return false, modelSwapPlanInterval - elapsed
+		}
+	}
+	g.last = now
+	g.runs++
+	return true, 0
+}
+
+// armTrailing schedules fn once, wait from now, unless a trailing plan is
+// already armed; it reports whether it armed one. The armed flag is cleared
+// before fn runs, so a heartbeat refused while the trailing plan is running
+// arms the next one rather than being lost.
+func (g *modelSwapPlanGate) armTrailing(wait time.Duration, fn func()) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.trailing {
+		return false
+	}
+	g.trailing = true
+	after := g.afterFunc
+	if after == nil {
+		after = func(d time.Duration, f func()) { time.AfterFunc(d, f) }
+	}
+	after(wait, func() {
+		g.mu.Lock()
+		g.trailing = false
+		g.mu.Unlock()
+		fn()
+	})
+	return true
+}
+
+// planRuns returns how many plans the gate has admitted (tests).
+func (g *modelSwapPlanGate) planRuns() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.runs
+}
+
+// trailingArmed reports whether a trailing plan is pending (tests).
+func (g *modelSwapPlanGate) trailingArmed() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.trailing
+}
+
+// triggerModelSwapsFromHeartbeat is Heartbeat's entry to the swap planner:
+// nothing to do while the queue is empty (one queue-lock probe, no
+// allocation), otherwise at most one TriggerModelSwaps per
+// modelSwapPlanInterval across all heartbeats, a refused heartbeat arming
+// the window's trailing plan. Returns whether a plan ran.
+func (r *Registry) triggerModelSwapsFromHeartbeat(now time.Time) bool {
+	queue := r.Queue()
+	if queue == nil || !queue.HasQueued() {
+		return false
+	}
+	ok, wait := r.swapPlanGate.claim(now)
+	if !ok {
+		r.swapPlanGate.armTrailing(wait, r.trailingModelSwapPlan)
+		return false
+	}
+	r.TriggerModelSwaps()
+	return true
+}
+
+// trailingModelSwapPlan retries the same gate using the current clock. If a
+// heartbeat opened a newer window before this callback ran, another suppressed
+// heartbeat may already have changed state while the old timer was armed. Keep
+// that notification by rearming for the new window rather than dropping it.
+func (r *Registry) trailingModelSwapPlan() {
+	now := time.Now
+	if r.swapPlanGate.now != nil {
+		now = r.swapPlanGate.now
+	}
+	r.triggerModelSwapsFromHeartbeat(now())
+}

--- a/coordinator/registry/model_swap_coalesce_test.go
+++ b/coordinator/registry/model_swap_coalesce_test.go
@@ -1,0 +1,350 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func swapTestHeartbeat(model, state string) *protocol.HeartbeatMessage {
+	active := model
+	return &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "idle",
+		ActiveModel: &active,
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots:         []protocol.BackendSlotCapacity{{Model: model, State: state}},
+		},
+	}
+}
+
+// swapTestCrashedHeartbeat reports the model's slot crashed — unroutable for
+// the drain — with the given free_for_load_gb, which is what decides whether
+// the swap planner may send load_model to reload it.
+func swapTestCrashedHeartbeat(model string, freeForLoadGB float64) *protocol.HeartbeatMessage {
+	hb := swapTestHeartbeat(model, "crashed")
+	hb.BackendCapacity.FreeForLoadGB = &freeForLoadGB
+	return hb
+}
+
+func swapTestQueued(id, model string) *QueuedRequest {
+	return &QueuedRequest{
+		RequestID:  id,
+		Model:      model,
+		ResponseCh: make(chan *Provider, 1),
+		Pending: &PendingRequest{
+			RequestID:             id,
+			Model:                 model,
+			RequestedMaxTokens:    64,
+			EstimatedPromptTokens: 32,
+		},
+	}
+}
+
+// trailingTimerStub replaces the gate's timer so a test fires the trailing
+// plan by hand instead of waiting out real time (and so no real timer can fire
+// into a fake-clock test).
+type trailingTimerStub struct {
+	waits []time.Duration
+	fire  []func()
+}
+
+func installTrailingTimerStub(reg *Registry) *trailingTimerStub {
+	s := &trailingTimerStub{}
+	reg.swapPlanGate.afterFunc = func(d time.Duration, f func()) {
+		s.waits = append(s.waits, d)
+		s.fire = append(s.fire, f)
+	}
+	return s
+}
+
+// TestSwapPlanGateCoalescesBurstAndReopensAfterWindow pins the gate itself
+// with an injected clock: 50 heartbeat triggers inside one window plan once
+// (and arm exactly one trailing plan), the first trigger after the window
+// plans again, and an empty queue never plans at all.
+func TestSwapPlanGateCoalescesBurstAndReopensAfterWindow(t *testing.T) {
+	reg := New(testLogger())
+	reg.loadModelSender = func(string, string) error { return nil }
+	const cold = "swap-gate-cold-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: cold, SizeGB: 8, MinRAMGB: 16}})
+	makeSchedulerProvider(t, reg, "warm-other", "swap-gate-other-model", 100)
+	stub := installTrailingTimerStub(reg)
+
+	t0 := time.Now()
+	// Empty queue: the planner is never consulted.
+	for i := 0; i < 5; i++ {
+		if reg.triggerModelSwapsFromHeartbeat(t0.Add(time.Duration(i) * time.Millisecond)) {
+			t.Fatal("empty queue must not run the planner")
+		}
+	}
+	if reg.swapPlanGate.planRuns() != 0 {
+		t.Fatalf("plans with empty queue = %d, want 0", reg.swapPlanGate.planRuns())
+	}
+	if len(stub.fire) != 0 {
+		t.Fatal("empty queue must not arm a trailing plan")
+	}
+
+	if err := reg.Queue().Enqueue(swapTestQueued("swap-gate-req", cold)); err != nil {
+		t.Fatal(err)
+	}
+	planned := 0
+	for i := 0; i < 50; i++ {
+		if reg.triggerModelSwapsFromHeartbeat(t0.Add(time.Duration(i) * time.Millisecond)) {
+			planned++
+		}
+	}
+	if planned != 1 || reg.swapPlanGate.planRuns() != 1 {
+		t.Fatalf("burst of 50 inside the window planned %d times (gate runs %d), want 1", planned, reg.swapPlanGate.planRuns())
+	}
+	if len(stub.waits) != 1 || stub.waits[0] != modelSwapPlanInterval-time.Millisecond {
+		t.Fatalf("burst armed trailing plans %v, want exactly one timed for the window's end (%v)",
+			stub.waits, modelSwapPlanInterval-time.Millisecond)
+	}
+	if !reg.triggerModelSwapsFromHeartbeat(t0.Add(modelSwapPlanInterval + time.Millisecond)) {
+		t.Fatal("first heartbeat after the window must plan again")
+	}
+	if reg.swapPlanGate.planRuns() != 2 {
+		t.Fatalf("gate runs = %d, want 2", reg.swapPlanGate.planRuns())
+	}
+	// Exactly at the boundary the window has not elapsed yet.
+	if reg.triggerModelSwapsFromHeartbeat(t0.Add(modelSwapPlanInterval + time.Millisecond + modelSwapPlanInterval - time.Nanosecond)) {
+		t.Fatal("a trigger inside the second window must be coalesced")
+	}
+}
+
+// TestSwapPlanGateRefusedHeartbeatArmsOneTrailingPlan pins the trailing plan
+// with an injected clock and timer: the first refused trigger of a window arms
+// exactly one trailing plan timed for the window's end, later refused triggers
+// do not arm another, firing it runs one plan and disarms, a trigger refused
+// by the window it opened arms the next one, and a trailing plan whose demand
+// drained meanwhile does nothing.
+func TestSwapPlanGateRefusedHeartbeatArmsOneTrailingPlan(t *testing.T) {
+	reg := New(testLogger())
+	reg.loadModelSender = func(string, string) error { return nil }
+	const cold = "swap-trailing-gate-cold-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: cold, SizeGB: 8, MinRAMGB: 16}})
+	makeSchedulerProvider(t, reg, "warm-other", "swap-trailing-gate-other-model", 100)
+	stub := installTrailingTimerStub(reg)
+	if err := reg.Queue().Enqueue(swapTestQueued("swap-trailing-gate-req", cold)); err != nil {
+		t.Fatal(err)
+	}
+
+	t0 := time.Now()
+	now := t0
+	reg.swapPlanGate.now = func() time.Time { return now }
+	if !reg.triggerModelSwapsFromHeartbeat(t0) {
+		t.Fatal("the trigger opening the window must plan")
+	}
+	if len(stub.fire) != 0 {
+		t.Fatal("an admitted plan must not arm a trailing plan")
+	}
+
+	if reg.triggerModelSwapsFromHeartbeat(t0.Add(100 * time.Millisecond)) {
+		t.Fatal("a trigger inside the window must be coalesced")
+	}
+	if reg.triggerModelSwapsFromHeartbeat(t0.Add(120 * time.Millisecond)) {
+		t.Fatal("a trigger inside the window must be coalesced")
+	}
+	if len(stub.waits) != 1 {
+		t.Fatalf("trailing plans armed = %d, want 1 for two refused triggers", len(stub.waits))
+	}
+	if want := modelSwapPlanInterval - 100*time.Millisecond; stub.waits[0] != want {
+		t.Fatalf("trailing plan wait = %v, want %v (the rest of the window)", stub.waits[0], want)
+	}
+	if !reg.swapPlanGate.trailingArmed() {
+		t.Fatal("gate must report the trailing plan armed")
+	}
+	if reg.swapPlanGate.planRuns() != 1 {
+		t.Fatalf("plans before the trailing fire = %d, want 1", reg.swapPlanGate.planRuns())
+	}
+
+	now = t0.Add(modelSwapPlanInterval)
+	stub.fire[0]()
+	if reg.swapPlanGate.planRuns() != 2 {
+		t.Fatalf("plans after the trailing fire = %d, want 2", reg.swapPlanGate.planRuns())
+	}
+	if reg.swapPlanGate.trailingArmed() {
+		t.Fatal("the trailing plan must disarm when it fires")
+	}
+
+	// The trailing plan opened a new window; a trigger it refuses arms the next
+	// trailing plan.
+	last := reg.swapPlanGate.last
+	if reg.triggerModelSwapsFromHeartbeat(last.Add(10 * time.Millisecond)) {
+		t.Fatal("a trigger inside the trailing plan's window must be coalesced")
+	}
+	if len(stub.waits) != 2 || stub.waits[1] != modelSwapPlanInterval-10*time.Millisecond {
+		t.Fatalf("trailing plans armed = %v, want a second one timed for the new window's end", stub.waits)
+	}
+
+	// Demand gone before it fires: nothing to plan.
+	reg.Queue().Remove("swap-trailing-gate-req", cold)
+	stub.fire[1]()
+	if reg.swapPlanGate.planRuns() != 2 {
+		t.Fatalf("trailing plan ran on an empty queue (%d plans)", reg.swapPlanGate.planRuns())
+	}
+	if reg.swapPlanGate.trailingArmed() {
+		t.Fatal("a fired trailing plan must disarm even when it finds nothing to do")
+	}
+}
+
+// TestHeartbeatBurstPlansSwapsOnce drives the real Heartbeat path: 50
+// heartbeats from providers advertising a queued-but-unservable model, all
+// inside one window, produce a single plan.
+func TestHeartbeatBurstPlansSwapsOnce(t *testing.T) {
+	reg := New(testLogger())
+	reg.loadModelSender = func(string, string) error { return nil }
+	const cold = "swap-burst-cold-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: cold, SizeGB: 8, MinRAMGB: 16}})
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("crashed-%d", i)
+		ids = append(ids, id)
+		makeSchedulerProvider(t, reg, id, cold, 100)
+		reg.Heartbeat(id, swapTestHeartbeat(cold, "crashed")) // unservable before the request queues
+	}
+	if err := reg.Queue().Enqueue(swapTestQueued("swap-burst-req", cold)); err != nil {
+		t.Fatal(err)
+	}
+	// Open the window deterministically, then burst. The window (and the
+	// trailing plan it may arm) is anchored at start so a trailing fire is
+	// only ever observed with elapsed >= modelSwapPlanInterval.
+	start := time.Now()
+	if ok, _ := reg.swapPlanGate.claim(start); !ok {
+		t.Fatal("precondition: gate claim")
+	}
+	before := reg.swapPlanGate.planRuns()
+	for i := 0; i < 50; i++ {
+		reg.Heartbeat(ids[i%len(ids)], swapTestHeartbeat(cold, "crashed"))
+	}
+	elapsed := time.Since(start)
+	extra := reg.swapPlanGate.planRuns() - before
+	if elapsed < modelSwapPlanInterval && extra != 0 {
+		t.Fatalf("50 heartbeats in %v planned %d extra times, want 0 inside the window", elapsed, extra)
+	}
+	if extra > 1 {
+		t.Fatalf("50 heartbeats planned %d extra times, want at most 1", extra)
+	}
+	if reg.Queue().QueueSize(cold) != 1 {
+		t.Fatalf("crashed providers must not drain the request (queue size %d)", reg.Queue().QueueSize(cold))
+	}
+}
+
+// TestHeartbeatRefusedByWindowStillPlansWithinInterval drives the real
+// Heartbeat path and the real timer: a plan has just run (and found nothing
+// to load), then a heartbeat inside the window reports the change that makes
+// a provider loadable — its slot for the queued model is crashed, so the drain
+// cannot place the request, and free_for_load_gb now covers a reload. The gate
+// refuses that heartbeat; the trailing plan must send the load_model that,
+// before it, waited for the next heartbeat (seconds away in a small fleet;
+// master planned on every heartbeat).
+func TestHeartbeatRefusedByWindowStillPlansWithinInterval(t *testing.T) {
+	reg := New(testLogger())
+	loads := make(chan string, 4)
+	reg.loadModelSender = func(providerID, model string) error {
+		loads <- providerID + "/" + model
+		return nil
+	}
+	const model = "swap-trailing-hb-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 8, MinRAMGB: 16}})
+	p := makeSchedulerProvider(t, reg, "p1", model, 100)
+	// Crashed slot, no room to reload: the planner cannot pick it either.
+	reg.Heartbeat(p.ID, swapTestCrashedHeartbeat(model, 1))
+	if err := reg.Queue().Enqueue(swapTestQueued("swap-trailing-hb-req", model)); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	if !reg.triggerModelSwapsFromHeartbeat(start) {
+		t.Fatal("precondition: the plan opening the window must run")
+	}
+	select {
+	case got := <-loads:
+		t.Fatalf("planner sent load_model (%s) with 1 GB free_for_load", got)
+	default:
+	}
+
+	// Inside the window the provider reports room to reload. The drain still
+	// cannot place the request (slot_crashed) and the gate refuses the plan.
+	reg.Heartbeat(p.ID, swapTestCrashedHeartbeat(model, 32))
+	if time.Since(start) < modelSwapPlanInterval && reg.swapPlanGate.planRuns() != 1 {
+		t.Fatalf("heartbeat inside the window planned synchronously (%d plans)", reg.swapPlanGate.planRuns())
+	}
+	select {
+	case got := <-loads:
+		if want := p.ID + "/" + model; got != want {
+			t.Fatalf("trailing plan sent load_model %s, want %s", got, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat refused by the window produced no load_model: the trailing plan did not run")
+	}
+	if reg.swapPlanGate.planRuns() != 2 {
+		t.Fatalf("plans = %d, want 2 (the one opening the window and the trailing one)", reg.swapPlanGate.planRuns())
+	}
+	if reg.Queue().QueueSize(model) != 1 {
+		t.Fatalf("crashed slot must not drain the request (queue size %d)", reg.Queue().QueueSize(model))
+	}
+}
+
+// TestHeartbeatWarmReportStillDrainsQueuedRequest pins the semantics the
+// coalescing must not touch: the per-heartbeat drain. A provider whose slot
+// is crashed leaves the request queued; the heartbeat that reports the model
+// running hands the request over immediately — with the swap planner gate
+// held closed, so the drain (not the planner) is what delivered it — and the
+// trailing plan the refused heartbeat armed then finds nothing to do.
+func TestHeartbeatWarmReportStillDrainsQueuedRequest(t *testing.T) {
+	reg := New(testLogger())
+	reg.loadModelSender = func(string, string) error { return nil }
+	const model = "swap-drain-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 8, MinRAMGB: 16}})
+	p := makeSchedulerProvider(t, reg, "p1", model, 100)
+	reg.Heartbeat(p.ID, swapTestHeartbeat(model, "crashed"))
+	stub := installTrailingTimerStub(reg)
+
+	req := swapTestQueued("swap-drain-req", model)
+	if err := reg.Queue().Enqueue(req); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := reg.swapPlanGate.claim(time.Now()); !ok {
+		t.Fatal("precondition: gate claim")
+	}
+	runsBefore := reg.swapPlanGate.planRuns()
+
+	reg.Heartbeat(p.ID, swapTestHeartbeat(model, "crashed"))
+	select {
+	case got := <-req.ResponseCh:
+		t.Fatalf("crashed slot must not drain the request (got %v)", got)
+	default:
+	}
+	if reg.Queue().QueueSize(model) != 1 {
+		t.Fatal("request must remain queued while the slot is crashed")
+	}
+	if len(stub.fire) != 1 {
+		t.Fatalf("refused heartbeat armed %d trailing plans, want 1", len(stub.fire))
+	}
+
+	reg.Heartbeat(p.ID, swapTestHeartbeat(model, "running"))
+	select {
+	case got := <-req.ResponseCh:
+		if got == nil || got.ID != p.ID {
+			t.Fatalf("drained to %v, want %s", got, p.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the heartbeat that reported the model running did not drain the queued request")
+	}
+	if reg.Queue().QueueSize(model) != 0 {
+		t.Fatal("request must leave the queue once drained")
+	}
+	if reg.swapPlanGate.planRuns() != runsBefore {
+		t.Fatalf("the planner ran %d times during the drain; the drain must not depend on it",
+			reg.swapPlanGate.planRuns()-runsBefore)
+	}
+	// The trailing plan armed while the request waited finds the queue empty.
+	stub.fire[0]()
+	if reg.swapPlanGate.planRuns() != runsBefore {
+		t.Fatal("trailing plan must not run once the drain has emptied the queue")
+	}
+}

--- a/coordinator/registry/model_swap_trailing_test.go
+++ b/coordinator/registry/model_swap_trailing_test.go
@@ -1,0 +1,140 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// A delayed old timer must not lose a state change suppressed by a newer
+// window. The first two plans see insufficient reload memory; only the final
+// heartbeat supplies enough, and no further heartbeat follows it.
+func TestDelayedTrailingPlanPreservesNewWindowHeartbeat(t *testing.T) {
+	reg := New(testLogger())
+	loads := make(chan string, 4)
+	reg.loadModelSender = func(providerID, model string) error {
+		loads <- providerID + "/" + model
+		return nil
+	}
+	const model = "swap-delayed-trailing-model"
+	reg.SetModelCatalog([]CatalogEntry{{ID: model, SizeGB: 8, MinRAMGB: 16}})
+	p := makeSchedulerProvider(t, reg, "p1", model, 100)
+	reg.Heartbeat(p.ID, swapTestCrashedHeartbeat(model, 1))
+	if err := reg.Queue().Enqueue(swapTestQueued("swap-delayed-trailing-request", model)); err != nil {
+		t.Fatal(err)
+	}
+	stub := installTrailingTimerStub(reg)
+	t0 := time.Now()
+	now := t0
+	reg.swapPlanGate.now = func() time.Time { return now }
+	reg.triggerModelSwapsFromHeartbeat(t0)
+	reg.triggerModelSwapsFromHeartbeat(t0.Add(100 * time.Millisecond))
+	if len(stub.fire) != 1 {
+		t.Fatal("suppressed heartbeat did not arm the old timer")
+	}
+	// Its timer is delayed; another heartbeat plans after the window opens.
+	newWindow := t0.Add(modelSwapPlanInterval + 10*time.Millisecond)
+	if !reg.triggerModelSwapsFromHeartbeat(newWindow) {
+		t.Fatal("new heartbeat did not open a new planning window")
+	}
+	select {
+	case got := <-loads:
+		t.Fatalf("planned a reload with insufficient memory: %s", got)
+	default:
+	}
+	// Simulate the heartbeat's state mutation and planner notification while
+	// the old timer is still armed. A crashed slot cannot drain this request.
+	p.mu.Lock()
+	freeForLoadGB := 32.0
+	p.BackendCapacity.FreeForLoadGB = &freeForLoadGB
+	p.mu.Unlock()
+	reg.triggerModelSwapsFromHeartbeat(newWindow.Add(10 * time.Millisecond))
+	now = newWindow.Add(20 * time.Millisecond)
+	stub.fire[0]()
+	if len(stub.fire) != 2 || stub.waits[1] != modelSwapPlanInterval-20*time.Millisecond {
+		t.Fatalf("old timer lost the new window's heartbeat: waits %v", stub.waits)
+	}
+	now = newWindow.Add(modelSwapPlanInterval)
+	stub.fire[1]()
+	select {
+	case got := <-loads:
+		if want := p.ID + "/" + model; got != want {
+			t.Fatalf("load = %s, want %s", got, want)
+		}
+	default:
+		t.Fatal("no reload after the delayed timer's follow-up")
+	}
+	if reg.swapPlanGate.planRuns() != 3 || reg.swapPlanGate.trailingArmed() {
+		t.Fatal("trailing callback did not finish the third plan")
+	}
+}
+
+// Hold an actual warm queue drain past the swap window. The remaining cold
+// demand must trigger its reload as soon as Heartbeat finishes that drain,
+// rather than scheduling a second delay from the stale heartbeat timestamp.
+func TestHeartbeatSwapPlanClaimsAfterSlowQueueDrain(t *testing.T) {
+	reg := New(testLogger())
+	const cold, warm = "swap-post-drain-cold", "swap-post-drain-warm"
+	reg.SetModelCatalog([]CatalogEntry{
+		{ID: cold, SizeGB: 8, MinRAMGB: 16}, {ID: warm, SizeGB: 8, MinRAMGB: 16},
+	})
+	coldProvider := makeSchedulerProvider(t, reg, "post-drain-cold", cold, 100)
+	warmProvider := makeSchedulerProvider(t, reg, "post-drain-warm", warm, 100)
+	reg.Heartbeat(coldProvider.ID, swapTestCrashedHeartbeat(cold, 32))
+	loads := make(chan string, 4)
+	reg.loadModelSender = func(providerID, model string) error {
+		loads <- providerID + "/" + model
+		return nil
+	}
+	stub := installTrailingTimerStub(reg)
+	for _, req := range []*QueuedRequest{swapTestQueued("post-drain-cold-request", cold), swapTestQueued("post-drain-warm-request", warm)} {
+		if err := reg.Queue().Enqueue(req); err != nil {
+			t.Fatal(err)
+		}
+	}
+	draining, release := make(chan struct{}), make(chan struct{})
+	releaseDrain := sync.OnceFunc(func() { close(release) })
+	defer releaseDrain()
+	reg.reservationAfterScan = func(model string) {
+		if model == warm {
+			close(draining)
+			<-release
+		}
+	}
+	done := make(chan struct{})
+	go func() {
+		reg.Heartbeat(warmProvider.ID, swapTestHeartbeat(warm, "running"))
+		close(done)
+	}()
+	select {
+	case <-draining:
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat did not enter the queued warm request's drain")
+	}
+	warmProvider.mu.Lock()
+	heartbeatAt := warmProvider.LastHeartbeat
+	warmProvider.mu.Unlock()
+	if ok, _ := reg.swapPlanGate.claim(heartbeatAt); !ok {
+		t.Fatal("precondition: another plan opens a window at the heartbeat timestamp")
+	}
+	if remaining := time.Until(heartbeatAt.Add(modelSwapPlanInterval + time.Millisecond)); remaining > 0 {
+		time.Sleep(remaining)
+	}
+	releaseDrain()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat did not finish after releasing the drain")
+	}
+	if len(stub.fire) != 0 {
+		t.Fatal("heartbeat added a trailing delay although the planning window already elapsed")
+	}
+	select {
+	case got := <-loads:
+		if want := coldProvider.ID + "/" + cold; got != want {
+			t.Fatalf("load = %s, want %s", got, want)
+		}
+	default:
+		t.Fatal("elapsed planning window did not immediately reload the queued cold model")
+	}
+}

--- a/coordinator/registry/pair_keys.go
+++ b/coordinator/registry/pair_keys.go
@@ -1,0 +1,27 @@
+package registry
+
+// pair_keys.go — struct keys for the per-(provider, model) maps that used to
+// be "providerID:modelID" string concatenations. A struct key is built with
+// no allocation on the routing hot path (the dispatch-load cooldown gate runs
+// once per provider per scan) and cannot alias across ids that contain the
+// delimiter — the same reasoning as capacityRejectKey and inferenceErrorKey.
+// Iteration-time filtering by provider (Disconnect, pending-load sweeps, the
+// fault-key migration) compares the field instead of parsing a prefix.
+
+// dispatchLoadKey identifies a dispatch-load cooldown bucket
+// (Registry.dispatchLoadCooldowns). FaultKey is the provider's STABLE fault
+// key (faultKeyLocked: serial/SE-key when bound, the session id otherwise) so
+// the cooldown survives a reconnect within its TTL.
+type dispatchLoadKey struct {
+	FaultKey string
+	ModelID  string
+}
+
+// modelLoadKey identifies a pending load_model command
+// (Registry.pendingModelLoads / pendingModelLoadStarted). ProviderID is the
+// live SESSION id, deliberately NOT the fault key: pending loads are
+// connection-scoped and dropped on Disconnect.
+type modelLoadKey struct {
+	ProviderID string
+	ModelID    string
+}

--- a/coordinator/registry/pair_keys_test.go
+++ b/coordinator/registry/pair_keys_test.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPairKeysCannotAliasAcrossDelimiter pins the struct-key guarantee the
+// old "providerID:modelID" strings lacked: ("a:b", "c") and ("a", "b:c") are
+// different pairs for both the dispatch-load cooldown and pending model loads.
+func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
+	r := New(testLogger())
+	makeSchedulerProvider(t, r, "a:b", "c", 50)
+	makeSchedulerProvider(t, r, "a", "b:c", 50)
+
+	if !r.RecordDispatchLoadFailure("a:b", "c") {
+		t.Fatal("first failure must start a cooldown")
+	}
+	r.mu.RLock()
+	aliased := r.dispatchLoadCooldownActiveLocked("a", "b:c", time.Now())
+	direct := r.dispatchLoadCooldownActiveLocked("a:b", "c", time.Now())
+	r.mu.RUnlock()
+	if aliased || !direct {
+		t.Fatalf("dispatch-load cooldown aliased across ':' (aliased=%v direct=%v)", aliased, direct)
+	}
+
+	r.reservePendingModelLoads([]modelLoadAction{{providerID: "a:b", modelID: "c"}}, time.Now())
+	if r.HasPendingModelLoad("a", "b:c") {
+		t.Fatal("pending model load aliased across ':'")
+	}
+	if !r.HasPendingModelLoad("a:b", "c") {
+		t.Fatal("pending model load not recorded for the real pair")
+	}
+}
+
+// TestDispatchLoadCooldownGateAllocatesNothing pins the hot-path contract for
+// the per-provider cooldown gate.
+func TestDispatchLoadCooldownGateAllocatesNothing(t *testing.T) {
+	r := New(testLogger())
+	makeSchedulerProvider(t, r, "p1", "m", 50)
+	r.RecordDispatchLoadFailure("p1", "m")
+	now := time.Now()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	hits := 0
+	allocs := testing.AllocsPerRun(200, func() {
+		if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+			hits++
+		}
+		if r.dispatchLoadCooldownActiveLocked("p2", "m", now) {
+			hits++
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("cooldown gate allocated %v per run; want 0", allocs)
+	}
+	if hits == 0 {
+		t.Fatal("active cooldown was not observed")
+	}
+}
+
+// TestDisconnectDropsOnlyThatProvidersPendingLoads pins the Disconnect sweep:
+// the session's own pending loads go, a provider whose id merely shares a
+// prefix keeps its entries (exact field match, as the old "id:" prefix test
+// also guaranteed), and a disconnected identity-less provider's dispatch-load
+// residue is dropped by exact fault-key match.
+func TestDisconnectDropsOnlyThatProvidersPendingLoads(t *testing.T) {
+	r := New(testLogger())
+	makeSchedulerProvider(t, r, "p1", "m", 50)
+	makeSchedulerProvider(t, r, "p10", "m", 50)
+	now := time.Now()
+	r.reservePendingModelLoads([]modelLoadAction{
+		{providerID: "p1", modelID: "m"},
+		{providerID: "p10", modelID: "m"},
+	}, now)
+	r.RecordDispatchLoadFailure("p1", "m")
+	r.RecordDispatchLoadFailure("p10", "m")
+
+	r.Disconnect("p1")
+
+	if r.HasPendingModelLoad("p1", "m") {
+		t.Fatal("disconnected provider's pending load survived")
+	}
+	if !r.HasPendingModelLoad("p10", "m") {
+		t.Fatal("prefix-sharing provider's pending load was dropped")
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+		t.Fatal("identity-less disconnected provider's cooldown residue survived")
+	}
+	if !r.dispatchLoadCooldownActiveLocked("p10", "m", now) {
+		t.Fatal("prefix-sharing provider's cooldown was dropped")
+	}
+}

--- a/coordinator/registry/pending_model_loads_test.go
+++ b/coordinator/registry/pending_model_loads_test.go
@@ -14,7 +14,7 @@ func hasPendingLoad(r *Registry, providerID string) bool {
 func pendingLoadExpiry(r *Registry, providerID, modelID string) (time.Time, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	exp, ok := r.pendingModelLoads[modelLoadKey(providerID, modelID)]
+	exp, ok := r.pendingModelLoads[modelLoadKey{ProviderID: providerID, ModelID: modelID}]
 	return exp, ok
 }
 
@@ -60,7 +60,7 @@ func TestHasPendingModelLoadMatchesExactUnexpiredCommand(t *testing.T) {
 	}
 
 	r.mu.Lock()
-	r.pendingModelLoads[modelLoadKey("p1", "m1")] = time.Now().Add(-time.Second)
+	r.pendingModelLoads[modelLoadKey{ProviderID: "p1", ModelID: "m1"}] = time.Now().Add(-time.Second)
 	r.mu.Unlock()
 	if r.HasPendingModelLoad("p1", "m1") {
 		t.Fatal("expired command reported as pending")
@@ -203,7 +203,7 @@ func TestDisconnectClearsPendingModelLoad(t *testing.T) {
 		t.Fatal("Disconnect did not clear the provider's pending model load")
 	}
 	r.mu.RLock()
-	_, startedLeft := r.pendingModelLoadStarted[modelLoadKey("p1", "m1")]
+	_, startedLeft := r.pendingModelLoadStarted[modelLoadKey{ProviderID: "p1", ModelID: "m1"}]
 	r.mu.RUnlock()
 	if startedLeft {
 		t.Fatal("Disconnect left a dangling pendingModelLoadStarted entry")

--- a/coordinator/registry/policy_clock_test.go
+++ b/coordinator/registry/policy_clock_test.go
@@ -1,0 +1,76 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestPolicyDeadlinePredicatesHonorPassedClock pins the walk-clock contract:
+// the ...AtLocked variants evaluate the two rollout deadlines against the
+// instant they are given (the walk's single captured now), while the no-arg
+// forms keep reading the wall clock for non-walk callers.
+func TestPolicyDeadlinePredicatesHonorPassedClock(t *testing.T) {
+	reg := New(testLogger())
+	future := time.Now().Add(time.Hour)
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	reg.codeAttestationConfigured = true
+	reg.codeAttestationDeadline = future
+	if reg.codeAttestationEnforcedLocked() {
+		t.Fatal("code attestation must not be enforced before the deadline (wall clock)")
+	}
+	if reg.codeAttestationEnforcedAtLocked(future.Add(-time.Second)) {
+		t.Fatal("At variant: before the deadline must not enforce")
+	}
+	if !reg.codeAttestationEnforcedAtLocked(future) {
+		t.Fatal("At variant: at the deadline must enforce")
+	}
+
+	reg.releasePolicyEnforced = true
+	reg.releasePolicyEnforceAfter = future
+	if reg.releasePolicyEnforcedLocked() {
+		t.Fatal("release policy must not be enforced before enforce-after (wall clock)")
+	}
+	if reg.releasePolicyEnforcedAtLocked(future.Add(-time.Second)) {
+		t.Fatal("At variant: before enforce-after must not enforce")
+	}
+	if !reg.releasePolicyEnforcedAtLocked(future.Add(time.Second)) {
+		t.Fatal("At variant: after enforce-after must enforce")
+	}
+}
+
+// TestPrivateTextGateThreadsWalkClock pins that the routing chokepoint
+// consults the deadlines at the clock it is handed: an un-attested provider
+// is admitted for a walk clocked before the APNs deadline and derouted for a
+// walk clocked after it, with no wall-clock read in between.
+func TestPrivateTextGateThreadsWalkClock(t *testing.T) {
+	reg := New(testLogger())
+	const model = "clock-model"
+	p := makeSchedulerProvider(t, reg, "p1", model, 100)
+	deadline := time.Now().Add(time.Hour)
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.codeAttestationConfigured = true
+	reg.codeAttestationDeadline = deadline
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.CodeAttested {
+		t.Fatal("precondition: provider un-attested")
+	}
+	// Keep the challenge fresh at both walk clocks so the only gate that can
+	// flip between them is the APNs deadline.
+	p.LastChallengeVerified = deadline
+	if !reg.providerSupportsPrivateTextAtLocked(p, deadline.Add(-time.Minute)) {
+		t.Fatal("before the deadline the un-attested provider must pass (grace)")
+	}
+	if reg.providerSupportsPrivateTextAtLocked(p, deadline.Add(time.Minute)) {
+		t.Fatal("after the deadline the un-attested provider must be derouted")
+	}
+	if !reg.providerLivenessGateLocked(p, TrustHardware, false, deadline.Add(-time.Minute)) {
+		t.Fatal("liveness gate must pass with a pre-deadline walk clock")
+	}
+	if reg.providerLivenessGateLocked(p, TrustHardware, false, deadline.Add(time.Minute)) {
+		t.Fatal("liveness gate must fail with a post-deadline walk clock")
+	}
+}

--- a/coordinator/registry/policy_getters_lock_test.go
+++ b/coordinator/registry/policy_getters_lock_test.go
@@ -1,0 +1,27 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReadOnlyPolicyGettersUseReadLock pins that the three gauge/stats
+// getters are readable while another goroutine holds the read lock — i.e.
+// they no longer take the write lock and cannot serialize behind readers.
+func TestReadOnlyPolicyGettersUseReadLock(t *testing.T) {
+	reg := New(testLogger())
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = reg.CodeAttestationConfigured()
+		_ = reg.CodeAttestationEnforced()
+		_ = reg.ReleasePolicyEnforced()
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("read-only getters blocked behind a held read lock (write lock?)")
+	}
+}

--- a/coordinator/registry/pooled_admission.go
+++ b/coordinator/registry/pooled_admission.go
@@ -54,12 +54,37 @@ const (
 	privateSlotGrantsMinVersion = "0.7.5"
 )
 
+// slotBudgetLayoutForVersion selects the pooled-budget layout for a provider
+// binary version. It runs once per provider per routing scan via
+// fillSnapshotPendingAndPool, so the result is memoized (version_memo.go) —
+// keyed on the NORMALIZED numeric core ("1.0.0" for "v1.0.0-rc1+meta"), so
+// suffix variants of one version share an entry and an oversized suffix can
+// never be retained; a core longer than maxMemoizedVersionLen is computed
+// without caching.
 func slotBudgetLayoutForVersion(version string) slotBudgetLayout {
+	return slotBudgetLayoutMemo.get(versionNumericCore(version), parseSlotBudgetLayoutCore)
+}
+
+// versionNumericCore strips surrounding whitespace and any pre-release/build
+// suffix ("-…" / "+…") from a version, leaving the dotted numeric core.
+func versionNumericCore(version string) string {
 	version = strings.TrimSpace(version)
 	if suffix := strings.IndexAny(version, "-+"); suffix >= 0 {
 		version = version[:suffix]
 	}
-	if CompareVersions(version, privateSlotGrantsMinVersion) >= 0 {
+	return version
+}
+
+// parseSlotBudgetLayout is the uncached selection behind
+// slotBudgetLayoutForVersion: a pre-release/build suffix is ignored and the
+// numeric core compared against privateSlotGrantsMinVersion.
+func parseSlotBudgetLayout(version string) slotBudgetLayout {
+	return parseSlotBudgetLayoutCore(versionNumericCore(version))
+}
+
+// parseSlotBudgetLayoutCore compares an already-normalized numeric core.
+func parseSlotBudgetLayoutCore(core string) slotBudgetLayout {
+	if CompareVersions(core, privateSlotGrantsMinVersion) >= 0 {
 		return privateSlotGrants
 	}
 	return sharedSlotHeadroom
@@ -96,7 +121,7 @@ func clampKVBytesPerToken(r int64) int64 {
 // not loaded yet, while retaining a higher observed resident rate avoids
 // weakening the fallback. Legacy/non-reconstructable pools return 0 and retain
 // token accounting.
-func resolvedPooledKVBytesPerToken(pool pooledTokenBudget, reportedRate int64) int64 {
+func resolvedPooledKVBytesPerToken(pool *pooledTokenBudget, reportedRate int64) int64 {
 	if !pool.byteMode {
 		return 0
 	}
@@ -168,10 +193,16 @@ type pooledTokenBudget struct {
 	// slot reports KVBytesPerToken > 0, i.e. the pool can be reconstructed in
 	// bytes. False ⇒ pooledBudgetAdmits uses token accounting exactly.
 	byteMode bool
-	// kvBytesPerToken maps each budget slot's model to its reported per-token
-	// KV rate, for normalizing coordinator-pending charges into bytes. Nil
-	// when no budget slot reports a rate.
-	kvBytesPerToken map[string]int64
+	// kvRates holds each budget slot's model and its reported (clamped)
+	// per-token KV rate, for normalizing coordinator-pending charges into
+	// bytes — a fixed inline table (a box serves a handful of co-resident
+	// models) that spills to a heap slice only past pooledKVRateInline entries,
+	// so reconstructing a pool once per provider per routing scan allocates
+	// nothing (pooled_kv_rates.go). Read through kvRateFor; empty when no
+	// budget slot reports a rate.
+	kvRates      [pooledKVRateInline]slotKVRate
+	kvRateCount  int
+	kvRatesSpill []slotKVRate
 	// maxResidentKVBytesPerToken is the largest clamped rate among budget
 	// slots. It can raise, but never lower, the conservative cold-model default.
 	maxResidentKVBytesPerToken int64
@@ -214,10 +245,7 @@ func providerPooledTokenBudgetWithLayout(slots []protocol.BackendSlotCapacity, l
 			// token-mode behavior for the whole provider.
 			pool.byteMode = false
 		} else {
-			if pool.kvBytesPerToken == nil {
-				pool.kvBytesPerToken = make(map[string]int64, len(slots))
-			}
-			pool.kvBytesPerToken[slot.Model] = rate
+			pool.setKVRate(slot.Model, rate)
 			if rate > pool.maxResidentKVBytesPerToken {
 				pool.maxResidentKVBytesPerToken = rate
 			}
@@ -300,8 +328,8 @@ func providerPooledTokenBudgetWithLayout(slots []protocol.BackendSlotCapacity, l
 // at least the conservative default, never a cheap resident-only estimate.
 // Token accounting is used only when the pool is not byte-reconstructable or
 // the snapshot predates/omits byte accumulation.
-func pooledBudgetAdmits(snap routingSnapshot, requestTokens int64) bool {
-	pool := snap.pooledTokenBudget
+func pooledBudgetAdmits(snap *routingSnapshot, requestTokens int64) bool {
+	pool := &snap.pooledTokenBudget
 	if !pool.hasBudgetReport {
 		return true
 	}
@@ -355,7 +383,7 @@ func pooledRemainingTokens(pool pooledTokenBudget, pendingTokensAllModels int, p
 		return 0
 	}
 	if pool.byteMode && pendingBytesKnown {
-		rate := resolvedPooledKVBytesPerToken(pool, modelRate)
+		rate := resolvedPooledKVBytesPerToken(&pool, modelRate)
 		if rate > 0 {
 			extra := pendingBytesAllModels - pool.committedBytes
 			if extra < 0 {

--- a/coordinator/registry/pooled_admission_test.go
+++ b/coordinator/registry/pooled_admission_test.go
@@ -33,7 +33,7 @@ func TestProviderPooledTokenBudgetClampsKVByteRate(t *testing.T) {
 	if pool.totalBytes < pool.usedBytes {
 		t.Fatalf("totalBytes %d < usedBytes %d (overflow)", pool.totalBytes, pool.usedBytes)
 	}
-	if got := pool.kvBytesPerToken["a"]; got != maxKVBytesPerToken {
+	if got := pool.kvRateFor("a"); got != maxKVBytesPerToken {
 		t.Fatalf("stored KV rate = %d, want clamp %d (raw absurd rate not clamped)", got, maxKVBytesPerToken)
 	}
 	// Admission must fail-closed for a request that overflows the pool, not
@@ -45,10 +45,10 @@ func TestProviderPooledTokenBudgetClampsKVByteRate(t *testing.T) {
 		pendingBytesKnown:    true,
 		pooledTokenBudget:    pool,
 	}
-	if pooledBudgetAdmits(snap, 10_000_000_000) {
+	if pooledBudgetAdmits(snapPtr(snap), 10_000_000_000) {
 		t.Fatal("admitted a 10B-token request into a finite byte pool (overflow admitted-everything)")
 	}
-	if !pooledBudgetAdmits(snap, 100_000) {
+	if !pooledBudgetAdmits(snapPtr(snap), 100_000) {
 		t.Fatal("rejected a 100k-token request that fits the 200k-token byte headroom")
 	}
 }
@@ -67,7 +67,7 @@ func TestPooledKnownZeroBudgetRejects(t *testing.T) {
 		pendingBytesKnown: true,
 		pooledTokenBudget: pool,
 	}
-	if pooledBudgetAdmits(snap, 1) {
+	if pooledBudgetAdmits(snapPtr(snap), 1) {
 		t.Fatal("known-zero Engine V2 budget admitted a request as if it were an unconstrained legacy slot")
 	}
 	if got := pooledRemainingTokens(pool, 0, 0, true, 800_000); got != 0 {
@@ -76,7 +76,7 @@ func TestPooledKnownZeroBudgetRejects(t *testing.T) {
 
 	legacy := providerPooledTokenBudget([]protocol.BackendSlotCapacity{{Model: "legacy"}})
 	legacySnap := routingSnapshot{pooledTokenBudget: legacy}
-	if !pooledBudgetAdmits(legacySnap, 1) {
+	if !pooledBudgetAdmits(snapPtr(legacySnap), 1) {
 		t.Fatal("legacy slot with no budget or KV rate became constrained")
 	}
 	if got := pooledRemainingTokens(legacy, 0, 0, false, 0); got != -1 {
@@ -110,7 +110,7 @@ func TestPooledZeroBudgetResidentRateStaysSymmetric(t *testing.T) {
 	pool := providerPooledTokenBudget(p.BackendCapacity.Slots)
 	p.mu.Unlock()
 
-	if got := pool.kvBytesPerToken[gemmaBuild]; got != knownZeroRate {
+	if got := pool.kvRateFor(gemmaBuild); got != knownZeroRate {
 		t.Fatalf("zero-budget resident KV rate = %d, want reported %d", got, knownZeroRate)
 	}
 
@@ -533,10 +533,10 @@ func TestPrivateGrantPoolUsesCeilingsWhenLiveUseExceedsReslice(t *testing.T) {
 				pendingBytesKnown: true,
 				pooledTokenBudget: pool,
 			}
-			if !pooledBudgetAdmits(snap, tc.wantRemain) {
+			if !pooledBudgetAdmits(snapPtr(snap), tc.wantRemain) {
 				t.Fatalf("rejected exact remaining capacity %d", tc.wantRemain)
 			}
-			if pooledBudgetAdmits(snap, tc.wantRemain+1) {
+			if pooledBudgetAdmits(snapPtr(snap), tc.wantRemain+1) {
 				t.Fatalf("admitted past remaining capacity %d", tc.wantRemain)
 			}
 		})
@@ -555,11 +555,13 @@ func TestPrivateGrantPoolSaturatesUsedBudgetAddition(t *testing.T) {
 		t.Fatalf("overflowed used budget = {tokens:%d bytes:%d}, want saturated MaxInt64",
 			pool.used, pool.usedBytes)
 	}
-	if pooledBudgetAdmits(routingSnapshot{
+	if pooledBudgetAdmits(snapPtr(routingSnapshot{
 		kvBytesPerToken:   1,
 		pendingBytesKnown: true,
 		pooledTokenBudget: pool,
-	}, 1) {
+	}),
+
+		1) {
 		t.Fatal("overflowed live use left invented private-grant headroom")
 	}
 }
@@ -590,10 +592,10 @@ func TestFreeMemoryAdmitsSingleModelUnchanged(t *testing.T) {
 			pooledTokenBudget:         providerPooledTokenBudget([]protocol.BackendSlotCapacity{slot}),
 		}
 	}
-	if !freeMemoryAdmits(mkSnap(7_000), 0, 5_500) {
+	if !freeMemoryAdmits(snapPtr(mkSnap(7_000)), 0, 5_500) {
 		t.Fatal("request at the exact old boundary (5_500) rejected — pooled check changed single-model behavior")
 	}
-	if freeMemoryAdmits(mkSnap(7_000), 0, 5_501) {
+	if freeMemoryAdmits(snapPtr(mkSnap(7_000)), 0, 5_501) {
 		t.Fatal("request past the old boundary (5_501) admitted — budget admission loosened")
 	}
 }
@@ -614,12 +616,12 @@ func TestFreeMemoryAdmitsPooledRejectsGapDoubleSpend(t *testing.T) {
 		activeTokenBudgetMax:      10_000,
 		pooledTokenBudget:         providerPooledTokenBudget(slots),
 	}
-	if freeMemoryAdmits(snap, 100, 1_900) {
+	if freeMemoryAdmits(snapPtr(snap), 100, 1_900) {
 		t.Fatal("admitted 2k tokens into a pool with 10k already pending to a co-resident model (per-slot double-spend)")
 	}
 	// Same snapshot with only 4k pending across models → admits.
 	snap.pendingMaxTokensAllModels = 4_000
-	if !freeMemoryAdmits(snap, 100, 1_900) {
+	if !freeMemoryAdmits(snapPtr(snap), 100, 1_900) {
 		t.Fatal("rejected 2k tokens although the pool has 6k of headroom")
 	}
 }
@@ -685,11 +687,11 @@ func TestFreeMemoryAdmitsByteNormalizedHeterogeneousKV(t *testing.T) {
 		}
 	}
 	// 90k small-KV tokens pending = 0.9 GB; +0.3 GB request = 1.2 GB > 1 GB.
-	if freeMemoryAdmits(mkSnap(90_000), 100, 2_900) {
+	if freeMemoryAdmits(snapPtr(mkSnap(90_000)), 100, 2_900) {
 		t.Fatal("admitted 0.3 GB of big-KV request into a byte pool with 0.9 GB already pending (token/byte unit confusion)")
 	}
 	// Control: 40k small-KV tokens pending = 0.4 GB; +0.3 GB = 0.7 GB ≤ 1 GB.
-	if !freeMemoryAdmits(mkSnap(40_000), 100, 2_900) {
+	if !freeMemoryAdmits(snapPtr(mkSnap(40_000)), 100, 2_900) {
 		t.Fatal("rejected a request although the byte pool has 0.6 GB of headroom (byte gate over-rejecting)")
 	}
 }
@@ -717,7 +719,7 @@ func TestFreeMemoryAdmitsByteModeCorrectsTokenOverReject(t *testing.T) {
 		pendingBytesKnown:         true,
 		pooledTokenBudget:         providerPooledTokenBudget(slots),
 	}
-	if !pooledBudgetAdmits(snap, 1_000) {
+	if !pooledBudgetAdmits(snapPtr(snap), 1_000) {
 		t.Fatal("rejected 10 MB into a 1 GB byte pool holding 0.6 GB (token-unit over-rejection not corrected)")
 	}
 }
@@ -783,11 +785,11 @@ func TestFreeMemoryAdmitsColdModelChargesPool(t *testing.T) {
 			pooledTokenBudget:         providerPooledTokenBudget(slots),
 		}
 	}
-	if freeMemoryAdmits(mkSnap(10_000), 100, 1_900) {
+	if freeMemoryAdmits(snapPtr(mkSnap(10_000)), 100, 1_900) {
 		t.Fatal("cold request admitted into a pool fully pending to a resident model (cold path skipped the pooled gate)")
 	}
 	// Control: with 4k of the 10k pool pending, the 2k cold request fits.
-	if !freeMemoryAdmits(mkSnap(4_000), 100, 1_900) {
+	if !freeMemoryAdmits(snapPtr(mkSnap(4_000)), 100, 1_900) {
 		t.Fatal("cold request rejected although the pool has 6k of headroom")
 	}
 }
@@ -951,11 +953,11 @@ func TestPooledByteTotalFromLiveUsedNotCommitted(t *testing.T) {
 		pendingBytesKnown:         true,
 		pooledTokenBudget:         pool,
 	}
-	if pooledBudgetAdmits(snap, 12_000) {
+	if pooledBudgetAdmits(snapPtr(snap), 12_000) {
 		t.Fatal("admitted 1.2 GB into a 1 GB byte pool — MaxTokensPotential double-counted as physical KV capacity")
 	}
 	// Control: 8k tokens = 0.8 GB genuinely fits the 1 GB pool.
-	if !pooledBudgetAdmits(snap, 8_000) {
+	if !pooledBudgetAdmits(snapPtr(snap), 8_000) {
 		t.Fatal("rejected 0.8 GB that fits the 1 GB byte pool (byte total under-counted)")
 	}
 }
@@ -1032,7 +1034,7 @@ func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
 		if !pool.byteMode {
 			t.Fatal("pool byteMode = false, want true")
 		}
-		if got := resolvedPooledKVBytesPerToken(pool, 0); got != kvCacheBytesPerToken {
+		if got := resolvedPooledKVBytesPerToken(poolPtr(pool), 0); got != kvCacheBytesPerToken {
 			t.Fatalf("resolved cold KV rate = %d, want conservative default %d", got, kvCacheBytesPerToken)
 		}
 		cold := routingSnapshot{
@@ -1042,11 +1044,11 @@ func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
 		}
 		// 50k tokens: token fallback would admit (50k <= 100k token pool), but
 		// conservative byte pricing is far beyond the 1 GB pool.
-		if pooledBudgetAdmits(cold, 50_000) {
+		if pooledBudgetAdmits(snapPtr(cold), 50_000) {
 			t.Fatal("cold unknown-KV request admitted via token/resident-rate fallback")
 		}
 		// Control: 2k tokens at the default rate remain below 1 GB.
-		if !pooledBudgetAdmits(cold, 2_000) {
+		if !pooledBudgetAdmits(snapPtr(cold), 2_000) {
 			t.Fatal("cold request rejected although its conservative byte charge fits the pool")
 		}
 		wantRemaining := pool.totalBytes / kvCacheBytesPerToken
@@ -1062,10 +1064,10 @@ func TestPooledColdUnknownKVChargedInBytes(t *testing.T) {
 			{Model: "m", ActiveTokenBudgetMax: 10_000, KVBytesPerToken: 50_000},
 		})
 		known := routingSnapshot{kvBytesPerToken: 50_000, pendingBytesKnown: true, pooledTokenBudget: pool}
-		if !pooledBudgetAdmits(known, 10_000) {
+		if !pooledBudgetAdmits(snapPtr(known), 10_000) {
 			t.Fatal("known request at the exact 10k boundary rejected")
 		}
-		if pooledBudgetAdmits(known, 10_001) {
+		if pooledBudgetAdmits(snapPtr(known), 10_001) {
 			t.Fatal("known request past the 10k boundary admitted")
 		}
 	})
@@ -1087,7 +1089,7 @@ func TestPooledFirstColdRequestUsesConservativeDefault(t *testing.T) {
 		pooledTokenBudget: pool,
 	}
 
-	if pooledBudgetAdmits(snap, 3_000) {
+	if pooledBudgetAdmits(snapPtr(snap), 3_000) {
 		t.Fatal("first cold request priced at resident-only KV max instead of the conservative unknown-model default")
 	}
 	wantRemaining := pool.totalBytes / kvCacheBytesPerToken
@@ -1127,7 +1129,7 @@ func TestPooledPendingColdRequestKeepsByteAccounting(t *testing.T) {
 	if snap.pendingMaxBytesAllModels != wantPendingBytes {
 		t.Errorf("cold pending bytes = %d, want %d at conservative default rate", snap.pendingMaxBytesAllModels, wantPendingBytes)
 	}
-	if pooledBudgetAdmits(snap, 20_000) {
+	if pooledBudgetAdmits(snapPtr(snap), 20_000) {
 		t.Error("subsequent resident request admitted via token fallback after cold pending request consumed byte headroom")
 	}
 	wantRemaining := (snap.pooledTokenBudget.totalBytes - wantPendingBytes) / residentRate
@@ -1142,7 +1144,7 @@ func TestPooledPendingColdRequestKeepsByteAccounting(t *testing.T) {
 	}
 
 	overflowTokens := int64(math.MaxInt64/kvCacheBytesPerToken + 1)
-	if got := addPooledKVByteCharge(0, overflowTokens, resolvedPooledKVBytesPerToken(snap.pooledTokenBudget, 0)); got != math.MaxInt64 {
+	if got := addPooledKVByteCharge(0, overflowTokens, resolvedPooledKVBytesPerToken(poolPtr(snap.pooledTokenBudget), 0)); got != math.MaxInt64 {
 		t.Errorf("overflowing cold pending charge = %d, want saturated MaxInt64", got)
 	}
 }
@@ -1195,7 +1197,7 @@ func TestPooledRemainingTokensMatchesAdmits(t *testing.T) {
 				tc.snap.kvBytesPerToken,
 			)
 			for n := int64(1); n <= rem+50; n++ {
-				if admits, want := pooledBudgetAdmits(tc.snap, n), n <= rem; admits != want {
+				if admits, want := pooledBudgetAdmits(snapPtr(tc.snap), n), n <= rem; admits != want {
 					t.Fatalf("n=%d: pooledBudgetAdmits=%v, but (n<=rem=%d)=%v", n, admits, rem, want)
 				}
 			}
@@ -1214,7 +1216,7 @@ func TestFreeMemoryAdmitsLegacyProviderUnchanged(t *testing.T) {
 		modelSizeGB:               14,
 		pendingMaxTokensAllModels: 1 << 30, // must be ignored on the legacy path
 	}
-	if !freeMemoryAdmits(snap, 100, 1_900) {
+	if !freeMemoryAdmits(snapPtr(snap), 100, 1_900) {
 		t.Fatal("legacy (budget-less) admission changed: loaded model with free memory must admit")
 	}
 }

--- a/coordinator/registry/pooled_kv_rates.go
+++ b/coordinator/registry/pooled_kv_rates.go
@@ -1,0 +1,59 @@
+package registry
+
+// pooled_kv_rates.go — the per-slot KV-rate table inside pooledTokenBudget.
+//
+// providerPooledTokenBudgetWithLayout used to allocate a map[string]int64 for
+// every provider on every routing scan (~11% of the fleet-scale scan's
+// allocation volume) to remember each budget slot's KVBytesPerToken. A box
+// serves a handful of co-resident models, so the table is a fixed inline
+// array that only spills to the heap past pooledKVRateInline entries.
+// Semantics match the map exactly: one entry per model, a later slot for the
+// same model overwrites the earlier rate (last write wins), and an unknown
+// model reads as 0.
+
+// pooledKVRateInline is the inline capacity of the rate table.
+const pooledKVRateInline = 4
+
+// slotKVRate pairs a budget slot's model with its clamped KV rate.
+type slotKVRate struct {
+	model string
+	rate  int64
+}
+
+// setKVRate records (or overwrites) the rate for model.
+func (p *pooledTokenBudget) setKVRate(model string, rate int64) {
+	for i := 0; i < p.kvRateCount && i < pooledKVRateInline; i++ {
+		if p.kvRates[i].model == model {
+			p.kvRates[i].rate = rate
+			return
+		}
+	}
+	for i := range p.kvRatesSpill {
+		if p.kvRatesSpill[i].model == model {
+			p.kvRatesSpill[i].rate = rate
+			return
+		}
+	}
+	if p.kvRateCount < pooledKVRateInline {
+		p.kvRates[p.kvRateCount] = slotKVRate{model: model, rate: rate}
+	} else {
+		p.kvRatesSpill = append(p.kvRatesSpill, slotKVRate{model: model, rate: rate})
+	}
+	p.kvRateCount++
+}
+
+// kvRateFor returns the recorded rate for model, or 0 when no budget slot
+// reported one (the same "map miss ⇒ 0" every consumer relied on).
+func (p *pooledTokenBudget) kvRateFor(model string) int64 {
+	for i := 0; i < p.kvRateCount && i < pooledKVRateInline; i++ {
+		if p.kvRates[i].model == model {
+			return p.kvRates[i].rate
+		}
+	}
+	for i := range p.kvRatesSpill {
+		if p.kvRatesSpill[i].model == model {
+			return p.kvRatesSpill[i].rate
+		}
+	}
+	return 0
+}

--- a/coordinator/registry/pooled_kv_rates_test.go
+++ b/coordinator/registry/pooled_kv_rates_test.go
@@ -1,0 +1,58 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// TestPooledKVRateTableMatchesMapSemantics pins the inline table against the
+// map it replaced: last write wins per model, unknown reads as 0, and entries
+// past the inline capacity spill without losing or reordering anything.
+func TestPooledKVRateTableMatchesMapSemantics(t *testing.T) {
+	var pool pooledTokenBudget
+	ref := map[string]int64{}
+	set := func(model string, rate int64) {
+		pool.setKVRate(model, rate)
+		ref[model] = rate
+	}
+	for i := 0; i < 3*pooledKVRateInline; i++ {
+		set(fmt.Sprintf("m-%d", i), int64(1000+i))
+	}
+	set("m-0", 5)                                     // overwrite inline
+	set(fmt.Sprintf("m-%d", 2*pooledKVRateInline), 6) // overwrite spilled
+	for model, want := range ref {
+		if got := pool.kvRateFor(model); got != want {
+			t.Fatalf("kvRateFor(%s) = %d, want %d", model, got, want)
+		}
+	}
+	if got := pool.kvRateFor("absent"); got != 0 {
+		t.Fatalf("unknown model rate = %d, want 0", got)
+	}
+	if pool.kvRateCount != len(ref) {
+		t.Fatalf("kvRateCount = %d, want %d", pool.kvRateCount, len(ref))
+	}
+}
+
+// TestPooledBudgetReconstructionAllocatesNothing pins the hot-path contract:
+// reconstructing a provider's pool from a typical multi-slot heartbeat does
+// not touch the heap.
+func TestPooledBudgetReconstructionAllocatesNothing(t *testing.T) {
+	slots := []protocol.BackendSlotCapacity{
+		{Model: "a", ActiveTokenBudgetMax: 100_000, ActiveTokenBudgetUsed: 1_000, KVBytesPerToken: 98_304},
+		{Model: "b", ActiveTokenBudgetMax: 80_000, KVBytesPerToken: 50_000},
+		{Model: "c", ActiveTokenBudgetMax: 60_000, QueuedTokenBudget: 500, KVBytesPerToken: 20_000},
+	}
+	var sink int64
+	allocs := testing.AllocsPerRun(200, func() {
+		pool := providerPooledTokenBudgetWithLayout(slots, privateSlotGrants)
+		sink += pool.kvRateFor("b") + pool.totalBytes
+	})
+	if allocs != 0 {
+		t.Fatalf("pool reconstruction allocated %v per run; want 0", allocs)
+	}
+	if sink == 0 {
+		t.Fatal("pool reconstruction produced nothing")
+	}
+}

--- a/coordinator/registry/provider_capabilities_test.go
+++ b/coordinator/registry/provider_capabilities_test.go
@@ -112,6 +112,7 @@ func TestProviderCapabilityRequirementsApplyToAliasAndSelfRoute(t *testing.T) {
 	provider.mu.Lock()
 	provider.AccountID = "account"
 	provider.Models = append(provider.Models, protocol.ModelInfo{ID: previous, ModelType: "chat"})
+	provider.syncModelIndexLocked()
 	provider.mu.Unlock()
 	reg.SetModelAliases(map[string]AliasTarget{"public": {
 		Desired: Qwen38NAXModelID, Previous: previous,
@@ -190,6 +191,7 @@ func TestProviderCapabilityEligibilityHotCatalogAndCommandDefenses(t *testing.T)
 	}})
 	old.mu.Lock()
 	old.Models = append(old.Models, protocol.ModelInfo{ID: ordinary, ModelType: "chat"})
+	old.syncModelIndexLocked()
 	old.mu.Unlock()
 	if entries := reg.DesiredModelsForProvider(old.ID); len(entries) != 0 {
 		t.Fatalf("ineligible provider received desired protected build: %+v", entries)

--- a/coordinator/registry/provider_snapshot.go
+++ b/coordinator/registry/provider_snapshot.go
@@ -96,22 +96,47 @@ func (r *Registry) PublicProviderModels() map[string]PublicProviderModelSnapshot
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	out := make(map[string]PublicProviderModelSnapshot, len(r.providers))
+
+	// Every provider's eligible model IDs share ONE backing array instead of
+	// one slice allocation per provider: at fleet scale (~1,260 providers) the
+	// per-provider allocations were the entire cost of this walk, paid as GC
+	// pressure by /v1/stats and /v1/providers/attestation. Each provider's view
+	// is a 3-index sub-slice (cap == len), so a consumer append can never write
+	// into a neighbour's entries. The size pass is only a hint — both passes
+	// take p.mu, but p.Models may change or grow between them (models_update
+	// and provider-model merges mutate and append it in place); append then
+	// reallocates, and views already handed out keep their (unchanged) old
+	// array. A provider with no eligible model still gets a non-nil empty slice:
+	// stats serializes it straight to JSON and must emit [] rather than null.
+	total := 0
+	for _, p := range r.providers {
+		p.mu.Lock()
+		total += len(p.Models)
+		p.mu.Unlock()
+	}
+	buf := make([]string, 0, total)
+
 	for id, p := range r.providers {
 		p.mu.Lock()
-		snapshot := PublicProviderModelSnapshot{
-			Models: make([]string, 0, len(p.Models)),
-		}
+		start := len(buf)
+		current := ""
 		for _, model := range p.Models {
-			if r.providerModelAllowedByCatalogLocked(p, model) {
-				snapshot.Models = append(snapshot.Models, model.ID)
+			if !r.providerModelAllowedByCatalogLocked(p, model) {
+				continue
+			}
+			buf = append(buf, model.ID)
+			// The current model is exposed only when the provider advertises it
+			// as a catalog-eligible entry — the same predicate as the filter.
+			if p.CurrentModel != "" && model.ID == p.CurrentModel {
+				current = p.CurrentModel
 			}
 		}
-		if p.CurrentModel != "" &&
-			r.providerServesCatalogModelLocked(p, p.CurrentModel) {
-			snapshot.CurrentModel = p.CurrentModel
-		}
+		end := len(buf)
 		p.mu.Unlock()
-		out[id] = snapshot
+		out[id] = PublicProviderModelSnapshot{
+			Models:       buf[start:end:end],
+			CurrentModel: current,
+		}
 	}
 	return out
 }

--- a/coordinator/registry/provider_writer_test.go
+++ b/coordinator/registry/provider_writer_test.go
@@ -627,9 +627,7 @@ func TestSendModelLoadActionsClearsPendingWhenWriterQueueFull(t *testing.T) {
 		pendingReqs: make(map[string]*PendingRequest),
 	}
 	p.writer.queue <- &providerWriteRequest{done: make(chan error, 1)}
-	r.mu.Lock()
-	r.providers[p.ID] = p
-	r.mu.Unlock()
+	insertTestProvider(r, p)
 
 	actions := r.reservePendingModelLoads([]modelLoadAction{{providerID: p.ID, modelID: "m"}}, time.Now())
 	if len(actions) != 1 {

--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -601,6 +601,19 @@ func (q *RequestQueue) FailQueuedRequestsForModel(model string, preferOwnerEligi
 	return failed
 }
 
+// HasQueued reports whether any request is queued for any model. Cheaper than
+// QueuedModels (no allocation, no stale sweep) for the per-heartbeat probe.
+func (q *RequestQueue) HasQueued() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, queue := range q.queues {
+		if len(queue) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // QueuedModels returns the set of model IDs that currently have at least
 // one request waiting in the queue.
 func (q *RequestQueue) QueuedModels() []string {

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -900,6 +900,14 @@ type Provider struct {
 	// concurrent heartbeat/proof failure cannot apply a stale cache discount.
 	prefixCacheRevision uint64
 
+	// modelIndexIDs is the advertised model-id list the registry's per-model
+	// provider index currently holds for this session (model_index.go) — the
+	// diff baseline for syncModelIndexLocked. modelIndexDetached is set by
+	// Disconnect so a models_update racing the disconnect can only ever remove
+	// entries, never re-insert the dead session. Both guarded by p.mu.
+	modelIndexIDs      []string
+	modelIndexDetached bool
+
 	// Warm model cache tracking
 	WarmModels   []string // models currently loaded in provider's memory
 	CurrentModel string   // model currently being served
@@ -1041,7 +1049,16 @@ type Provider struct {
 // that is what lets the grace→enforce deadline flip without a reconnect. Callers
 // hold r.mu (every call site is inside an r-locked Registry method).
 func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
-	return r.providerSupportsPrivateTextModeLocked(p, r.releasePolicyEnforcedLocked())
+	return r.providerSupportsPrivateTextAtLocked(p, time.Now())
+}
+
+// providerSupportsPrivateTextAtLocked is providerSupportsPrivateTextLocked
+// evaluated at an explicit instant. The fleet walks capture one clock per
+// walk and pass it here (via providerLivenessGateLocked) so the two rollout
+// deadlines (release-policy enforce-after, APNs code-attestation) are not
+// re-read from the wall clock once per eligible provider. Caller holds r.mu.
+func (r *Registry) providerSupportsPrivateTextAtLocked(p *Provider, now time.Time) bool {
+	return r.providerSupportsPrivateTextModeAtLocked(p, r.releasePolicyEnforcedAtLocked(now), now)
 }
 
 // providerSupportsPrivateTextModeLocked is the chokepoint body with the
@@ -1050,6 +1067,12 @@ func (r *Registry) providerSupportsPrivateTextLocked(p *Provider) bool {
 // the per-model flip criterion); enforceEvidence=true additionally requires
 // generation-current application evidence. Caller holds r.mu.
 func (r *Registry) providerSupportsPrivateTextModeLocked(p *Provider, enforceEvidence bool) bool {
+	return r.providerSupportsPrivateTextModeAtLocked(p, enforceEvidence, time.Now())
+}
+
+// providerSupportsPrivateTextModeAtLocked is the chokepoint body at an explicit
+// instant (see providerSupportsPrivateTextAtLocked). Caller holds r.mu.
+func (r *Registry) providerSupportsPrivateTextModeAtLocked(p *Provider, enforceEvidence bool, now time.Time) bool {
 	if p.PublicKey == "" || !privateTextBackendSupported(p.Backend) || !p.EncryptedResponseChunks {
 		return false
 	}
@@ -1073,7 +1096,7 @@ func (r *Registry) providerSupportsPrivateTextModeLocked(p *Provider, enforceEvi
 		return false
 	}
 	// APNs code-identity gate — the SINGLE chokepoint, no self-route exemption.
-	if r.codeAttestationEnforcedLocked() && !p.CodeAttested {
+	if r.codeAttestationEnforcedAtLocked(now) && !p.CodeAttested {
 		return false
 	}
 	caps := p.PrivacyCapabilities
@@ -1709,15 +1732,21 @@ func (r *Registry) SetReleasePolicyEnforceAfter(t time.Time) {
 // releasePolicyEnforcedLocked reports whether the evidence gate is LIVE right
 // now: enforcement configured and past any enforce-after delay. Caller holds r.mu.
 func (r *Registry) releasePolicyEnforcedLocked() bool {
+	return r.releasePolicyEnforcedAtLocked(time.Now())
+}
+
+// releasePolicyEnforcedAtLocked is releasePolicyEnforcedLocked at an explicit
+// instant (the fleet walks pass their captured clock). Caller holds r.mu.
+func (r *Registry) releasePolicyEnforcedAtLocked(now time.Time) bool {
 	return r.releasePolicyEnforced &&
-		!time.Now().Before(r.releasePolicyEnforceAfter)
+		!now.Before(r.releasePolicyEnforceAfter)
 }
 
 // ReleasePolicyEnforced reports whether missing application evidence currently
 // blocks routing. Thread-safe.
 func (r *Registry) ReleasePolicyEnforced() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.releasePolicyEnforcedLocked()
 }
 
@@ -1795,16 +1824,16 @@ func (r *Registry) CountProvidersWithCurrentApplicationEvidence() (int, int) {
 // CodeAttestationConfigured reports whether an APNs attestor is wired (so the
 // connection handler should issue code-identity challenges). Thread-safe.
 func (r *Registry) CodeAttestationConfigured() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.codeAttestationConfigured
 }
 
 // CodeAttestationEnforced reports whether code-identity attestation is currently
 // mandatory for routing (configured AND past the deadline). Thread-safe.
 func (r *Registry) CodeAttestationEnforced() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.codeAttestationEnforcedLocked()
 }
 
@@ -1814,10 +1843,16 @@ func (r *Registry) CodeAttestationEnforced() bool {
 // then the fleet routes un-attested providers (grace window) while still being
 // challenged.
 func (r *Registry) codeAttestationEnforcedLocked() bool {
+	return r.codeAttestationEnforcedAtLocked(time.Now())
+}
+
+// codeAttestationEnforcedAtLocked is codeAttestationEnforcedLocked at an
+// explicit instant (the fleet walks pass their captured clock). Caller holds r.mu.
+func (r *Registry) codeAttestationEnforcedAtLocked(now time.Time) bool {
 	if !r.codeAttestationConfigured || r.codeAttestationDeadline.IsZero() {
 		return false
 	}
-	return !time.Now().Before(r.codeAttestationDeadline)
+	return !now.Before(r.codeAttestationDeadline)
 }
 
 // Mu returns the provider's mutex for external callers that need to read
@@ -2172,6 +2207,18 @@ type Registry struct {
 	// Production leaves it nil; tests set it before starting concurrent scans.
 	reservationAfterScan func(model string)
 
+	// modelIndex maps advertised model id → providers advertising it, so the
+	// per-request fleet walks visit only providers that can pass the first
+	// gate (model_index.go). Leaf lock — see that file for the contract.
+	modelIndex providerModelIndex
+	// modelIndexDisabled (tests only) makes providersForModelLocked return the
+	// whole fleet so a walk can be proven identical with and without the index.
+	modelIndexDisabled bool
+
+	// swapPlanGate coalesces heartbeat-triggered model-swap planning to at
+	// most one plan per modelSwapPlanInterval fleet-wide (model_swap_coalesce.go).
+	swapPlanGate modelSwapPlanGate
+
 	onlineCount      atomic.Int64
 	modelProviders   map[string]*atomic.Int64
 	modelProvidersMu sync.Mutex
@@ -2190,15 +2237,15 @@ type Registry struct {
 	// is derived entirely from BackendCapacity.Slots (with WarmModels as the
 	// legacy fallback). Do not add routing reads of this field — see the
 	// "Coordinator State Model" section in AGENTS.md.
-	pendingModelLoads       map[string]time.Time // key: "providerID:modelID", value: expiry
-	pendingModelLoadStarted map[string]time.Time
+	pendingModelLoads       map[modelLoadKey]time.Time // value: expiry (see pair_keys.go)
+	pendingModelLoadStarted map[modelLoadKey]time.Time
 
 	// dispatchLoadCooldowns: provider-model pairs that rejected a dispatch with a
 	// load failure ("insufficient memory"). Routing skips the pair until expiry —
 	// it would instant-503 again, and without this the scheduler re-picks it
 	// (looks idle), causing the dispatch→503→retry storms seen in prod. Cleared
 	// on re-registration and on a served request for the pair.
-	dispatchLoadCooldowns map[string]time.Time // key: "providerID:modelID", value: expiry
+	dispatchLoadCooldowns map[dispatchLoadKey]time.Time // value: expiry (see pair_keys.go)
 
 	// inferenceErrorStrikes / inferenceErrorCooldowns implement the error-class
 	// circuit breaker for provider-side inference failures: a (provider, model,
@@ -2398,9 +2445,9 @@ func New(logger *slog.Logger) *Registry {
 		MinTrustLevel:                  TrustHardware,
 		tpsRegistry:                    NewTPSRegistry(),
 		modelProviders:                 make(map[string]*atomic.Int64),
-		pendingModelLoads:              make(map[string]time.Time),
-		pendingModelLoadStarted:        make(map[string]time.Time),
-		dispatchLoadCooldowns:          make(map[string]time.Time),
+		pendingModelLoads:              make(map[modelLoadKey]time.Time),
+		pendingModelLoadStarted:        make(map[modelLoadKey]time.Time),
+		dispatchLoadCooldowns:          make(map[dispatchLoadKey]time.Time),
 		inferenceErrorStrikes:          make(map[inferenceErrorKey][]time.Time),
 		inferenceErrorCooldowns:        make(map[inferenceErrorKey]time.Time),
 		providerOutcomes:               make(map[string]*providerHealthWindow),
@@ -2500,9 +2547,9 @@ func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
 			}
 		}
 	}
-	key := r.faultKeyLocked(providerID) + ":" + modelID
-	_, active := r.dispatchLoadCooldowns[key]
-	active = active && now.Before(r.dispatchLoadCooldowns[key])
+	key := dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}
+	expiry, active := r.dispatchLoadCooldowns[key]
+	active = active && now.Before(expiry)
 	r.dispatchLoadCooldowns[key] = now.Add(dispatchLoadCooldownTTL)
 	return !active
 }
@@ -2512,14 +2559,14 @@ func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
 func (r *Registry) ClearDispatchLoadCooldown(providerID, modelID string) {
 	hold := r.lockWrite("dispatch_load_cooldown")
 	defer hold.unlock()
-	delete(r.dispatchLoadCooldowns, r.faultKeyLocked(providerID)+":"+modelID)
+	delete(r.dispatchLoadCooldowns, dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID})
 }
 
 // dispatchLoadCooldownActiveLocked reports whether routing should skip the pair.
 // READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
 // r.mu in either mode.
 func (r *Registry) dispatchLoadCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	expiry, ok := r.dispatchLoadCooldowns[r.faultKeyLocked(providerID)+":"+modelID]
+	expiry, ok := r.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}]
 	return ok && now.Before(expiry)
 }
 
@@ -2786,7 +2833,7 @@ func (r *Registry) ResolveModelConstrainedWithTraits(
 // structural=true ignores transient slot/cooldown state so alias resolution can
 // queue against a capable build instead of falling back to an incapable one.
 // Self-route to an owned machine relaxes trust and allows private-only
-// providers, mirroring snapshotProviderLocked. Caller holds r.mu.
+// providers, mirroring snapshotProviderIntoLockedEx. Caller holds r.mu.
 func (r *Registry) anyProviderCanServeAliasWithTraitsLocked(
 	buildID string,
 	allowedSerials map[string]struct{},
@@ -2796,7 +2843,9 @@ func (r *Registry) anyProviderCanServeAliasWithTraitsLocked(
 	traits RequestTraits,
 	structural bool,
 ) bool {
-	for _, p := range r.providers {
+	// Only providers advertising the build can route it; the per-model index
+	// prunes the rest (gates unchanged). Copied before any p.mu is taken.
+	for _, p := range r.providersForModelLocked(buildID) {
 		p.mu.Lock()
 		ok := func() bool {
 			if len(allowedSerials) > 0 {
@@ -2867,7 +2916,7 @@ func (r *Registry) providerStructurallyCanRouteBuildLocked(
 	}
 	// Hardware fit: don't count a provider whose RAM can't hold the build (e.g.
 	// migrating to a larger build than the source). totalMemory prefers the
-	// backend-reported figure, matching snapshotProviderLocked. A resident
+	// backend-reported figure, matching snapshotProviderIntoLockedEx. A resident
 	// running/idle slot has already demonstrated fit and must bypass the
 	// heuristic. Owner-only off-catalog models use their advertised size.
 	totalMemoryGB := float64(p.Hardware.MemoryGB)
@@ -2924,7 +2973,8 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 func (r *Registry) anyProviderCanRouteBuildLocked(buildID string) bool {
 	now := time.Now()
 	minTrust := r.MinTrustLevel
-	for _, p := range r.providers {
+	// Per-model index: only advertisers can route the build (model_index.go).
+	for _, p := range r.providersForModelLocked(buildID) {
 		p.mu.Lock()
 		ok := r.providerCanRouteBuildLocked(p, buildID, minTrust, now, false)
 		p.mu.Unlock()
@@ -3121,6 +3171,7 @@ func (r *Registry) mergeProviderModels(
 			p.PrefixCacheStatuses,
 			p.PrefixCacheStatusReported,
 		)
+	p.syncModelIndexLocked()
 	p.mu.Unlock()
 	if len(cacheStateInvalidated) > 0 {
 		r.mu.RLock()
@@ -3138,7 +3189,7 @@ func (r *Registry) mergeProviderModels(
 
 // RoutableProviderIDsForBuild returns the ids of providers that would actually
 // pass the routing gate for the build right now — the SAME checks
-// snapshotProviderLocked applies (advertises the build, not offline/untrusted,
+// snapshotProviderIntoLockedEx applies (advertises the build, not offline/untrusted,
 // public, trust ≥ floor, runtime verified, private-text capable, fresh
 // challenge), minus per-request capacity/headroom. Cold-but-healthy providers
 // count (no warm slot required — they load on first demand). Used to measure how
@@ -3226,6 +3277,7 @@ func (r *Registry) UpdateModelWeightHashes(providerID string, hashes map[string]
 	}
 	if changed {
 		p.Models = models
+		p.syncModelIndexLocked() // ids unchanged; keeps the invariant explicit
 	}
 }
 
@@ -3796,6 +3848,9 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		return existing
 	}
 	r.providers[id] = p
+	p.mu.Lock()
+	r.modelIndex.sync(p)
+	p.mu.Unlock()
 	r.onlineCount.Add(1)
 	for _, m := range models {
 		r.modelProviderInc(m.ID)
@@ -4091,6 +4146,9 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			p.Status = StatusServing
 		}
 	}
+	// Backstop for the per-model provider index: allocation-free when p.Models
+	// is already in step, and self-healing within one heartbeat otherwise.
+	p.syncModelIndexLocked()
 	p.mu.Unlock()
 
 	// This heartbeat may be the release proof for a budget clamp
@@ -4113,8 +4171,13 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	r.drainQueuedRequestsForModelsWithReason(providerModelIDs(p), DrainTriggerHeartbeat)
 
 	// If queue drain didn't satisfy all pending requests (no warm provider),
-	// check if a cold provider should swap models to serve queued demand.
-	r.TriggerModelSwaps()
+	// check if a cold provider should swap models to serve queued demand —
+	// coalesced fleet-wide to one plan per modelSwapPlanInterval, since N
+	// heartbeats inside that window would each re-derive the same plan; a
+	// heartbeat the window refuses arms one trailing plan for its end
+	// (model_swap_coalesce.go). Drain work can outlast the planning window,
+	// so claim against the current time rather than the heartbeat timestamp.
+	r.triggerModelSwapsFromHeartbeat(time.Now())
 }
 
 // SendLoadModel instructs a provider to eagerly load a model so it becomes
@@ -4466,7 +4529,11 @@ func (r *Registry) planModelLoadActions(queuedModels []string, now time.Time) []
 // hasWarmProviderLocked reports whether a connected provider already has the
 // model warm. Caller must hold r.mu (read or write).
 func (r *Registry) hasWarmProviderLocked(model string, now time.Time) bool {
-	for _, p := range r.providers {
+	// Only advertisers can hold the model warm (warm/slot reports are
+	// canonicalized against p.Models; providerHasWarmModelLocked also requires
+	// providerServesRoutableModelLocked), so the per-model index prunes the
+	// walk losslessly (model_index.go).
+	for _, p := range r.providersForModelLocked(model) {
 		p.mu.Lock()
 		warm := r.providerHasWarmModelLocked(p, model, now)
 		p.mu.Unlock()
@@ -4523,7 +4590,11 @@ func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now tim
 // pending requests. Caller must hold r.mu (read or write).
 func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, selectedProviders map[string]struct{}) string {
 	bestProviderID := ""
-	for id, p := range r.providers {
+	// Only advertisers qualify (modelLoadCandidatePendingLocked requires
+	// providerServesRoutableModelLocked), so the per-model index prunes the
+	// walk losslessly (model_index.go).
+	for _, p := range r.providersForModelLocked(model) {
+		id := p.ID
 		if _, selected := selectedProviders[id]; selected {
 			continue
 		}
@@ -4600,7 +4671,7 @@ func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.pendingModelLoads == nil {
-		r.pendingModelLoads = make(map[string]time.Time)
+		r.pendingModelLoads = make(map[modelLoadKey]time.Time)
 	}
 
 	reserved := actions[:0]
@@ -4619,7 +4690,7 @@ func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.
 		if r.providerHasPendingLoad(action.providerID) {
 			continue
 		}
-		key := modelLoadKey(action.providerID, action.modelID)
+		key := modelLoadKey{ProviderID: action.providerID, ModelID: action.modelID}
 		r.pendingModelLoads[key] = now.Add(pendingModelLoadTTL)
 		r.pendingModelLoadStarted[key] = now
 		reserved = append(reserved, action)
@@ -4640,16 +4711,11 @@ func (r *Registry) sendModelLoadActions(actions []modelLoadAction) {
 	}
 }
 
-func modelLoadKey(providerID, modelID string) string {
-	return providerID + ":" + modelID
-}
-
 // providerHasPendingLoad reports whether the provider has any pending
 // load_model command. Caller must hold r.mu (read or write).
 func (r *Registry) providerHasPendingLoad(providerID string) bool {
-	prefix := providerID + ":"
 	for key := range r.pendingModelLoads {
-		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+		if key.ProviderID == providerID && key.ModelID != "" {
 			return true
 		}
 	}
@@ -4670,14 +4736,12 @@ func (r *Registry) ClearIneligiblePendingModelLoads(providerID string) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	prefix := providerID + ":"
 	cleared := 0
 	for key := range r.pendingModelLoads {
-		if !strings.HasPrefix(key, prefix) || len(key) == len(prefix) {
+		if key.ProviderID != providerID || key.ModelID == "" {
 			continue
 		}
-		modelID := key[len(prefix):]
-		if r.providerCanAcquireCatalogModelLocked(p, modelID) {
+		if r.providerCanAcquireCatalogModelLocked(p, key.ModelID) {
 			continue
 		}
 		delete(r.pendingModelLoads, key)
@@ -4747,7 +4811,7 @@ func (r *Registry) MarkModelWarm(providerID, modelID string) {
 // load_model_status response.
 func (r *Registry) ClearPendingModelLoad(providerID, modelID string) time.Duration {
 	r.mu.Lock()
-	key := modelLoadKey(providerID, modelID)
+	key := modelLoadKey{ProviderID: providerID, ModelID: modelID}
 	started := r.pendingModelLoadStarted[key]
 	delete(r.pendingModelLoads, key)
 	delete(r.pendingModelLoadStarted, key)
@@ -4760,7 +4824,7 @@ func (r *Registry) ClearPendingModelLoad(providerID, modelID string) time.Durati
 
 func (r *Registry) PendingModelLoadDuration(providerID, modelID string) time.Duration {
 	r.mu.RLock()
-	started := r.pendingModelLoadStarted[modelLoadKey(providerID, modelID)]
+	started := r.pendingModelLoadStarted[modelLoadKey{ProviderID: providerID, ModelID: modelID}]
 	r.mu.RUnlock()
 	if started.IsZero() {
 		return 0
@@ -4774,7 +4838,7 @@ func (r *Registry) PendingModelLoadDuration(providerID, modelID string) time.Dur
 // allowing them to mutate warm-model state.
 func (r *Registry) HasPendingModelLoad(providerID, modelID string) bool {
 	r.mu.RLock()
-	expiresAt, ok := r.pendingModelLoads[modelLoadKey(providerID, modelID)]
+	expiresAt, ok := r.pendingModelLoads[modelLoadKey{ProviderID: providerID, ModelID: modelID}]
 	r.mu.RUnlock()
 	return ok && time.Now().Before(expiresAt)
 }
@@ -4790,12 +4854,12 @@ func (r *Registry) backoffPendingModelLoad(providerID, modelID string, backoff t
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.pendingModelLoads == nil {
-		r.pendingModelLoads = make(map[string]time.Time)
+		r.pendingModelLoads = make(map[modelLoadKey]time.Time)
 	}
 	if r.pendingModelLoadStarted == nil {
-		r.pendingModelLoadStarted = make(map[string]time.Time)
+		r.pendingModelLoadStarted = make(map[modelLoadKey]time.Time)
 	}
-	key := modelLoadKey(providerID, modelID)
+	key := modelLoadKey{ProviderID: providerID, ModelID: modelID}
 	now := time.Now()
 	r.pendingModelLoads[key] = now.Add(backoff)
 	if r.pendingModelLoadStarted[key].IsZero() {
@@ -4953,19 +5017,37 @@ func mergeHeartbeatSessionStats(previous, current protocol.HeartbeatStats) proto
 
 // Disconnect removes a provider from the registry and cleans up pending requests.
 func (r *Registry) Disconnect(id string) {
+	r.disconnectProvider(id, nil, 0)
+}
+
+// disconnectProvider applies an optional eviction guard atomically with removal.
+// expected is the exact session observed by the stale scan; nil is an ordinary
+// unconditional disconnect. Both its identity and latest heartbeat are checked
+// while r.mu and p.mu exclude replacement and heartbeat updates.
+func (r *Registry) disconnectProvider(id string, expected *Provider, timeout time.Duration) bool {
 	var disconnectedModels []string
 	r.mu.Lock()
 	p, ok := r.providers[id]
 	if ok {
+		if expected != nil && p != expected {
+			r.mu.Unlock()
+			return false
+		}
+		p.mu.Lock()
+		if expected != nil && time.Since(p.LastHeartbeat) <= timeout {
+			p.mu.Unlock()
+			r.mu.Unlock()
+			return false
+		}
 		delete(r.providers, id)
 		// Clear any pending model load entries for this provider.
 		for key := range r.pendingModelLoads {
-			if len(key) > len(id)+1 && key[:len(id)+1] == id+":" {
+			if key.ProviderID == id {
 				delete(r.pendingModelLoads, key)
 				delete(r.pendingModelLoadStarted, key)
 			}
 		}
-		p.mu.Lock()
+		p.detachModelIndexLocked(r)
 		// FAULT STATE IS NOT CLEARED ON DISCONNECT. Every fault-tracking map
 		// (node-health breaker, inference-error cooldowns, dispatch-load
 		// cooldowns, health ejection) keys by the STABLE identity when one is
@@ -4995,9 +5077,8 @@ func (r *Registry) Disconnect(id string) {
 					delete(r.inferenceErrorCooldowns, key)
 				}
 			}
-			prefix := id + ":"
 			for key := range r.dispatchLoadCooldowns {
-				if strings.HasPrefix(key, prefix) {
+				if key.FaultKey == id {
 					delete(r.dispatchLoadCooldowns, key)
 				}
 			}
@@ -5018,7 +5099,7 @@ func (r *Registry) Disconnect(id string) {
 	r.mu.Unlock()
 
 	if !ok {
-		return
+		return false
 	}
 	// Removing the last capable provider can turn a queued constrained request
 	// from temporarily capacity-blocked into permanently unservable. Re-run
@@ -5107,6 +5188,7 @@ func (r *Registry) Disconnect(id string) {
 	}
 
 	r.logger.Info("provider disconnected", "provider_id", id)
+	return true
 }
 
 // GetProvider returns a provider by ID, or nil if not found.
@@ -5507,46 +5589,44 @@ func (r *Registry) ListModels() []AggregateModel {
 	// Aggregate by model ID only — consumers request by ID, so providers
 	// offering the same model ID should be counted together regardless of
 	// minor metadata differences.
-	agg := make(map[string]*modelAgg)
+	//
+	// The whole per-provider step runs under p.mu: it reads only strings and
+	// booleans, retains nothing from the provider, and costs a few map lookups.
+	// There is deliberately NO per-provider snapshot slice — at fleet scale
+	// (~1,260 providers) that was one heap allocation per provider per call,
+	// and /v1/models (uncached, two ListModels calls per request) paid for it
+	// mostly as GC pressure rather than as the walk itself.
+	agg := make(map[string]*modelAgg, len(r.modelCatalog))
 	for _, p := range r.providers {
 		p.mu.Lock()
-		status := p.Status
-		trust := p.TrustLevel
-		attested := p.Attested
-		attestResult := p.AttestationResult
-		privateReady := r.providerSupportsPrivateTextLocked(p)
-		privateOnly := p.PrivateOnly
-		// Snapshot only provider-model pairs that satisfy the live catalog and
-		// connection-scoped capability requirements.
-		models := make([]protocol.ModelInfo, 0, len(p.Models))
-		for _, model := range p.Models {
-			if r.providerModelAllowedByCatalogLocked(p, model) {
-				models = append(models, model)
-			}
-		}
-		p.mu.Unlock()
-
-		if status == StatusOffline || status == StatusUntrusted {
-			continue
-		}
+		// Provider-level gates first, so an ineligible provider costs one lock
+		// and a handful of field reads — never a walk of its inventory.
 		// Private-only providers serve only their owner's self-route traffic, so
 		// they must not appear in or inflate the public /v1/models aggregation.
-		if privateOnly {
+		if p.Status == StatusOffline || p.Status == StatusUntrusted ||
+			p.PrivateOnly ||
+			!r.trustMeetsMinimum(p.TrustLevel) ||
+			!r.providerSupportsPrivateTextLocked(p) {
+			p.mu.Unlock()
 			continue
 		}
-		if !r.trustMeetsMinimum(trust) || !privateReady {
-			continue
-		}
-		for _, m := range models {
-			k := m.ID
-			a, ok := agg[k]
+		trust := p.TrustLevel
+		attestResult := p.AttestationResult
+		attested := p.Attested && attestResult != nil
+		for _, m := range p.Models {
+			// Count only provider-model pairs that satisfy the live catalog and
+			// connection-scoped capability requirements.
+			if !r.providerModelAllowedByCatalogLocked(p, m) {
+				continue
+			}
+			a, ok := agg[m.ID]
 			if !ok {
 				a = &modelAgg{
 					modelType:    m.ModelType,
 					quantization: m.Quantization,
 					highestTrust: TrustNone,
 				}
-				agg[k] = a
+				agg[m.ID] = a
 			}
 			a.count++
 
@@ -5555,13 +5635,14 @@ func (r *Registry) ListModels() []AggregateModel {
 				a.highestTrust = trust
 			}
 
-			if attested && attestResult != nil {
+			if attested {
 				a.attestedCount++
 				a.secureEnclave = a.secureEnclave || attestResult.SecureEnclaveAvailable
 				a.sipEnabled = a.sipEnabled || attestResult.SIPEnabled
 				a.secureBoot = a.secureBoot || attestResult.SecureBootEnabled
 			}
 		}
+		p.mu.Unlock()
 	}
 
 	models := make([]AggregateModel, 0, len(agg))
@@ -6101,7 +6182,7 @@ func (r *Registry) publiclyRoutableLocked(p *Provider, now time.Time) bool {
 
 // ModelCapacitySnapshot returns a capacity snapshot for every model served
 // by at least one provider. Providers must pass the same routing gates as
-// snapshotProviderLocked (status, trust, runtime, privacy, challenge
+// snapshotProviderIntoLockedEx (status, trust, runtime, privacy, challenge
 // freshness, concurrency headroom) to be counted as routable.
 func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 	now := time.Now()
@@ -6113,7 +6194,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 	for _, p := range r.providers {
 		p.mu.Lock()
 
-		// Apply the same gates as snapshotProviderLocked. Private-only machines
+		// Apply the same gates as snapshotProviderIntoLockedEx. Private-only machines
 		// never serve the public fleet, so they do not count toward public
 		// model capacity.
 		if !r.publiclyRoutableLocked(p, now) {
@@ -6171,7 +6252,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 				poolSnap.pendingMaxTokensAllModels,
 				poolSnap.pendingMaxBytesAllModels,
 				poolSnap.pendingBytesKnown,
-				poolSnap.pooledTokenBudget.kvBytesPerToken[m.ID],
+				poolSnap.pooledTokenBudget.kvRateFor(m.ID),
 			)
 
 			snap := providerCapSnap{
@@ -6387,17 +6468,21 @@ func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration)
 func (r *Registry) evictStale(timeout time.Duration) {
 	now := time.Now()
 
-	// Scan under the write lock: we both READ LastHeartbeat and REBUILD
-	// evictStrikes. Collect every provider's heartbeat age for the summary, and
-	// decide who to evict: a provider is reaped only after it is stale on TWO
-	// consecutive sweeps (strike >= 2), so a single transient stall that ages
-	// many timestamps at once gives the fleet a sweep to recover instead of a
-	// mass reap.
-	r.mu.Lock()
+	// Scan under the READ lock: the walk only reads LastHeartbeat (under p.mu)
+	// and the previous sweep's strikes. evictStrikes is written solely by this
+	// function on the single eviction goroutine, so a read-scan followed by a
+	// short write-locked install is race-free — and the routing scans that
+	// share r.mu are no longer blocked for a whole fleet walk every timeout/3.
+	// Collect every provider's heartbeat age for the summary, and decide who to
+	// evict: a provider is reaped only after it is stale on TWO consecutive
+	// sweeps (strike >= 2), so a single transient stall that ages many
+	// timestamps at once gives the fleet a sweep to recover instead of a mass
+	// reap.
+	r.mu.RLock()
 	fleet := len(r.providers)
 	ages := make([]time.Duration, 0, fleet)
-	nextStrikes := make(map[string]int, len(r.evictStrikes))
-	var toEvict []string
+	var nextStrikes map[string]int // allocated lazily: steady state carries nothing
+	var toEvict []*Provider
 	var evictAges []time.Duration
 	for id, p := range r.providers {
 		p.mu.Lock()
@@ -6408,15 +6493,30 @@ func (r *Registry) evictStale(timeout time.Duration) {
 		if age > timeout {
 			strikes := r.evictStrikes[id] + 1
 			if strikes >= evictStrikeThreshold {
-				toEvict = append(toEvict, id)
+				toEvict = append(toEvict, p)
 				evictAges = append(evictAges, age)
 			} else {
+				if nextStrikes == nil {
+					nextStrikes = make(map[string]int)
+				}
 				nextStrikes[id] = strikes // carry the strike to next sweep
 			}
 		}
 	}
-	r.evictStrikes = nextStrikes
-	r.mu.Unlock()
+	hadStrikes := len(r.evictStrikes) > 0
+	r.mu.RUnlock()
+
+	// Install the rebuilt strike map under the write lock only when it changes
+	// anything (a strike carried or cleared). The steady state — nobody stale,
+	// nothing carried — never takes the write lock at all.
+	if hadStrikes || len(nextStrikes) > 0 {
+		if nextStrikes == nil {
+			nextStrikes = make(map[string]int)
+		}
+		r.mu.Lock()
+		r.evictStrikes = nextStrikes
+		r.mu.Unlock()
+	}
 
 	if len(ages) > 0 {
 		amin, amed, ap90, amax := durationStats(ages)
@@ -6436,9 +6536,12 @@ func (r *Registry) evictStale(timeout time.Duration) {
 		)
 	}
 
-	for _, id := range toEvict {
-		r.logger.Warn("evicting stale provider", "provider_id", id, "timeout", timeout)
-		r.Disconnect(id)
+	for _, p := range toEvict {
+		// A heartbeat may recover this session after the read scan, or the
+		// same id may name a replacement. Revalidate inside the removal lock.
+		if r.disconnectProvider(p.ID, p, timeout) {
+			r.logger.Warn("evicted stale provider", "provider_id", p.ID, "timeout", timeout)
+		}
 	}
 }
 

--- a/coordinator/registry/registry_catalog_test.go
+++ b/coordinator/registry/registry_catalog_test.go
@@ -231,11 +231,11 @@ func TestCatalogWeightHash(t *testing.T) {
 // desired_models — without which the legacy fleet could never migrate.
 func TestDesiredModelsForLegacyAdvertiserAfterTakeover(t *testing.T) {
 	r := New(testLogger())
-	r.providers["p1"] = &Provider{
+	insertTestProvider(r, &Provider{
 		ID:     "p1",
 		Status: StatusOnline,
 		Models: []protocol.ModelInfo{{ID: "gemma-4-26b"}}, // advertises the public name
-	}
+	})
 	r.SetModelAliases(map[string]AliasTarget{
 		"gemma-4-26b": {Desired: "gemma-4-26b-qat-4bit", Previous: "gemma-4-26b"},
 	})

--- a/coordinator/registry/registry_test.go
+++ b/coordinator/registry/registry_test.go
@@ -208,8 +208,8 @@ func TestVisionRoutingHelpers(t *testing.T) {
 		Status: StatusOnline,
 		Models: []protocol.ModelInfo{{ID: "gemma-4-26b"}}, // text-only build of the same model
 	}
-	r.providers["p-vis"] = visProv
-	r.providers["p-text"] = textProv
+	insertTestProvider(r, visProv)
+	insertTestProvider(r, textProv)
 
 	r.mu.RLock()
 	visOK := r.providerServesVisionModelLocked(visProv, "gemma-4-26b", false)

--- a/coordinator/registry/registry_trust_challenge_test.go
+++ b/coordinator/registry/registry_trust_challenge_test.go
@@ -640,10 +640,10 @@ func TestChallengeExpirationRemovesRoutability(t *testing.T) {
 // to judge when it is safe to let APNS_ENFORCE_AFTER pass.
 func TestCodeAttestationCoverage(t *testing.T) {
 	r := New(testLogger())
-	r.providers["a"] = &Provider{ID: "a", Status: StatusOnline, CodeAttested: true}
-	r.providers["b"] = &Provider{ID: "b", Status: StatusOnline, CodeAttested: false}
-	r.providers["c"] = &Provider{ID: "c", Status: StatusUntrusted, CodeAttested: true} // excluded
-	r.providers["d"] = &Provider{ID: "d", Status: StatusOffline, CodeAttested: true}   // excluded
+	insertTestProvider(r, &Provider{ID: "a", Status: StatusOnline, CodeAttested: true})
+	insertTestProvider(r, &Provider{ID: "b", Status: StatusOnline, CodeAttested: false})
+	insertTestProvider(r, &Provider{ID: "c", Status: StatusUntrusted, CodeAttested: true}) // excluded
+	insertTestProvider(r, &Provider{ID: "d", Status: StatusOffline, CodeAttested: true})   // excluded
 
 	attested, online := r.CodeAttestationCoverage()
 	if online != 2 {

--- a/coordinator/registry/request_traits.go
+++ b/coordinator/registry/request_traits.go
@@ -122,8 +122,22 @@ func CompareVersions(a, b string) int {
 }
 
 // versionSegments parses "v0.6.3" into [0 6 3]. Unparseable or negative
-// segments parse as 0.
+// segments parse as 0. Results are memoized per distinct input string
+// (version_memo.go) — the fleet runs a handful of binary versions, and the
+// routing scan compares every provider's version against the capability
+// floors and the pooled-budget layout floor on every request — so the
+// returned slice is SHARED and must be treated as read-only.
 func versionSegments(v string) []int {
+	return versionSegmentsMemo.getBounded(v, parseVersionSegments, versionSegmentsMemoizable)
+}
+
+// versionSegmentsMemoizable bounds the parsed slice a memo entry may retain.
+func versionSegmentsMemoizable(segs []int) bool {
+	return len(segs) <= maxMemoizedVersionSegments
+}
+
+// parseVersionSegments is the uncached parser behind versionSegments.
+func parseVersionSegments(v string) []int {
 	v = strings.TrimSpace(v)
 	if len(v) > 0 && (v[0] == 'v' || v[0] == 'V') {
 		v = v[1:]

--- a/coordinator/registry/routing_context_test.go
+++ b/coordinator/registry/routing_context_test.go
@@ -103,6 +103,9 @@ func TestGateRejectionTallies(t *testing.T) {
 		// withHealthy adds a second, fully eligible provider so the breaker /
 		// ejection fail-open re-scan does not rescue the gated one.
 		withHealthy bool
+		// indexSkips: the gated provider does not advertise the model, so the
+		// indexed scan never visits it (H4); see the not_serving_model case.
+		indexSkips bool
 		// setup mutates the gated provider / registry / request; returns the
 		// excludeIDs to pass to ReserveProviderEx.
 		setup func(t *testing.T, reg *Registry, p *Provider, pr *PendingRequest) []string
@@ -228,8 +231,20 @@ func TestGateRejectionTallies(t *testing.T) {
 			pr.AllowedProviderSerials = []string{"no-such-serial"}
 			return nil
 		}},
-		{name: "not_serving_model", want: GateNotServingModel, setup: func(_ *testing.T, _ *Registry, _ *Provider, pr *PendingRequest) []string {
+		// H4 (per-model index): the indexed scan never VISITS a provider that
+		// does not advertise the model, so it reports Scanned 0 and no gate
+		// tally at all; the GateNotServingModel tally only lands on the
+		// brute-force walk (index disabled). indexSkips pins both shapes.
+		{name: "not_serving_model", want: GateNotServingModel, indexSkips: true, setup: func(_ *testing.T, _ *Registry, _ *Provider, pr *PendingRequest) []string {
 			pr.Model = ctxOtherModel
+			return nil
+		}},
+		// H4, the other branch: an ADVERTISER of the requested model that fails
+		// the catalog rule (public route, model absent from a non-nil catalog) IS
+		// visited by the indexed scan and still tallies not_serving_model —
+		// Scanned 1, CandidateSetSize 0.
+		{name: "not_serving_model_off_catalog", want: GateNotServingModel, setup: func(_ *testing.T, reg *Registry, _ *Provider, _ *PendingRequest) []string {
+			reg.SetModelCatalog([]CatalogEntry{{ID: ctxOtherModel, SizeGB: 1}})
 			return nil
 		}},
 	}
@@ -248,6 +263,19 @@ func TestGateRejectionTallies(t *testing.T) {
 			pr := ctxRequest(model)
 			excludeIDs := tc.setup(t, reg, p, pr)
 			winner, d := reg.ReserveProviderEx(pr.Model, pr, excludeIDs...)
+			if tc.indexSkips {
+				// Indexed walk: the non-advertiser is pruned before any gate runs.
+				if winner != nil {
+					t.Fatalf("indexed: winner = %s, want none", winner.ID)
+				}
+				if d.Scanned != 0 || d.CandidateSetSize != 0 || sumGateRejections(d) != 0 {
+					t.Fatalf("indexed: scanned=%d set=%d rejections=%v, want 0/0/none", d.Scanned, d.CandidateSetSize, gateTallyMap(d))
+				}
+				// Brute-force walk: the legacy tally below still holds.
+				reg.modelIndexDisabled = true
+				winner, d = reg.ReserveProviderEx(pr.Model, pr, excludeIDs...)
+				reg.modelIndexDisabled = false
+			}
 			if winner != nil {
 				winner.RemovePending(pr.RequestID)
 			}

--- a/coordinator/registry/routing_eligibility.go
+++ b/coordinator/registry/routing_eligibility.go
@@ -65,7 +65,7 @@ func (r *Registry) providerLivenessGateReasonLocked(p *Provider, minTrust TrustL
 	if !p.RuntimeVerified {
 		return false, GateRuntimeUnverified
 	}
-	if !r.providerSupportsPrivateTextLocked(p) {
+	if !r.providerSupportsPrivateTextAtLocked(p, now) {
 		return false, GatePrivateText
 	}
 	if p.LastChallengeVerified.IsZero() || now.Sub(p.LastChallengeVerified) > challengeFreshnessMaxAge {

--- a/coordinator/registry/routing_gates_characterization_test.go
+++ b/coordinator/registry/routing_gates_characterization_test.go
@@ -387,7 +387,7 @@ func TestReleasePolicyGenerationImmediatelyDeroutesStaleApplicationEvidence(t *t
 			EvidenceGeneration: 1, PolicyGeneration: 1,
 		},
 	}
-	reg.providers[provider.ID] = provider
+	insertTestProvider(reg, provider)
 	if !reg.providerSupportsPrivateTextLocked(provider) {
 		t.Fatal("current release evidence should authorize the routing contribution")
 	}
@@ -441,7 +441,7 @@ func TestReleasePolicyGenerationCarriesForwardStillApprovedEvidence(t *testing.T
 			EvidenceGeneration: 1, PolicyGeneration: 1,
 		},
 	}
-	reg.providers[provider.ID] = provider
+	insertTestProvider(reg, provider)
 
 	invalidated := reg.SetReleasePolicyGeneration(2, true,
 		func(evidence ApplicationEvidence) bool { return evidence.BinaryHash == "hash" })
@@ -496,7 +496,7 @@ func TestReleasePolicyShadowModeNeverBlocksRouting(t *testing.T) {
 			EnvScrubbed:          true,
 		},
 	}
-	reg.providers[provider.ID] = provider
+	insertTestProvider(reg, provider)
 
 	if !reg.providerSupportsPrivateTextLocked(provider) {
 		t.Fatal("shadow mode must route a provider without application evidence")
@@ -560,7 +560,7 @@ func TestReleasePolicyEnforceAfterDelaysEnforcement(t *testing.T) {
 		releasePolicyRequired:   true,
 	}
 	provider := evidenceGateTestProvider()
-	reg.providers[provider.ID] = provider
+	insertTestProvider(reg, provider)
 
 	reg.SetReleasePolicyEnforcement(true)
 	reg.SetReleasePolicyEnforceAfter(time.Now().Add(time.Hour))
@@ -593,7 +593,7 @@ func TestReleasePolicySweepKeepsCapabilitiesInShadow(t *testing.T) {
 	}
 	provider := evidenceGateTestProvider()
 	provider.RuntimeCapabilities = []string{ProviderCapabilityMLXNAX}
-	reg.providers[provider.ID] = provider
+	insertTestProvider(reg, provider)
 
 	if reg.SetReleasePolicyGeneration(2, true, nil); provider.RuntimeCapabilities == nil {
 		t.Fatal("shadow sweep must not clear runtime capabilities")
@@ -636,8 +636,8 @@ func TestApplicationEvidenceModelCoverage(t *testing.T) {
 	uncovered.RuntimeVerified = true
 	uncovered.LastChallengeVerified = time.Now()
 	uncovered.Models = []protocol.ModelInfo{{ID: "model-uncovered"}}
-	reg.providers[covered.ID] = covered
-	reg.providers[uncovered.ID] = uncovered
+	insertTestProvider(reg, covered)
+	insertTestProvider(reg, uncovered)
 
 	coverage := reg.ApplicationEvidenceModelCoverage()
 	if c := coverage["model-covered"]; c.Routable != 1 || c.WithEvidence != 1 {

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -378,11 +378,18 @@ type RoutingDecision struct {
 	// decision into the request profile AFTER ReserveProviderEx returns and
 	// serialises it on the profile sink worker, never under the registry lock.
 
-	// Scanned is the number of providers the candidate loop visited (the whole
-	// registry); CandidateSetSize is the subset not ruled out for failing to
-	// advertise the model (Scanned − GateNotServingModel rejections; providers
-	// skipped by the exclude/allowlist filters, which run before the catalog
-	// check, are counted as advertising).
+	// Scanned is the number of providers the candidate loop visited.
+	// Since the per-model provider index (model_index.go) the loop walks only
+	// the providers ADVERTISING the requested model — so Scanned is the
+	// advertising count, not the fleet size, and GateRejections[
+	// GateNotServingModel] is 0 unless an advertiser still fails the catalog
+	// rule (off-catalog model on a public route). CandidateSetSize is
+	// Scanned − GateNotServingModel rejections either way; providers skipped by
+	// the exclude/allowlist filters, which run before the catalog check, are
+	// counted as advertising. The same applies to the GateAllowlist /
+	// GateExcluded tallies themselves: they now count only advertisers (a
+	// serial-allowlist miss used to tally ~fleet size per request). Pre-index
+	// records have Scanned == fleet size.
 	CandidateSetSize, Scanned int
 	// GateRejections tallies, per closed GateReason, the providers dropped
 	// before cost ranking. Index with GateReason; GateReason.String() is the
@@ -414,7 +421,7 @@ type RoutingDecision struct {
 	// PendingForModel / TotalPending are the winner's coordinator-side pending
 	// counts (this model / all models) at snapshot time, before this reservation.
 	PendingForModel, TotalPending int
-	// ScanCount is how many full fleet scans this reservation attempt ran —
+	// ScanCount is how many candidate scans this reservation attempt ran —
 	// one for a clean commit, more when a commit had to rescan (winner gone
 	// or full between scan and commit, cache-routing reconfiguration). Zero
 	// for a plan-based retry, which reuses the previous scan. The api layer
@@ -578,11 +585,21 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 	// The tracker has its own mutex and must never be nested under r.mu.
 	r.mu.RLock()
 	cacheTracker, cacheMode := r.cacheRouting, r.cacheRoutingMode
-	cacheRouteKey := append([]byte(nil), r.cacheRouteKeys.route...)
+	// cacheRoutingTracker.hints returns nil unless ALL of these hold, so the
+	// capability walk (a second full-fleet pass that takes p.mu on every
+	// provider) and the route-key copy are skipped exactly when they could not
+	// influence selection: cache routing off, no plan on the request, or no
+	// route key configured. Same predicate as hints(); keep them in sync.
+	wantHints := cacheTracker != nil && cacheMode == CacheRoutingOn &&
+		pr.CachePlan.present() && len(r.cacheRouteKeys.route) > 0
+	var cacheRouteKey []byte
+	if wantHints {
+		cacheRouteKey = append([]byte(nil), r.cacheRouteKeys.route...)
+	}
 	r.mu.RUnlock()
-	cacheCapabilities := r.prefixCacheV2CapabilitiesForModel(model)
 	pr.cacheRoutingHints = nil
-	if cacheTracker != nil {
+	if wantHints {
+		cacheCapabilities := r.prefixCacheV2CapabilitiesForModel(model)
 		pr.cacheRoutingHints = cacheTracker.hints(
 			pr.CachePlan, cacheCapabilities, cacheRouteKey, cacheMode, time.Now())
 	}
@@ -637,8 +654,10 @@ func (r *Registry) commitProviderReservation(
 
 	// The shared scan and write-lock wait consume the same absolute request
 	// clock as queueing and provider handoff. Never debit capacity for work whose
-	// first-content budget is already gone.
-	if !pr.RefreshFirstContentBudget(time.Now()) {
+	// first-content budget is already gone. One clock read serves the whole
+	// commit section (deadline, re-snapshot, cost, admit, probe claim).
+	now := time.Now()
+	if !pr.RefreshFirstContentBudget(now) {
 		return nil, nil, reservationDeadlineExpired, RoutingDecision{}
 	}
 
@@ -685,7 +704,7 @@ func (r *Registry) commitProviderReservation(
 	}
 	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
 	snapshot, ok := r.snapshotProviderLockedEx(
-		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker)
+		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now)
 	if !ok {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
@@ -698,7 +717,7 @@ func (r *Registry) commitProviderReservation(
 				routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
 		}
 	}
-	candidate, reason, ok := r.buildCandidateWithReason(snapshot, pr)
+	candidate, reason, ok := r.buildCandidateWithReason(snapshot, pr, now)
 	if !ok {
 		return nil, nil, reservationCandidateRejected,
 			routingDecisionForCommitRejection(model, reason, false)
@@ -708,7 +727,7 @@ func (r *Registry) commitProviderReservation(
 		return nil, nil, reservationCandidateRejected,
 			routingDecisionForCommitRejection(model, rejectNone, true)
 	}
-	r.applyCacheRoutingDiscount(p, model, pr, snapshot, candidate)
+	r.applyCacheRoutingDiscount(p, model, pr, candidate)
 
 	// Another reservation changed this winner after the shared scan. Re-scan the
 	// fleet so cost ranking observes that debit instead of herding the whole scan
@@ -723,14 +742,14 @@ func (r *Registry) commitProviderReservation(
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if !r.providerCanAdmitLockedEx(
-		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker) ||
+		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
 
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
-	r.claimCapacityProbeLocked(p.ID, model, time.Now())
+	r.claimCapacityProbeLocked(p.ID, model, now)
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
@@ -768,7 +787,7 @@ func (r *Registry) currentTTFTShadow(
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var current candidateScan
-	if snapshotOccupancy(winner.snapshot) > 0 {
+	if snapshotOccupancy(&winner.snapshot) > 0 {
 		current = r.scanCandidatesLocked(model, pr, false, excludeIDs...)
 	}
 	return r.evaluateTTFTShadowLocked(model, pr, winner, current)
@@ -850,7 +869,7 @@ func routingDecisionForCandidate(model string, provider *Provider, candidate *ro
 	// winner's inputs were, what it was predicted to deliver, and what it was
 	// already carrying — all from the pre-reserve snapshot, no extra locking.
 	decision.SnapshotAgeMs = int(candidate.snapshot.hbAgeMs)
-	decision.PredictedDecodeTPS = projectedPerRequestDecodeTPS(candidate.snapshot)
+	decision.PredictedDecodeTPS = projectedPerRequestDecodeTPS(&candidate.snapshot)
 	decision.PendingForModel = candidate.snapshot.pendingForModel
 	decision.TotalPending = candidate.snapshot.totalPending
 	// The ratio this candidate was actually scored with (captured at build,
@@ -861,12 +880,17 @@ func routingDecisionForCandidate(model string, provider *Provider, candidate *ro
 	return decision
 }
 
-func (r *Registry) applyCacheRoutingDiscount(p *Provider, model string, pr *PendingRequest, snapshot routingSnapshot, candidate *routingCandidate) {
+// applyCacheRoutingDiscount reads the candidate's own snapshot (the scan
+// builds it in place; no copy is taken).
+func (r *Registry) applyCacheRoutingDiscount(p *Provider, model string, pr *PendingRequest, candidate *routingCandidate) {
+	if len(pr.cacheRoutingHints) == 0 {
+		return
+	}
 	hint, ok := pr.cacheRoutingHints[p.ID]
 	if !ok || !hint.currentForProvider(p, model) {
 		return
 	}
-	prefillTPS := resolvePrefillTPS(snapshot)
+	prefillTPS := resolvePrefillTPS(&candidate.snapshot)
 	if prefillTPS <= 0 || math.IsNaN(prefillTPS) || math.IsInf(prefillTPS, 0) {
 		return
 	}
@@ -1064,16 +1088,23 @@ func (s *candidateScan) noteBestIdle(c *routingCandidate) {
 // breaker gate is skipped (every other gate still applies); breakerRejected is
 // always 0 in that mode. Caller holds r.mu and no provider lock.
 func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignoreProviderBreaker bool, excludeIDs ...string) candidateScan {
-	excludeSet := make(map[string]struct{}, len(excludeIDs)+len(pr.ExcludedProviderIDs))
-	for _, id := range excludeIDs {
-		excludeSet[id] = struct{}{}
+	// Nil maps read as empty; only allocate when there is something to hold.
+	var excludeSet map[string]struct{}
+	if len(excludeIDs)+len(pr.ExcludedProviderIDs) > 0 {
+		excludeSet = make(map[string]struct{}, len(excludeIDs)+len(pr.ExcludedProviderIDs))
+		for _, id := range excludeIDs {
+			excludeSet[id] = struct{}{}
+		}
+		for _, id := range pr.ExcludedProviderIDs {
+			excludeSet[id] = struct{}{}
+		}
 	}
-	for _, id := range pr.ExcludedProviderIDs {
-		excludeSet[id] = struct{}{}
-	}
-	allowedSerials := make(map[string]struct{}, len(pr.AllowedProviderSerials))
-	for _, serial := range pr.AllowedProviderSerials {
-		allowedSerials[serial] = struct{}{}
+	var allowedSerials map[string]struct{}
+	if len(pr.AllowedProviderSerials) > 0 {
+		allowedSerials = make(map[string]struct{}, len(pr.AllowedProviderSerials))
+		for _, serial := range pr.AllowedProviderSerials {
+			allowedSerials[serial] = struct{}{}
+		}
 	}
 
 	// Two-pass selection: collect all eligible candidates first, then
@@ -1082,7 +1113,15 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	// window, candidates near the OLD best (and still near the NEW
 	// best) were dropped from the pool, making the queue-depth tie-
 	// break flaky under map iteration randomness.
-	candidates := make([]*routingCandidate, 0, len(r.providers))
+	// Only providers advertising the model can pass the first gate; the
+	// per-model index (model_index.go) prunes the rest without touching any
+	// gate. Copied before any p.mu is taken (index lock discipline).
+	providers := r.providersForModelLocked(model)
+	candidates := make([]*routingCandidate, 0, len(providers))
+	// Candidates live in arena chunks: one allocation per candidateArenaChunk
+	// candidates instead of one per candidate, and each snapshot is written
+	// straight into its slot (candidate_arena.go).
+	var arena candidateArena
 	candidateCount := 0
 	capacityRejections := 0
 	tooLargeRejections := 0
@@ -1099,7 +1138,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	// estimates are advisory even if a caller accidentally supplies a ceiling.
 	// The request-absolute first-content deadline remains authoritative.
 	enforceTTFT := pr.MaxTTFTMs > 0 && !pr.RequiresVision
-	for _, p := range r.providers {
+	for _, p := range providers {
 		scan.scanned++
 		owned := providerOwnedBy(p, pr.OwnerAccountID)
 		// Exclusive self-route: restrict to the caller's own machines and never
@@ -1123,14 +1162,17 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		// un-enrolled) machine — whether exclusive self-route or prefer — never
 		// for public providers.
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-		// snapshotProviderLocked applies every per-provider gate via the shared
+		// snapshotProviderIntoLockedEx applies every per-provider gate via the shared
 		// providerPassesRoutingGatesLocked, INCLUDING the shape-keyed
 		// inference-error cooldown and the trait gates (render-broken fences all
 		// shapes; the tools version floor fences tool requests). A failing
-		// provider is simply dropped here — the reason-returning twin names the
-		// gate for the profiler tally without changing the verdict.
-		snap, ok, gateReason := r.snapshotProviderReasonLockedEx(p, model, pr.Traits, relaxTrust, ignoreProviderBreaker)
+		// provider is simply dropped here — the returned gate reason names WHICH
+		// gate dropped it for the profiler tally without changing the verdict.
+		// The snapshot is written straight into an arena slot (candidate_arena.go).
+		c := arena.next()
+		ok, gateReason := r.snapshotProviderIntoLockedEx(&c.snapshot, p, model, pr.Traits, relaxTrust, ignoreProviderBreaker, now)
 		if !ok {
+			arena.release(c)
 			scan.tallyGate(gateReason)
 			// Count providers a breaker-bypassed fail-open re-scan COULD rescue: those
 			// dropped by the node-health breaker OR the stable-identity health-ejection
@@ -1180,13 +1222,15 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
 			p.mu.Unlock()
 			if !servesVision {
+				arena.release(c)
 				visionRejections++
 				scan.tallyGate(GateVision)
 				continue
 			}
 		}
-		candidate, reason, gateReason, ok := r.buildCandidateGateLocked(snap, pr)
+		reason, gateReason, ok := r.buildCandidateInto(c, pr, now)
 		if !ok {
+			arena.release(c)
 			switch reason {
 			case rejectCapacity:
 				capacityRejections++
@@ -1204,8 +1248,8 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		// ceiling, the value is used for Retry-After on the TTFT 429 path.
 		// Providers without BackendCapacity do not contribute a reliable TTFT
 		// estimate, so they are skipped here.
-		if snap.hasBackendCapacity && (candidate.breakdown.TTFTMs < bestTTFTMs || bestTTFTMs == 0) {
-			bestTTFTMs = candidate.breakdown.TTFTMs
+		if c.snapshot.hasBackendCapacity && (c.breakdown.TTFTMs < bestTTFTMs || bestTTFTMs == 0) {
+			bestTTFTMs = c.breakdown.TTFTMs
 		}
 
 		// Enforce the per-request TTFT ceiling for public inference routes.
@@ -1214,20 +1258,25 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		// provider that misses the OpenRouter SLA target. Providers without
 		// BackendCapacity have no reliable TTFT estimate, so the ceiling is
 		// not enforced on them (matching the preflight behavior).
-		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+		if enforceTTFT && c.snapshot.hasBackendCapacity && c.breakdown.TTFTMs > pr.MaxTTFTMs {
+			arena.release(c)
 			ttftRejections++
 			scan.tallyGate(GateTTFTCeiling)
 			continue
 		}
 
-		r.applyCacheRoutingDiscount(p, model, pr, snap, candidate)
+		r.applyCacheRoutingDiscount(p, model, pr, c)
 		// Best-idle is computed UNCONDITIONALLY over every routable candidate
 		// (before pool narrowing) so the record can answer "was an idle warm box
 		// available?" whether or not the shadow evaluator is on.
-		scan.noteBestIdle(candidate)
-		candidates = append(candidates, candidate)
+		scan.noteBestIdle(c)
+		candidates = append(candidates, c)
 		candidateCount++
 	}
+	// With the per-model index scan.scanned counts the providers advertising
+	// the model (the index members), not the whole fleet, and the
+	// GateNotServingModel tally is normally 0 — the relation below still holds
+	// (see RoutingDecision.Scanned).
 	scan.candidateSetSize = scan.scanned - int(scan.gateRejections[GateNotServingModel])
 
 	// Prefer-with-fallback: if the caller asked to prefer their own machine and
@@ -1275,7 +1324,7 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 	if pr.MinDecodeTPS > 0 {
 		quality := make([]*routingCandidate, 0, len(pool))
 		for _, c := range pool {
-			if projectedPerRequestDecodeTPS(c.snapshot) >= pr.MinDecodeTPS {
+			if projectedPerRequestDecodeTPS(&c.snapshot) >= pr.MinDecodeTPS {
 				quality = append(quality, c)
 			}
 		}
@@ -1536,7 +1585,7 @@ func (r *Registry) OwnedProviderSummary(accountID, model string, traits RequestT
 			r.providerEligibleForTraitsLocked(p, model, traits) &&
 			(!requiresVision || r.providerServesVisionModelLocked(p, model, true)) &&
 			p.RuntimeVerified &&
-			r.providerSupportsPrivateTextLocked(p) &&
+			r.providerSupportsPrivateTextAtLocked(p, now) &&
 			!p.LastChallengeVerified.IsZero() &&
 			now.Sub(p.LastChallengeVerified) <= challengeFreshnessMaxAge
 		p.mu.Unlock()
@@ -1582,7 +1631,7 @@ func (r *Registry) logRoutingDecision(model string, pr *PendingRequest, winner *
 
 // providerPassesRoutingGatesLocked is the single source of truth for the
 // per-provider structural/privacy/cooldown/trait gates a request must clear
-// before a provider is eligible to serve it. snapshotProviderLocked (the
+// before a provider is eligible to serve it. snapshotProviderIntoLockedEx (the
 // production dispatch hot path) and QuickCapacityCheck (the preflight) BOTH call
 // it so the two can never drift — a prior bug had QuickCapacityCheck silently
 // missing the dispatch-load cooldown, the inference-error cooldown, and the
@@ -1710,7 +1759,7 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	return true, GateReasonCount
 }
 
-// snapshotProviderLocked builds a routing snapshot for p, returning ok=false
+// snapshotProviderLockedEx builds a routing snapshot for p, returning ok=false
 // when p fails any structural/privacy/capacity/trait gate. selfRouteOwner is
 // true when this is a self-route request and p is owned by the requesting
 // account. It (1) drops the hardware-trust floor to TrustNone — a personal Mac
@@ -1721,52 +1770,62 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 // never exposed and only the genuinely-signed provider binary serves. traits
 // carry the request shape into the shape-keyed inference-error cooldown and the
 // render-broken / version-floor eligibility gates.
-func (r *Registry) snapshotProviderLocked(p *Provider, model string, traits RequestTraits, selfRouteOwner bool) (routingSnapshot, bool) {
-	return r.snapshotProviderLockedEx(p, model, traits, selfRouteOwner, false)
-}
-
-// snapshotProviderLockedEx is snapshotProviderLocked with an explicit
-// ignoreProviderBreaker switch threaded into the routing gate. Only the
+//
+// ignoreProviderBreaker is threaded into the routing gate: only the
 // selectBestCandidateLockedFull fail-open fallback pass sets it true (to bypass
-// the node-health breaker); every other caller uses the default
-// (breaker-honored) wrapper above.
-func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) (routingSnapshot, bool) {
-	snap, ok, _ := r.snapshotProviderReasonLockedEx(p, model, traits, selfRouteOwner, ignoreProviderBreaker)
+// the node-health breaker); every other caller passes false. (The former
+// breaker-honored wrapper snapshotProviderLocked is gone — the fleet walks use
+// snapshotProviderIntoLockedEx directly.) now is the scan clock: hot-path callers
+// walk the whole fleet and must read the wall clock ONCE per scan, not once
+// per provider (runtime.walltime was ~35% of the reservation scan at fleet
+// scale); every time-keyed gate below (challenge freshness, cooldowns,
+// breaker, clamp) evaluates against that single instant.
+func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (routingSnapshot, bool) {
+	var snap routingSnapshot
+	ok, _ := r.snapshotProviderIntoLockedEx(&snap, p, model, traits, selfRouteOwner, ignoreProviderBreaker, now)
 	return snap, ok
 }
 
-// snapshotProviderReasonLockedEx is snapshotProviderLockedEx returning, when
-// the provider fails the routing gate, WHICH gate dropped it (a closed
-// GateReason; GateReasonCount when ok). The boolean form is a wrapper so every
-// existing caller is byte-for-byte unchanged. It also stamps the snapshot's
-// heartbeat age from the `now` it already reads.
-func (r *Registry) snapshotProviderReasonLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) (routingSnapshot, bool, GateReason) {
-	now := time.Now()
-
+// snapshotProviderIntoLockedEx is snapshotProviderLockedEx writing into
+// caller-owned storage instead of returning the (large) snapshot by value,
+// and naming WHICH gate dropped a failing provider. The fleet walks
+// (scanCandidatesLocked, PredictServable) and the fleet sampler
+// (slotEligibilityReasonLocked) hand it the final resting place of the
+// snapshot — a candidate-arena slot or a reused buffer — so a routable
+// provider's snapshot is written exactly once and never copied
+// (routingSnapshot is ~600 bytes; the per-provider return + candidate copies
+// were ~9% of the fleet-scale scan). On a gate failure it returns (false, the
+// closed GateReason that dropped p) WITHOUT touching *dst; on success *dst is
+// fully overwritten — including hbAgeMs, stamped from the threaded now so the
+// system-profiler record carries the heartbeat age the scan actually saw —
+// and the reason is GateReasonCount.
+func (r *Registry) snapshotProviderIntoLockedEx(dst *routingSnapshot, p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (bool, GateReason) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if ok, reason := r.providerRoutingGateReasonLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false); !ok {
-		return routingSnapshot{}, false, reason
+		return false, reason
 	}
 
-	snap := routingSnapshot{
-		provider:      p,
-		model:         model,
-		chipFamily:    p.Hardware.ChipFamily,
-		binaryVersion: p.Version,
-		slotState:     "unknown",
-		totalPending:  p.pendingCount(),
-		systemMetrics: p.SystemMetrics,
-		decodeTPS:     resolvedDecodeTPS(p),
-		prefillTPS:    resolvedPrefillTPS(p),
-		totalMemoryGB: float64(p.Hardware.MemoryGB),
-		modelSizeGB:   r.modelSizeGBForFitLocked(p, model),
-		minRAMGb:      r.catalogMinRAMGbLocked(model),
-		hbAgeMs:       heartbeatAgeMs(now, p.LastHeartbeat),
-	}
+	*dst = routingSnapshot{}
+	snap := dst
+	snap.provider = p
+	snap.model = model
+	snap.chipFamily = p.Hardware.ChipFamily
+	snap.binaryVersion = p.Version
+	snap.slotState = "unknown"
+	snap.totalPending = p.pendingCount()
+	snap.systemMetrics = p.SystemMetrics
+	snap.decodeTPS = resolvedDecodeTPS(p)
+	snap.prefillTPS = resolvedPrefillTPS(p)
+	snap.totalMemoryGB = float64(p.Hardware.MemoryGB)
+	snap.modelSizeGB = r.modelSizeGBForFitLocked(p, model)
+	snap.minRAMGb = r.catalogMinRAMGbLocked(model)
+	// Heartbeat age from the scan clock (system-profiler record); a zero
+	// LastHeartbeat saturates rather than reading as "fresh".
+	snap.hbAgeMs = heartbeatAgeMs(now, p.LastHeartbeat)
 
-	fillSnapshotPendingAndPool(&snap, p, model)
+	fillSnapshotPendingAndPool(snap, p, model)
 	// Concurrency headroom with the quality-concurrency cap: a slow model whose
 	// quality batch is below the flat fallback (e.g. Gemma at ~14 tok/s solo →
 	// batch 1-2) stops being admittable once it is at its quality cap, so load
@@ -1827,7 +1886,7 @@ func (r *Registry) snapshotProviderReasonLockedEx(p *Provider, model string, tra
 	rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
 	snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
-	return snap, true, GateReasonCount
+	return true, GateReasonCount
 }
 
 // heartbeatAgeMs is now − lastHeartbeat in milliseconds, clamped to int32
@@ -1888,7 +1947,7 @@ func reportedFreeForLoadAdmits(
 // freeMemoryAdmits returns true when the provider has enough headroom.
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
-func freeMemoryAdmits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
+func freeMemoryAdmits(snap *routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
 	// Gray-box budget clamp: a capacity-503 proved the provider's live gate
 	// rejects while the heartbeat budget below still advertises headroom
 	// (stale-optimistic). While the clamp holds, the slot is FULL — no
@@ -2023,7 +2082,7 @@ func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string
 		tokens := pendingTokenBudget(pr)
 		snap.pendingMaxTokensAllModels += tokens
 		if bytesKnown {
-			rate := resolvedPooledKVBytesPerToken(snap.pooledTokenBudget, snap.pooledTokenBudget.kvBytesPerToken[pr.Model])
+			rate := resolvedPooledKVBytesPerToken(&snap.pooledTokenBudget, snap.pooledTokenBudget.kvRateFor(pr.Model))
 			snap.pendingMaxBytesAllModels = addPooledKVByteCharge(snap.pendingMaxBytesAllModels, int64(tokens), rate)
 		}
 		if pr.Model != model {
@@ -2050,7 +2109,7 @@ func pendingTokenBudget(pr *PendingRequest) int {
 	return prompt + maxTok
 }
 
-func committedTokenBudget(snap routingSnapshot) int64 {
+func committedTokenBudget(snap *routingSnapshot) int64 {
 	committed := snap.activeTokenBudgetUsed + snap.queuedTokenBudget
 	if snap.maxTokensPotential > committed {
 		committed = snap.maxTokensPotential
@@ -2061,34 +2120,45 @@ func committedTokenBudget(snap routingSnapshot) int64 {
 	return committed
 }
 
-// buildCandidateGateLocked returns the cost-ranked candidate for a snapshot
-// that passed the routing gates, or — on rejection — the candidateRejection
-// class the legacy counters split on (capacity / model-too-large / vision) AND
-// the closed GateReason naming the exact drop, including the drops the
-// candidateRejection enum reports as rejectNone (crashed/reloading slot,
-// thermal critical), so the system-profiler routing record can tally them.
-// The counter semantics of candidateRejection are unchanged. Caller holds r.mu.
-// buildCandidateWithReason is the pre-profiler shape of buildCandidateGateLocked
-// (no GateReason) kept for the commit phase and the dispatch-plan revalidation.
-func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingRequest) (*routingCandidate, candidateRejection, bool) {
-	candidate, reason, _, ok := r.buildCandidateGateLocked(snap, pr)
-	return candidate, reason, ok
+// buildCandidateWithReason returns the candidate plus, on rejection,
+// the reason so callers can split metrics by failure mode.
+// now is the caller's scan clock (see snapshotProviderLockedEx). This is the
+// by-value convenience form for cold callers (the commit re-check, the plan
+// revalidation, tests); the fleet scan uses buildCandidateInto on an arena
+// slot whose snapshot was filled in place.
+func (r *Registry) buildCandidateWithReason(snap routingSnapshot, pr *PendingRequest, now time.Time) (*routingCandidate, candidateRejection, bool) {
+	c := &routingCandidate{snapshot: snap}
+	reason, _, ok := r.buildCandidateInto(c, pr, now)
+	if !ok {
+		return nil, reason, false
+	}
+	return c, rejectNone, true
 }
 
-func (r *Registry) buildCandidateGateLocked(snap routingSnapshot, pr *PendingRequest) (*routingCandidate, candidateRejection, GateReason, bool) {
+// buildCandidateInto computes the routing cost for c from c.snapshot (already
+// filled by snapshotProviderIntoLockedEx) and writes the cost fields into c.
+// On rejection it returns the candidateRejection class the legacy counters
+// split on (capacity / model-too-large / vision) AND the closed GateReason
+// naming the exact drop, including the drops the candidateRejection enum
+// reports as rejectNone (crashed/reloading slot, thermal critical), so the
+// system-profiler routing record can tally them; c is then left partially
+// written and must be discarded by the caller (the arena releases the slot).
+// The counter semantics of candidateRejection are unchanged. Caller holds r.mu.
+func (r *Registry) buildCandidateInto(c *routingCandidate, pr *PendingRequest, now time.Time) (candidateRejection, GateReason, bool) {
+	snap := &c.snapshot
 	statePenalty, eligible := slotStatePenalty(snap.slotState)
 	if !eligible {
 		if snap.slotState == "crashed" {
-			return nil, rejectNone, GateSlotCrashed, false
+			return rejectNone, GateSlotCrashed, false
 		}
-		return nil, rejectNone, GateSlotReloading, false
+		return rejectNone, GateSlotReloading, false
 	}
 	if !snap.hasHeadroom {
-		return nil, rejectCapacity, GateNoHeadroom, false
+		return rejectCapacity, GateNoHeadroom, false
 	}
 
 	if snap.systemMetrics.ThermalState == "critical" {
-		return nil, rejectNone, GateThermalCritical, false
+		return rejectNone, GateThermalCritical, false
 	}
 
 	reqMax := pr.RequestedMaxTokens
@@ -2116,14 +2186,14 @@ func (r *Registry) buildCandidateGateLocked(snap routingSnapshot, pr *PendingReq
 	// idle-but-loaded provider would be wrongly excluded. Reported as
 	// rejectModelTooLarge (permanent, not capacity).
 	if !slotStateModelLoaded(snap.slotState) && !modelFitsHardware(snap.minRAMGb, snap.modelSizeGB, snap.totalMemoryGB) {
-		return nil, rejectModelTooLarge, GateModelTooLarge, false
+		return rejectModelTooLarge, GateModelTooLarge, false
 	}
 
 	// Free-memory admission gate (Phase 1). A provider that claims to
 	// serve the model but doesn't have headroom for weights + KV cache
 	// is rejected here so we don't OOM the backend post-routing.
 	if !freeMemoryAdmits(snap, reqPrompt, reqMax) {
-		return nil, rejectCapacity, GateFreeMemory, false
+		return rejectCapacity, GateFreeMemory, false
 	}
 
 	effectiveQueue := snapshotOccupancy(snap)
@@ -2184,7 +2254,7 @@ func (r *Registry) buildCandidateGateLocked(snap routingSnapshot, pr *PendingReq
 	// proportionally to its windowed reject rate. A soft derater, never an
 	// ejection: the candidate stays in the pool, so a degraded-but-only fleet
 	// still serves, and the penalty decays as outcomes age out of the window.
-	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyLocked(snap.provider.ID, snap.model, time.Now())
+	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyLocked(snap.provider.ID, snap.model, now)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs + capacityRateMs
 
 	// Estimated time-to-first-token for this candidate. Used for the
@@ -2204,27 +2274,27 @@ func (r *Registry) buildCandidateGateLocked(snap routingSnapshot, pr *PendingReq
 	calibrationRatio := ttftCalibration.appliedRatio(snap.model, snap.chipFamily)
 	ttftMs := calibratedTTFTMsWithRatio(snap, rawTTFTMs, calibrationRatio)
 
-	return &routingCandidate{
-		provider:           snap.provider,
-		calibrationRatio:   calibrationRatio,
-		snapshot:           snap,
-		costMs:             cost,
-		effectiveQueue:     effectiveQueue,
-		effectiveTPS:       effectiveTPS,
-		capacityRejectRate: capacityRejectRate,
-		breakdown: costBreakdown{
-			StateMs:        statePenalty,
-			QueueMs:        queueMs,
-			PendingMs:      pendingMs,
-			BacklogMs:      backlogMs,
-			ThisReqMs:      thisReqMs,
-			HealthMs:       healthMs,
-			CapacityRateMs: capacityRateMs,
-			TTFTMs:         ttftMs,
-			RawTTFTMs:      rawTTFTMs,
-			Total:          cost,
-		},
-	}, rejectNone, GateReasonCount, true
+	c.provider = snap.provider
+	// The ratio the profiler records is exactly the one this candidate was
+	// gated on (TTFTCalibrationRatio on the decision).
+	c.calibrationRatio = calibrationRatio
+	c.costMs = cost
+	c.effectiveQueue = effectiveQueue
+	c.effectiveTPS = effectiveTPS
+	c.capacityRejectRate = capacityRejectRate
+	c.breakdown = costBreakdown{
+		StateMs:        statePenalty,
+		QueueMs:        queueMs,
+		PendingMs:      pendingMs,
+		BacklogMs:      backlogMs,
+		ThisReqMs:      thisReqMs,
+		HealthMs:       healthMs,
+		CapacityRateMs: capacityRateMs,
+		TTFTMs:         ttftMs,
+		RawTTFTMs:      rawTTFTMs,
+		Total:          cost,
+	}
+	return rejectNone, GateReasonCount, true
 }
 
 func slotStatePenalty(state string) (float64, bool) {
@@ -2285,7 +2355,7 @@ func healthPenaltyMs(m protocol.SystemMetrics, gpuActiveGB, totalMemGB float64) 
 
 // resolveEffectiveTPS returns the best available decode TPS estimate.
 // Fallback chain: observed EWMA → fleet median → load-scaled benchmark.
-func resolveEffectiveTPS(snap routingSnapshot) float64 {
+func resolveEffectiveTPS(snap *routingSnapshot) float64 {
 	if snap.observedDecodeTPS > 0 {
 		return snap.observedDecodeTPS
 	}
@@ -2304,7 +2374,7 @@ func resolveEffectiveTPS(snap routingSnapshot) float64 {
 //
 // observedPrefillTPS stays 0 until providers ship the W1 measurement, so on
 // today's fleet this is a no-op that returns the existing ×12-chain value.
-func resolvePrefillTPS(snap routingSnapshot) float64 {
+func resolvePrefillTPS(snap *routingSnapshot) float64 {
 	tps := snap.prefillTPS
 	if snap.observedPrefillTPS > 0 {
 		tps = snap.observedPrefillTPS
@@ -2324,7 +2394,7 @@ func resolvePrefillTPS(snap routingSnapshot) float64 {
 // per-request decode cost (reqMax / effectiveTPS * 1000) can become
 // very large for big reqMax values. This is intentional — a saturated
 // provider should look strictly worse than less-saturated peers — and
-// the maxConcurrency gate in snapshotProviderLocked already prevents
+// the maxConcurrency gate in snapshotProviderIntoLockedEx already prevents
 // us from getting here when batchSize exceeds the per-tier cap.
 func effectiveDecodeTPS(staticTPS float64, backendRunning int) float64 {
 	if staticTPS <= 0 {
@@ -2349,7 +2419,7 @@ func effectiveDecodeTPS(staticTPS float64, backendRunning int) float64 {
 // cost's effectiveQueue and the quality-concurrency cap consume; the Phase-0
 // occupancy-aware TTFT term and the shadow admission/spread evaluator reuse it so
 // every occupancy-keyed decision reads one signal.
-func snapshotOccupancy(snap routingSnapshot) int {
+func snapshotOccupancy(snap *routingSnapshot) int {
 	occ := snap.pendingForModel
 	if backendDepth := snap.backendRunning + snap.backendWaiting; backendDepth > occ {
 		occ = backendDepth
@@ -2553,7 +2623,7 @@ func resolvedPrefillTPS(p *Provider) float64 {
 // rate (when present) is unwound from the current batch to a solo rate and then
 // reapplied at b+1; otherwise the static benchmark is the solo proxy. Used by the
 // decode-floor quality preference (PendingRequest.MinDecodeTPS).
-func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
+func projectedPerRequestDecodeTPS(snap *routingSnapshot) float64 {
 	return projectedPerRequestDecodeTPSAtBatch(snap, snap.backendRunning)
 }
 
@@ -2567,7 +2637,7 @@ func projectedPerRequestDecodeTPS(snap routingSnapshot) float64 {
 // the occupancy term passes joinBatch == occ so a herd that has already reserved
 // peers the heartbeat has not yet reflected (occ > backend_running) is charged at
 // the contended rate it will actually see — not the idle/low-batch rate.
-func projectedPerRequestDecodeTPSAtBatch(snap routingSnapshot, joinBatch int) float64 {
+func projectedPerRequestDecodeTPSAtBatch(snap *routingSnapshot, joinBatch int) float64 {
 	k := effectiveTPSLoadFactor
 	if k < 0 {
 		k = 0
@@ -2635,8 +2705,7 @@ func providerModelIDs(p *Provider) []string {
 // very candidate the fail-open valve just selected, derouting the fleet anyway.
 // The default wrapper (breaker honored) is unchanged for every other caller.
 // Caller holds r.mu and p.mu.
-func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool) bool {
-	now := time.Now()
+func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) bool {
 	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false) {
 		return false
 	}
@@ -2730,7 +2799,9 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 
 	unknownTTFTCandidate := false
 	now := time.Now()
-	for _, p := range r.providers {
+	// Per-model index: visit only providers advertising the model (gates
+	// unchanged; see model_index.go).
+	for _, p := range r.providersForModelLocked(model) {
 		// Filter by allowed serials before acquiring the provider lock
 		// (providerMatchesAllowedSerial takes p.mu internally).
 		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
@@ -2739,7 +2810,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 
 		p.mu.Lock()
 
-		// Per-provider routing gates (same source of truth as snapshotProviderLocked
+		// Per-provider routing gates (same source of truth as snapshotProviderIntoLockedEx
 		// and the admit re-check). This pre-flight only runs for public
 		// (non-self-route) requests, so selfRouteOwner is false — private-only
 		// machines are excluded unconditionally.
@@ -2893,14 +2964,14 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		}
 
 		// Free memory / token budget admission gate.
-		if !freeMemoryAdmits(snap, dummyPR.EstimatedPromptTokens, dummyPR.RequestedMaxTokens) {
+		if !freeMemoryAdmits(&snap, dummyPR.EstimatedPromptTokens, dummyPR.RequestedMaxTokens) {
 			capacityRejections++
 			continue
 		}
 
 		candidateCount++
 		if snap.hasBackendCapacity {
-			ttft := estimatedTTFTFromSnapshot(snap, estimatedPromptTokens)
+			ttft := estimatedTTFTFromSnapshot(&snap, estimatedPromptTokens)
 			if !hasTTFT || ttft < bestTTFT {
 				bestTTFT = ttft
 				hasTTFT = true
@@ -2915,7 +2986,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 	return candidateCount, capacityRejections, modelTooLarge, bestTTFT, hasTTFT
 }
 
-func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.Duration {
+func estimatedTTFTFromSnapshot(snap *routingSnapshot, reqPromptTokens int) time.Duration {
 	ttftMs := ttftMsFromSnapshot(snap, reqPromptTokens)
 	if ttftMs <= 0 || math.IsNaN(ttftMs) || math.IsInf(ttftMs, 0) {
 		return 0
@@ -2939,7 +3010,7 @@ func estimatedTTFTFromSnapshot(snap routingSnapshot, reqPromptTokens int) time.D
 // step, which is already reflected by effectiveTPS. Count waiting prefills ahead
 // and this request's own prefill instead of treating active_token_budget_used as
 // a serial decode backlog.
-func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+func ttftMsFromSnapshot(snap *routingSnapshot, reqPromptTokens int) float64 {
 	if !snap.hasBackendCapacity {
 		return 0
 	}
@@ -2980,7 +3051,7 @@ func ttftMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
 // leaked into ttftMsFromSnapshot, raising alpha would tighten the live ceiling
 // and over-shed ~2x (telemetry-db findings §2). The term may therefore only
 // ever reach the shadow estimate, never breakdown.TTFTMs.
-func occupancyAwareTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int) float64 {
+func occupancyAwareTTFTMsFromSnapshot(snap *routingSnapshot, reqPromptTokens int) float64 {
 	base := ttftMsFromSnapshot(snap, reqPromptTokens)
 	if base <= 0 {
 		// No reliable base (provider without BackendCapacity) → no occupancy-aware
@@ -3013,7 +3084,7 @@ func occupancyAwareTTFTMsFromSnapshot(snap routingSnapshot, reqPromptTokens int)
 // preserved). The deadline this is gated against in the shadow evaluator is the
 // model's upstream SLA (standard ~10s), not the shorter live coordinator cutoff.
 // Conflating those clocks over-sheds (telemetry-db findings §2).
-func ttftOccupancyMs(snap routingSnapshot) float64 {
+func ttftOccupancyMs(snap *routingSnapshot) float64 {
 	alpha := ttftOccupancyAlpha
 	if alpha <= 0 {
 		return 0
@@ -3033,7 +3104,7 @@ func ttftOccupancyMs(snap routingSnapshot) float64 {
 	return alpha * float64(occ) * 1000.0 / perReqDecodeTPS
 }
 
-func queuedPrefillTokensAhead(snap routingSnapshot, reqPromptTokens int) float64 {
+func queuedPrefillTokensAhead(snap *routingSnapshot, reqPromptTokens int) float64 {
 	if reqPromptTokens <= 0 {
 		return 0
 	}

--- a/coordinator/registry/scheduler_decode_floor_test.go
+++ b/coordinator/registry/scheduler_decode_floor_test.go
@@ -14,19 +14,19 @@ func TestProjectedDecodeTPS_DecodeFloorTiers(t *testing.T) {
 	approx := func(got, want float64) bool { return math.Abs(got-want) < 0.01 }
 
 	// Tier 2: idle, no observed rate, fleet median 9 → uses 9, NOT static 23.
-	got := projectedPerRequestDecodeTPS(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 9, backendRunning: 0})
+	got := projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 9, backendRunning: 0}))
 	if want := 9.0 / (1 + k*1); !approx(got, want) {
 		t.Errorf("idle+median: got %.3f want %.3f (must use median 9, not static 23)", got, want)
 	}
 
 	// Tier 1: live observed rate wins over the median, unwound from batch then reapplied.
-	got = projectedPerRequestDecodeTPS(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 5, observedDecodeTPS: 20, backendRunning: 2})
+	got = projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 5, observedDecodeTPS: 20, backendRunning: 2}))
 	if want := 20.0 * (1 + k*2) / (1 + k*3); !approx(got, want) {
 		t.Errorf("observed wins: got %.3f want %.3f", got, want)
 	}
 
 	// Tier 3: no observed, no median → static benchmark.
-	got = projectedPerRequestDecodeTPS(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 0, backendRunning: 0})
+	got = projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 0, backendRunning: 0}))
 	if want := 23.0 / (1 + k*1); !approx(got, want) {
 		t.Errorf("static fallback: got %.3f want %.3f", got, want)
 	}
@@ -36,7 +36,7 @@ func TestProjectedDecodeTPS_FleetMedianKillSwitch(t *testing.T) {
 	t.Setenv("EIGENINFERENCE_DECODE_FLOOR_USE_FLEET_MEDIAN", "false")
 	k := effectiveTPSLoadFactor
 	// Kill switch off: idle box ignores the median and falls to static 23.
-	got := projectedPerRequestDecodeTPS(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 9, backendRunning: 0})
+	got := projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{decodeTPS: 23, fleetMedianTPS: 9, backendRunning: 0}))
 	if want := 23.0 / (1 + k*1); math.Abs(got-want) > 0.01 {
 		t.Errorf("kill switch off: got %.3f want %.3f (must use static, not median)", got, want)
 	}

--- a/coordinator/registry/scheduler_memory_admission_test.go
+++ b/coordinator/registry/scheduler_memory_admission_test.go
@@ -40,7 +40,7 @@ func TestResolveEffectiveTPSFallback(t *testing.T) {
 		backendRunning:    2,
 		observedDecodeTPS: 0,
 	}
-	got := resolveEffectiveTPS(snap)
+	got := resolveEffectiveTPS(snapPtr(snap))
 	want := effectiveDecodeTPS(100, 2)
 	if got != want {
 		t.Fatalf("resolveEffectiveTPS()=%f, want %f (formula fallback)", got, want)
@@ -48,7 +48,7 @@ func TestResolveEffectiveTPSFallback(t *testing.T) {
 
 	// When observedDecodeTPS is set, should use it directly.
 	snap.observedDecodeTPS = 55.5
-	got = resolveEffectiveTPS(snap)
+	got = resolveEffectiveTPS(snapPtr(snap))
 	if got != 55.5 {
 		t.Fatalf("resolveEffectiveTPS()=%f, want 55.5 (observed)", got)
 	}
@@ -111,11 +111,11 @@ func TestFreeMemoryAdmitsTokenBudget(t *testing.T) {
 		totalMemoryGB:         64,
 	}
 	// Request for 500 + 4096 = 4596 tokens. 28000 + 4596 = 32596 <= 32768. Fits.
-	if !freeMemoryAdmits(snap, 500, 4096) {
+	if !freeMemoryAdmits(snapPtr(snap), 500, 4096) {
 		t.Fatal("should admit: 28000 + 4596 = 32596 <= 32768")
 	}
 	// Request for 500 + 4500 = 5000 tokens. 28000 + 5000 = 33000 > 32768. Rejected.
-	if freeMemoryAdmits(snap, 500, 4500) {
+	if freeMemoryAdmits(snapPtr(snap), 500, 4500) {
 		t.Fatal("should reject: 28000 + 5000 = 33000 > 32768")
 	}
 }
@@ -129,12 +129,12 @@ func TestFreeMemoryAdmitsIncludesQueuedBudget(t *testing.T) {
 		totalMemoryGB:         64,
 	}
 	// active(20K) + queued(10K) + request(500+4096=4596) = 34596 > 32768. Rejected.
-	if freeMemoryAdmits(snap, 500, 4096) {
+	if freeMemoryAdmits(snapPtr(snap), 500, 4096) {
 		t.Fatal("should reject: active + queued + request exceeds budget")
 	}
 	// Without queued budget: active(20K) + request(4596) = 24596 <= 32768. Fits.
 	snap.queuedTokenBudget = 0
-	if !freeMemoryAdmits(snap, 500, 4096) {
+	if !freeMemoryAdmits(snapPtr(snap), 500, 4096) {
 		t.Fatal("should admit when queued budget is zero")
 	}
 }
@@ -150,7 +150,7 @@ func TestFreeMemoryAdmitsFallsBackWithoutBudget(t *testing.T) {
 		modelLoaded:           true,
 	}
 	// Model already loaded, so only KV matters. Lots of free memory.
-	if !freeMemoryAdmits(snap, 100, 256) {
+	if !freeMemoryAdmits(snapPtr(snap), 100, 256) {
 		t.Fatal("should admit with plenty of free memory in legacy mode")
 	}
 }
@@ -170,13 +170,13 @@ func TestFreeMemoryAdmitsColdLoadUsesReportedFreeForLoad(t *testing.T) {
 
 	fits := base
 	fits.modelSizeGB = 8 // 8 <= 9 → admit
-	if !freeMemoryAdmits(fits, 100, 256) {
+	if !freeMemoryAdmits(snapPtr(fits), 100, 256) {
 		t.Fatal("8GB model must be admitted: fits in reported 9GB free-for-load")
 	}
 
 	tooBig := base
 	tooBig.modelSizeGB = 14 // 14 > 9 → reject, even though heuristic on 64GB would admit
-	if freeMemoryAdmits(tooBig, 100, 256) {
+	if freeMemoryAdmits(snapPtr(tooBig), 100, 256) {
 		t.Fatal("14GB model must be rejected: exceeds reported 9GB free-for-load")
 	}
 }
@@ -193,7 +193,7 @@ func TestFreeMemoryAdmitsColdLoadReportedZeroRejects(t *testing.T) {
 		totalPending:    0,
 		freeForLoadGB:   &zero,
 	}
-	if freeMemoryAdmits(snap, 100, 256) {
+	if freeMemoryAdmits(snapPtr(snap), 100, 256) {
 		t.Fatal("reported free-for-load 0 must reject a cold load")
 	}
 }
@@ -212,11 +212,11 @@ func TestFreeMemoryAdmitsColdLoadNormalizesCatalogSize(t *testing.T) {
 		totalPending:    0,
 		freeForLoadGB:   &free,
 	}
-	if freeMemoryAdmits(snap, 100, 256) {
+	if freeMemoryAdmits(snapPtr(snap), 100, 256) {
 		t.Fatal("near-threshold model must reject: padded estimate exceeds reported free-for-load")
 	}
 	snap.modelSizeGB = 8 // padded 8*1.1176≈8.94 <= 10 → admit
-	if !freeMemoryAdmits(snap, 100, 256) {
+	if !freeMemoryAdmits(snapPtr(snap), 100, 256) {
 		t.Fatal("8GB model must admit: padded estimate fits reported free-for-load")
 	}
 }
@@ -270,7 +270,7 @@ func TestFreeMemoryAdmitsColdLoadFallsBackWhenUnreported(t *testing.T) {
 		totalPending:    0,
 		freeForLoadGB:   nil,
 	}
-	if !freeMemoryAdmits(snap, 100, 256) {
+	if !freeMemoryAdmits(snapPtr(snap), 100, 256) {
 		t.Fatal("legacy provider must fall back to the total-memory heuristic (admit)")
 	}
 }

--- a/coordinator/registry/scheduler_queue_drain_test.go
+++ b/coordinator/registry/scheduler_queue_drain_test.go
@@ -345,6 +345,7 @@ func TestDrainQueuedRequestsRespectsPerSlotCapsAcrossModels(t *testing.T) {
 	p := makeSchedulerProvider(t, reg, "multi-slot", modelA, 100)
 	p.mu.Lock()
 	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.syncModelIndexLocked()
 	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
 		{Model: modelA, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
 		{Model: modelB, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
@@ -401,6 +402,7 @@ func TestSetProviderIdleDrainsOnlyFreedModelCapacity(t *testing.T) {
 	p := makeSchedulerProvider(t, reg, "idle-multi", modelA, 100)
 	p.mu.Lock()
 	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.syncModelIndexLocked()
 	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
 		{Model: modelA, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},
 		{Model: modelB, State: "running", NumRunning: 0, NumWaiting: 0, MaxConcurrency: 1},

--- a/coordinator/registry/scheduler_test.go
+++ b/coordinator/registry/scheduler_test.go
@@ -176,20 +176,20 @@ func TestResolvePrefillTPSPrefersObserved(t *testing.T) {
 	// No measured rate: the resolver returns the existing prefillTPS chain
 	// (resolvedPrefillTPS: benchmark → decode×12) unchanged. This is the
 	// today-fleet path and MUST be a no-op.
-	if got := resolvePrefillTPS(routingSnapshot{prefillTPS: 600}); got != 600 {
+	if got := resolvePrefillTPS(snapPtr(routingSnapshot{prefillTPS: 600})); got != 600 {
 		t.Fatalf("fallback prefill = %v, want 600 (×12 chain preserved)", got)
 	}
 	// A non-positive observed value is treated as unmeasured → fallback.
-	if got := resolvePrefillTPS(routingSnapshot{prefillTPS: 600, observedPrefillTPS: 0}); got != 600 {
+	if got := resolvePrefillTPS(snapPtr(routingSnapshot{prefillTPS: 600, observedPrefillTPS: 0})); got != 600 {
 		t.Fatalf("zero observed prefill = %v, want 600 (fallback)", got)
 	}
 	// A measured per-slot prefill EWMA wins over the static chain.
-	if got := resolvePrefillTPS(routingSnapshot{prefillTPS: 600, observedPrefillTPS: 1800}); got != 1800 {
+	if got := resolvePrefillTPS(snapPtr(routingSnapshot{prefillTPS: 600, observedPrefillTPS: 1800})); got != 1800 {
 		t.Fatalf("observed prefill = %v, want 1800 (measured preferred)", got)
 	}
 	// The result is clamped to maxPrefillTPS so one outlier heartbeat cannot
 	// collapse the TTFT estimate.
-	if got := resolvePrefillTPS(routingSnapshot{observedPrefillTPS: maxPrefillTPS * 2}); got != maxPrefillTPS {
+	if got := resolvePrefillTPS(snapPtr(routingSnapshot{observedPrefillTPS: maxPrefillTPS * 2})); got != maxPrefillTPS {
 		t.Fatalf("clamped observed prefill = %v, want %v", got, maxPrefillTPS)
 	}
 }
@@ -205,7 +205,7 @@ func TestTTFTMsFromSnapshotUsesObservedPrefillTPS(t *testing.T) {
 		prefillTPS:         600, // e.g. decode 50 × 12
 		decodeTPS:          50,
 	}
-	fallbackTTFT := ttftMsFromSnapshot(fallback, prompt)
+	fallbackTTFT := ttftMsFromSnapshot(snapPtr(fallback), prompt)
 	wantFallback := float64(prompt)/600*1000 + 1000.0/50.0
 	if d := fallbackTTFT - wantFallback; d > 0.01 || d < -0.01 {
 		t.Fatalf("fallback TTFT = %.4f, want %.4f (×12 chain preserved)", fallbackTTFT, wantFallback)
@@ -214,7 +214,7 @@ func TestTTFTMsFromSnapshotUsesObservedPrefillTPS(t *testing.T) {
 	// Measured path: a 3× faster observed prefill lowers only the prefill term.
 	observed := fallback
 	observed.observedPrefillTPS = 1800
-	observedTTFT := ttftMsFromSnapshot(observed, prompt)
+	observedTTFT := ttftMsFromSnapshot(snapPtr(observed), prompt)
 	wantObserved := float64(prompt)/1800*1000 + 1000.0/50.0
 	if d := observedTTFT - wantObserved; d > 0.01 || d < -0.01 {
 		t.Fatalf("observed TTFT = %.4f, want %.4f (measured prefill used)", observedTTFT, wantObserved)
@@ -277,17 +277,17 @@ func TestProjectedPerRequestDecodeTPS(t *testing.T) {
 	approx := func(a, b float64) bool { return abs(a-b) < 0.01 }
 
 	// Static fallback (no observed rate), idle provider: rate at batch 1 = static/(1+k).
-	if got, want := projectedPerRequestDecodeTPS(routingSnapshot{decodeTPS: 25}), 25.0/(1+k); !approx(got, want) {
+	if got, want := projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{decodeTPS: 25})), 25.0/(1+k); !approx(got, want) {
 		t.Fatalf("static idle projected = %.2f, want %.2f", got, want)
 	}
 	// Observed rate measured at batch 2 is unwound to a solo rate, then reapplied
 	// at batch 3 (the new request joins): solo = obs*(1+2k); proj = solo/(1+3k).
 	snap := routingSnapshot{decodeTPS: 25, observedDecodeTPS: 20, backendRunning: 2}
-	if got, want := projectedPerRequestDecodeTPS(snap), 20.0*(1+2*k)/(1+3*k); !approx(got, want) {
+	if got, want := projectedPerRequestDecodeTPS(snapPtr(snap)), 20.0*(1+2*k)/(1+3*k); !approx(got, want) {
 		t.Fatalf("observed projected = %.2f, want %.2f", got, want)
 	}
 	// No decode info -> 0 (treated as below any positive floor).
-	if got := projectedPerRequestDecodeTPS(routingSnapshot{}); got != 0 {
+	if got := projectedPerRequestDecodeTPS(snapPtr(routingSnapshot{})); got != 0 {
 		t.Fatalf("empty snapshot projected = %.2f, want 0", got)
 	}
 }

--- a/coordinator/registry/scheduler_token_budget_test.go
+++ b/coordinator/registry/scheduler_token_budget_test.go
@@ -372,6 +372,7 @@ func TestManyPerSlotCapsRespectProviderWideAggregateCap(t *testing.T) {
 			ActiveTokenBudgetMax: 32_768,
 		})
 	}
+	p.syncModelIndexLocked()
 	p.mu.Unlock()
 
 	for i := range 24 {
@@ -407,6 +408,7 @@ func TestModelCapacitySnapshotRespectsPerSlotMaxConcurrency(t *testing.T) {
 	p := makeSchedulerProvider(t, reg, "snapshot-provider", modelA, 100)
 	p.mu.Lock()
 	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.syncModelIndexLocked()
 	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{
 		{Model: modelA, State: "running", NumRunning: 1, MaxConcurrency: 1},
 		{Model: modelB, State: "running", NumRunning: 0, MaxConcurrency: 2},

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -1,5 +1,7 @@
 package registry
 
+import "time"
+
 // Servability prediction.
 //
 // The coordinator's free-memory admission gate (freeMemoryAdmits) is, on the
@@ -315,7 +317,7 @@ func coldTokenBudgetEstimate(totalMemoryGB, modelSizeGB float64, kvBytesPerToken
 // included (see coldTokenBudgetEstimate). "known=false" means we cannot tell
 // (legacy resident slot with no budget, or missing memory data) — the caller
 // treats unknown as fail-open and skips the budget tier entirely.
-func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
+func snapshotStructuralBudget(snap *routingSnapshot) (budget int64, known bool) {
 	if snap.activeTokenBudgetMax > 0 {
 		return snap.activeTokenBudgetMax, true
 	}
@@ -343,7 +345,7 @@ func snapshotStructuralBudget(snap routingSnapshot) (budget int64, known bool) {
 // that queues. It must NOT feed the fleet-level servability shed, which is
 // structural-only (see PredictServable) — a live-remaining fleet 429 would shed
 // a merely-busy fleet ahead of the queue.
-func liveRemainingBudget(snap routingSnapshot) (budget int64, known bool) {
+func liveRemainingBudget(snap *routingSnapshot) (budget int64, known bool) {
 	if snap.activeTokenBudgetMax > 0 {
 		// Gray-box budget clamp (budget_clamp.go): a capacity-503 proved the
 		// live gate rejects, so the pair's LIVE headroom is zero regardless of
@@ -388,7 +390,7 @@ func liveRemainingBudget(snap routingSnapshot) (budget int64, known bool) {
 // no reported budget, or missing memory/size data) and the caller must fail
 // open. A reqMaxTokens ≤ 0 is normalized to defaultRequestedMaxTokens, the
 // same defaulting the pending-budget accounting applies.
-func providerBudgetFits(snap routingSnapshot, reqPromptTokens, reqMaxTokens int) (fits, known bool) {
+func providerBudgetFits(snap *routingSnapshot, reqPromptTokens, reqMaxTokens int) (fits, known bool) {
 	budget, known := liveRemainingBudget(snap)
 	if !known {
 		return true, false
@@ -465,12 +467,15 @@ func (r *Registry) PredictServable(model string, estimatedPromptTokens, contextP
 	var fleetMax int64
 	sawUnknown := false
 	providerCount := 0
-	for _, p := range r.providers {
+	now := time.Now()
+	var snap routingSnapshot // one caller-owned buffer, refilled per provider
+	// Per-model index: visit only providers advertising the model (gates
+	// unchanged; see model_index.go).
+	for _, p := range r.providersForModelLocked(model) {
 		if len(allowedSet) > 0 && !providerMatchesAllowedSerial(p, allowedSet) {
 			continue
 		}
-		snap, ok := r.snapshotProviderLocked(p, model, traits, false)
-		if !ok {
+		if ok, _ := r.snapshotProviderIntoLockedEx(&snap, p, model, traits, false, false, now); !ok {
 			continue
 		}
 		// Modality (vision) is intentionally NOT filtered here: a vision-incapable
@@ -493,7 +498,7 @@ func (r *Registry) PredictServable(model string, estimatedPromptTokens, contextP
 		// path could hold the request for the seconds a slot takes to free.
 		// Transient fullness belongs to the capacity/queue ladder; this tier
 		// sheds only requests that exceed every ceiling and could NEVER fit.
-		budget, known := snapshotStructuralBudget(snap)
+		budget, known := snapshotStructuralBudget(&snap)
 		if !known {
 			sawUnknown = true
 			continue

--- a/coordinator/registry/servability_provider_fit_test.go
+++ b/coordinator/registry/servability_provider_fit_test.go
@@ -20,27 +20,27 @@ func TestProviderBudgetFitsWarmSlotLiveBudget(t *testing.T) {
 	}
 	// Live remaining budget = 32768 - 20000 - 4000 = 8768.
 
-	if fits, known := providerBudgetFits(snap, 8_000, 1_000); !known || fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), 8_000, 1_000); !known || fits {
 		t.Fatalf("9000-token request vs 8768 live budget = (fits=%v, known=%v), want (false, true)", fits, known)
 	}
-	if fits, known := providerBudgetFits(snap, 8_000, 512); !known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), 8_000, 512); !known || !fits {
 		t.Fatalf("8512-token request vs 8768 live budget = (fits=%v, known=%v), want (true, true)", fits, known)
 	}
 	// Exact boundary is a fit (provider gate is `>` to reject, `<=` to admit).
-	if fits, known := providerBudgetFits(snap, 8_512, 256); !known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), 8_512, 256); !known || !fits {
 		t.Fatalf("exact-boundary 8768-token request = (fits=%v, known=%v), want (true, true)", fits, known)
 	}
 
 	// reqMaxTokens <= 0 normalizes to defaultRequestedMaxTokens (256), matching
 	// the pending-budget accounting: 8512+256 = 8768 fits, 8513+256 does not.
-	if fits, _ := providerBudgetFits(snap, 8_512, 0); !fits {
+	if fits, _ := providerBudgetFits(snapPtr(snap), 8_512, 0); !fits {
 		t.Fatal("reqMax=0 must default to defaultRequestedMaxTokens (8512+256=8768 fits)")
 	}
-	if fits, _ := providerBudgetFits(snap, 8_513, 0); fits {
+	if fits, _ := providerBudgetFits(snapPtr(snap), 8_513, 0); fits {
 		t.Fatal("reqMax=0 must default to defaultRequestedMaxTokens (8513+256=8769 must not fit)")
 	}
 	// Negative prompt clamps to 0.
-	if fits, known := providerBudgetFits(snap, -5, 256); !known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), -5, 256); !known || !fits {
 		t.Fatalf("negative prompt = (fits=%v, known=%v), want (true, true)", fits, known)
 	}
 }
@@ -79,11 +79,11 @@ func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 	}
 
 	// A 30k-token request loads fine but can never be served post-load.
-	if fits, known := providerBudgetFits(snap, 30_000, 256); !known || fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), 30_000, 256); !known || fits {
 		t.Fatalf("30k request vs %d-token post-load budget = (fits=%v, known=%v), want (false, true)", budget, fits, known)
 	}
 	// A request within the post-load budget fits.
-	if fits, known := providerBudgetFits(snap, 10_000, 256); !known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(snap), 10_000, 256); !known || !fits {
 		t.Fatalf("10k request vs %d-token post-load budget = (fits=%v, known=%v), want (true, true)", budget, fits, known)
 	}
 }
@@ -93,14 +93,14 @@ func TestProviderBudgetFitsColdLoadPostLoadBudget(t *testing.T) {
 // behavior (fail open) rather than shedding on missing data.
 func TestProviderBudgetFitsFailsOpenOnUnknown(t *testing.T) {
 	// Resident legacy slot with no reported budget.
-	if fits, known := providerBudgetFits(routingSnapshot{modelLoaded: true}, 1_000_000, 256); known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(routingSnapshot{modelLoaded: true}), 1_000_000, 256); known || !fits {
 		t.Fatalf("legacy resident slot = (fits=%v, known=%v), want (true, false)", fits, known)
 	}
 	// Cold slot missing memory/size data.
-	if fits, known := providerBudgetFits(routingSnapshot{modelSizeGB: 28}, 1_000_000, 256); known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(routingSnapshot{modelSizeGB: 28}), 1_000_000, 256); known || !fits {
 		t.Fatalf("cold slot missing memory = (fits=%v, known=%v), want (true, false)", fits, known)
 	}
-	if fits, known := providerBudgetFits(routingSnapshot{totalMemoryGB: 48}, 1_000_000, 256); known || !fits {
+	if fits, known := providerBudgetFits(snapPtr(routingSnapshot{totalMemoryGB: 48}), 1_000_000, 256); known || !fits {
 		t.Fatalf("cold slot missing size = (fits=%v, known=%v), want (true, false)", fits, known)
 	}
 }

--- a/coordinator/registry/servability_test.go
+++ b/coordinator/registry/servability_test.go
@@ -264,23 +264,23 @@ func providerPostLoadTokenBudget(totalMemoryGB, modelSizeGB float64, kvBytesPerT
 // three branches in snapshotStructuralBudget.
 func TestSnapshotStructuralBudget(t *testing.T) {
 	// Resident slot with a reported active budget: authoritative and known.
-	if budget, known := snapshotStructuralBudget(routingSnapshot{activeTokenBudgetMax: 8192}); !known || budget != 8192 {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{activeTokenBudgetMax: 8192})); !known || budget != 8192 {
 		t.Fatalf("resident-with-budget = (%d, %v), want (8192, true)", budget, known)
 	}
 
 	// The reported active budget wins even when memory/size data is also present
 	// (it must NOT fall through to the cold estimate for a loaded model).
-	if budget, known := snapshotStructuralBudget(routingSnapshot{
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{
 		activeTokenBudgetMax: 8192,
 		modelLoaded:          true,
 		totalMemoryGB:        64,
 		modelSizeGB:          12,
-	}); !known || budget != 8192 {
+	})); !known || budget != 8192 {
 		t.Fatalf("resident-with-budget+mem = (%d, %v), want (8192, true)", budget, known)
 	}
 
 	// Resident but no budget reported (legacy provider): unknown → fail-open.
-	if budget, known := snapshotStructuralBudget(routingSnapshot{modelLoaded: true}); known || budget != 0 {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{modelLoaded: true})); known || budget != 0 {
 		t.Fatalf("resident-no-budget = (%d, %v), want (0, false)", budget, known)
 	}
 
@@ -288,27 +288,27 @@ func TestSnapshotStructuralBudget(t *testing.T) {
 	// estimate. Unreported kvBytesPerToken falls back to the 400000 default;
 	// an unreported binaryVersion falls toward the legacy reserve.
 	wantCold := coldTokenBudgetEstimate(64, 12, 0, "", "")
-	if budget, known := snapshotStructuralBudget(routingSnapshot{totalMemoryGB: 64, modelSizeGB: 12}); !known || budget != wantCold {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{totalMemoryGB: 64, modelSizeGB: 12})); !known || budget != wantCold {
 		t.Fatalf("cold-fitting = (%d, %v), want (%d, true)", budget, known, wantCold)
 	}
 	// A cold slot threads its reported per-model KV cost into the estimate.
 	wantColdKVPT := coldTokenBudgetEstimate(64, 12, 200000, "", "")
-	if budget, known := snapshotStructuralBudget(routingSnapshot{
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{
 		totalMemoryGB:   64,
 		modelSizeGB:     12,
 		kvBytesPerToken: 200000,
-	}); !known || budget != wantColdKVPT {
+	})); !known || budget != wantColdKVPT {
 		t.Fatalf("cold-fitting+kvpt = (%d, %v), want (%d, true)", budget, known, wantColdKVPT)
 	}
 	// A cold slot threads its provider's binary version into the estimate:
 	// a ≥0.8.0 binary is charged the 5.5 GiB reserve it actually holds,
 	// which lands strictly below the legacy default above.
 	wantColdV080 := coldTokenBudgetEstimate(64, 12, 0, "0.8.0", "")
-	if budget, known := snapshotStructuralBudget(routingSnapshot{
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{
 		totalMemoryGB: 64,
 		modelSizeGB:   12,
 		binaryVersion: "0.8.0",
-	}); !known || budget != wantColdV080 {
+	})); !known || budget != wantColdV080 {
 		t.Fatalf("cold-fitting+version = (%d, %v), want (%d, true)", budget, known, wantColdV080)
 	}
 	if wantColdV080 >= wantCold {
@@ -317,17 +317,17 @@ func TestSnapshotStructuralBudget(t *testing.T) {
 	}
 
 	// Cold but missing memory or size data: cannot estimate → unknown.
-	if budget, known := snapshotStructuralBudget(routingSnapshot{modelSizeGB: 12}); known || budget != 0 {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{modelSizeGB: 12})); known || budget != 0 {
 		t.Fatalf("cold-missing-memory = (%d, %v), want (0, false)", budget, known)
 	}
-	if budget, known := snapshotStructuralBudget(routingSnapshot{totalMemoryGB: 64}); known || budget != 0 {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{totalMemoryGB: 64})); known || budget != 0 {
 		t.Fatalf("cold-missing-size = (%d, %v), want (0, false)", budget, known)
 	}
 
 	// Cold with memory + size data but NO post-load KV headroom (weights ~fill the
 	// node): the estimate is 0 yet it is a KNOWN budget, not "unknown" — so the
 	// gate can confidently reject rather than fail open.
-	if budget, known := snapshotStructuralBudget(routingSnapshot{totalMemoryGB: 16, modelSizeGB: 14}); !known || budget != 0 {
+	if budget, known := snapshotStructuralBudget(snapPtr(routingSnapshot{totalMemoryGB: 16, modelSizeGB: 14})); !known || budget != 0 {
 		t.Fatalf("cold-no-headroom = (%d, %v), want (0, true)", budget, known)
 	}
 }

--- a/coordinator/registry/snapshot_ptr_helpers_test.go
+++ b/coordinator/registry/snapshot_ptr_helpers_test.go
@@ -1,0 +1,9 @@
+package registry
+
+// Test-only adapters for the pointer-taking snapshot helpers: tests build
+// routingSnapshot / pooledTokenBudget values (often inline, from helper
+// calls) and these take their address so the assertions read as before.
+
+func snapPtr(s routingSnapshot) *routingSnapshot { return &s }
+
+func poolPtr(p pooledTokenBudget) *pooledTokenBudget { return &p }

--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -1,8 +1,6 @@
 package registry
 
 import (
-	"sort"
-
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
@@ -46,12 +44,22 @@ func (r *TPSRegistry) RecordSolo(model, chipClass string, tps float64) {
 	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	samples := r.soloSamples[key]
-	if len(samples) >= r.maxSamples {
-		// Drop oldest sample (FIFO ring), same shape as Record.
-		samples = samples[1:]
+	if r.soloSamples == nil { // zero-value registry
+		r.soloSamples = make(map[tpsKey][]float64)
 	}
-	r.soloSamples[key] = append(samples, tps)
+	if r.soloByModel == nil {
+		r.soloByModel = make(map[string]map[string]tpsSampleStat)
+	}
+	// FIFO ring, same shape as Record.
+	samples := appendRingSample(r.soloSamples[key], tps, r.maxSamples)
+	r.soloSamples[key] = samples
+	byClass := r.soloByModel[model]
+	if byClass == nil {
+		byClass = make(map[string]tpsSampleStat)
+		r.soloByModel[model] = byClass
+	}
+	byClass[chipClass] = tpsSampleStat{median: r.medianOfRingLocked(samples), n: len(samples)}
+	r.refreshSoloAllChipsLocked(model)
 }
 
 // SoloMedian returns the median solo decode TPS for the given model and chip
@@ -59,13 +67,10 @@ func (r *TPSRegistry) RecordSolo(model, chipClass string, tps float64) {
 // solo samples exist. The count lets callers apply a min-sample trust floor
 // before using the median for admission decisions.
 func (r *TPSRegistry) SoloMedian(model, chipClass string) (float64, int) {
-	key := tpsKey{Model: model, ChipFamily: chipClass}
 	r.mu.RLock()
-	samples := r.soloSamples[key]
-	sorted := make([]float64, len(samples))
-	copy(sorted, samples)
+	stat := r.soloByModel[model][chipClass]
 	r.mu.RUnlock()
-	return medianOfCopied(sorted), len(sorted)
+	return stat.median, stat.n
 }
 
 // SoloMedianAllChips is the CONSERVATIVE cross-class transfer used when a
@@ -94,46 +99,16 @@ func (r *TPSRegistry) SoloMedian(model, chipClass string) (float64, int) {
 // The total sample count keeps the resolver's >= qualityCapSoloMinSamples trust
 // floor unchanged. The tpsKey.ChipFamily field carries the chip-class string
 // for solo entries, so grouping by key.Model + key.ChipFamily groups by class.
+//
+// O(1) and allocation-free on read: the aggregate is maintained by RecordSolo
+// (tps_median_cache.go), which is what lets the routing scan resolve the
+// quality cap for every provider without copying and sorting the fleet's
+// samples per provider.
 func (r *TPSRegistry) SoloMedianAllChips(model string) (tps float64, samples, classes int) {
 	r.mu.RLock()
-	perClass := make(map[string][]float64)
-	for key, s := range r.soloSamples {
-		if key.Model != model || len(s) == 0 {
-			continue
-		}
-		// append copies the values, so perClass is safe to sort after RUnlock.
-		perClass[key.ChipFamily] = append(perClass[key.ChipFamily], s...)
-	}
+	agg := r.soloAllChips[model]
 	r.mu.RUnlock()
-
-	minMedian, total, classCount := 0.0, 0, 0
-	for _, s := range perClass {
-		// s is a private copy; medianOfCopied sorts it in place.
-		m := medianOfCopied(s)
-		total += len(s)
-		if m <= 0 {
-			continue
-		}
-		if classCount == 0 || m < minMedian {
-			minMedian = m
-		}
-		classCount++
-	}
-	return minMedian, total, classCount
-}
-
-// medianOfCopied returns the median of samples, sorting in place (callers pass
-// a private copy). 0 for an empty slice.
-func medianOfCopied(sorted []float64) float64 {
-	if len(sorted) == 0 {
-		return 0
-	}
-	sort.Float64s(sorted)
-	mid := len(sorted) / 2
-	if len(sorted)%2 == 0 {
-		return (sorted[mid-1] + sorted[mid]) / 2
-	}
-	return sorted[mid]
+	return agg.minMedian, agg.total, agg.classes
 }
 
 // soloSampleEligible reports whether a heartbeat's capacity snapshot qualifies

--- a/coordinator/registry/stable_fault_key_test.go
+++ b/coordinator/registry/stable_fault_key_test.go
@@ -331,8 +331,8 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.RecordInferenceError("sess-1", model, 500, "base")
 	reg.RecordDispatchLoadFailure("sess-1", model)
 	reg.mu.Lock()
-	reg.pendingModelLoads["sess-1:"+model] = time.Now().Add(time.Minute)
-	reg.pendingModelLoadStarted["sess-1:"+model] = time.Now()
+	reg.pendingModelLoads[modelLoadKey{ProviderID: "sess-1", ModelID: model}] = time.Now().Add(time.Minute)
+	reg.pendingModelLoadStarted[modelLoadKey{ProviderID: "sess-1", ModelID: model}] = time.Now()
 	reg.mu.Unlock()
 
 	reg.Disconnect("sess-1")
@@ -342,8 +342,8 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	_, hasWin := reg.providerOutcomes[stableKey]
 	_, hasOpen := reg.providerBreakerOpenUntil[stableKey]
 	_, hasStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: stableKey, ModelID: model, Shape: "base"}]
-	_, hasDLC := reg.dispatchLoadCooldowns[stableKey+":"+model]
-	_, hasPending := reg.pendingModelLoads["sess-1:"+model]
+	_, hasDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: stableKey, ModelID: model}]
+	_, hasPending := reg.pendingModelLoads[modelLoadKey{ProviderID: "sess-1", ModelID: model}]
 	_, hasBinding := reg.faultKeyBySession["sess-1"]
 	reg.mu.RUnlock()
 	if !hasWin || !hasOpen || !hasStrikes || !hasDLC {
@@ -366,7 +366,7 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.mu.RLock()
 	_, anonWin := reg.providerOutcomes["sess-anon"]
 	_, anonStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: "sess-anon", ModelID: model, Shape: "base"}]
-	_, anonDLC := reg.dispatchLoadCooldowns["sess-anon:"+model]
+	_, anonDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: "sess-anon", ModelID: model}]
 	reg.mu.RUnlock()
 	if anonWin || anonStrikes || anonDLC {
 		t.Fatalf("session-keyed residue of an identity-less provider must be dropped: win=%v strikes=%v dlc=%v",

--- a/coordinator/registry/tps_median_cache.go
+++ b/coordinator/registry/tps_median_cache.go
@@ -1,0 +1,106 @@
+package registry
+
+import "sort"
+
+// tps_median_cache.go — read-side aggregates for TPSRegistry.
+//
+// The routing scan reads Median / SoloMedian / SoloMedianAllChips once PER
+// PROVIDER per scan (snapshotProviderLockedEx and the quality-concurrency cap
+// via resolvedSoloModelTPSLocked). Computing a median on read meant copying
+// and sorting up to 50 samples ~1,300 times per request at fleet scale, and
+// SoloMedianAllChips additionally allocated a per-class map and copied every
+// sample for the model. Samples are bounded (maxSamples per key) and only
+// change on heartbeat ingest, so every aggregate is recomputed on WRITE
+// (Record / RecordSolo) and read as an O(1) map lookup with zero allocation.
+//
+// Semantics are byte-for-byte those of the former read-time computation:
+// the median of the retained FIFO ring (mean of the two middle values for an
+// even count), 0 for an empty key; the AllChips minimum-of-class-medians,
+// total sample count and contributing-class count exactly as before.
+
+// tpsSampleStat is the cached aggregate for one (model, chip) sample ring.
+type tpsSampleStat struct {
+	median float64
+	n      int
+}
+
+// soloAllChipsStat is the cached cross-class aggregate for one model (see
+// SoloMedianAllChips): the minimum per-class solo median, the total sample
+// count across every class, and the number of classes with a positive median.
+type soloAllChipsStat struct {
+	minMedian float64
+	total     int
+	classes   int
+}
+
+// medianOfRingLocked returns the median of samples without mutating them,
+// sorting a private scratch copy owned by the registry. Caller holds r.mu for
+// writing (the scratch buffer is not safe for concurrent use).
+func (r *TPSRegistry) medianOfRingLocked(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	if cap(r.scratch) < len(samples) {
+		// A zero-value registry (maxSamples 0) has an unbounded ring, so the
+		// scratch capacity must follow the ring, never the nominal bound.
+		capacity := r.maxSamples
+		if len(samples) > capacity {
+			capacity = len(samples)
+		}
+		r.scratch = make([]float64, len(samples), capacity)
+	}
+	sorted := r.scratch[:len(samples)]
+	copy(sorted, samples)
+	return medianOfCopied(sorted)
+}
+
+// appendRingSample appends tps to a FIFO ring bounded at maxSamples, dropping
+// the oldest sample when full. The backing array is reused once the ring is
+// full (shift-left + overwrite) so steady-state ingest allocates nothing; the
+// retained sequence is identical to the former re-slice-and-append form.
+func appendRingSample(samples []float64, tps float64, maxSamples int) []float64 {
+	if maxSamples > 0 && len(samples) >= maxSamples {
+		copy(samples, samples[1:])
+		samples[len(samples)-1] = tps
+		return samples
+	}
+	return append(samples, tps)
+}
+
+// refreshSoloAllChipsLocked recomputes the cached cross-class aggregate for
+// model from the per-class stats. O(classes for the model). Caller holds r.mu
+// for writing.
+func (r *TPSRegistry) refreshSoloAllChipsLocked(model string) {
+	var agg soloAllChipsStat
+	for _, stat := range r.soloByModel[model] {
+		if stat.n == 0 {
+			continue
+		}
+		agg.total += stat.n
+		if stat.median <= 0 {
+			continue
+		}
+		if agg.classes == 0 || stat.median < agg.minMedian {
+			agg.minMedian = stat.median
+		}
+		agg.classes++
+	}
+	if r.soloAllChips == nil {
+		r.soloAllChips = make(map[string]soloAllChipsStat)
+	}
+	r.soloAllChips[model] = agg
+}
+
+// medianOfCopied returns the median of samples, sorting in place (callers pass
+// a private copy). 0 for an empty slice.
+func medianOfCopied(sorted []float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}

--- a/coordinator/registry/tps_median_cache_test.go
+++ b/coordinator/registry/tps_median_cache_test.go
@@ -1,0 +1,248 @@
+package registry
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// referenceTPSStore is the pre-cache read-time implementation of the TPS
+// aggregates (copy + sort on every read), kept here as the oracle the cached
+// registry must match sample-for-sample, including FIFO eviction at
+// maxSamples and the cross-class minimum/total/class-count aggregate.
+type referenceTPSStore struct {
+	max         int
+	samples     map[tpsKey][]float64
+	soloSamples map[tpsKey][]float64
+}
+
+func newReferenceTPSStore(max int) *referenceTPSStore {
+	return &referenceTPSStore{
+		max:         max,
+		samples:     make(map[tpsKey][]float64),
+		soloSamples: make(map[tpsKey][]float64),
+	}
+}
+
+func referenceMedian(samples []float64) float64 {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), samples...)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 0 {
+		return (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return sorted[mid]
+}
+
+func (s *referenceTPSStore) record(m map[tpsKey][]float64, model, chip string, tps float64) {
+	if tps <= 0 || model == "" {
+		return
+	}
+	key := tpsKey{Model: model, ChipFamily: chip}
+	samples := m[key]
+	if len(samples) >= s.max {
+		samples = samples[1:]
+	}
+	m[key] = append(samples, tps)
+}
+
+func (s *referenceTPSStore) median(model, chip string) float64 {
+	return referenceMedian(s.samples[tpsKey{Model: model, ChipFamily: chip}])
+}
+
+func (s *referenceTPSStore) soloMedian(model, chip string) (float64, int) {
+	samples := s.soloSamples[tpsKey{Model: model, ChipFamily: chip}]
+	return referenceMedian(samples), len(samples)
+}
+
+func (s *referenceTPSStore) soloMedianAllChips(model string) (float64, int, int) {
+	perClass := make(map[string][]float64)
+	for key, samples := range s.soloSamples {
+		if key.Model != model || len(samples) == 0 {
+			continue
+		}
+		perClass[key.ChipFamily] = append(perClass[key.ChipFamily], samples...)
+	}
+	minMedian, total, classes := 0.0, 0, 0
+	for _, samples := range perClass {
+		m := referenceMedian(samples)
+		total += len(samples)
+		if m <= 0 {
+			continue
+		}
+		if classes == 0 || m < minMedian {
+			minMedian = m
+		}
+		classes++
+	}
+	return minMedian, total, classes
+}
+
+// TestTPSRegistryCachedAggregatesMatchReference drives random Record /
+// RecordSolo sequences (well past the 50-sample ring) through the cached
+// registry and the reference store and checks every aggregate after every
+// write, so the write-time maintenance can never drift from the former
+// read-time computation.
+func TestTPSRegistryCachedAggregatesMatchReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260902))
+	reg := NewTPSRegistry()
+	ref := newReferenceTPSStore(reg.maxSamples)
+	models := []string{"m-a", "m-b", "m-c"}
+	chips := []string{"M1", "M2|Max", "M3|Pro", "M4|Max"}
+
+	check := func(step int) {
+		t.Helper()
+		for _, model := range models {
+			for _, chip := range chips {
+				if got, want := reg.Median(model, chip), ref.median(model, chip); got != want {
+					t.Fatalf("step %d Median(%s,%s)=%v want %v", step, model, chip, got, want)
+				}
+				gotM, gotN := reg.SoloMedian(model, chip)
+				wantM, wantN := ref.soloMedian(model, chip)
+				if gotM != wantM || gotN != wantN {
+					t.Fatalf("step %d SoloMedian(%s,%s)=(%v,%d) want (%v,%d)", step, model, chip, gotM, gotN, wantM, wantN)
+				}
+			}
+			gotT, gotS, gotC := reg.SoloMedianAllChips(model)
+			wantT, wantS, wantC := ref.soloMedianAllChips(model)
+			if gotT != wantT || gotS != wantS || gotC != wantC {
+				t.Fatalf("step %d SoloMedianAllChips(%s)=(%v,%d,%d) want (%v,%d,%d)", step, model, gotT, gotS, gotC, wantT, wantS, wantC)
+			}
+		}
+		// Unknown keys read as empty on both.
+		if reg.Median("nope", "M1") != 0 {
+			t.Fatalf("step %d unknown Median must be 0", step)
+		}
+		if m, n := reg.SoloMedian("nope", "M1"); m != 0 || n != 0 {
+			t.Fatalf("step %d unknown SoloMedian must be (0,0)", step)
+		}
+		if m, s, c := reg.SoloMedianAllChips("nope"); m != 0 || s != 0 || c != 0 {
+			t.Fatalf("step %d unknown SoloMedianAllChips must be zero", step)
+		}
+	}
+
+	check(0)
+	for step := 1; step <= 4000; step++ {
+		model := models[rng.Intn(len(models))]
+		chip := chips[rng.Intn(len(chips))]
+		// Include rejected values (<= 0) and an empty model to pin the ingest guards.
+		tps := float64(rng.Intn(120)) - 5
+		if rng.Intn(50) == 0 {
+			model = ""
+		}
+		if rng.Intn(2) == 0 {
+			reg.Record(model, chip, tps)
+			ref.record(ref.samples, model, chip, tps)
+		} else {
+			reg.RecordSolo(model, chip, tps)
+			ref.record(ref.soloSamples, model, chip, tps)
+		}
+		check(step)
+	}
+	// The ring must actually have evicted: a key that received > maxSamples
+	// writes holds exactly maxSamples.
+	for key, samples := range reg.samples {
+		if len(samples) > reg.maxSamples {
+			t.Fatalf("ring for %+v grew past maxSamples: %d", key, len(samples))
+		}
+	}
+}
+
+// TestTPSRegistryZeroValueDoesNotPanic pins that a bare TPSRegistry{} (no
+// NewTPSRegistry: maps nil, maxSamples 0 ⇒ unbounded ring) records and reads
+// correctly, including a ring longer than the nominal 50-sample bound, which
+// used to make the scratch allocation panic (len > cap).
+func TestTPSRegistryZeroValueDoesNotPanic(t *testing.T) {
+	var reg TPSRegistry
+	ref := newReferenceTPSStore(1 << 30) // effectively unbounded, like maxSamples 0
+	for i := 0; i < 130; i++ {
+		v := float64(1 + i%23)
+		reg.Record("m", "M3", v)
+		ref.record(ref.samples, "m", "M3", v)
+		reg.RecordSolo("m", "M3|Max", v)
+		ref.record(ref.soloSamples, "m", "M3|Max", v)
+	}
+	if n := len(reg.samples[tpsKey{Model: "m", ChipFamily: "M3"}]); n != 130 {
+		t.Fatalf("unbounded ring length = %d, want 130", n)
+	}
+	if got, want := reg.Median("m", "M3"), ref.median("m", "M3"); got != want {
+		t.Fatalf("zero-value Median = %v, want %v", got, want)
+	}
+	gotM, gotN := reg.SoloMedian("m", "M3|Max")
+	wantM, wantN := ref.soloMedian("m", "M3|Max")
+	if gotM != wantM || gotN != wantN {
+		t.Fatalf("zero-value SoloMedian = (%v,%d), want (%v,%d)", gotM, gotN, wantM, wantN)
+	}
+	gotT, gotS, gotC := reg.SoloMedianAllChips("m")
+	wantT, wantS, wantC := ref.soloMedianAllChips("m")
+	if gotT != wantT || gotS != wantS || gotC != wantC {
+		t.Fatalf("zero-value SoloMedianAllChips = (%v,%d,%d), want (%v,%d,%d)", gotT, gotS, gotC, wantT, wantS, wantC)
+	}
+	var empty TPSRegistry
+	if empty.Median("x", "y") != 0 {
+		t.Fatal("empty zero-value registry must read 0")
+	}
+	if m, s, c := empty.SoloMedianAllChips("x"); m != 0 || s != 0 || c != 0 {
+		t.Fatal("empty zero-value registry must read zero aggregates")
+	}
+}
+
+// TestTPSRegistryReadsAllocateNothing pins the hot-path contract: every read
+// aggregate is a map lookup with zero allocations.
+func TestTPSRegistryReadsAllocateNothing(t *testing.T) {
+	reg := NewTPSRegistry()
+	for i := 0; i < 120; i++ {
+		reg.Record("m", "M3", float64(10+i%37))
+		reg.RecordSolo("m", "M3|Max", float64(10+i%29))
+		reg.RecordSolo("m", "M4|Max", float64(20+i%31))
+	}
+	var sink float64
+	var sinkN int
+	allocs := testing.AllocsPerRun(200, func() {
+		sink += reg.Median("m", "M3")
+		m, n := reg.SoloMedian("m", "M3|Max")
+		sink += m
+		sinkN += n
+		a, s, c := reg.SoloMedianAllChips("m")
+		sink += a
+		sinkN += s + c
+	})
+	if allocs != 0 {
+		t.Fatalf("TPS reads allocated %v per run; want 0", allocs)
+	}
+	if sink == 0 || sinkN == 0 {
+		t.Fatal("reads returned nothing; fixture broken")
+	}
+}
+
+// TestTPSRegistryRingEvictionSemantics pins FIFO eviction: once full, the
+// oldest sample leaves and the newest enters, so the median tracks the most
+// recent maxSamples observations exactly as the former re-slice form did.
+func TestTPSRegistryRingEvictionSemantics(t *testing.T) {
+	reg := NewTPSRegistry()
+	for i := 1; i <= reg.maxSamples; i++ {
+		reg.Record("m", "M3", 10) // ring full of 10s
+	}
+	if got := reg.Median("m", "M3"); got != 10 {
+		t.Fatalf("full ring median = %v, want 10", got)
+	}
+	// Push maxSamples values of 30: after exactly maxSamples writes every 10
+	// has been evicted, and halfway the median is the mean of the middle pair.
+	for i := 1; i <= reg.maxSamples; i++ {
+		reg.Record("m", "M3", 30)
+		if i == reg.maxSamples/2 {
+			if got := reg.Median("m", "M3"); got != 20 {
+				t.Fatalf("half-replaced ring median = %v, want 20", got)
+			}
+		}
+	}
+	if got := reg.Median("m", "M3"); got != 30 {
+		t.Fatalf("fully replaced ring median = %v, want 30", got)
+	}
+	if n := len(reg.samples[tpsKey{Model: "m", ChipFamily: "M3"}]); n != reg.maxSamples {
+		t.Fatalf("ring length = %d, want %d", n, reg.maxSamples)
+	}
+}

--- a/coordinator/registry/tps_registry.go
+++ b/coordinator/registry/tps_registry.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"sort"
 	"sync"
 )
 
@@ -19,11 +18,26 @@ import (
 //     while the WHOLE box was uncontended. Feeds the quality-concurrency cap,
 //     which needs a static solo rate that cannot collapse under the very
 //     overload the cap exists to prevent.
+//
+// Every read-side aggregate (medians, the cross-class solo aggregate) is
+// maintained on write and served as an O(1), allocation-free lookup — see
+// tps_median_cache.go. The routing scan reads them once per provider.
 type TPSRegistry struct {
 	mu          sync.RWMutex
 	samples     map[tpsKey][]float64
 	soloSamples map[tpsKey][]float64
 	maxSamples  int
+
+	// medians caches the median of samples[key]; refreshed by Record.
+	medians map[tpsKey]float64
+	// soloByModel caches the solo median + count per model → chip class;
+	// refreshed by RecordSolo. soloAllChips is the per-model cross-class
+	// aggregate derived from it.
+	soloByModel  map[string]map[string]tpsSampleStat
+	soloAllChips map[string]soloAllChipsStat
+	// scratch is the write-side sort buffer (cap maxSamples), used only under
+	// the write lock so no read ever allocates or sorts.
+	scratch []float64
 }
 
 type tpsKey struct {
@@ -32,10 +46,15 @@ type tpsKey struct {
 }
 
 func NewTPSRegistry() *TPSRegistry {
+	const maxSamples = 50 // keep last 50 observations per model+chip
 	return &TPSRegistry{
-		samples:     make(map[tpsKey][]float64),
-		soloSamples: make(map[tpsKey][]float64),
-		maxSamples:  50, // keep last 50 observations per model+chip
+		samples:      make(map[tpsKey][]float64),
+		soloSamples:  make(map[tpsKey][]float64),
+		maxSamples:   maxSamples,
+		medians:      make(map[tpsKey]float64),
+		soloByModel:  make(map[string]map[string]tpsSampleStat),
+		soloAllChips: make(map[string]soloAllChipsStat),
+		scratch:      make([]float64, 0, maxSamples),
 	}
 }
 
@@ -48,30 +67,24 @@ func (r *TPSRegistry) Record(model, chipFamily string, tps float64) {
 	key := tpsKey{Model: model, ChipFamily: chipFamily}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	samples := r.samples[key]
-	if len(samples) >= r.maxSamples {
-		// Drop oldest sample (FIFO ring)
-		samples = samples[1:]
+	if r.samples == nil { // zero-value registry
+		r.samples = make(map[tpsKey][]float64)
 	}
-	r.samples[key] = append(samples, tps)
+	if r.medians == nil {
+		r.medians = make(map[tpsKey]float64)
+	}
+	samples := appendRingSample(r.samples[key], tps, r.maxSamples)
+	r.samples[key] = samples
+	r.medians[key] = r.medianOfRingLocked(samples)
 }
 
 // Median returns the median observed TPS for the given model and chip family.
-// Returns 0 if no observations exist.
+// Returns 0 if no observations exist. O(1), allocation-free (the value is
+// maintained by Record).
 func (r *TPSRegistry) Median(model, chipFamily string) float64 {
 	key := tpsKey{Model: model, ChipFamily: chipFamily}
 	r.mu.RLock()
-	samples := r.samples[key]
-	sorted := make([]float64, len(samples))
-	copy(sorted, samples)
+	median := r.medians[key]
 	r.mu.RUnlock()
-	if len(sorted) == 0 {
-		return 0
-	}
-	sort.Float64s(sorted)
-	mid := len(sorted) / 2
-	if len(sorted)%2 == 0 {
-		return (sorted[mid-1] + sorted[mid]) / 2
-	}
-	return sorted[mid]
+	return median
 }

--- a/coordinator/registry/ttft_calibration.go
+++ b/coordinator/registry/ttft_calibration.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -85,6 +84,15 @@ const (
 	// capacity-triggered sweeps.
 	ttftCalibrationSweepThreshold = 1024
 	ttftCalibrationSweepInterval  = time.Minute
+	// ttftCalibrationCapacitySweepInterval lets the whole-map TTL sweep run
+	// more often while the map sits AT capacity, so a sustained reserve storm
+	// reclaims expired entries within seconds rather than a minute — while
+	// still never sweeping on every reservation.
+	ttftCalibrationCapacitySweepInterval = 5 * time.Second
+	// ttftCalibrationEvictProbe bounds the per-reservation eviction scan at
+	// capacity between sweeps: probe this many entries, drop the first
+	// expired one, else the last probed.
+	ttftCalibrationEvictProbe = 8
 )
 
 // ttftCalibrationEnabled is the live-read kill switch:
@@ -157,14 +165,22 @@ func clampTTFTCalibrationRatio(ratio float64) float64 {
 type ttftCalibrator struct {
 	mu        sync.RWMutex
 	windows   map[ttftCalibrationKey]*ttftRatioWindow
-	pending   map[string]ttftPendingPrediction
+	pending   map[ttftPendingID]ttftPendingPrediction
 	lastSweep time.Time
+}
+
+// ttftPendingID identifies a reserved attempt's pending prediction. A struct
+// key (vs requestID+"#"+attempt) is built without allocating on every
+// reservation and cannot alias across ids containing the delimiter.
+type ttftPendingID struct {
+	requestID string
+	attempt   int
 }
 
 func newTTFTCalibrator() *ttftCalibrator {
 	return &ttftCalibrator{
 		windows: make(map[ttftCalibrationKey]*ttftRatioWindow),
-		pending: make(map[string]ttftPendingPrediction),
+		pending: make(map[ttftPendingID]ttftPendingPrediction),
 	}
 }
 
@@ -172,8 +188,8 @@ func newTTFTCalibrator() *ttftCalibrator {
 // scheduler (reads + prediction recording) and the API layer (observations).
 var ttftCalibration = newTTFTCalibrator()
 
-func ttftPendingKey(requestID string, attempt int) string {
-	return requestID + "#" + strconv.Itoa(attempt)
+func ttftPendingKey(requestID string, attempt int) ttftPendingID {
+	return ttftPendingID{requestID: requestID, attempt: attempt}
 }
 
 // notePrediction records the RAW (pre-calibration) warm-slot TTFT estimate for
@@ -185,9 +201,23 @@ func (c *ttftCalibrator) notePrediction(requestID string, attempt int, model, ch
 	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if len(c.pending) >= ttftCalibrationMaxPending ||
-		(len(c.pending) > ttftCalibrationSweepThreshold && now.Sub(c.lastSweep) > ttftCalibrationSweepInterval) {
+	// The TTL sweep walks the whole map, so it is rate-limited: once per
+	// ttftCalibrationSweepInterval above the threshold, and once per (shorter)
+	// ttftCalibrationCapacitySweepInterval while AT capacity. Between sweeps a
+	// full map (a reserve storm whose attempts never reach first content — the
+	// exact retry-cascade shape) frees one slot with a bounded probe instead of
+	// walking all ttftCalibrationMaxPending entries under this global lock on
+	// every reservation (that walk was ~20% of a fleet-scale reservation). The
+	// map stays bounded either way.
+	atCapacity := len(c.pending) >= ttftCalibrationMaxPending
+	sinceSweep := now.Sub(c.lastSweep)
+	if len(c.pending) > ttftCalibrationSweepThreshold &&
+		(sinceSweep > ttftCalibrationSweepInterval ||
+			(atCapacity && sinceSweep > ttftCalibrationCapacitySweepInterval)) {
 		c.sweepPendingLocked(now)
+	}
+	if len(c.pending) >= ttftCalibrationMaxPending {
+		c.evictOneLocked(now)
 	}
 	c.pending[ttftPendingKey(requestID, attempt)] = ttftPendingPrediction{
 		model: model,
@@ -207,6 +237,30 @@ func (c *ttftCalibrator) discardPrediction(requestID string, attempt int) {
 	c.mu.Lock()
 	delete(c.pending, ttftPendingKey(requestID, attempt))
 	c.mu.Unlock()
+}
+
+// evictOneLocked frees one slot in a full map with bounded work: it probes up
+// to ttftCalibrationEvictProbe entries (map order — effectively random),
+// deletes the first EXPIRED one it sees, and only when none of the probed
+// entries has expired deletes the last probed (possibly live) entry. Caller
+// holds c.mu.
+func (c *ttftCalibrator) evictOneLocked(now time.Time) {
+	var last ttftPendingID
+	probed := 0
+	for k, p := range c.pending {
+		if now.Sub(p.at) > ttftCalibrationPendingTTL {
+			delete(c.pending, k)
+			return
+		}
+		last = k
+		probed++
+		if probed >= ttftCalibrationEvictProbe {
+			break
+		}
+	}
+	if probed > 0 {
+		delete(c.pending, last)
+	}
 }
 
 // sweepPendingLocked drops expired predictions; if the map is still at
@@ -297,7 +351,7 @@ func (c *ttftCalibrator) appliedRatio(model, chip string) float64 {
 func (c *ttftCalibrator) reset() {
 	c.mu.Lock()
 	c.windows = make(map[ttftCalibrationKey]*ttftRatioWindow)
-	c.pending = make(map[string]ttftPendingPrediction)
+	c.pending = make(map[ttftPendingID]ttftPendingPrediction)
 	c.mu.Unlock()
 }
 
@@ -307,13 +361,13 @@ func (c *ttftCalibrator) reset() {
 // unscaled: it is a load-latency proxy, not part of the throughput model the
 // ratio measures, and scaling it would collapse the deliberate cold-route bias
 // (e.g. 30s × 0.33 ≈ 10s would let a cold box pass gates it should not).
-func calibratedTTFTMs(snap routingSnapshot, rawMs float64) float64 {
+func calibratedTTFTMs(snap *routingSnapshot, rawMs float64) float64 {
 	return calibratedTTFTMsWithRatio(snap, rawMs, ttftCalibration.appliedRatio(snap.model, snap.chipFamily))
 }
 
 // calibratedTTFTMsWithRatio is calibratedTTFTMs with the ratio already read,
 // so the scheduler can record exactly the ratio it scored with.
-func calibratedTTFTMsWithRatio(snap routingSnapshot, rawMs float64, ratio float64) float64 {
+func calibratedTTFTMsWithRatio(snap *routingSnapshot, rawMs float64, ratio float64) float64 {
 	if rawMs <= 0 {
 		return rawMs
 	}

--- a/coordinator/registry/ttft_calibration_pending_test.go
+++ b/coordinator/registry/ttft_calibration_pending_test.go
@@ -1,0 +1,148 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestTTFTCalibratorAtCapacityEvictsOneWithoutSweeping pins the bounded-work
+// contract for a full pending map between sweeps: one reservation evicts
+// exactly one entry (the map stays at the cap), records the new prediction,
+// and does NOT run the whole-map TTL sweep (lastSweep is untouched).
+func TestTTFTCalibratorAtCapacityEvictsOneWithoutSweeping(t *testing.T) {
+	resetCalibrator(t)
+	c := ttftCalibration
+	c.mu.Lock()
+	fresh := time.Now()
+	for i := 0; i < ttftCalibrationMaxPending; i++ {
+		c.pending[ttftPendingKey(fmt.Sprintf("live-%d", i), 0)] = ttftPendingPrediction{model: "m", rawMs: 1, at: fresh}
+	}
+	c.lastSweep = fresh
+	c.mu.Unlock()
+
+	c.notePrediction("new", 0, "m", "M3", 1000)
+
+	c.mu.RLock()
+	n := len(c.pending)
+	swept := !c.lastSweep.Equal(fresh)
+	_, present := c.pending[ttftPendingKey("new", 0)]
+	c.mu.RUnlock()
+	if n != ttftCalibrationMaxPending {
+		t.Fatalf("pending map size %d, want exactly the cap %d", n, ttftCalibrationMaxPending)
+	}
+	if swept {
+		t.Fatal("a full map with a recent sweep must not re-walk the whole map")
+	}
+	if !present {
+		t.Fatal("the new prediction must be recorded")
+	}
+}
+
+// TestTTFTCalibratorAtCapacityExpiredGoesFirst is the coordinator's case:
+// 8,191 live + 1 expired at capacity. With the capacity sweep due (last sweep
+// older than ttftCalibrationCapacitySweepInterval) the expired entry is the
+// one reclaimed, every live entry survives, and the new prediction lands.
+func TestTTFTCalibratorAtCapacityExpiredGoesFirst(t *testing.T) {
+	resetCalibrator(t)
+	c := ttftCalibration
+	c.mu.Lock()
+	now := time.Now()
+	for i := 0; i < ttftCalibrationMaxPending-1; i++ {
+		c.pending[ttftPendingKey(fmt.Sprintf("live-%d", i), 0)] = ttftPendingPrediction{model: "m", rawMs: 1, at: now}
+	}
+	c.pending[ttftPendingKey("expired", 0)] = ttftPendingPrediction{
+		model: "m", rawMs: 1, at: now.Add(-ttftCalibrationPendingTTL - time.Minute)}
+	c.lastSweep = now.Add(-ttftCalibrationCapacitySweepInterval - time.Second)
+	c.mu.Unlock()
+
+	c.notePrediction("new", 0, "m", "M3", 1000)
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if _, alive := c.pending[ttftPendingKey("expired", 0)]; alive {
+		t.Fatal("expired entry must be reclaimed before any live one")
+	}
+	if _, present := c.pending[ttftPendingKey("new", 0)]; !present {
+		t.Fatal("new prediction must be recorded")
+	}
+	for i := 0; i < ttftCalibrationMaxPending-1; i++ {
+		if _, ok := c.pending[ttftPendingKey(fmt.Sprintf("live-%d", i), 0)]; !ok {
+			t.Fatalf("live entry %d was evicted while an expired one existed", i)
+		}
+	}
+	if len(c.pending) != ttftCalibrationMaxPending {
+		t.Fatalf("pending size %d, want %d", len(c.pending), ttftCalibrationMaxPending)
+	}
+}
+
+// TestTTFTCalibratorEvictProbePrefersExpired pins the between-sweeps probe:
+// with expired entries dominating a full map, the bounded probe (≤ 8 entries,
+// so it always sees at least one expired entry when only one is live) deletes
+// an expired entry and never the live one — deterministic regardless of map
+// iteration order.
+func TestTTFTCalibratorEvictProbePrefersExpired(t *testing.T) {
+	resetCalibrator(t)
+	c := ttftCalibration
+	c.mu.Lock()
+	now := time.Now()
+	stale := now.Add(-ttftCalibrationPendingTTL - time.Minute)
+	for i := 0; i < ttftCalibrationMaxPending-1; i++ {
+		c.pending[ttftPendingKey(fmt.Sprintf("old-%d", i), 0)] = ttftPendingPrediction{model: "m", rawMs: 1, at: stale}
+	}
+	c.pending[ttftPendingKey("live", 0)] = ttftPendingPrediction{model: "m", rawMs: 1, at: now}
+	c.lastSweep = now // no sweep is due on either interval
+	c.mu.Unlock()
+
+	for i := 0; i < 64; i++ {
+		c.notePrediction("new", i, "m", "M3", 1000)
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if _, ok := c.pending[ttftPendingKey("live", 0)]; !ok {
+		t.Fatal("probe evicted the live entry while expired ones remained")
+	}
+	if !c.lastSweep.Equal(now) {
+		t.Fatal("probe path must not run the whole-map sweep")
+	}
+	if len(c.pending) != ttftCalibrationMaxPending {
+		t.Fatalf("pending size %d, want the cap %d", len(c.pending), ttftCalibrationMaxPending)
+	}
+	for i := 0; i < 64; i++ {
+		if _, ok := c.pending[ttftPendingKey("new", i)]; !ok {
+			t.Fatalf("new prediction %d missing", i)
+		}
+	}
+}
+
+// TestTTFTCalibratorPendingKeyCannotAlias pins the struct key: request ids
+// containing the former '#' delimiter can no longer collide across attempts.
+func TestTTFTCalibratorPendingKeyCannotAlias(t *testing.T) {
+	resetCalibrator(t)
+	c := ttftCalibration
+	c.notePrediction("req#1", 0, "m", "M3", 1000)
+	c.notePrediction("req", 10, "m", "M3", 2000)
+	c.mu.RLock()
+	n := len(c.pending)
+	c.mu.RUnlock()
+	if n != 2 {
+		t.Fatalf("pending entries = %d, want 2 distinct keys", n)
+	}
+}
+
+// BenchmarkTTFTCalibratorNotePredictionAtCapacity is the reserve-storm shape:
+// every reservation records a prediction none of which is ever resolved.
+func BenchmarkTTFTCalibratorNotePredictionAtCapacity(b *testing.B) {
+	c := newTTFTCalibrator()
+	now := time.Now()
+	for i := 0; i < ttftCalibrationMaxPending; i++ {
+		c.pending[ttftPendingKey(fmt.Sprintf("live-%d", i), 0)] = ttftPendingPrediction{model: "m", rawMs: 1, at: now}
+	}
+	c.lastSweep = now
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.notePrediction("req", i, "m", "M3", 1000)
+	}
+}

--- a/coordinator/registry/ttft_calibration_test.go
+++ b/coordinator/registry/ttft_calibration_test.go
@@ -215,17 +215,17 @@ func TestCalibratedTTFTMsLeavesColdPenaltyUnscaled(t *testing.T) {
 	feedObservations(t, model, "M3", ttftCalibrationWarmupObs, 0.5)
 
 	warm := routingSnapshot{model: model, chipFamily: "M3", slotState: "running"}
-	if got := calibratedTTFTMs(warm, 3000); math.Abs(got-1500) > 0.001 {
+	if got := calibratedTTFTMs(snapPtr(warm), 3000); math.Abs(got-1500) > 0.001 {
 		t.Fatalf("warm calibrated = %f, want 1500", got)
 	}
 
 	cold := routingSnapshot{model: model, chipFamily: "M3", slotState: "unknown"}
 	want := slotStatePenaltyUnknown + 3000*0.5
-	if got := calibratedTTFTMs(cold, slotStatePenaltyUnknown+3000); math.Abs(got-want) > 0.001 {
+	if got := calibratedTTFTMs(snapPtr(cold), slotStatePenaltyUnknown+3000); math.Abs(got-want) > 0.001 {
 		t.Fatalf("cold calibrated = %f, want %f (penalty unscaled)", got, want)
 	}
 
-	if got := calibratedTTFTMs(warm, 0); got != 0 {
+	if got := calibratedTTFTMs(snapPtr(warm), 0); got != 0 {
 		t.Fatalf("zero estimate calibrated = %f, want 0", got)
 	}
 }
@@ -252,7 +252,7 @@ func TestTTFTCalibratorConcurrentAccess(t *testing.T) {
 			for i := 0; i < 400; i++ {
 				_ = ttftCalibration.appliedRatio(model, "M3")
 				_ = TTFTCalibrationRatio(model, "")
-				_ = calibratedTTFTMs(routingSnapshot{model: model, chipFamily: "M3", slotState: "running"}, 2000)
+				_ = calibratedTTFTMs(snapPtr(routingSnapshot{model: model, chipFamily: "M3", slotState: "running"}), 2000)
 			}
 		}()
 	}

--- a/coordinator/registry/ttft_shadow.go
+++ b/coordinator/registry/ttft_shadow.go
@@ -171,7 +171,7 @@ func (r *Registry) evaluateTTFTShadowLocked(
 	if reqPrompt < 0 {
 		reqPrompt = 0
 	}
-	snap := winner.snapshot
+	snap := &winner.snapshot
 	// Occupancy-aware estimate (base + occupancy term). The occupancy term lives
 	// here, in the SHADOW path only — ttftMsFromSnapshot (the live cost / ceiling /
 	// bestTTFT input) stays occupancy-free so raising alpha cannot tighten the
@@ -212,7 +212,7 @@ func loadedIdleAlternativeExistsFromScan(scan candidateScan, winner *Provider) b
 		if candidate.provider == nil || candidate.provider.ID == winnerID {
 			continue
 		}
-		if candidate.snapshot.modelLoaded && snapshotOccupancy(candidate.snapshot) == 0 {
+		if candidate.snapshot.modelLoaded && snapshotOccupancy(&candidate.snapshot) == 0 {
 			return true
 		}
 	}

--- a/coordinator/registry/ttft_shadow_test.go
+++ b/coordinator/registry/ttft_shadow_test.go
@@ -47,7 +47,7 @@ func TestTTFTOccupancyTermZeroWhenAlphaZero(t *testing.T) {
 		backendRunning:     8,
 		pendingForModel:    8,
 	}
-	if got := ttftOccupancyMs(snap); got != 0 {
+	if got := ttftOccupancyMs(snapPtr(snap)); got != 0 {
 		t.Fatalf("ttftOccupancyMs must be 0 when alpha=0, got %f", got)
 	}
 }
@@ -76,11 +76,11 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	// The occupancy term must add to the SHADOW estimate at b>0 (compare alpha on
 	// vs off). The LIVE estimate (ttftMsFromSnapshot) must NOT move with alpha.
 	SetTTFTOccupancyAlpha(0)
-	liveOff := ttftMsFromSnapshot(mk(4), reqPrompt)
-	shadowOff := occupancyAwareTTFTMsFromSnapshot(mk(4), reqPrompt)
+	liveOff := ttftMsFromSnapshot(snapPtr(mk(4)), reqPrompt)
+	shadowOff := occupancyAwareTTFTMsFromSnapshot(snapPtr(mk(4)), reqPrompt)
 	SetTTFTOccupancyAlpha(45)
-	liveOn := ttftMsFromSnapshot(mk(4), reqPrompt)
-	shadowOn := occupancyAwareTTFTMsFromSnapshot(mk(4), reqPrompt)
+	liveOn := ttftMsFromSnapshot(snapPtr(mk(4)), reqPrompt)
+	shadowOn := occupancyAwareTTFTMsFromSnapshot(snapPtr(mk(4)), reqPrompt)
 	if liveOn != liveOff {
 		t.Fatalf("ttftMsFromSnapshot must be occupancy-FREE (invariant): alpha=0 %f vs alpha=45 %f", liveOff, liveOn)
 	}
@@ -96,7 +96,7 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 	last := -1.0
 	knee := -1
 	for b := 0; b <= 8; b++ {
-		est := occupancyAwareTTFTMsFromSnapshot(mk(b), reqPrompt)
+		est := occupancyAwareTTFTMsFromSnapshot(snapPtr(mk(b)), reqPrompt)
 		if est <= last {
 			t.Fatalf("estimate not strictly increasing at b=%d: %f <= %f", b, est, last)
 		}
@@ -109,7 +109,7 @@ func TestTTFTEstimateOccupancyTermActiveAndMonotonic(t *testing.T) {
 		t.Fatalf("estimate should cross the %.0fms deadline at a knee in b=1..8, got knee=%d", deadline, knee)
 	}
 	// b=0 (idle) must stay well under the deadline — route-to-idle is preserved.
-	if idle := occupancyAwareTTFTMsFromSnapshot(mk(0), reqPrompt); idle > deadline {
+	if idle := occupancyAwareTTFTMsFromSnapshot(snapPtr(mk(0)), reqPrompt); idle > deadline {
 		t.Fatalf("idle box (b=0) must be under the deadline, got %f > %f", idle, deadline)
 	}
 }
@@ -162,14 +162,14 @@ func TestTTFTOccupancyTermRateUsesOccupancyNotBackendRunning(t *testing.T) {
 		backendWaiting:     0,
 		pendingForModel:    8,
 	}
-	occ := snapshotOccupancy(herd)
+	occ := snapshotOccupancy(snapPtr(herd))
 	if occ != 8 {
 		t.Fatalf("precondition: occ should be 8 (herd), got %d", occ)
 	}
-	got := ttftOccupancyMs(herd)
+	got := ttftOccupancyMs(snapPtr(herd))
 
 	// Correct: rate projected at the batch the request joins (occ).
-	wantRate := projectedPerRequestDecodeTPSAtBatch(herd, occ)
+	wantRate := projectedPerRequestDecodeTPSAtBatch(snapPtr(herd), occ)
 	want := 45 * float64(occ) * 1000.0 / wantRate
 	if math.Abs(got-want) > 1e-6 {
 		t.Fatalf("occupancy term must use occ for the rate: got %f want %f", got, want)
@@ -177,7 +177,7 @@ func TestTTFTOccupancyTermRateUsesOccupancyNotBackendRunning(t *testing.T) {
 
 	// The pre-fix rate (projected at the bare backend_running gauge) is FASTER, so
 	// the buggy term would be SMALLER. Assert the fix charges strictly more.
-	buggyRate := projectedPerRequestDecodeTPSAtBatch(herd, herd.backendRunning)
+	buggyRate := projectedPerRequestDecodeTPSAtBatch(snapPtr(herd), herd.backendRunning)
 	buggyTerm := 45 * float64(occ) * 1000.0 / buggyRate
 	if !(got > buggyTerm) {
 		t.Fatalf("herd term must exceed the backend_running-rate term: got %f buggy %f", got, buggyTerm)
@@ -187,9 +187,9 @@ func TestTTFTOccupancyTermRateUsesOccupancyNotBackendRunning(t *testing.T) {
 	// the term — both via the occ numerator AND the shrinking occ-projected rate.
 	lowBurst := herd
 	lowBurst.pendingForModel = 3 // occ = max(3, 2) = 3
-	if !(ttftOccupancyMs(herd) > ttftOccupancyMs(lowBurst)) {
+	if !(ttftOccupancyMs(snapPtr(herd)) > ttftOccupancyMs(snapPtr(lowBurst))) {
 		t.Fatalf("term must grow with pending burst at equal backend_running: occ8=%f occ3=%f",
-			ttftOccupancyMs(herd), ttftOccupancyMs(lowBurst))
+			ttftOccupancyMs(snapPtr(herd)), ttftOccupancyMs(snapPtr(lowBurst)))
 	}
 }
 

--- a/coordinator/registry/utilization_test.go
+++ b/coordinator/registry/utilization_test.go
@@ -360,6 +360,7 @@ func TestFleetCapacitySnapshotDedupsTokenBudget(t *testing.T) {
 	p := makeSchedulerProvider(t, reg, "fleet-budget-provider", modelA, 100)
 	p.mu.Lock()
 	p.Models = append(p.Models, protocol.ModelInfo{ID: modelB, ModelType: "chat", Quantization: "4bit"})
+	p.syncModelIndexLocked()
 	// Two co-resident models sharing a single 3000-token live headroom: each
 	// slot reports max = its own committed (7000) + shared headroom (3000).
 	p.BackendCapacity.Slots = []protocol.BackendSlotCapacity{

--- a/coordinator/registry/version_memo.go
+++ b/coordinator/registry/version_memo.go
@@ -1,0 +1,146 @@
+package registry
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// version_memo.go — memoized parsing of provider binary versions.
+//
+// The routing scan compares every provider's reported version against the
+// capability floors (providerMeetsTraitFloorsLocked) and the pooled-budget
+// layout floor (slotBudgetLayoutForVersion → CompareVersions) on every
+// request. Parsing a dotted version allocates (strings.Split + a segment
+// slice) — ~4% of the fleet-scale scan's allocation volume for what is, in
+// practice, a handful of distinct strings across the whole fleet. Each memo
+// below maps the RAW input string to its parsed result behind a copy-on-write
+// map: reads are one atomic load plus a map lookup with no lock and no
+// allocation; inserts (rare — a new version string) rebuild the small map.
+//
+// Bounds. Provider versions are attacker-supplied at registration, so the
+// memos are bounded in BOTH dimensions:
+//
+//   - count: at most versionMemoCap entries; a full memo keeps its existing
+//     entries and computes misses without inserting or taking the writer lock.
+//     A diverse working set therefore cannot flush hot versions or repeatedly
+//     rebuild the map; later versions still parse correctly without caching;
+//   - bytes: a key longer than maxMemoizedVersionLen, or a parse with more
+//     than maxMemoizedVersionSegments segments, is computed but NEVER inserted
+//     (a valid "1.0.0+<multi-MiB metadata>" inside the frame limit could
+//     otherwise pin megabytes per entry). The worst case is therefore
+//     versionMemoCap × (64-byte key + 16-segment slice) ≈ tens of KiB. Keys
+//     are cloned on insertion so a short normalized core cannot keep the
+//     backing allocation of an oversized version suffix alive.
+//
+// The layout memo additionally keys on the NORMALIZED numeric core
+// ("1.0.0" for "v1.0.0-rc1+meta"), so suffix variants of one version share an
+// entry (pooled_admission.go).
+
+const (
+	// versionMemoCap bounds each memo's entry count.
+	versionMemoCap = 256
+	// maxMemoizedVersionLen bounds the key bytes retained per entry. Real
+	// versions are ~6-12 bytes; 64 leaves room for a short prerelease tag.
+	maxMemoizedVersionLen = 64
+	// maxMemoizedVersionSegments bounds the parsed slice retained per entry.
+	maxMemoizedVersionSegments = 16
+)
+
+// cowMemo is a bounded, copy-on-write, string-keyed memo. The zero value is
+// ready to use.
+type cowMemo[V any] struct {
+	entries atomic.Pointer[map[string]V]
+	mu      sync.Mutex // serializes rebuilds; readers never take it
+}
+
+// get returns the memoized value for key, computing and inserting it on a
+// miss. Values are shared between callers and must be treated as read-only.
+func (m *cowMemo[V]) get(key string, compute func(string) V) V {
+	return m.getBounded(key, compute, nil)
+}
+
+// getBounded is get with an admission predicate: on a miss the value is
+// always computed and returned, but only inserted when keep (if non-nil)
+// accepts it and the key is no longer than maxMemoizedVersionLen. Oversized
+// inputs therefore cost a parse per call and retain nothing.
+func (m *cowMemo[V]) getBounded(key string, compute func(string) V, keep func(V) bool) V {
+	if cur := m.entries.Load(); cur != nil {
+		if v, ok := (*cur)[key]; ok {
+			return v
+		}
+		if len(*cur) >= versionMemoCap {
+			return compute(key)
+		}
+	}
+	v := compute(key)
+	if len(key) > maxMemoizedVersionLen || (keep != nil && !keep(v)) {
+		return v
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur := m.entries.Load()
+	var next map[string]V
+	if cur == nil {
+		next = make(map[string]V, 8)
+	} else {
+		if have, ok := (*cur)[key]; ok {
+			// Lost the insert race: hand back the shared value, not a duplicate.
+			return have
+		}
+		if len(*cur) >= versionMemoCap {
+			return v
+		}
+		next = make(map[string]V, len(*cur)+1)
+		for k, val := range *cur {
+			next[k] = val
+		}
+	}
+	next[strings.Clone(key)] = v
+	m.entries.Store(&next)
+	return v
+}
+
+// size reports the current entry count (tests).
+func (m *cowMemo[V]) size() int {
+	if cur := m.entries.Load(); cur != nil {
+		return len(*cur)
+	}
+	return 0
+}
+
+// has reports whether key is currently memoized (tests).
+func (m *cowMemo[V]) has(key string) bool {
+	if cur := m.entries.Load(); cur != nil {
+		_, ok := (*cur)[key]
+		return ok
+	}
+	return false
+}
+
+// maxKeyLen returns the longest memoized key in bytes (tests).
+func (m *cowMemo[V]) maxKeyLen() int {
+	longest := 0
+	if cur := m.entries.Load(); cur != nil {
+		for k := range *cur {
+			if len(k) > longest {
+				longest = len(k)
+			}
+		}
+	}
+	return longest
+}
+
+// reset drops every entry (tests).
+func (m *cowMemo[V]) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries.Store(nil)
+}
+
+var (
+	// versionSegmentsMemo backs versionSegments (request_traits.go).
+	versionSegmentsMemo cowMemo[[]int]
+	// slotBudgetLayoutMemo backs slotBudgetLayoutForVersion (pooled_admission.go).
+	slotBudgetLayoutMemo cowMemo[slotBudgetLayout]
+)

--- a/coordinator/registry/version_memo_gate_test.go
+++ b/coordinator/registry/version_memo_gate_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import "testing"
+
+// TestVersionMemosOnlySeeGatePassingProviders pins that versions rejected by
+// the public trust gates never reach the routing scan's memos. The memo's
+// bounds do not depend on this: owner self-route may relax those gates.
+func TestVersionMemosOnlySeeGatePassingProviders(t *testing.T) {
+	versionSegmentsMemo.reset()
+	slotBudgetLayoutMemo.reset()
+	reg := New(testLogger())
+	const model = "memo-gate-model"
+	const trustedVersion = "77.66.56-memo-trusted"
+	const untrustedVersion = "77.66.55-memo-untrusted"
+
+	trusted := makeSchedulerProvider(t, reg, "memo-trusted", model, 100)
+	trusted.mu.Lock()
+	trusted.Version = trustedVersion
+	trusted.mu.Unlock()
+
+	untrusted := makeSchedulerProvider(t, reg, "memo-untrusted", model, 100)
+	untrusted.mu.Lock()
+	untrusted.Version = untrustedVersion
+	untrusted.TrustLevel = TrustSelfSigned // below the TrustHardware floor
+	untrusted.mu.Unlock()
+
+	pr := &PendingRequest{RequestID: "memo-gate", Model: model, RequestedMaxTokens: 16}
+	reg.mu.RLock()
+	scan := reg.scanCandidatesLocked(model, pr, false)
+	reg.mu.RUnlock()
+
+	if scan.scanned != 2 || scan.candidateCount != 1 || scan.gateRejections[GateTrustFloor] != 1 {
+		t.Fatalf("scan: scanned=%d candidates=%d trust_floor=%d, want 2/1/1",
+			scan.scanned, scan.candidateCount, scan.gateRejections[GateTrustFloor])
+	}
+	// Positive control: the gate-passing provider's version reached both memos
+	// through the budget-layout selection (keyed on the numeric core), so the
+	// negative assertions below are not vacuous.
+	if core := versionNumericCore(trustedVersion); !slotBudgetLayoutMemo.has(core) || !versionSegmentsMemo.has(core) {
+		t.Fatalf("gate-passing provider's version core %q was not memoized (layout=%v segments=%v)",
+			core, slotBudgetLayoutMemo.has(core), versionSegmentsMemo.has(core))
+	}
+	// The gated-out provider's version never reached a parser.
+	for _, key := range []string{untrustedVersion, versionNumericCore(untrustedVersion)} {
+		if versionSegmentsMemo.has(key) || slotBudgetLayoutMemo.has(key) {
+			t.Fatalf("gate-failing provider's version %q reached a version memo", key)
+		}
+	}
+}

--- a/coordinator/registry/version_memo_test.go
+++ b/coordinator/registry/version_memo_test.go
@@ -1,0 +1,244 @@
+package registry
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+var versionMemoCorpus = []string{
+	"", " ", "v", "V", "0", "0.6", "0.6.0", "0.6.3", "0.6.10", "v0.6.3", "V0.6.3",
+	" 0.7.5 ", "0.7.5", "0.7.4", "0.7.5-rc1", "0.7.5+build.7", "0.8.15", "v0.8.15-beta",
+	"garbage", "1..2", "1.-2.3", "1.2.3.4.5", "a.b.c", "0.6.3-rc1", "00.06.03", "٣.٣",
+}
+
+// TestVersionSegmentsMemoMatchesParser pins that the memoized front returns
+// exactly what the uncached parser returns, on first and repeated use, for
+// every shape of input the fleet (or an attacker) can send.
+func TestVersionSegmentsMemoMatchesParser(t *testing.T) {
+	versionSegmentsMemo.reset()
+	slotBudgetLayoutMemo.reset()
+	for round := 0; round < 3; round++ {
+		for _, v := range versionMemoCorpus {
+			if got, want := versionSegments(v), parseVersionSegments(v); !reflect.DeepEqual(got, want) {
+				t.Fatalf("round %d versionSegments(%q) = %v, want %v", round, v, got, want)
+			}
+			if got, want := slotBudgetLayoutForVersion(v), parseSlotBudgetLayout(v); got != want {
+				t.Fatalf("round %d slotBudgetLayoutForVersion(%q) = %v, want %v", round, v, got, want)
+			}
+		}
+		for _, a := range versionMemoCorpus {
+			for _, b := range versionMemoCorpus {
+				want := compareParsedVersions(parseVersionSegments(a), parseVersionSegments(b))
+				if got := CompareVersions(a, b); got != want {
+					t.Fatalf("round %d CompareVersions(%q,%q) = %d, want %d", round, a, b, got, want)
+				}
+			}
+		}
+	}
+	// Spot-check the documented tolerances so the reference is not vacuous.
+	if CompareVersions("0.6.10", "0.6.3") <= 0 || CompareVersions("0.6", "0.6.0") != 0 ||
+		CompareVersions("garbage", "0") != 0 || CompareVersions("0.6.3-rc1", "0.6.0") != 0 {
+		t.Fatal("documented CompareVersions tolerances no longer hold")
+	}
+	if slotBudgetLayoutForVersion("0.7.5-rc1") != privateSlotGrants || slotBudgetLayoutForVersion("0.7.4") != sharedSlotHeadroom {
+		t.Fatal("layout floor no longer honored")
+	}
+}
+
+func compareParsedVersions(as, bs []int) int {
+	n := len(as)
+	if len(bs) > n {
+		n = len(bs)
+	}
+	for i := 0; i < n; i++ {
+		var av, bv int
+		if i < len(as) {
+			av = as[i]
+		}
+		if i < len(bs) {
+			bv = bs[i]
+		}
+		if av < bv {
+			return -1
+		}
+		if av > bv {
+			return 1
+		}
+	}
+	return 0
+}
+
+// A full memo retains its hot entries and computes later versions correctly
+// without rebuilding. The saved map identity and allocation check catch the
+// old reset-and-regrow behavior even when every returned value is correct.
+func TestVersionMemoFullCachePreservesHotEntries(t *testing.T) {
+	var memo cowMemo[int]
+	compute := func(key string) int { return len(key) }
+	memo.get("0.8.15", compute)
+	for i := 1; i < versionMemoCap; i++ {
+		memo.get(fmt.Sprintf("9.%d.0", i), compute)
+	}
+	full := memo.entries.Load()
+	for i := 0; i < 3*versionMemoCap; i++ {
+		key := fmt.Sprintf("10.%d.0", i)
+		if got := memo.get(key, compute); got != len(key) {
+			t.Fatalf("uncached version %q = %d, want %d", key, got, len(key))
+		}
+		if memo.entries.Load() != full || memo.size() != versionMemoCap || !memo.has("0.8.15") {
+			t.Fatal("a full memo discarded or rebuilt its cached entries")
+		}
+	}
+	if allocs := testing.AllocsPerRun(200, func() { memo.get("uncached", compute) }); allocs != 0 {
+		t.Fatalf("full-cache misses allocated %v per run; want 0 beyond the parser", allocs)
+	}
+}
+
+// TestVersionMemoNeverRetainsOversizedVersions pins the byte bound: a 1 MiB
+// version string (a valid "1.0.0+<metadata>" that fits the frame limit) is
+// parsed correctly and selects the right layout, but leaves the segments memo
+// unchanged and adds at most the shared numeric-core entry to the layout memo
+// — so distinct oversized strings cannot grow either memo. A short string
+// with too many segments is likewise parsed but not retained.
+func TestVersionMemoNeverRetainsOversizedVersions(t *testing.T) {
+	versionSegmentsMemo.reset()
+	slotBudgetLayoutMemo.reset()
+	_ = versionSegments("0.8.15") // warm one real entry
+	_ = slotBudgetLayoutForVersion("0.8.15")
+	segsBefore, layoutBefore := versionSegmentsMemo.size(), slotBudgetLayoutMemo.size()
+
+	meta := strings.Repeat("a", 1<<20)
+	for i := 0; i < 8; i++ {
+		huge := fmt.Sprintf("1.%d.0+%s%d", i, meta, i) // distinct 1 MiB strings, distinct cores
+		if got := versionSegments(huge); !reflect.DeepEqual(got, []int{1, i, 0}) {
+			t.Fatalf("oversized version parsed as %v", got)
+		}
+		if got := slotBudgetLayoutForVersion(huge); got != privateSlotGrants {
+			t.Fatalf("oversized version layout = %v, want privateSlotGrants", got)
+		}
+		if CompareVersions(huge, "0.7.5") <= 0 {
+			t.Fatal("oversized version must still compare correctly")
+		}
+	}
+	// Only the short numeric cores ("1.N.0", via the layout path's
+	// CompareVersions) may have been retained — never a 1 MiB key.
+	if grown := versionSegmentsMemo.size() - segsBefore; grown > 8 {
+		t.Fatalf("segments memo grew by %d entries on oversized keys", grown)
+	}
+	for i := 0; i < 8; i++ {
+		huge := fmt.Sprintf("1.%d.0+%s%d", i, meta, i)
+		if versionSegmentsMemo.has(huge) || slotBudgetLayoutMemo.has(huge) {
+			t.Fatal("a 1 MiB version string was retained in a memo")
+		}
+	}
+	if l := versionSegmentsMemo.maxKeyLen(); l > maxMemoizedVersionLen {
+		t.Fatalf("segments memo holds a %d-byte key", l)
+	}
+	if l := slotBudgetLayoutMemo.maxKeyLen(); l > maxMemoizedVersionLen {
+		t.Fatalf("layout memo holds a %d-byte key", l)
+	}
+	// The layout memo keys on the numeric core ("1.N.0"): 8 distinct cores at
+	// most, never the 1 MiB strings themselves.
+	if grown := slotBudgetLayoutMemo.size() - layoutBefore; grown > 8 {
+		t.Fatalf("layout memo grew by %d entries", grown)
+	}
+	// The same core with different oversized suffixes shares ONE layout entry.
+	layoutMid := slotBudgetLayoutMemo.size()
+	for i := 0; i < 8; i++ {
+		_ = slotBudgetLayoutForVersion(fmt.Sprintf("2.0.0+%s%d", meta, i))
+	}
+	if slotBudgetLayoutMemo.size() != layoutMid+1 {
+		t.Fatalf("suffix variants of one core created %d layout entries, want 1", slotBudgetLayoutMemo.size()-layoutMid)
+	}
+	// An oversized numeric core is computed without caching.
+	longCore := strings.Repeat("1.", 60) + "1" // 121 bytes, all segments
+	if got := slotBudgetLayoutForVersion(longCore); got != privateSlotGrants {
+		t.Fatalf("long-core layout = %v", got)
+	}
+	if slotBudgetLayoutMemo.size() != layoutMid+1 {
+		t.Fatal("oversized numeric core was retained in the layout memo")
+	}
+	// Too many segments in a short string: parsed, not retained.
+	many := "1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17"
+	if got := versionSegments(many); len(got) != 17 || got[16] != 17 {
+		t.Fatalf("many-segment version parsed as %v", got)
+	}
+	if versionSegmentsMemo.has(many) {
+		t.Fatal("over-segmented version was retained in the segments memo")
+	}
+	// A key exactly at the length bound is still memoized.
+	atBound := "1.0.0-" + strings.Repeat("x", maxMemoizedVersionLen-6)
+	_ = versionSegments(atBound)
+	if !versionSegmentsMemo.has(atBound) {
+		t.Fatal("a key at the length bound must be memoized")
+	}
+}
+
+// A normalized core is a substring of the registration version. Retaining
+// that substring's storage would defeat the byte bound even though len(key)
+// is small; compare storage identity without dereferencing either pointer.
+func TestVersionMemoCopiesNormalizedKeyStorage(t *testing.T) {
+	var memo cowMemo[slotBudgetLayout]
+	version := "1.2.3+" + strings.Repeat("x", 1<<20)
+	core := versionNumericCore(version)
+	memo.get(core, parseSlotBudgetLayoutCore)
+	for key := range *memo.entries.Load() {
+		if key != core {
+			t.Fatalf("memo key = %q, want %q", key, core)
+		}
+		if unsafe.StringData(key) == unsafe.StringData(version) {
+			t.Fatal("short memo key retains the oversized version's backing storage")
+		}
+	}
+}
+
+// TestVersionMemoReadsAllocateNothing pins the hot-path contract: once a
+// version has been seen, comparing it and selecting its budget layout
+// allocate nothing.
+func TestVersionMemoReadsAllocateNothing(t *testing.T) {
+	versionSegmentsMemo.reset()
+	slotBudgetLayoutMemo.reset()
+	_ = CompareVersions("0.8.15", privateSlotGrantsMinVersion)
+	_ = CompareVersions("0.8.15", "0.6.3")
+	_ = slotBudgetLayoutForVersion("0.8.15")
+	_ = slotBudgetLayoutForVersion("v0.7.5-rc1")
+	sink := 0
+	allocs := testing.AllocsPerRun(200, func() {
+		sink += CompareVersions("0.8.15", "0.6.3")
+		sink += CompareVersions("0.8.15", privateSlotGrantsMinVersion)
+		sink += int(slotBudgetLayoutForVersion("0.8.15"))
+		sink += int(slotBudgetLayoutForVersion("v0.7.5-rc1"))
+	})
+	if allocs != 0 {
+		t.Fatalf("warm version reads allocated %v per run; want 0", allocs)
+	}
+	if sink == 0 {
+		t.Fatal("reads returned nothing")
+	}
+}
+
+// TestVersionMemoConcurrentUse exercises racing readers and inserters
+// (meaningful under -race): every goroutine must observe correct parses.
+func TestVersionMemoConcurrentUse(t *testing.T) {
+	versionSegmentsMemo.reset()
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				v := fmt.Sprintf("1.%d.%d", (g*i)%40, i%5)
+				if got, want := versionSegments(v), parseVersionSegments(v); !reflect.DeepEqual(got, want) {
+					t.Errorf("versionSegments(%q) = %v, want %v", v, got, want)
+					return
+				}
+				_ = CompareVersions(v, "1.2.3")
+				_ = slotBudgetLayoutForVersion(v)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-04 · commit `d574bd5af`
+> Last updated: 2026-09-04 · commit `4e7a68739`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -46,8 +46,9 @@ content beyond that. See [`data-flow.md`](data-flow.md) and
 
 `ReserveProviderWithPlan` (`coordinator/registry/scheduler.go`) is the
 dispatch-time entry point. It scans the fleet
-(`scanCandidatesLocked`), gates and prices each provider
-(`buildCandidateGateLocked`), selects a winner (`selectRoutingCandidate`) and
+(`scanCandidatesLocked`), gates each provider
+(`snapshotProviderIntoLockedEx`), prices it (`buildCandidateInto`), selects a
+winner (`selectRoutingCandidate`) and
 returns a bounded **dispatch plan** (`coordinator/registry/dispatch_plan.go`)
 holding the winner plus up to `dispatchPlanMaxAlternates = 8` retained
 alternates. The API layer (`coordinator/api/dispatch.go`) consumes the plan:
@@ -69,7 +70,7 @@ flowchart TD
     G -->|not_serving_model, dedicated, cooldowns, breaker, ejection, liveness, trait_floor| X2[tallyGate]
     G --> V{RequiresVision?}
     V -->|provider lacks vision| X3[tallyGate vision]
-    V --> B[buildCandidateGateLocked]
+    V --> B[buildCandidateInto]
     B -->|slot_crashed / slot_reloading / no_headroom / thermal_critical / model_too_large / free_memory| X4[tallyGate]
     B --> C[cost = state + queue + pending + backlog + thisReq + health + capacityRate]
     C -->|ttft_ceiling| X5[tallyGate]
@@ -111,10 +112,10 @@ Gates run in the order below. The first failing gate names the rejection;
 | 16 | `GateChallengeStale` | `challenge_stale` | `providerLivenessGateReasonLocked` | Last passed challenge is missing or older than `challengeFreshnessMaxAge` ([below](#challenge-freshness)). |
 | 17 | `GateTraitFloor` | `trait_floor` | `providerRoutingGateReasonLockedEx` | Provider cannot satisfy a request trait (for example inference-time tool constraints). |
 | 18 | `GateVision` | `vision` | `providerServesVisionModelLocked` | Request `RequiresVision` and the provider's build of the model does not serve vision. |
-| 19 | `GateSlotCrashed` | `slot_crashed` | `buildCandidateGateLocked` / `slotStatePenalty` | Slot state `crashed`. |
-| 20 | `GateSlotReloading` | `slot_reloading` | `buildCandidateGateLocked` / `slotStatePenalty` | Slot state `reloading`. |
+| 19 | `GateSlotCrashed` | `slot_crashed` | `buildCandidateInto` / `slotStatePenalty` | Slot state `crashed`. |
+| 20 | `GateSlotReloading` | `slot_reloading` | `buildCandidateInto` / `slotStatePenalty` | Slot state `reloading`. |
 | 21 | `GateNoHeadroom` | `no_headroom` | `hasConcurrencyHeadroomForModelCapResolvedLocked` | Provider or slot is at its concurrency cap ([`scheduling.md`](scheduling.md#concurrency-caps)). |
-| 22 | `GateThermalCritical` | `thermal_critical` | `buildCandidateGateLocked` | `SystemMetrics.ThermalState == "critical"`. |
+| 22 | `GateThermalCritical` | `thermal_critical` | `buildCandidateInto` | `SystemMetrics.ThermalState == "critical"`. |
 | 23 | `GateModelTooLarge` | `model_too_large` | `modelFitsHardware` | Model is not resident and cannot fit the node's total memory. Permanent, not capacity. |
 | 24 | `GateFreeMemory` | `free_memory` | `freeMemoryAdmits` | Token-budget or memory admission fails, or the pair is budget-clamped. |
 | 25 | `GateTTFTCeiling` | `ttft_ceiling` | `scanCandidatesLocked` | Estimated TTFT exceeds `pr.MaxTTFTMs` (public non-vision requests with a ceiling only). |
@@ -162,7 +163,7 @@ seconds earlier. Both paths also record the failure into reputation.
 
 ### Cost model
 
-`buildCandidateGateLocked` prices an eligible provider as
+`buildCandidateInto` prices an eligible provider as
 
 ```text
 cost = statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs + capacityRateMs
@@ -460,7 +461,7 @@ score = 0.4 × jobRate + 0.3 × uptimeRate + 0.2 × challengeRate + 0.1 × respo
 
 A provider with no history scores `0.5`. The score is exposed on the
 provider-facing `/me` endpoints (`coordinator/api/me_handlers.go`) and
-persisted; **it is not a term in the routing cost** — `buildCandidateGateLocked`
+persisted; **it is not a term in the routing cost** — `buildCandidateInto`
 never reads it. The header comment in `reputation.go` still says the score
 factors into routing; the code does not. Reputation inputs do reach routing
 indirectly: `RecordChallengeFailure` feeds `challenge_stale`, and the latency
@@ -526,11 +527,11 @@ must not run in parallel with other scheduler tests in the same process.
 3. **No provider is routed without a fresh passed challenge** —
    `providerLivenessGateReasonLocked` with `challengeFreshnessMaxAge`.
 4. **A model that is not resident is never routed to hardware it cannot
-   fit** — `modelFitsHardware` in `buildCandidateGateLocked`; resident slots
+   fit** — `modelFitsHardware` in `buildCandidateInto`; resident slots
    (`slotStateModelLoaded`) are exempt because they have demonstrably fit.
 5. **Every scanned provider is accounted for exactly once**: as a candidate
    or under one `GateReason` — `scanCandidatesLocked.tallyGate`.
-6. **The cost breakdown sums to the total** — `buildCandidateGateLocked`
+6. **The cost breakdown sums to the total** — `buildCandidateInto`
    folds `longPromptPenalty` into `ThisReqMs` and sets `Total = cost`.
 7. **Pool narrowing never empties the pool** — each `PreferOwner`,
    `AvoidVersion` and `MinDecodeTPS` filter in `scanCandidatesLocked` is
@@ -560,7 +561,7 @@ must not run in parallel with other scheduler tests in the same process.
 
 | Concern | File / symbol |
 |---|---|
-| Dispatch-time selection, cost model, TTFT estimate | `coordinator/registry/scheduler.go` — `ReserveProviderWithPlan`, `scanCandidatesLocked`, `buildCandidateGateLocked`, `selectRoutingCandidate`, `slotStatePenalty`, `healthPenaltyMs`, `resolveEffectiveTPS`, `ttftMsFromSnapshot`, `longPromptPenalty` |
+| Dispatch-time selection, cost model, TTFT estimate | `coordinator/registry/scheduler.go` — `ReserveProviderWithPlan`, `scanCandidatesLocked`, `snapshotProviderIntoLockedEx`, `buildCandidateInto`, `selectRoutingCandidate`, `slotStatePenalty`, `healthPenaltyMs`, `resolveEffectiveTPS`, `ttftMsFromSnapshot`, `longPromptPenalty` |
 | Shared gate primitives | `coordinator/registry/routing_eligibility.go` — `providerLivenessGateReasonLocked`, `providerServesRoutableModelLocked` |
 | Closed vocabularies | `coordinator/registry/gate_reason.go` — `GateReason`, `SelectionPath`, `SlotState` |
 | Trust floor, challenge failures, dispatch-load cooldown, `Disconnect` | `coordinator/registry/registry.go` — `MinTrustLevel`, `MaxFailedChallenges`, `RecordChallengeFailure`, `dispatchLoadCooldownTTL` |

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `075d37a91`
+> Last updated: 2026-09-04 · commit `3f3fe7f00`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -222,18 +222,36 @@ states and, when it asks for a load, relies on the provider to evict.
 | `pendingModelLoadDrainBackoff` | `30 * time.Second` | Provider rejected the load because it is draining for an auto-update restart. |
 | `pendingModelLoadMemoryBackoff` | `30 * time.Second` | Proactive load failed for a non-draining reason (typically transient memory pressure). |
 | `dispatchLoadCooldownTTL` | see [`routing.md`](routing.md#cooldowns-breakers-and-ejection) | Routing skips the pair after a *dispatch-time* load failure (`dispatch_load_cooldown` gate). |
+| `modelSwapPlanInterval` | `250 * time.Millisecond` | Minimum spacing between heartbeat-triggered swap plans, fleet-wide (`coordinator/registry/model_swap_coalesce.go`). |
 
 Pending entries are cleared when the load completes, when the provider
 disconnects (`Disconnect`), and by the warm-pool sweep as they expire.
 
 **Model swaps.** `TriggerModelSwaps` (`coordinator/registry/registry.go`)
-runs after every heartbeat and queue drain. For each model with queued
-requests and no warm provider, it picks a cold provider that has the model
-on disk (`bestModelLoadProviderLocked`) and sends `load_model`, so demand
-that no resident slot can satisfy pulls the model in rather than waiting out
-the queue. Cold dispatch ([`EIGENINFERENCE_COLD_DISPATCH`](../reference/configuration.md#routing-admission-and-ttft),
-`coordinator/api/cold_dispatch.go`) additionally kicks this machinery the
-moment a request is enqueued.
+plans one swap per model with queued requests and no warm provider: it picks
+a cold provider that has the model on disk (`bestModelLoadProviderLocked`)
+and sends `load_model`, so demand that no resident slot can satisfy pulls the
+model in rather than waiting out the queue. It has two entry points:
+
+- **Heartbeat** — after its queue drain, `Registry.Heartbeat` calls
+  `triggerModelSwapsFromHeartbeat` (`coordinator/registry/model_swap_coalesce.go`),
+  which returns without planning while the queue is empty and otherwise
+  admits at most one plan per `modelSwapPlanInterval` across all heartbeats
+  (`modelSwapPlanGate`). The planner walks the fleet per queued model, so N
+  heartbeats inside the window would each re-derive the same plan. A
+  heartbeat the window refuses is coalesced, not dropped: it arms one
+  trailing plan for the end of the window (`armTrailing`,
+  `trailingModelSwapPlan`), so a provider that heartbeat made loadable waits
+  at most `modelSwapPlanInterval` for the planner rather than for the next
+  heartbeat; the trailing plan claims the same gate, so the planner still
+  runs at most once per window. If a delayed timer finds that a heartbeat
+  opened a newer window, it rearms for that window to preserve any later
+  suppressed state change. The queue *drain* is per-heartbeat and is not
+  coalesced.
+- **Cold dispatch** ([`EIGENINFERENCE_COLD_DISPATCH`](../reference/configuration.md#routing-admission-and-ttft),
+  `coordinator/api/cold_dispatch.go`) calls `TriggerModelSwaps` directly the
+  moment a request is enqueued; that kick is immediate and not subject to
+  the heartbeat gate.
 
 ### Warm-pool controller
 
@@ -325,7 +343,11 @@ Each heartbeat (`Registry.Heartbeat`) refreshes `LastHeartbeat`,
 `SystemMetrics` and `BackendCapacity`, credits uptime for the gap since the
 previous heartbeat when that gap is at most `maxUptimeCredit =
 2 * time.Minute`, releases satisfied budget clamps, drains the provider's
-model queues with `DrainTriggerHeartbeat`, and calls `TriggerModelSwaps`.
+model queues with `DrainTriggerHeartbeat`, and calls
+`triggerModelSwapsFromHeartbeat`, which runs the swap planner only when the
+queue is non-empty and at most once per `modelSwapPlanInterval` fleet-wide,
+a heartbeat the window refuses arming one trailing plan for the window's end
+([above](#model-slots-pending-loads-and-swaps)).
 
 The provider CLI heartbeats every
 [`heartbeat_interval_secs`](../provider/cli-reference.md#providertoml-keys-read-by-the-cli)
@@ -342,6 +364,10 @@ A provider whose heartbeat age exceeds the timeout earns a strike; at
 `evictStrikeThreshold = 2` consecutive strikes it is disconnected. A provider
 must therefore be silent past the timeout at two successive sweeps — at
 least ~120 s — before eviction, which rides out a single delayed heartbeat.
+The read scan retains each candidate's exact provider pointer. Before removal,
+`disconnectProvider` rechecks that pointer and the latest heartbeat under the
+registry and provider locks. A heartbeat that recovered after the scan, or a
+replacement session registered under the same ID, cancels the stale eviction.
 
 ### Provider writer: two lanes
 
@@ -410,7 +436,8 @@ keeps `StatusUntrusted` instead. Eviction reaches `Disconnect` directly. It:
 7. **Warm-pool loads per tick are bounded** — `rampLoadsThisTick`,
    `MaxGlobalPendingLoads`.
 8. **A provider is evicted only after `evictStrikeThreshold` consecutive stale
-   sweeps** — `evictStale` ([above](#heartbeat-cadence-and-eviction)).
+   sweeps and a fresh identity/heartbeat recheck at removal** — `evictStale`,
+   `disconnectProvider` ([above](#heartbeat-cadence-and-eviction)).
 9. **Control frames never wait behind queued data frames** — lane priority
    in `providerWriter`.
 10. **Disconnect preserves stable-identity fault state** — `Disconnect`.
@@ -438,10 +465,10 @@ keeps `StatusUntrusted` instead. Eviction reaches `Disconnect` directly. It:
 | Heartbeat payload | `coordinator/protocol/messages.go` — `BackendCapacity`, `BackendSlotCapacity` |
 | Token-budget and memory admission | `coordinator/registry/scheduler.go` — `freeMemoryAdmits`, `pooledBudgetAdmits`, `knownZeroTokenBudget`, `committedTokenBudget` |
 | Concurrency caps | `coordinator/registry/registry.go` — `maxConcurrency`, `maxConcurrencyForModelLocked`, `DefaultMaxConcurrent`; `coordinator/registry/concurrency_cap.go` — `SetQualityConcurrencyCap`, `effectiveMaxConcurrencyForModelRateLocked`, `hasConcurrencyHeadroomForModelCapResolvedLocked` |
-| Pending loads and swaps | `coordinator/registry/registry.go` — `pendingModelLoadTTL`, `TriggerModelSwaps`, `bestModelLoadProviderLocked`, `SendLoadModel` |
+| Pending loads and swaps | `coordinator/registry/registry.go` — `pendingModelLoadTTL`, `TriggerModelSwaps`, `bestModelLoadProviderLocked`, `SendLoadModel`; `coordinator/registry/model_swap_coalesce.go` — `modelSwapPlanInterval`, `modelSwapPlanGate`, `triggerModelSwapsFromHeartbeat` |
 | Warm pool | `coordinator/registry/warm_pool_controller.go` — `tick`, `plan`, `hasDemandPressure`, `targetWarm`, `WarmPoolSnapshot`; `coordinator/registry/warm_pool_target.go` — `warmTarget`, `qualityConcurrency`, `estimateServiceTime`, `rampLoadsThisTick`; `coordinator/registry/warm_pool_state.go` — `warmPoolArrivalEWMAAlpha` |
 | Warm-pool and quality-cap configuration | `coordinator/registry/config.go` — `WarmPoolConfig`, `QualityCapConfig`, `ReadConfig` |
-| Eviction | `coordinator/registry/registry.go` — `StartEvictionLoop`, `evictStale`, `evictStrikeThreshold`; wired in `coordinator/cmd/coordinator/main.go` |
+| Eviction | `coordinator/registry/registry.go` — `StartEvictionLoop`, `evictStale`, `disconnectProvider`, `evictStrikeThreshold`; wired in `coordinator/cmd/coordinator/main.go` |
 | Provider writer | `coordinator/registry/provider_writer.go` — `providerWriter`, `providerWriteTimeout`, `watchWrites` |
 | Teardown | `coordinator/registry/registry.go` — `Disconnect` |
 | Cold dispatch and queue-before-shed flags | `coordinator/api/cold_dispatch.go` |

--- a/docs/architecture/system-profiler.md
+++ b/docs/architecture/system-profiler.md
@@ -1,6 +1,6 @@
 # System profiler
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-04 · commit `4a08f2a44`
 
 The profiler answers "where did the time go, and what did the router know when
 it chose?" for one request, without carrying a single prompt-derived byte. It
@@ -204,9 +204,9 @@ JSON-encoded on the sink worker.
 
 | Column(s) | Definition | Where |
 |---|---|---|
-| `scanned` | providers the candidate loop visited | `ReserveProviderEx` |
-| `candidate_set_size` | `scanned − gate_rejections.not_serving_model`; exclude/allowlist drops happen before the catalog check and count as advertising | `scheduler.go` |
-| `gate_rejections` JSONB `{reason: count}` | per-`GateReason` tally, uint16-saturating; keys are `gateReasonNames` (`coordinator/registry/gate_reason.go`): `offline`, `untrusted`, `trust_floor`, `private_only`, `runtime_unverified`, `private_text`, `challenge_stale`, `trait_floor`, `dedicated`, `dispatch_load_cooldown`, `error_cooldown`, `capacity_cooldown`, `breaker`, `ejection`, `slot_crashed`, `slot_reloading`, `thermal_critical`, `no_headroom`, `model_too_large`, `free_memory`, `vision`, `ttft_ceiling`, `excluded`, `allowlist`, `not_serving_model`. `allowlist` absorbs exclusive self-route-not-owned and serial allowlist misses; `excluded` is the caller's exclude list. Meaning of each gate: [`routing.md`](routing.md) | `buildCandidateGateLocked` |
+| `scanned` | providers the candidate loop visited. Since the per-model provider index (`coordinator/registry/model_index.go`) the loop visits only providers **advertising** the requested model, so `scanned` is the advertising count, not the fleet size, and `gate_rejections.not_serving_model` is 0 unless an advertiser still fails the catalog rule (off-catalog model on a public route); the `allowlist` / `excluded` tallies likewise count only advertisers. Records written before the index landed have `scanned == fleet size`; fleet size is available from `fleet_snapshots` | `ReserveProviderEx` |
+| `candidate_set_size` | `scanned − gate_rejections.not_serving_model` (unchanged in meaning by the index); exclude/allowlist drops happen before the catalog check and count as advertising | `scheduler.go` |
+| `gate_rejections` JSONB `{reason: count}` | per-`GateReason` tally, uint16-saturating; keys are `gateReasonNames` (`coordinator/registry/gate_reason.go`): `offline`, `untrusted`, `trust_floor`, `private_only`, `runtime_unverified`, `private_text`, `challenge_stale`, `trait_floor`, `dedicated`, `dispatch_load_cooldown`, `error_cooldown`, `capacity_cooldown`, `breaker`, `ejection`, `slot_crashed`, `slot_reloading`, `thermal_critical`, `no_headroom`, `model_too_large`, `free_memory`, `vision`, `ttft_ceiling`, `excluded`, `allowlist`, `not_serving_model`. `allowlist` absorbs exclusive self-route-not-owned and serial allowlist misses; `excluded` is the caller's exclude list. Meaning of each gate: [`routing.md`](routing.md) | `buildCandidateInto` |
 | `candidates` JSONB (≤ 4 rows) | `Top[0]` is the winner, then the lowest-cost other candidates ascending; each row is a `CandidateSummary` (cost + terms, `ttft_ms`, `effective_tps`, `effective_queue`, `total_pending`, `backend_running/waiting`, `active_token_budget_used/max`, `queued_prefill_tokens`, folded `slot_state`, `hb_age_ms`) | `CandidateSummary` (`gate_reason.go`) |
 | `runner_up_provider_id`, `runner_up_cost_ms` | lowest-cost candidate of the narrowed pool other than the winner; absent with one candidate | `lowestCostOther` |
 | `best_idle_provider_id`, `best_idle_ttft_ms` | lowest-TTFT candidate with the model resident and `backend_running + backend_waiting == 0`, computed over every gate-passing candidate before pool narrowing | `scheduler.go` |
@@ -260,7 +260,7 @@ saturated to int32 by `ClampFleetRowInts`. The sampler's lock discipline: one
 short `r.mu.RLock` copies the provider list; phase A reads each provider under
 `p.mu` only; phase B takes a brief `r.mu.RLock` per provider for breaker,
 ejection, cooldown, clamp and eligibility through the real routing gates
-(`snapshotProviderReasonLockedEx`, `buildCandidateGateLocked`); a provider
+(`snapshotProviderIntoLockedEx`, `buildCandidateInto`); a provider
 replaced between phases is dropped. `registry/routingsim`
 (`coordinator/registry/routingsim/fleet_ndjson.go`, `LoadFleetNDJSON`) rebuilds
 a fleet from these rows, capability columns included.
@@ -437,6 +437,8 @@ ring or `DaemonState` mirror.
 | Engine side | `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/CBv2RequestTiming+Stamps.swift` |
 
 ## Related
+
+- [`../reports/2026-09-03-perf-pr-b-body.md`](../reports/2026-09-03-perf-pr-b-body.md) — the routing-scan landing (per-model provider index) that changed the meaning of `scanned` above.
 
 - [`../reference/protocol-messages.md`](../reference/protocol-messages.md) — `profile` row, heartbeat `telemetry` sub-objects
 - [`request-outcome-observability.md`](request-outcome-observability.md) — `final_status`, `error_class`, `terminal_cause` vocabularies

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-04 · commit `075d37a91`
+> Last updated: 2026-09-04 · commit `4e7a68739`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -115,7 +115,7 @@ Trust floor, model routing and per-request quality:
 | `EIGENINFERENCE_PREFILL_DECODE_RATIO` | float > 0 | `12.0` | `coordinator/cmd/coordinator/main.go`; `coordinator/registry/scheduler.go` (`SetPrefillToDecodeRatio`) | Prefill-to-decode speed ratio in the TTFT estimate. |
 | `EIGENINFERENCE_PROMPT_CALIBRATION` | `family:factor,…` (factors ≥ 1.0) | built-in table (`gpt-oss:1.3`) | `coordinator/api/prompt_calibration.go` (`SetPromptContextCalibrationFromEnv`) | Replaces the per-family prompt-token calibration used by the context gate. |
 | `EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES` | `model=upstream_ms,…` (`0`/`off` removes) | built-in table | `coordinator/modelpolicy/first_content_deadline.go` (`SetFirstContentBasesFromEnv`) | Overrides exact-model first-content deadline bases. |
-| `EIGENINFERENCE_HEALTH_EJECTION` | `off`/`0`/`false`/`no` disables | on (*live*) | `coordinator/registry/health_ejection.go` (`healthEjectionEnabled`) | Kill switch for provider health ejection; see [`../architecture/routing.md`](../architecture/routing.md). |
+| `EIGENINFERENCE_HEALTH_EJECTION` | `off`/`0`/`false`/`no` disables | on | `coordinator/registry/health_ejection_switch.go` (`healthEjectionSwitch`, parsed once at package init); `coordinator/registry/health_ejection.go` (`healthEjectionEnabled`) | Kill switch for provider health ejection; see [`../architecture/routing.md`](../architecture/routing.md). |
 | `EIGENINFERENCE_DISABLE_CLIENT_ERROR_STOP` | bool | `false` | `coordinator/cmd/coordinator/main.go` (`SetDisableClientErrorStop`) | Lets deterministic provider 4xx errors fail over instead of stopping the dispatch ladder. |
 
 TTFT admission and dispatch termination:

--- a/docs/reports/2026-09-03-perf-pr-b-body.md
+++ b/docs/reports/2026-09-03-perf-pr-b-body.md
@@ -1,0 +1,157 @@
+# perf(registry): land the routing-scan half of the 2026-09-02 performance program
+
+> Last updated: 2026-09-03 · commit `99b03a161`
+
+PR B of the landing plan in
+`docs/reports/2026-09-03-coordinator-perf-proposal/05-port-feasibility.md`
+(on the `coordinator-perf-proposal` worktree branch, not yet on master):
+the `coordinator/registry/` slice of the perf branch
+`worktree-bridge-cse_01TuyfD42fkRyG4ZqSTmeN4U` (tip `5508b4f84`; program report
+§4.2 routing scan, §4.5 aggregate/periodic paths), merged onto master
+`ac60c5ada` (#816) with the four conflicted files re-derived by hand so the
+#809 system-profiler contract survives the in-place/indexed scan.
+
+**Merge order:** merge after `perf/coordinator-store-api-2026-09-03` (PR A —
+`api/` + `store/` + `cmd/`). `perf/coordinator-registry-lock-2026-09-03`
+(Tier 3, `Registry.mu` off the request path) stacks on this branch.
+
+**Scope:** 70 files under `coordinator/registry/` plus one documentation
+edit outside it — `docs/architecture/system-profiler.md` (the `scanned` /
+`candidate_set_size` column definitions, see H4). Zero changes to
+`coordinator/api/`, `store/`, `cmd/`, `protocol/`: master's `api/` compiles
+and its tests pass against the new registry unchanged.
+
+## What changes
+
+### Behaviour: the per-attempt routing scan
+
+```mermaid
+flowchart LR
+  subgraph before ["Before (master): per-attempt full-fleet walk"]
+    A1["ReserveProviderEx"] --> B1["time.Now() per provider gate"]
+    B1 --> C1["for p in r.providers (1,260)"]
+    C1 --> D1["p.mu; gates; snapshot returned by value (~600 B, copied twice)"]
+    D1 --> E1["tpsRegistry.Median: copy + sort per provider"]
+    E1 --> F1["heap-allocate routingCandidate per eligible provider"]
+    F1 --> G1["cost rank"]
+  end
+  subgraph after ["After (PR B): indexed walk over advertising providers"]
+    A2["ReserveProviderEx"] --> B2["now := time.Now() once per walk"]
+    B2 --> C2["providersForModelLocked(model) — only advertisers (~10% of fleet)"]
+    C2 --> D2["p.mu; gates; snapshot written in place into an arena slot"]
+    D2 --> E2["Median O(1) from cache maintained on Record"]
+    E2 --> F2["buildCandidateInto on the slot; GateReason tallied"]
+    F2 --> G2["cost rank"]
+  end
+```
+
+Eligibility gates are unchanged; the index only prunes providers that do not
+advertise the model (`index[model] == { p : model ∈ ids(p.Models) }`, pinned
+by `TestModelIndexMatchesBruteForceAfterEveryMutation`). Same-walk changes:
+the health-ejection kill switch is read once at init, the cache-capability
+walk is skipped when hints are impossible, semver segments are memoized and
+`{providerID, model}` struct keys replace string concatenation, and the TTFT
+calibrator no longer re-sweeps its pending map on every reservation.
+
+### Code: `scanCandidatesLocked` and its helpers
+
+```mermaid
+flowchart TD
+  subgraph master ["master (#809)"]
+    S1["scanCandidatesLocked: for p in r.providers"] --> S2["snapshotProviderReasonLockedEx(p, …) → (routingSnapshot, ok, GateReason)<br/>own time.Now(); stamps hbAgeMs"]
+    S2 --> S3["buildCandidateGateLocked(snap, pr) → (*routingCandidate, candidateRejection, GateReason, ok)<br/>heap candidate; sets calibrationRatio"]
+    S4["fleet_sample.slotEligibilityReasonLocked"] --> S2
+    S4 --> S3
+  end
+  subgraph prb ["PR B"]
+    P1["scanCandidatesLocked: for p in providersForModelLocked(model)"] --> P2["c := arena.next()"]
+    P2 --> P3["snapshotProviderIntoLockedEx(dst = c.snapshot slot, p, …, now) → (ok, GateReason)<br/>stamps hbAgeMs from now"]
+    P3 --> P4["buildCandidateInto(c, pr, now) → (candidateRejection, GateReason, ok)<br/>sets c.calibrationRatio; calibratedTTFTMsWithRatio(*snap)"]
+    P4 --> P5["scan.tallyGate / scan.noteBestIdle / append"]
+    P6["fleet_sample.slotEligibilityReasonLocked(…, now)<br/>one stack routingCandidate"] --> P3
+    P6 --> P4
+    P7["snapshotProviderLockedEx / buildCandidateWithReason (by-value wrappers)<br/>commit re-check, dispatch_plan, PredictServable"] --> P3
+    P7 --> P4
+  end
+```
+
+Other registry paths landed with it (program report §4.5): `ListModels`,
+`PublicProviderModels` and `evictStale` walks (evictStale now under the read
+lock; write lock only to install a changed strike map), three read-only
+getters moved from `Lock` to `RLock`, and `model_swap_coalesce.go` (heartbeats
+admit at most one swap plan per 250 ms fleet-wide; the api cold-dispatch kick
+still plans immediately; the planner's two walks iterate the per-model index).
+
+## Before / after (merged tree vs `origin/master`)
+
+Same M4 Max, same session, `go test ./registry/ -run xxx -bench … -benchtime 2s
+-benchmem -count=2`, min of 2. The box was under **load average ~300** (many
+concurrent sessions) for both runs, so absolute ns/op are ~5× the quiet-machine
+numbers in the program report (reserve 365 µs → 79 µs there); the **ratios and
+allocs/op are the load-independent signal**.
+
+| Benchmark (1,260 providers, 15 models) | master ns/op | master B/op | master allocs/op | PR B ns/op | PR B B/op | PR B allocs/op | speed-up |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `FleetReserveProviderEx` (scan + commit + release) | 1,897,335 | 194,031 | 815 | **402,588** | 103,400 | **12** | 4.7× |
+| `FleetReserveProviderExParallel-16` | 2,177,976 | 245,232 | 1,036 | **394,489** | 127,128 | **12** | 5.5× |
+| `FleetQuickCapacityCheck` (preflight RLock walk) | 683,019 | 80,976 | 672 | **164,835** | 1,024 | **1** | 4.1× |
+| `FleetPredictServable` | 1,337,510 | 80,976 | 672 | **158,087** | 1,024 | **1** | 8.5× |
+| `FleetListModels` (`/v1/models` aggregate) | 888,732 | 249,272 | 1,281 | **469,991** | 3,544 | **19** | 1.9× |
+| `FleetHeartbeat` (ingest) | 2,336 | 473 | 6 | 2,239 | 464 | 6 | 1.0× |
+
+`reserve_bench_test` (`BenchmarkReserveProviderEx_350x2`, 350 providers × 2
+models, under the same load): 887 µs, 15 allocs/op.
+
+## Conflict resolution and semantic hazards (05 §"Semantic hazards")
+
+Method: `git merge --no-commit --no-ff <perf tip>`; every non-registry path
+reset to `origin/master` and the 53 added non-registry files removed. `rerere`
+had silently auto-applied an earlier session's resolution of the four
+conflicted files (`rerere.enabled=true`, 75-entry cache); it was discarded
+(`git checkout --conflict=diff3`) and the files re-derived from the three-way
+hunks. That cached resolution took a different H4 route (tallying the
+index-pruned providers as `not_serving_model` to keep `Scanned == fleet size`);
+this PR instead documents the semantics change (see H4) so the record reports
+the work the scan actually did.
+
+| # | Hazard | Resolution |
+|---|---|---|
+| H1 | `fleet_sample.go` (#809) called the removed `snapshotProviderReasonLockedEx` / `buildCandidateGateLocked` | `slotEligibilityReasonLocked(p, model, probe, now)` builds one stack `routingCandidate` through `snapshotProviderIntoLockedEx` + `buildCandidateInto` and takes the sampler's clock; header/doc comments updated to the new names. The two removed helpers had no other caller. |
+| H2 | `buildCandidateInto` holds `snap := &c.snapshot`; master's `calibratedTTFTMsWithRatio` was value-typed and its `calibrationRatio` assignment predated the in-place tail | `calibratedTTFTMs` and `calibratedTTFTMsWithRatio` are both pointer-typed; `buildCandidateInto` reads the ratio once, scores with it, and sets `c.calibrationRatio` on success. `TestReserveProviderExTopRunnerUpAndPath` asserts `TTFTCalibrationRatio == 1.0` after reset (a dropped assignment reads 0). |
+| H3 | `snapshotProviderIntoLockedEx` receives `now` but its field list predated `hbAgeMs` | `snap.hbAgeMs = heartbeatAgeMs(now, p.LastHeartbeat)` in the in-place fill; `heartbeatAgeMs` kept. `TestReserveProviderExSnapshotAgeAndPending` asserts `SnapshotAgeMs ≈ 7000` through a real reservation. |
+| H4 | Per-model index: the scan only visits advertisers | **Semantics change, documented, not a bug.** `RoutingDecision.Scanned` is now the advertising count (not the fleet size); `GateRejections[not_serving_model]` is 0 unless an advertiser still fails the catalog rule (off-catalog model on a public route); `CandidateSetSize = Scanned − not_serving_model` is unchanged in meaning. The same applies to the pre-snapshot `allowlist` / `excluded` tallies, which now count only advertisers (a serial-allowlist miss used to tally ~fleet size per request) — a consumer trending `gate_rejections.allowlist` sees the magnitude drop at deploy. Comments at `RoutingDecision.Scanned` and at the `candidateSetSize` assignment; `TestGateRejectionTallies/not_serving_model` pins the indexed shape (Scanned 0, no tally) and the brute-force shape (`modelIndexDisabled`); `…/not_serving_model_off_catalog` pins the advertiser-fails-catalog branch (Scanned 1, tally 1, set 0). `docs/architecture/system-profiler.md` column definitions updated. Downstream: the profiler's fleet size is available from the 60 s fleet snapshots. |
+| H5 | #799 `routingScanSem` (`NumCPU` slots) shed threshold was calibrated against the old scan cost | Textually orthogonal (the semaphore lives in `api/`). Re-measure `errRoutingScanSaturated` after landing; sizing the semaphore to the container's CPU quota is the Tier-3 follow-up. |
+| H8 | #791 `coldTokenBudgetEstimate(…, providerVersion, modelID)` vs the perf branch's pointer-ified budget helpers | Auto-merged; `servability_test.go` takes both (5-arg calls + `snapPtr`). Activation floors untouched. |
+
+Other reconciliations: `routing_eligibility.go` combines `now` and the
+reason (`providerSupportsPrivateTextAtLocked(p, now)` → `GatePrivateText`);
+`servability.go` `PredictServable` discards the gate reason; the #809 decision
+fill passes `&candidate.snapshot` to the now pointer-typed
+`projectedPerRequestDecodeTPS`. The 05 "perf side" error list (`registry.go`
+`drainQueuedRequestsForModelsWithReason` / `reportedFreeForLoadAdmits` arity,
+`gate_reason.go`, `attempt_profile.go` `ScanUS`/`AdmitUS`, `cold_dispatch.go`,
+`warm_pool_controller.go`) did not materialise: those callers auto-merged
+against master's definitions once `scheduler.go` kept master's profiler
+symbols.
+
+## Review
+
+One independent reviewer (Claude general-purpose agent, read-only + `go test`)
+over the `scheduler.go` / `fleet_sample.go` diff vs `origin/master`: PASS on
+all four items (profiler contract preserved on every drop/success path; index
+== brute-force tests present and 13/13 green incl. `-race`; nothing outside
+`coordinator/registry/`; bench allocs decomposed with pprof and consistent).
+Findings fixed in the follow-up commit: the stale `scanned` definition in
+`docs/architecture/system-profiler.md`, the unpinned off-catalog-advertiser
+branch of H4, and 13 comments still naming the removed `snapshotProviderLocked`
+wrapper. Noted, not changed: `candidateArena.next` and
+`snapshotProviderIntoLockedEx` both zero the slot (~600 B memclr per visited
+provider; the `next()` zero is needed for reused slots); the branch history is
+only safe under squash-merge (master is squash-only — do not rebase-merge).
+
+## Gates
+
+- `gofmt -l .` clean; `go build ./...`; `go vet ./...`; `golangci-lint v2.1.6 run ./...` — 0 issues.
+- `go test ./registry/...` green (incl. `routing_context_test`, `fleet_sample_test`, `TestModelIndexMatchesBruteForceAfterEveryMutation`, `TestRoutingWalksIdenticalWithAndWithoutModelIndex`, `TestRoutingWalksIdenticalWithFaultStateWithAndWithoutIndex`, `TestModelIndexOffCatalogSelfRouteStillRoutes`, `reserve_bench_test`).
+- `go test ./api/` green — master's api against the new registry, unchanged.
+- Known flakes not touched: `promptcontract` supervisor test under load; `TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix` (pre-existing).

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-04 · commit `bda995368`
+> Last updated: 2026-09-04 · commit `fd2f0be2c`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -62,6 +62,7 @@ Plans and decision memos live in [`../design/`](../design/README.md).
 | 2026-09-02 | [coordinator-performance-program](2026-09-02-coordinator-performance-program.md) | First-principles pass over every coordinator operation with a measurable cost: fleet-scale benchmarks, store cache, route batching, relay coalescing, parse-once bodies |
 | 2026-09-02 | [coordinator-performance-pr-body](2026-09-02-coordinator-performance-pr-body.md) | Original PR body of the 75-commit program branch, kept as the record |
 | 2026-09-03 | [perf-pr-a-body](2026-09-03-perf-pr-a-body.md) | Landing the store/api half of the program on master (read-through cache, batched route sink, parse-once bodies, relay coalescing) |
+| 2026-09-03 | [perf-pr-b-body](2026-09-03-perf-pr-b-body.md) | PR description for the routing-scan landing (PR B): per-model provider index, in-place snapshots, TPS median caches, version memos, heartbeat swap-plan coalescing; before/after benchmarks and the `scanned` semantics change |
 
 ## Raw benchmark outputs
 


### PR DESCRIPTION
Routing scans repeatedly walked unrelated providers, copied snapshot data, recomputed medians, and parsed versions. This PR maintains per-model provider indexes and median caches, reuses snapshot storage, bounds version memoization, and coalesces heartbeat-driven swap planning.

- Index updates follow registration, model changes, and disconnect; equivalence tests compare indexed scans with brute-force results.
- Median updates move to the write side and routing snapshots use reusable arenas.
- Version memo entries remain bounded and own normalized strings. A full cache does not trigger repeated whole-cache clears.
- Suppressed heartbeat changes retain a trailing swap plan. Scheduling uses the current time after queue draining, so drain time cannot add a stale delay.
- Stale eviction rechecks the exact Provider pointer and fresh heartbeat under registry/provider locks before removal. A recovered or replaced session survives the old scan.

## Before
```mermaid
flowchart LR
  R[Reservation scan] --> F[Walk fleet and rebuild derived data]
  H[Each heartbeat] --> S[Repeated swap planning]
  E[Stale scan] --> D[Unconditional Disconnect by id]
  D --> X[Recovered or replaced session can be removed]
```

## After
```mermaid
flowchart LR
  R[Reservation scan] --> I[providerModelIndex.providersFor]
  I --> A[Reusable snapshots and maintained medians]
  H[Heartbeat after queue drain] --> C[Coalesced planner with trailing run]
  E[Stale scan retains Provider pointer] --> G[disconnectProvider validates identity and freshness under locks]
  G -->|still stale| D[Remove exact session]
  G -->|recovered or replaced| K[Keep session]
```

Validation: full registry race tests, indexed/brute-force equivalence, deterministic trailing-plan and eviction regressions, full coordinator tests, build, vet, lint, and documentation checks passed. Historical benchmarks motivate the change; production speedup after rollout remains to be measured.

Merge order: #821 → #820 → #819 → #823 → #822. Each PR targets its immediate parent; retarget to master as its parent lands.

The maintainer has deferred the known Threat Model Review credential failure. The benchmark environment remains subject to its existing manual approval gate.
