### PR TITLE
perf(store/api): cache lookups, batch telemetry and bound relay work (Tier 2 A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ When adding code that mutates provider state or sends commands (`load_model`, et
 3. Check concurrent access — heartbeats arrive per-provider on separate goroutines; `TriggerModelSwaps` can race with `drainQueuedRequestsForModels`.
 4. Check the cleanup path — `Disconnect()` must clear any per-provider state you add.
 5. Verify pre-existing invariants: `maxModelSlots`, heartbeat field omission semantics (`nil` vs empty), and the `UnifiedMemoryCap` load gate on the provider side.
+6. **Store read-through cache** (`store/cached.go`): `CachedStore` serves `GetUserByAccountID`/`GetUserByPrivyID` and `GetModelRegistryRecord`/`GetModelManifest` from memory and invalidates on the store mutators it overrides. Any NEW `store.Store` method that writes the `users` table or the model-registry tables must be overridden in `CachedStore` to invalidate its domain, or callers read stale data for up to the TTL. Backend-only capabilities discovered by type assertion must go through `store.As` (the decorator implements `Unwrap`).
 
 ## Code Structure & Modularity
 

--- a/coordinator/api/cache.go
+++ b/coordinator/api/cache.go
@@ -1,14 +1,16 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"sync"
 	"time"
 )
 
-// ttlCache stores pre-serialized JSON bytes keyed by request signature.
-// Skipping both the DB query and json.Marshal on hit makes hot endpoints
-// (stats, leaderboard, model catalog) sub-millisecond.
+// ttlCache stores pre-serialized JSON bytes — or, for shared intermediate
+// results such as the public model entry list, a typed value — keyed by
+// request signature. Skipping both the DB query and json.Marshal on hit makes
+// hot endpoints (stats, leaderboard, model catalog) sub-millisecond.
 //
 // Single-node in-memory only — sized for tens of keys, not millions. Hits
 // are just a map lookup under RLock; misses recompute and Set without
@@ -16,10 +18,13 @@ import (
 type ttlCache struct {
 	mu   sync.RWMutex
 	data map[string]ttlEntry
+	// generation orders guarded fills against invalidation.
+	generation uint64
 }
 
 type ttlEntry struct {
 	value     []byte
+	obj       any
 	expiresAt time.Time
 }
 
@@ -27,15 +32,33 @@ func newTTLCache() *ttlCache {
 	return &ttlCache{data: make(map[string]ttlEntry)}
 }
 
-// Get returns the cached bytes if present and not expired.
-func (c *ttlCache) Get(key string) ([]byte, bool) {
+func (c *ttlCache) lookup(key string) (ttlEntry, bool) {
 	c.mu.RLock()
 	e, ok := c.data[key]
 	c.mu.RUnlock()
 	if !ok || time.Now().After(e.expiresAt) {
+		return ttlEntry{}, false
+	}
+	return e, true
+}
+
+// Get returns the cached bytes if present and not expired.
+func (c *ttlCache) Get(key string) ([]byte, bool) {
+	e, ok := c.lookup(key)
+	if !ok || e.value == nil {
 		return nil, false
 	}
 	return e.value, true
+}
+
+// GetValue returns the cached typed value if present and not expired. The
+// value is shared between all callers and must be treated as immutable.
+func (c *ttlCache) GetValue(key string) (any, bool) {
+	e, ok := c.lookup(key)
+	if !ok || e.obj == nil {
+		return nil, false
+	}
+	return e.obj, true
 }
 
 // Set stores bytes with an absolute expiry time.
@@ -45,12 +68,20 @@ func (c *ttlCache) Set(key string, value []byte, ttl time.Duration) {
 	c.mu.Unlock()
 }
 
+// SetValue stores a typed value with an absolute expiry time.
+func (c *ttlCache) SetValue(key string, v any, ttl time.Duration) {
+	c.mu.Lock()
+	c.data[key] = ttlEntry{obj: v, expiresAt: time.Now().Add(ttl)}
+	c.mu.Unlock()
+}
+
 // Invalidate removes a single key. Useful when an action changes the
 // underlying data (e.g. registering a new release invalidates cached
 // /api/version and /v1/runtime/manifest).
 func (c *ttlCache) Invalidate(key string) {
 	c.mu.Lock()
 	delete(c.data, key)
+	c.generation++
 	c.mu.Unlock()
 }
 
@@ -81,4 +112,38 @@ func writeCachedJSON(w http.ResponseWriter, body []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
+}
+
+// encodeCachedJSON renders v exactly as writeJSON does (json.Encoder appends
+// a trailing newline to the compact encoding), so a cache hit served by
+// writeCachedJSON is byte-identical to the miss that populated it.
+func encodeCachedJSON(v any) ([]byte, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return append(body, '\n'), nil
+}
+
+// Nil-safe readCache accessors: handlers reached through a bare Server
+// literal (some tests) have no cache and simply recompute every time.
+
+func (s *Server) readCacheGet(key string) ([]byte, bool) {
+	if s.readCache == nil {
+		return nil, false
+	}
+	return s.readCache.Get(key)
+}
+
+func (s *Server) readCacheSet(key string, body []byte, ttl time.Duration) {
+	if s.readCache != nil {
+		s.readCache.Set(key, body, ttl)
+	}
+}
+
+func (s *Server) readCacheGetValue(key string) (any, bool) {
+	if s.readCache == nil {
+		return nil, false
+	}
+	return s.readCache.GetValue(key)
 }

--- a/coordinator/api/cache_generation.go
+++ b/coordinator/api/cache_generation.go
@@ -1,0 +1,34 @@
+package api
+
+import "time"
+
+// readCacheGeneration snapshots the invalidation generation before a catalog
+// computation reads its inputs. A concurrent admin sync may invalidate the
+// result while it is being built; that request can finish with its snapshot,
+// but must not repopulate the cache for requests after the sync completes.
+func (s *Server) readCacheGeneration() uint64 {
+	if s.readCache == nil {
+		return 0
+	}
+	c := s.readCache
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.generation
+}
+
+// readCacheSetEntryIfCurrent publishes a catalog fill only if no invalidation
+// has raced it. The comparison and write use the same lock as Invalidate, so
+// a successful check cannot race with the eviction it is meant to preserve.
+func (s *Server) readCacheSetEntryIfCurrent(key string, entry ttlEntry, ttl time.Duration, generation uint64) {
+	if s.readCache == nil {
+		return
+	}
+	c := s.readCache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.generation != generation {
+		return
+	}
+	entry.expiresAt = time.Now().Add(ttl)
+	c.data[key] = entry
+}

--- a/coordinator/api/chat_stream_relay.go
+++ b/coordinator/api/chat_stream_relay.go
@@ -1,0 +1,140 @@
+package api
+
+// chatStreamRelay is the per-request state of the chat-completions SSE relay:
+// the Responses-format detection latch, the held terminal usage/finish frames,
+// and the batch buffer that coalesced chunks are written into before one
+// Flush. handleChunk applies exactly the per-chunk pipeline the relay has
+// always applied, in the same order; only the write/flush granularity changed.
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+type chatStreamRelay struct {
+	pr *registry.PendingRequest
+
+	// w and flusher are the client sink every batch is written to, and stamps
+	// records each flush in the request profile. The relay owns them so that
+	// writeFrame can flush on its own when a batch reaches the byte cap.
+	w       http.ResponseWriter
+	flusher http.Flusher
+	stamps  *relayStamps
+
+	// sawResponsesAPI latches once a Responses API event is seen; from then on
+	// chat-completions-specific handling (DONE swallowing, usage/finish holds,
+	// normalizeSSEChunk, coordinator terminators) is skipped.
+	sawResponsesAPI bool
+
+	// pendingUsage is the held terminal include_usage chunk (parsed once); it
+	// is re-emitted at stream end with the provider's authoritative reasoning
+	// count spliced in. A zero-delta completion can make it the very first chunk.
+	pendingUsage map[string]any
+
+	// pendingFinish is the held chunk carrying the terminal finish_reason; the
+	// coordinator re-derives "length" from the authoritative token counts
+	// before forwarding it.
+	pendingFinish map[string]any
+
+	// buf accumulates the frames of one batch (each already framed with its
+	// trailing blank line) until flush writes them in one call; frames counts
+	// them so the relay stamps can keep chunks_out in SSE frames, not flushes.
+	// The batch is bounded by maxCoalescedBatchBytes (see writeFrame), and
+	// flush releases a backing array that grew past that bound.
+	buf    bytes.Buffer
+	frames int
+}
+
+func newChatStreamRelay(pr *registry.PendingRequest, w http.ResponseWriter, flusher http.Flusher, stamps *relayStamps) *chatStreamRelay {
+	return &chatStreamRelay{pr: pr, w: w, flusher: flusher, stamps: stamps}
+}
+
+// handleChunk runs one provider chunk through the relay pipeline: Responses
+// detection, provider-[DONE] swallowing, cache-detail/metadata stripping, the
+// usage and finish holds, null-field normalization, and the public-model
+// rewrite — appending the forwarded frame (if any) to the current batch.
+func (rl *chatStreamRelay) handleChunk(chunk string) {
+	if !rl.sawResponsesAPI && isResponsesAPIEventChunk(chunk) {
+		rl.sawResponsesAPI = true
+	}
+	// Swallow provider-owned [DONE] events, including SSE groups decorated
+	// with event/id/comment fields, while retaining any sibling event. The
+	// coordinator appends terminal events of its own (held usage with the
+	// reasoning breakdown, SE signature) and then emits exactly ONE [DONE] —
+	// forwarding the provider's produced a stream shaped
+	// `...usage, [DONE], signature, [DONE]`, and third-party SDKs treat the
+	// first [DONE] as final (MacPaw/OpenAI then chokes parsing the signature
+	// event).
+	if !rl.sawResponsesAPI {
+		chunk, _ = stripSSEDoneEvents(chunk)
+		if strings.TrimSpace(chunk) == "" {
+			return
+		}
+	}
+	chunk = stripProviderChatMetadata(sanitizeStreamCacheDetails(chunk))
+	if !rl.sawResponsesAPI {
+		// Hold the terminal usage chunk (chat completions only) so the
+		// reasoning breakdown can be spliced in at stream end; forwarding it
+		// inline would emit it without reasoning_tokens.
+		if obj, isUsage := parseUsageOnlyStreamChunk(chunk); isUsage {
+			rl.pendingUsage = obj
+			return
+		}
+		chunk = normalizeSSEChunk(chunk)
+		// Hold the chunk carrying the terminal finish_reason so it can be
+		// corrected to "length" against the authoritative token counts at
+		// stream end (the provider engine always reports "stop").
+		if obj, isFinish := parseFinishStreamChunk(chunk); isFinish {
+			rl.pendingFinish = obj
+			return
+		}
+	}
+	rl.writeFrame(rewriteChunkModel(chunk, rl.pr))
+}
+
+// writeFrame appends one SSE frame (a "data: ..." payload without its
+// trailing blank line) to the current batch. It is the only point at which
+// bytes enter buf, so the byte cap is enforced here and covers every drain
+// (the 32-chunk main-loop drain and the whole-channel drain ahead of a
+// provider error alike): when appending would push the batch past
+// maxCoalescedBatchBytes, the pending batch is flushed first. A single frame
+// larger than the cap is still written whole — the batch then holds exactly
+// that frame, the same peak the pre-coalescing per-chunk write had.
+func (rl *chatStreamRelay) writeFrame(frame string) {
+	if rl.buf.Len() > 0 && rl.buf.Len()+len(frame)+len("\n\n") > maxCoalescedBatchBytes {
+		rl.flush()
+	}
+	rl.buf.WriteString(frame)
+	rl.buf.WriteString("\n\n")
+	rl.frames++
+}
+
+// flush writes the batched frames, if any, in one call and flushes once,
+// recording the number of frames in the batch, the bytes the ResponseWriter
+// accepted and the write error through relayStamps.wroteFrames so the request
+// profile counts frames delivered and bytes actually accepted (a failed or
+// short write marks client_write_err) exactly as it did when every frame was
+// its own write. An empty batch neither writes nor flushes.
+//
+// A backing array that grew past maxCoalescedBatchBytes (an oversized frame,
+// or bytes.Buffer's doubling overshooting the cap) is released rather than
+// kept by Reset: a stream that once carried a large burst must not pin that
+// allocation for the rest of its life.
+func (rl *chatStreamRelay) flush() {
+	if rl.buf.Len() == 0 {
+		return
+	}
+	frames := rl.frames
+	n, err := rl.w.Write(rl.buf.Bytes())
+	if rl.buf.Cap() > maxCoalescedBatchBytes {
+		rl.buf = bytes.Buffer{}
+	} else {
+		rl.buf.Reset()
+	}
+	rl.frames = 0
+	rl.flusher.Flush()
+	rl.stamps.wroteFrames(frames, n, err)
+}

--- a/coordinator/api/chat_stream_relay_test.go
+++ b/coordinator/api/chat_stream_relay_test.go
@@ -1,0 +1,170 @@
+package api
+
+// Byte-cap tests for the chat relay's coalesced batch (chatStreamRelay.buf):
+// the batch is flushed before an append would push it past
+// maxCoalescedBatchBytes, a backing array that outgrew the cap is released
+// after the flush, and the consumer-visible byte stream is unchanged — the cap
+// only moves flush boundaries.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// capturingResponseWriter is countingResponseWriter plus the body itself and
+// the size of the largest single Write, so a test can pin both the bytes on
+// the wire and the batch size each write carried.
+type capturingResponseWriter struct {
+	countingResponseWriter
+	body     bytes.Buffer
+	maxWrite int
+}
+
+func newCapturingResponseWriter() *capturingResponseWriter {
+	return &capturingResponseWriter{countingResponseWriter: countingResponseWriter{header: make(http.Header)}}
+}
+
+func (w *capturingResponseWriter) Write(p []byte) (int, error) {
+	if len(p) > w.maxWrite {
+		w.maxWrite = len(p)
+	}
+	w.body.Write(p)
+	return w.countingResponseWriter.Write(p)
+}
+
+// Frames whose total exceeds the cap go out in batches no larger than the cap,
+// in order and byte-for-byte, the profile still counts every frame, and the
+// buffer that carried them does not keep a backing array larger than the cap.
+func TestChatStreamRelay_ByteCapFlushesBeforeAppendExceedsIt(t *testing.T) {
+	w := newCapturingResponseWriter()
+	rp := registry.NewRequestProfile(time.Now(), "c", nil, 0)
+	relay := newChatStreamRelay(&registry.PendingRequest{}, w, w, newRelayStamps(rp))
+
+	// 100 KiB frames against the 256 KiB cap: two fit, the third would
+	// overflow and forces the flush before it is appended.
+	frame := "data: " + strings.Repeat("x", 100<<10)
+	const n = 7
+	var want strings.Builder
+	for i := 0; i < n; i++ {
+		relay.writeFrame(frame)
+		want.WriteString(frame + "\n\n")
+	}
+	if w.flushes != 3 || w.writes != 3 {
+		t.Fatalf("after %d frames: %d writes / %d flushes, want 3 / 3 (two frames per batch, one pending)", n, w.writes, w.flushes)
+	}
+	relay.flush()
+	if w.flushes != 4 || w.writes != 4 {
+		t.Fatalf("final flush: %d writes / %d flushes, want 4 / 4", w.writes, w.flushes)
+	}
+	if w.body.String() != want.String() {
+		t.Fatalf("byte stream diverged: got %d bytes, want %d", w.body.Len(), want.Len())
+	}
+	if w.maxWrite > maxCoalescedBatchBytes {
+		t.Fatalf("largest write = %d bytes, exceeds the %d-byte cap", w.maxWrite, maxCoalescedBatchBytes)
+	}
+	if got := relay.buf.Cap(); got > maxCoalescedBatchBytes {
+		t.Fatalf("buffer retained %d bytes of capacity after the burst, want <= %d", got, maxCoalescedBatchBytes)
+	}
+	if rp.ChunksOut.Load() != n || rp.BytesOut.Load() != int64(want.Len()) {
+		t.Fatalf("profile chunks_out=%d bytes_out=%d, want %d / %d", rp.ChunksOut.Load(), rp.BytesOut.Load(), n, want.Len())
+	}
+}
+
+// A frame larger than the cap (a provider chunk near the 10 MiB read limit) is
+// still relayed intact as one write — after the pending batch — and the buffer
+// that held it is released rather than pinned for the rest of the stream.
+func TestChatStreamRelay_OversizedFrameIsWrittenWholeAndReleased(t *testing.T) {
+	w := newCapturingResponseWriter()
+	relay := newChatStreamRelay(&registry.PendingRequest{}, w, w, nil)
+
+	small := `data: {"a":1}`
+	big := "data: " + strings.Repeat("y", 2*maxCoalescedBatchBytes)
+	relay.writeFrame(small)
+	relay.writeFrame(big)
+	if w.writes != 1 || w.body.String() != small+"\n\n" {
+		t.Fatalf("the pending frame must be flushed ahead of an oversized one: writes=%d body=%q", w.writes, w.body.String())
+	}
+	relay.flush()
+	want := small + "\n\n" + big + "\n\n"
+	if w.writes != 2 || w.flushes != 2 || w.body.String() != want {
+		t.Fatalf("oversized frame: %d writes / %d flushes, body %d bytes; want 2 / 2 / %d", w.writes, w.flushes, w.body.Len(), len(want))
+	}
+	if w.maxWrite != len(big)+2 {
+		t.Fatalf("oversized frame was not written whole: largest write = %d, want %d", w.maxWrite, len(big)+2)
+	}
+	if got := relay.buf.Cap(); got != 0 {
+		t.Fatalf("buffer retained %d bytes of capacity after an oversized batch, want released", got)
+	}
+	// The relay keeps working on a fresh buffer.
+	relay.writeFrame(small)
+	relay.flush()
+	if w.body.String() != want+small+"\n\n" {
+		t.Fatalf("relay broken after releasing the buffer: %q", w.body.String())
+	}
+}
+
+// A prefilled burst of large chunks relayed through the chat streaming path
+// never puts more than maxCoalescedBatchBytes in one write, costs more flushes
+// than the chunk-count bound alone would allow (the byte cap engaged), and
+// yields exactly the byte stream per-chunk relaying produces: every content
+// chunk verbatim, the held finish chunk, and one [DONE].
+func TestStreamRelay_ChatLargeBurstFlushesAtByteCap(t *testing.T) {
+	const n = 40
+	payload := strings.Repeat("z", 64<<10)
+	s := newRelayBenchServer()
+	pr := &registry.PendingRequest{
+		RequestID:  "large-burst",
+		Model:      burstTestModel,
+		ChunkCh:    make(chan registry.ProviderChunk, n+8),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	var want strings.Builder
+	for i := 0; i < n; i++ {
+		chunk := chatContentChunk(payload + strconv.Itoa(i))
+		pr.ChunkCh <- registry.ProviderChunk{Data: chunk}
+		want.WriteString(chunk + "\n\n")
+	}
+	pr.ChunkCh <- registry.ProviderChunk{Data: chatFinishChunk("stop")}
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 10, CompletionTokens: n}
+	close(pr.CompleteCh)
+	// The held finish chunk, re-emitted at stream end (finish_reason preserved:
+	// no max_tokens bound), then exactly one terminator.
+	want.WriteString(`data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1700000000,"id":"chatcmpl-1","model":"` +
+		burstTestModel + `","object":"chat.completion.chunk"}` + "\n\n")
+	want.WriteString("data: [DONE]\n\n")
+
+	w := newCapturingResponseWriter()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	s.handleStreamingResponseWithFirstChunkAndError(w, r, pr, nil, nil)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d", w.status)
+	}
+	if got := w.body.String(); got != want.String() {
+		t.Fatalf("SSE stream diverged from per-chunk relaying: got %d bytes / %d events, want %d bytes / %d events",
+			len(got), len(sseEvents([]byte(got))), want.Len(), len(sseEvents([]byte(want.String()))))
+	}
+	if w.maxWrite > maxCoalescedBatchBytes {
+		t.Fatalf("largest write = %d bytes, exceeds the %d-byte cap", w.maxWrite, maxCoalescedBatchBytes)
+	}
+	// Count-only coalescing would fit n+1 frames in ceil((n+1)/32) batches;
+	// the byte cap must have split them further.
+	countOnlyFlushes := (n+1+maxCoalescedChunks-1)/maxCoalescedChunks + 2
+	if w.flushes <= countOnlyFlushes {
+		t.Fatalf("flushes = %d, want more than the count-only bound %d (byte cap did not engage)", w.flushes, countOnlyFlushes)
+	}
+	if minFlushes := want.Len() / maxCoalescedBatchBytes; w.flushes < minFlushes {
+		t.Fatalf("flushes = %d, fewer than the %d batches %d bytes need at the cap", w.flushes, minFlushes, want.Len())
+	}
+}

--- a/coordinator/api/code_attest_cached_store_test.go
+++ b/coordinator/api/code_attest_cached_store_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// main.go wraps the backend in store.CachedStore, whose static Store method
+// set hides the optional codeAttestPushBudgetStore capability from a direct
+// type assertion. These tests run the durable reserve, clear and restart-seed
+// paths over NewCached(NewMemory(...)) exactly as the bare-store tests do, and
+// first prove the wrapped shape is what is under test.
+func newCachedCodeAttestStore(t *testing.T) *store.CachedStore {
+	t.Helper()
+	cached := store.NewCached(store.NewMemory(store.Config{}), store.CacheConfig{})
+	if _, direct := any(cached).(codeAttestPushBudgetStore); direct {
+		t.Fatal("direct assertion on CachedStore succeeded; this test no longer exercises the wrapped path")
+	}
+	if _, ok := store.As[codeAttestPushBudgetStore](cached); !ok {
+		t.Fatal("store.As cannot find codeAttestPushBudgetStore through CachedStore")
+	}
+	return cached
+}
+
+func TestCodeAttestDurableReservationThroughCachedStore(t *testing.T) {
+	cached := newCachedCodeAttestStore(t)
+	th := newCodeAttestThrottle()
+	th.store = cached
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	th.now = func() time.Time { return now }
+
+	generation := th.beginLoop("se-cached")
+	if !th.tryReservePush(context.Background(), "se-cached", "token", false, generation) {
+		t.Fatal("first push not admitted over the cached store")
+	}
+	budgets, _ := store.As[codeAttestPushBudgetStore](cached)
+	rows, err := budgets.ListCodeAttestPushBudgets(context.Background())
+	if err != nil || len(rows) != 2 { // token row + admission-floor sentinel
+		t.Fatalf("durable reservation missing over cached store: rows=%+v err=%v", rows, err)
+	}
+	for _, row := range rows {
+		if !row.NextPushAt.After(now) {
+			t.Fatalf("non-future reservation window persisted: %+v", row)
+		}
+	}
+
+	// The durable row, not just in-memory state, blocks a second instance.
+	other := newCodeAttestThrottle()
+	other.store = cached
+	other.now = th.now
+	if other.tryReservePush(context.Background(), "se-cached", "token", false, other.beginLoop("se-cached")) {
+		t.Fatal("second instance re-spent a budget the durable store already holds")
+	}
+}
+
+func TestCodeAttestDurableClearThroughCachedStore(t *testing.T) {
+	cached := newCachedCodeAttestStore(t)
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	first := newCodeAttestThrottle()
+	first.store = cached
+	first.now = func() time.Time { return now }
+	if !first.clearPushBudget(context.Background(), "se-clear") {
+		t.Fatal("first rotation clear rejected over the cached store")
+	}
+
+	// A fresh instance (empty in-memory state) sharing the store must see
+	// the durably spent clear window and refuse.
+	second := newCodeAttestThrottle()
+	second.store = cached
+	second.now = first.now
+	if second.clearPushBudget(context.Background(), "se-clear") {
+		t.Fatal("durable clear cooldown not honored through the cached store")
+	}
+}
+
+func TestCodeAttestSeedRestoresDurableBudgetsThroughCachedStore(t *testing.T) {
+	cached := newCachedCodeAttestStore(t)
+	now := time.Now().UTC()
+	next := now.Add(time.Hour)
+	tokenHash := codeAttestTokenHash("token-1")
+	budgets, _ := store.As[codeAttestPushBudgetStore](cached)
+	if ok, err := budgets.ReserveCodeAttestPushBudget(context.Background(), "se-seed", tokenHash, now, next); err != nil || !ok {
+		t.Fatalf("pre-restart reservation: ok=%v err=%v", ok, err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := NewServer(registry.New(logger), cached, ServerConfig{}, logger)
+	t.Cleanup(srv.Close)
+	srv.SeedCodeAttestCache(context.Background())
+
+	th := srv.codeAttestThrottle
+	th.mu.Lock()
+	seeded, ok := th.durableNextPush[codeAttestPushBudgetKey("se-seed", tokenHash)]
+	th.mu.Unlock()
+	if !ok || !seeded.Equal(next) {
+		t.Fatalf("restart seed over cached store: durableNextPush = %v (present=%v), want %v", seeded, ok, next)
+	}
+	if th.tryReservePush(context.Background(), "se-seed", "token-1", false, th.beginLoop("se-seed")) {
+		t.Fatal("seeded durable budget did not block an immediate re-push")
+	}
+}

--- a/coordinator/api/code_attest_throttle.go
+++ b/coordinator/api/code_attest_throttle.go
@@ -467,7 +467,7 @@ func (t *codeAttestThrottle) reservePush(
 	}
 	reservationCooldown := max(cooldown, time.Nanosecond)
 	next := now.Add(reservationCooldown)
-	st, hasDurableBudget := t.store.(codeAttestPushBudgetStore)
+	st, hasDurableBudget := store.As[codeAttestPushBudgetStore](t.store)
 	t.mu.Unlock()
 
 	if hasDurableBudget {
@@ -571,7 +571,7 @@ func (t *codeAttestThrottle) clearPushBudgetReservationHeld(
 		t.mu.Unlock()
 		return false
 	}
-	st, hasDurable := t.store.(codeAttestPushBudgetStore)
+	st, hasDurable := store.As[codeAttestPushBudgetStore](t.store)
 	cooldown := t.budgetClearCooldown
 	t.mu.Unlock()
 
@@ -880,7 +880,7 @@ func (s *Server) SeedCodeAttestCache(ctx context.Context) {
 	} else if n := s.codeAttestThrottle.seed(rows); n > 0 {
 		s.logger.Info("code-attest: seeded reuse cache from persisted records (survives deploys)", "records", n)
 	}
-	if st, ok := s.store.(codeAttestPushBudgetStore); ok {
+	if st, ok := store.As[codeAttestPushBudgetStore](s.store); ok {
 		budgets, err := st.ListCodeAttestPushBudgets(ctx)
 		if err != nil {
 			s.logger.Warn("code-attest: failed to seed durable push budgets", "error", err)

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1341,6 +1341,12 @@ func bodyForProvider(rawBody []byte, requiresVision bool, provider *registry.Pro
 	if provider.Version != "" && !semverLess(provider.Version, penaltySafeProviderVersion) {
 		return rawBody // fixed provider — pass penalties through
 	}
+	// A body carrying none of the penalty fields at its top level is returned
+	// unchanged without decoding it — the same outcome the decode path reaches
+	// through changed=false, minus a full-body parse per sizing probe.
+	if has, ok := topLevelObjectHasAnyKey(rawBody, visionPenaltyFields); ok && !has {
+		return rawBody
+	}
 	parsed, err := decodeInferenceJSONObject(rawBody)
 	if err != nil {
 		return rawBody
@@ -1392,17 +1398,9 @@ func legacyCacheBustBodyBytes(
 	if provider == nil {
 		return 0, nil
 	}
-	sizingPR := &registry.PendingRequest{
-		LegacyCacheBustKey: strings.Repeat("x", registry.LegacyCacheBustKeyLength),
-	}
-	_, err := bodyForCacheAttempt(rawBody, requiresVision, provider, sizingPR)
-	if err == nil {
-		return 0, nil
-	}
-	if errors.Is(err, errProviderBodyTooLarge) {
-		return oversizedProviderBodyBytes(err), err
-	}
-	return 0, err
+	return cacheAttemptSizeError(
+		bodyForProvider(rawBody, requiresVision, provider),
+		strings.Repeat("x", registry.LegacyCacheBustKeyLength))
 }
 
 func providerBodySizeError(
@@ -1413,22 +1411,15 @@ func providerBodySizeError(
 	if provider == nil {
 		return 0, nil
 	}
-	sizingPR := &registry.PendingRequest{}
 	provider.Mu().Lock()
 	usesLegacyCacheBust := provider.PrefixCacheProtocol < 1
 	provider.Mu().Unlock()
+	legacyKey := ""
 	if usesLegacyCacheBust {
-		sizingPR.LegacyCacheBustKey = strings.Repeat(
-			"x", registry.LegacyCacheBustKeyLength)
+		legacyKey = strings.Repeat("x", registry.LegacyCacheBustKeyLength)
 	}
-	_, err := bodyForCacheAttempt(rawBody, requiresVision, provider, sizingPR)
-	if err == nil {
-		return 0, nil
-	}
-	if errors.Is(err, errProviderBodyTooLarge) {
-		return oversizedProviderBodyBytes(err), err
-	}
-	return 0, err
+	return cacheAttemptSizeError(
+		bodyForProvider(rawBody, requiresVision, provider), legacyKey)
 }
 
 func minimumLegacyCacheBustOverflow(rawBody []byte, requiresVision bool) (int, error) {
@@ -1465,6 +1456,10 @@ func exhaustedProviderPreparationError(
 	return providerBodyOverflowErr
 }
 
+// bodyForCacheAttempt returns the body to seal for one dispatch attempt: the
+// provider-specific body (bodyForProvider) with the protocol-0 cache-bust key
+// added as prompt_cache_key when the attempt carries one, size-checked
+// against the sealed-frame cap.
 func bodyForCacheAttempt(rawBody []byte, requiresVision bool, provider *registry.Provider, pr *registry.PendingRequest) ([]byte, error) {
 	body := bodyForProvider(rawBody, requiresVision, provider)
 	if pr == nil || pr.LegacyCacheBustKey == "" {
@@ -1473,18 +1468,15 @@ func bodyForCacheAttempt(rawBody []byte, requiresVision bool, provider *registry
 		}
 		return body, nil
 	}
-	var parsed map[string]json.RawMessage
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return nil, err
-	}
 	keyJSON, err := json.Marshal(pr.LegacyCacheBustKey)
 	if err != nil {
 		return nil, err
 	}
-	parsed["prompt_cache_key"] = keyJSON
-	sealed, err := marshalForwardBody(parsed)
-	if err != nil {
-		return nil, err
+	sealed, ok := spliceTopLevelMember(body, legacyCacheBustField, keyJSON)
+	if !ok {
+		if sealed, err = sealLegacyCacheBust(body, keyJSON); err != nil {
+			return nil, err
+		}
 	}
 	if len(sealed) > maxInferenceBodyBytes {
 		return nil, &providerBodyTooLargeError{size: len(sealed)}
@@ -1772,7 +1764,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	rawBody := prelude.rawBody
+	// body is the provider-bound request: every rewrite below mutates
+	// body.parsed (== parsed) and marks it dirty; the bytes are serialized ONCE,
+	// at the single serialization point ahead of the first consumer of the
+	// provider body. originalRawBody stays the caller's untouched input.
+	body := &prelude.body
 	originalRawBody := prelude.originalRawBody
 	parsed := prelude.parsed
 	model := prelude.model
@@ -1818,12 +1814,11 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var allowedProviderSerials []string
-	stripped := stripProviderRoutingFields(parsed)
-	if applyMetadataDetailsRequest(r, parsed) {
-		stripped = true
+	if stripProviderRoutingFields(parsed) {
+		body.markDirty()
 	}
-	if stripped {
-		rawBody, _ = marshalForwardBody(parsed)
+	if applyMetadataDetailsRequest(r, parsed) {
+		body.markDirty()
 	}
 
 	// "Use my own machine, for free" opt-in. The signal is the
@@ -1833,13 +1828,14 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// coordinator-stamped provider AccountID, so nothing here is forgeable.
 	policy := s.resolveSelfRoutePolicy(r)
 
-	// Derive request-shape traits before alias resolution. During a
-	// mixed-version rollout Desired may have ordinary providers while Previous
-	// has the only provider capable of enforcing this exact tool policy.
-	requiresVision := detectMediaRequirement(parsed)
-	hasTools := requestHasTools(parsed)
 	isResponsesAPI := input != nil && len(messages) == 0
-	constraintBody := originalRawBody
+	// Tool-constraint validation must judge the PRE-normalization tools (a
+	// normalization marker in the caller's body is forged). On the chat surface
+	// that is the parsed map with the caller's original tools restored; the
+	// Responses surface needs the input→chat lowering, which works on bytes, so
+	// the untouched input is lowered and parsed once.
+	var validatedPolicy validatedToolConstraintPolicy
+	var validationErr error
 	if isResponsesAPI {
 		loweredConstraintBody, err := promptcontract.LowerProviderBody(
 			promptcontract.EndpointResponses, originalRawBody)
@@ -1848,14 +1844,26 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				"invalid_request_error", err.Error()))
 			return
 		}
-		constraintBody = loweredConstraintBody
+		validatedPolicy, validationErr = validateToolConstraintPolicy(loweredConstraintBody)
+	} else {
+		validatedPolicy, validationErr = validateParsedToolConstraintPolicy(
+			constraintView(parsed, prelude.originalTools))
 	}
-	validatedPolicy, validationErr := validateToolConstraintPolicy(constraintBody)
 	if validationErr != nil {
 		s.recordToolConstraintMetric(validatedPolicy.mode, "compile_rejection")
 		writeToolConstraintValidationError(w, validationErr)
 		return
 	}
+	// Derive request-shape traits before alias resolution. During a
+	// mixed-version rollout Desired may have ordinary providers while Previous
+	// has the only provider capable of enforcing this exact tool policy. One
+	// walk of the message tree yields the media count, the tools flag, and the
+	// routing/billing token estimates (consumed below, after the rewrites). It
+	// runs after constraint validation so a rejected tool policy on a large
+	// body never pays the walk.
+	shape := introspectRequest(parsed)
+	requiresVision := shape.requiresVision()
+	hasTools := shape.hasTools
 	validatedMode := validatedPolicy.mode
 	toolChoiceName := validatedPolicy.name
 	parallelToolCalls := validatedPolicy.parallel
@@ -1881,8 +1889,8 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// the pick only considers builds the constrained provider set can actually
 	// serve. From here on `model` is the build (routing/billing/serving) while
 	// `publicModel` is echoed back so the consumer never sees the quant.
-	buildModel, publicModel, resolvedBody, ok := s.resolveRequestedModel(
-		parsed, rawBody, model, allowedProviderSerials, policy, aliasTraits)
+	buildModel, publicModel, modelRewritten, ok := s.resolveRequestedBuild(
+		parsed, model, allowedProviderSerials, policy, aliasTraits)
 	if !ok {
 		s.recordRejection(rejectionInfo{
 			r:               r,
@@ -1898,18 +1906,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("model %q has no available build right now", model), withParam("model")))
 		return
 	}
-	model, rawBody = buildModel, resolvedBody
+	model = buildModel
+	if modelRewritten {
+		body.markDirty()
+	}
 	user := auth.UserFromContext(r.Context())
 	serviceChatConsumer := r.URL.Path == "/v1/chat/completions" &&
 		user != nil && user.Role == store.RoleService
-	preparedBody, _, err := applyResolvedModelReasoningPolicy(
-		parsed, rawBody, model, serviceChatConsumer, reasoningProvided)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, errorResponse(
-			"server_error", "failed to prepare inference request"))
-		return
+	if applyResolvedModelReasoningPolicy(parsed, model, serviceChatConsumer, reasoningProvided) {
+		body.markDirty()
 	}
-	rawBody = preparedBody
 
 	// Shared media/tools fail-fast. Chat completions additionally rejects media
 	// sent via the Responses API surface (input-without-messages), because the
@@ -1943,7 +1949,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		profileDBCall(rp, registryReadStart)
 		resolvedRuntimeParameters = rec.RuntimeParameters
 		if runtimeDefaults.apply(parsed, rec.RuntimeParameters) {
-			rawBody, _ = marshalForwardBody(parsed)
+			body.markDirty()
 		}
 		// Use the registry's max_output_length as the default max_tokens
 		// bound instead of the hardcoded 8192. This lets models like
@@ -1970,12 +1976,12 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// silent post-inference charge failure would hand the consumer free
 	// inference (GitHub issue #33).
 	if ensureMaxTokensBound(parsed, isResponsesAPI, maxOutputBound) {
-		rawBody, _ = marshalForwardBody(parsed)
+		body.markDirty()
 	}
 
 	stream, _ := parsed["stream"].(bool)
-	estimatedPromptTokens := estimatePromptTokens(parsed)
-	billingPromptTokens := estimateBillingPromptTokens(parsed)
+	estimatedPromptTokens := shape.routingPromptTokens(parsed)
+	billingPromptTokens := shape.billingPromptTokens(parsed)
 	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
 	deadline := s.FirstContentDeadline(model, estimatedPromptTokens)
 	timing.ParsedAt = time.Now()
@@ -1984,6 +1990,16 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Single serialization point: every rewrite above (stop, stripped fields,
+	// alias, reasoning policy, runtime defaults, max_tokens) landed in parsed;
+	// serialize once here — or hand the caller's exact bytes through when
+	// nothing changed.
+	rawBody, err := body.current()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse(
+			"server_error", "failed to prepare inference request"))
+		return
+	}
 	providerBody := rawBody
 	if isResponsesAPI {
 		loweredProviderBody, err := promptcontract.LowerProviderBody(promptcontract.EndpointResponses, rawBody)
@@ -2009,57 +2025,34 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		}
 		providerBody = loweredProviderBody
 	}
-	providerBodyForModel := func(candidateModel string) ([]byte, error) {
-		candidateParsed := make(map[string]any, len(parsed))
-		for key, value := range parsed {
-			candidateParsed[key] = value
-		}
-		candidateParsed["model"] = candidateModel
-		candidateDefaults := runtimeDefaults
-		if rec, err := s.store.GetModelRegistryRecord(candidateModel); err == nil {
-			candidateDefaults.apply(candidateParsed, rec.RuntimeParameters)
-		} else {
-			candidateDefaults.apply(candidateParsed, nil)
-		}
-		candidateBody, marshalErr := marshalForwardBody(candidateParsed)
-		if marshalErr == nil {
-			candidateBody, _, marshalErr = applyResolvedModelReasoningPolicy(
-				candidateParsed, candidateBody, candidateModel, serviceChatConsumer, reasoningProvided)
-		}
-		if marshalErr == nil && isResponsesAPI {
-			candidateBody, marshalErr = promptcontract.LowerProviderBody(
-				promptcontract.EndpointResponses, candidateBody)
-		}
-		return candidateBody, marshalErr
+	// Candidate provider bodies (the resolved build, the alias fallback build
+	// the preflight probes) and the routing verdicts derived from them are
+	// memoized per request: traits, the protocol-0 size verdict, and dispatch
+	// all reuse one serialization per candidate. When the body above is the
+	// coordinator's own serialization, the resolved build is seeded with it —
+	// parsed is fully reconciled for that build, so a rebuild would produce the
+	// same bytes. A verbatim caller body is NOT a substitute (its whitespace,
+	// key order and escapes differ from the serialized form the size verdicts
+	// have always measured), so that rare case builds its candidate as before.
+	bodies := newProviderBodyMemo(func(candidateModel string) ([]byte, error) {
+		return s.candidateProviderBody(parsed, runtimeDefaults, candidateModel,
+			serviceChatConsumer, reasoningProvided, isResponsesAPI)
+	}, hasTools, requiresVision)
+	if body.serialized {
+		bodies.seed(model, providerBody)
 	}
 	routingTraitsForModel := func(candidateModel string) registry.RequestTraits {
-		candidateBody, bodyErr := providerBodyForModel(candidateModel)
-		if bodyErr != nil {
-			return registry.RequestTraits{
-				HasTools:               hasTools,
-				RequiresToolConstraint: requiresToolConstraint,
-				ToolChoiceMode:         string(validatedMode),
-				ToolChoiceName:         toolChoiceName,
-				ParallelToolCalls:      parallelToolCalls,
-			}
+		traits, ok := bodies.traits(candidateModel)
+		if !ok {
+			traits = registry.RequestTraits{HasTools: hasTools}
 		}
-		traits, _ := routingTraitsForProviderBody(
-			hasTools, candidateBody, requiresVision)
 		traits.RequiresToolConstraint = requiresToolConstraint
 		traits.ToolChoiceMode = string(validatedMode)
 		traits.ToolChoiceName = toolChoiceName
 		traits.ParallelToolCalls = parallelToolCalls
 		return traits
 	}
-	providerBodyErrorForModel := func(candidateModel string) error {
-		candidateBody, bodyErr := providerBodyForModel(candidateModel)
-		if bodyErr != nil {
-			return nil
-		}
-		_, sizeErr := routingTraitsForProviderBody(
-			hasTools, candidateBody, requiresVision)
-		return sizeErr
-	}
+	providerBodyErrorForModel := bodies.sizeError
 	routingTraits := routingTraitsForModel(model)
 
 	// Per-account token rate limiting (ITPM/OTPM) — the industry-standard
@@ -2156,14 +2149,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// refreshForwardBody re-derives every view of the provider-bound request from
 	// a freshly marshaled `parsed`: the threaded rawBody, the body actually
 	// forwarded to the provider (re-lowered input→chat on the Responses surface,
-	// which can itself fail with a 400), and the routing traits computed from it.
-	// Any in-place mutation of `parsed` MUST go through it — an alias fallback
-	// rewriting the model, or remote media being inlined as data: URIs. Returns
-	// false after writing a terminal response.
-	refreshForwardBody := func(body []byte, forModel string) bool {
-		rawBody = body
+	// which can itself fail with a 400), the memoized candidate bodies (every
+	// earlier candidate described a parsed that no longer exists), and the
+	// routing traits computed from it. Any in-place mutation of `parsed` MUST go
+	// through it — an alias fallback rewriting the model, or remote media being
+	// inlined as data: URIs. Returns false after writing a terminal response.
+	refreshForwardBody := func(forwardBytes []byte, forModel string) bool {
+		rawBody = forwardBytes
+		body.replace(forwardBytes)
+		bodies.reset()
 		if !isResponsesAPI {
 			providerBody = rawBody
+			bodies.seed(forModel, providerBody)
 			routingTraits = routingTraitsForModel(forModel)
 			return true
 		}
@@ -2190,6 +2187,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
 			return false
 		}
+		bodies.seed(forModel, providerBody)
 		routingTraits = routingTraitsForModel(forModel)
 		return true
 	}
@@ -2249,10 +2247,18 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			refundReservation()
 			return false
 		}
-		body, _ := marshalForwardBody(parsed)
-		body, _, _ = applyResolvedModelReasoningPolicy(
-			parsed, body, newModel, serviceChatConsumer, reasoningProvided)
-		return refreshForwardBody(body, newModel)
+		applyResolvedModelReasoningPolicy(parsed, newModel, serviceChatConsumer, reasoningProvided)
+		// maybeFallbackAlias rewrote parsed["model"]; the defaults and reasoning
+		// policy above may have moved more. One serialization covers all of it.
+		body.markDirty()
+		forwardBytes, err := body.current()
+		if err != nil {
+			refundReservation()
+			writeJSON(w, http.StatusInternalServerError, errorResponse(
+				"server_error", "failed to prepare inference request"))
+			return false
+		}
+		return refreshForwardBody(forwardBytes, newModel)
 	}
 	var preflightHandled bool
 	preflightStart := time.Now()
@@ -2345,7 +2351,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		estimatedPromptTokens:  estimatedPromptTokens,
 		requestedMaxTokens:     requestedMaxTokens,
 		requiresVision:         requiresVision,
-		visionImageCount:       countMediaParts(parsed),
+		visionImageCount:       shape.mediaParts,
 		hasTools:               hasTools,
 		requiresToolConstraint: requiresToolConstraint,
 		toolChoiceMode:         string(validatedMode),
@@ -2405,60 +2411,21 @@ func (s *Server) handleStreamingResponseWithFirstChunkAndError(
 	flusher.Flush()
 	rs := newRelayStamps(pr.Profile.Parent())
 
-	// Detect Responses API format to skip appending chat-completions-style
-	// termination events (SE signature chunk + [DONE]).
-	sawResponsesAPI := false
-
-	// The terminal include_usage chunk lacks the reasoning breakdown; we hold its
-	// parsed object and re-emit it at stream end with the provider's authoritative
-	// reasoning count (CompleteCh) spliced in — matching the non-streaming/Responses
-	// paths. Held as a parsed map so it is decoded exactly once. Declared before the
-	// first-chunk write because a zero-delta completion (empty/filtered output) can
-	// make the include_usage frame the very first chunk.
-	var pendingUsage map[string]any
-
-	// The chunk carrying the terminal finish_reason is held the same way: the
-	// provider engine reports "stop" even when generation hit the max-tokens
-	// bound, so the coordinator re-derives "length" from the authoritative
-	// token counts (CompleteCh) before forwarding it.
-	var pendingFinish map[string]any
+	// Per-request relay state: the Responses-format latch, the held terminal
+	// usage/finish frames, and the batch buffer. Every chunk — the ones already
+	// consumed during dispatch and the ones relayed below — goes through the
+	// same relay.handleChunk pipeline (see chat_stream_relay.go).
+	relay := newChatStreamRelay(pr, w, flusher, rs)
 
 	// Write the chunks that were already consumed during dispatch (held
-	// preamble first, then the committing content chunk), each through the
-	// same per-chunk special-casing the relay loop below applies.
+	// preamble first, then the committing content chunk).
 	for _, firstChunk := range firstChunks {
 		if firstChunk == "" {
 			continue
 		}
-		if isResponsesAPIEventChunk(firstChunk) {
-			sawResponsesAPI = true
-		}
-		if !sawResponsesAPI {
-			firstChunk, _ = stripSSEDoneEvents(firstChunk)
-			if strings.TrimSpace(firstChunk) == "" {
-				continue
-			}
-		}
-		firstChunk = stripProviderChatMetadata(sanitizeStreamCacheDetails(firstChunk))
-		// A usage-only first chunk (no content/reasoning deltas streamed before it)
-		// is still terminal usage — hold it so the reasoning breakdown is spliced in
-		// at stream end instead of being emitted raw without reasoning_tokens.
-		if obj, isUsage := parseUsageOnlyStreamChunk(firstChunk); !sawResponsesAPI && isUsage {
-			pendingUsage = obj
-		} else {
-			if !sawResponsesAPI {
-				firstChunk = normalizeSSEChunk(firstChunk)
-			}
-			if obj, isFinish := parseFinishStreamChunk(firstChunk); !sawResponsesAPI && isFinish {
-				pendingFinish = obj
-			} else {
-				firstChunk = rewriteChunkModel(firstChunk, pr)
-				n, werr := fmt.Fprintf(w, "%s\n\n", firstChunk)
-				flusher.Flush()
-				rs.wrote(n, werr)
-			}
-		}
+		relay.handleChunk(firstChunk)
 	}
+	relay.flush()
 	if initialError != nil {
 		s.writeChatStreamProviderError(w, flusher, pr, *initialError)
 		return
@@ -2469,156 +2436,132 @@ func (s *Server) handleStreamingResponseWithFirstChunkAndError(
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
 
+	// finishStream runs once ChunkCh is observed closed — on the blocking
+	// receive or while draining already-queued chunks (after those were
+	// flushed): surface a trailing provider error, refund an incomplete stream,
+	// or emit the held finish/usage frames and the single [DONE].
+	finishStream := func() {
+		select {
+		case errMsg, ok := <-pr.ErrorCh:
+			if ok && errMsg.Error != "" {
+				s.writeChatStreamProviderError(w, flusher, pr, errMsg)
+				return
+			}
+		default:
+		}
+		if s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID) {
+			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_incomplete"})
+			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
+			s.writeChatStreamTerminalError(
+				w, flusher, pr, "provider_error", "provider ended without completion")
+			return
+		}
+		// Channel closed — inference complete.
+		s.noteInferenceSuccess(pr)
+		// For Responses API streams, the provider already sent
+		// "response.completed" as the terminal event. Adding
+		// extra chunks would break SDK parsers.
+		if relay.sawResponsesAPI {
+			return
+		}
+		// Emit the held finish/usage chunks with the authoritative token
+		// counts (CompleteCh) spliced in: the finish chunk gets its
+		// finish_reason corrected to "length" when generation hit the
+		// max-tokens bound, and the usage chunk gets the reasoning
+		// breakdown. This select runs once, at stream end: the provider's
+		// inferenceComplete (which populates CompleteCh) is what ends the
+		// stream, so it is effectively already buffered — the timeout is a
+		// fallback, not a hot-path wait.
+		var usage protocol.UsageInfo
+		if relay.pendingUsage != nil || relay.pendingFinish != nil {
+			select {
+			case u, uok := <-pr.CompleteCh:
+				if uok {
+					usage = u
+				}
+			case <-time.After(2 * time.Second):
+			case <-r.Context().Done():
+			}
+		}
+		if relay.pendingFinish != nil {
+			if out := finalizeFinishChunk(relay.pendingFinish, usage, pr); out != "" {
+				relay.writeFrame(out)
+			}
+		}
+		if relay.pendingUsage != nil {
+			// Ride the SE signature on the held usage chunk (a complete,
+			// well-formed chat.completion.chunk) instead of emitting a
+			// separate bare event that strict SDK parsers reject.
+			if pr.SESignature != "" {
+				relay.pendingUsage["se_signature"] = pr.SESignature
+				relay.pendingUsage["response_hash"] = pr.ResponseHash
+			}
+			attachChatCompletionMetadata(relay.pendingUsage, pr)
+			if out := finalizeUsageChunk(relay.pendingUsage, usage, pr); out != "" {
+				relay.writeFrame(out)
+			}
+		} else if pr.SESignature != "" || hasChatCompletionMetadata(pr) {
+			// No held usage chunk to ride on: emit the signature and/or
+			// opt-in metadata as a fully-shaped chat.completion.chunk
+			// (id/object/created/model/choices) so strict decoders parse
+			// it; the extra fields are additive. It precedes the single
+			// [DONE] below.
+			event := newChatCompletionExtrasEvent(pr)
+			if pr.SESignature != "" {
+				event["se_signature"] = pr.SESignature
+				event["response_hash"] = pr.ResponseHash
+			}
+			attachChatCompletionMetadata(event, pr)
+			sigEvent, _ := json.Marshal(event)
+			relay.writeFrame("data: " + string(sigEvent))
+		}
+		// Exactly one terminator, after every coordinator-appended event. The
+		// terminal frames normally reach the wire together in one flush (the
+		// relay splits a batch only at maxCoalescedBatchBytes).
+		relay.writeFrame("data: [DONE]")
+		relay.flush()
+		rs.done()
+	}
+
+	// relayChunk forwards one provider chunk. Every chunk is a liveness
+	// signal — re-arm the idle timeout up front, before deciding whether to
+	// forward or hold it, so holding the terminal usage chunk still resets
+	// the window that bounds the wait for the provider's inference_complete
+	// (which closes ChunkCh after billing).
+	relayChunk := func(chunk registry.ProviderChunk) {
+		resetIdleTimer(timer, inferenceTimeout)
+		relay.handleChunk(chunk.Data)
+	}
+
 	for {
 		select {
 		case providerChunk, ok := <-pr.ChunkCh:
 			if !ok {
-				select {
-				case errMsg, ok := <-pr.ErrorCh:
-					if ok && errMsg.Error != "" {
-						s.writeChatStreamProviderError(w, flusher, pr, errMsg)
-						return
-					}
-				default:
-				}
-				if s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID) {
-					s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_incomplete"})
-					s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
-					s.writeChatStreamTerminalError(
-						w, flusher, pr, "provider_error", "provider ended without completion")
-					return
-				}
-				// Channel closed — inference complete.
-				s.noteInferenceSuccess(pr)
-				// For Responses API streams, the provider already sent
-				// "response.completed" as the terminal event. Adding
-				// extra chunks would break SDK parsers.
-				if !sawResponsesAPI {
-					// Emit the held finish/usage chunks with the authoritative token
-					// counts (CompleteCh) spliced in: the finish chunk gets its
-					// finish_reason corrected to "length" when generation hit the
-					// max-tokens bound, and the usage chunk gets the reasoning
-					// breakdown. This select runs once, at stream end: the provider's
-					// inferenceComplete (which populates CompleteCh) is what ends the
-					// stream, so it is effectively already buffered — the timeout is a
-					// fallback, not a hot-path wait.
-					var usage protocol.UsageInfo
-					if pendingUsage != nil || pendingFinish != nil {
-						select {
-						case u, uok := <-pr.CompleteCh:
-							if uok {
-								usage = u
-							}
-						case <-time.After(2 * time.Second):
-						case <-r.Context().Done():
-						}
-					}
-					if pendingFinish != nil {
-						if out := finalizeFinishChunk(pendingFinish, usage, pr); out != "" {
-							fmt.Fprintf(w, "%s\n\n", out)
-							flusher.Flush()
-						}
-					}
-					if pendingUsage != nil {
-						// Ride the SE signature on the held usage chunk (a complete,
-						// well-formed chat.completion.chunk) instead of emitting a
-						// separate bare event that strict SDK parsers reject.
-						if pr.SESignature != "" {
-							pendingUsage["se_signature"] = pr.SESignature
-							pendingUsage["response_hash"] = pr.ResponseHash
-						}
-						attachChatCompletionMetadata(pendingUsage, pr)
-						if out := finalizeUsageChunk(pendingUsage, usage, pr); out != "" {
-							fmt.Fprintf(w, "%s\n\n", out)
-							flusher.Flush()
-						}
-					} else if pr.SESignature != "" || hasChatCompletionMetadata(pr) {
-						// No held usage chunk to ride on: emit the signature and/or
-						// opt-in metadata as a fully-shaped chat.completion.chunk
-						// (id/object/created/model/choices) so strict decoders parse
-						// it; the extra fields are additive. It precedes the single
-						// [DONE] below.
-						event := newChatCompletionExtrasEvent(pr)
-						if pr.SESignature != "" {
-							event["se_signature"] = pr.SESignature
-							event["response_hash"] = pr.ResponseHash
-						}
-						attachChatCompletionMetadata(event, pr)
-						sigEvent, _ := json.Marshal(event)
-						n, werr := fmt.Fprintf(w, "data: %s\n\n", sigEvent)
-						flusher.Flush()
-						rs.wrote(n, werr)
-					}
-					// Exactly one terminator, after every coordinator-appended event.
-					n, werr := fmt.Fprint(w, "data: [DONE]\n\n")
-					flusher.Flush()
-					rs.wrote(n, werr)
-					rs.done()
-				}
+				finishStream()
 				return
 			}
-			chunk := providerChunk.Data
-			// Every chunk is a liveness signal — re-arm the idle timeout up front,
-			// before deciding whether to forward or hold it, so holding the terminal
-			// usage chunk still resets the window that bounds the wait for the
-			// provider's inference_complete (which closes ChunkCh after billing).
-			// One reset covers both the forward and hold paths.
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
+			relayChunk(providerChunk)
+			// Fold in whatever the provider already queued behind this chunk
+			// (never waiting for more), then flush the batch once. A close
+			// observed mid-drain is handled exactly like the blocking-receive
+			// close — after the drained chunks are on the wire.
+			closed := drainQueuedChunks(pr.ChunkCh, maxCoalescedChunks-1, relayChunk)
+			relay.flush()
+			if closed {
+				finishStream()
+				return
 			}
-			timer.Reset(inferenceTimeout)
-
-			if !sawResponsesAPI {
-				if isResponsesAPIEventChunk(chunk) {
-					sawResponsesAPI = true
-				}
-			}
-			// Swallow provider-owned [DONE] events, including SSE groups decorated
-			// with event/id/comment fields, while retaining any sibling event. The
-			// coordinator appends terminal events of its own (held usage with
-			// the reasoning breakdown, SE signature) and then emits exactly ONE
-			// [DONE] — forwarding the provider's produced a stream shaped
-			// `...usage, [DONE], signature, [DONE]`, and third-party SDKs treat
-			// the first [DONE] as final (MacPaw/OpenAI then chokes parsing the
-			// signature event).
-			if !sawResponsesAPI {
-				chunk, _ = stripSSEDoneEvents(chunk)
-				if strings.TrimSpace(chunk) == "" {
-					continue
-				}
-			}
-			chunk = stripProviderChatMetadata(sanitizeStreamCacheDetails(chunk))
-			// Hold the terminal usage chunk (chat completions only) so we can splice
-			// in the reasoning breakdown at stream end; forwarding it inline would
-			// emit it without reasoning_tokens.
-			if !sawResponsesAPI {
-				if obj, isUsage := parseUsageOnlyStreamChunk(chunk); isUsage {
-					pendingUsage = obj
-					continue
-				}
-			}
-			if !sawResponsesAPI {
-				chunk = normalizeSSEChunk(chunk)
-				// Hold the chunk carrying the terminal finish_reason so it can be
-				// corrected to "length" against the authoritative token counts at
-				// stream end (the provider engine always reports "stop").
-				if obj, isFinish := parseFinishStreamChunk(chunk); isFinish {
-					pendingFinish = obj
-					continue
-				}
-			}
-			chunk = rewriteChunkModel(chunk, pr)
-			n, werr := fmt.Fprintf(w, "%s\n\n", chunk)
-			flusher.Flush()
-			rs.wrote(n, werr)
 
 		case errMsg, ok := <-pr.ErrorCh:
 			if !ok {
 				continue
 			}
+			// The provider error is delivered before ChunkCh is closed, so
+			// chunks that arrived ahead of it may still be queued: forward them
+			// (never waiting) before the terminal error so a late failure never
+			// truncates content the provider already produced.
+			drainQueuedChunks(pr.ChunkCh, cap(pr.ChunkCh), relayChunk)
+			relay.flush()
 			s.writeChatStreamProviderError(w, flusher, pr, errMsg)
 			return
 
@@ -2665,9 +2608,15 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(
 
 	writeSSEResponseHeader(w, pr.RequestID)
 
+	// The emitter flushes after every event; defer those flushes so a burst of
+	// already-queued provider chunks reaches the wire in one Flush. Every
+	// return path performs the owed flush.
+	deferred := newDeferredFlusher(flusher)
+	defer deferred.flushNow()
+
 	responseID := "resp_" + strings.ReplaceAll(pr.RequestID, "-", "")
 	createdAt := time.Now().Unix()
-	emitter := newResponsesStreamEmitter(w, flusher, pr, responseID, createdAt)
+	emitter := newResponsesStreamEmitter(w, deferred, pr, responseID, createdAt)
 	emitter.start()
 
 	for _, firstChunk := range firstChunks {
@@ -2683,53 +2632,89 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(*initialError))
 		return
 	}
+	// The preamble (lifecycle events + dispatch-time chunks) goes on the wire
+	// before blocking on the provider.
+	deferred.flushNow()
 
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
+
+	// emitProviderError settles and reports an in-band provider error.
+	emitProviderError := func(errMsg protocol.InferenceErrorMessage) {
+		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
+		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
+		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
+		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))
+	}
+
+	// finishStream runs once ChunkCh is observed closed — on the blocking
+	// receive or while draining already-queued chunks (after those were
+	// flushed). A provider error is delivered on ErrorCh just before the
+	// channels close, so it is checked first: a close must never turn a real
+	// provider error into "incomplete" (or, with nothing reserved, success).
+	finishStream := func() {
+		select {
+		case errMsg, ok := <-pr.ErrorCh:
+			if ok && errMsg.Error != "" {
+				emitProviderError(errMsg)
+				return
+			}
+		default:
+		}
+		var usage protocol.UsageInfo
+		completed := false
+		select {
+		case u, ok := <-pr.CompleteCh:
+			if ok {
+				usage = u
+				completed = true
+			}
+		case <-time.After(2 * time.Second):
+		}
+		if !completed && s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID) {
+			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_incomplete"})
+			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
+			emitter.emitError("provider_error", "provider ended without completion")
+			return
+		}
+		s.noteInferenceSuccess(pr)
+		emitter.finish(usage)
+	}
+
+	relayChunk := func(chunk registry.ProviderChunk) {
+		emitter.handleChunk(sanitizeStreamCacheDetails(chunk.Data))
+		resetIdleTimer(timer, inferenceTimeout)
+	}
 
 	for {
 		select {
 		case providerChunk, ok := <-pr.ChunkCh:
 			if !ok {
-				var usage protocol.UsageInfo
-				completed := false
-				select {
-				case u, ok := <-pr.CompleteCh:
-					if ok {
-						usage = u
-						completed = true
-					}
-				case <-time.After(2 * time.Second):
-				}
-				if !completed && s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID) {
-					s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_incomplete"})
-					s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
-					emitter.emitError("provider_error", "provider ended without completion")
-					return
-				}
-				s.noteInferenceSuccess(pr)
-				emitter.finish(usage)
+				finishStream()
 				return
 			}
-			chunk := providerChunk.Data
-			emitter.handleChunk(sanitizeStreamCacheDetails(chunk))
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
+			relayChunk(providerChunk)
+			// Fold in whatever the provider already queued behind this chunk
+			// (never waiting for more), then flush the batch once. A close
+			// observed mid-drain is handled exactly like the blocking-receive
+			// close — after the drained chunks are on the wire.
+			closed := drainQueuedChunks(pr.ChunkCh, maxCoalescedChunks-1, relayChunk)
+			deferred.flushNow()
+			if closed {
+				finishStream()
+				return
 			}
-			timer.Reset(inferenceTimeout)
 
 		case errMsg, ok := <-pr.ErrorCh:
 			if !ok {
 				continue
 			}
-			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
-			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
-			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
-			emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))
+			// Forward chunks queued ahead of the error before the terminal
+			// event (see the chat relay for the rationale).
+			drainQueuedChunks(pr.ChunkCh, cap(pr.ChunkCh), relayChunk)
+			deferred.flushNow()
+			emitProviderError(errMsg)
 			return
 
 		case <-timer.C:
@@ -3130,21 +3115,22 @@ func stripThinkBlocks(text string) (string, string) {
 func normalizeSSEChunk(chunk string) string {
 	line := strings.TrimPrefix(chunk, "data: ")
 	// Only trigger the expensive JSON parse for fields we actually fix.
-	// "finish_reason":null appears on every chunk but we don't touch it,
-	// so checking for generic ":null" causes unnecessary JSON round-trips.
-	needsNullFix := strings.Contains(line, `"content":null`) ||
-		strings.Contains(line, `"tool_calls":null`) ||
-		strings.Contains(line, `"usage":null`) ||
-		strings.Contains(line, `"reasoning":null`) ||
-		strings.Contains(line, `"reasoning_content":null`) ||
-		strings.Contains(line, `"refusal":null`) ||
-		strings.Contains(line, `"system_fingerprint":null`)
-	needsReasoningNormalization := strings.Contains(line, `"reasoning"`) ||
-		strings.Contains(line, `"reasoning_content"`)
-	if !needsNullFix && !needsReasoningNormalization {
+	// "finish_reason":null appears on every chunk but we don't touch it, so
+	// the gates scan for the fixable `"<key>":null` shapes and the reasoning
+	// aliases in a pass each (sse_normalize_gate.go) instead of one
+	// strings.Contains per field.
+	if !sseChunkNeedsNullFix(line) && !sseChunkHasReasoningField(line) {
 		return chunk
 	}
+	return rewriteSSEChunkFields(chunk, line)
+}
 
+// rewriteSSEChunkFields is normalizeSSEChunk's slow path: the JSON round-trip
+// that rewrites null delta fields, drops null top-level fields, mirrors the
+// reasoning aliases and synthesises reasoning_details. line is chunk without
+// its "data: " prefix. Returns chunk unchanged when nothing needed fixing or
+// the payload is not a JSON object.
+func rewriteSSEChunkFields(chunk, line string) string {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(line), &raw); err != nil {
 		return chunk
@@ -4338,7 +4324,10 @@ func (s *Server) handleGenericInference(w http.ResponseWriter, r *http.Request, 
 	if !ok {
 		return
 	}
-	rawBody := prelude.rawBody
+	// This handler rebuilds its provider body from `parsed` (inferenceBody
+	// below); the prelude's forward bytes are only threaded into
+	// resolveRequestedModel, which never uses them here.
+	rawBody := prelude.originalRawBody
 	originalRawBody := prelude.originalRawBody
 	parsed := prelude.parsed
 	model := prelude.model

--- a/coordinator/api/consumer_normalize_test.go
+++ b/coordinator/api/consumer_normalize_test.go
@@ -732,3 +732,27 @@ func BenchmarkNormalizeSSEChunk_Usage(b *testing.B) {
 		_ = normalizeSSEChunk(chunk)
 	}
 }
+
+func BenchmarkNormalizeSSEChunk_ReasoningDelta(b *testing.B) {
+	b.ReportAllocs()
+	// Slow path: a reasoning delta must be mirrored across both aliases and
+	// gain reasoning_details (the gate is not what makes this case expensive).
+	chunk := `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"reasoning_content":"Let me think about this"},"finish_reason":null}]}`
+
+	b.ResetTimer()
+	for range b.N {
+		_ = normalizeSSEChunk(chunk)
+	}
+}
+
+func BenchmarkNormalizeSSEChunk_ReasoningDetailsPassthrough(b *testing.B) {
+	b.ReportAllocs()
+	// Fast path: reasoning_details without either reasoning alias (and the
+	// usual finish_reason:null) must be forwarded without a round-trip.
+	chunk := `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"content":"Hello","reasoning_details":[{"type":"reasoning.text","text":"t","index":0}]},"finish_reason":null}]}`
+
+	b.ResetTimer()
+	for range b.N {
+		_ = normalizeSSEChunk(chunk)
+	}
+}

--- a/coordinator/api/deadline_unreachable_integration_test.go
+++ b/coordinator/api/deadline_unreachable_integration_test.go
@@ -70,11 +70,27 @@ func waitForDeadlineTelemetry(
 	minRoutes, minRejections int,
 ) ([]store.InferenceRouteRecord, []store.RejectionRecord) {
 	t.Helper()
+	return waitForDeadlineTelemetryWhere(t, st, minRoutes, minRejections, nil)
+}
+
+// waitForDeadlineTelemetryWhere waits for the row counts AND, when given, for
+// the route rows to satisfy settled. The route sink writes the attempt record
+// and its outcome as separate batched statements, so a row can be visible
+// before its final_status/error_reason are; callers that assert on outcome
+// fields must wait for them explicitly.
+func waitForDeadlineTelemetryWhere(
+	t *testing.T,
+	st *store.MemoryStore,
+	minRoutes, minRejections int,
+	settled func(routes []store.InferenceRouteRecord) bool,
+) ([]store.InferenceRouteRecord, []store.RejectionRecord) {
+	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		routes := st.InferenceRouteRecordsSince(time.Time{})
 		rejections := st.RejectionRecordsSince(time.Time{})
-		if len(routes) >= minRoutes && len(rejections) >= minRejections {
+		if len(routes) >= minRoutes && len(rejections) >= minRejections &&
+			(settled == nil || settled(routes)) {
 			return routes, rejections
 		}
 		if time.Now().After(deadline) {
@@ -218,7 +234,14 @@ func TestDeadlineUnreachableFailoverCarriesDecreasingBudgets(t *testing.T) {
 	assertDeadlineRefusalDidNotFeedCapacity(
 		t, reg, byName[attempts[0].provider], model)
 
-	routes, _ := waitForDeadlineTelemetry(t, st, 2, 0)
+	routes, _ := waitForDeadlineTelemetryWhere(t, st, 2, 0, func(routes []store.InferenceRouteRecord) bool {
+		for _, route := range routes {
+			if route.ErrorReason == errorReasonDeadlineUnreachable {
+				return true
+			}
+		}
+		return false
+	})
 	deadlineRoutes := 0
 	for _, route := range routes {
 		if route.ErrorReason != errorReasonDeadlineUnreachable {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -530,17 +530,9 @@ func (d *dispatchState) recordRoutingDecisionFor(provider *registry.Provider, pr
 		})
 	}
 
-	s.submitTelemetry("recordInferenceRoute", func() {
-		if err := s.store.RecordInferenceRoute(record); err != nil && s.logger != nil {
-			s.logger.Error("inference_routes record write failed",
-				"request_id", record.RequestID,
-				"attempt", record.Attempt,
-				"provider_id", record.ProviderID,
-				"model", record.Model,
-				"error", err,
-			)
-		}
-	})
+	// Off the request path: the batching sink coalesces this snapshot with its
+	// neighbours into one multi-row write (route_telemetry_submit.go).
+	s.submitRouteRecord(record)
 }
 
 // timingMsBetween returns the elapsed milliseconds between two request-lifecycle

--- a/coordinator/api/dispatch_plan_wiring_test.go
+++ b/coordinator/api/dispatch_plan_wiring_test.go
@@ -299,11 +299,19 @@ func TestGovernorAllowKeepsLegacyBackupPath(t *testing.T) {
 	if !ok {
 		t.Fatalf("store = %T", d.s.store)
 	}
+	// The route row is persisted off the request path by the batching
+	// telemetry sink (flushed within its group window), so poll briefly.
 	backupRouted := false
-	for _, route := range st.InferenceRouteRecordsSince(time.Time{}) {
-		if route.ProviderID == "idle-backup" {
-			backupRouted = true
-			break
+	deadline := time.Now().Add(2 * time.Second)
+	for !backupRouted && time.Now().Before(deadline) {
+		for _, route := range st.InferenceRouteRecordsSince(time.Time{}) {
+			if route.ProviderID == "idle-backup" {
+				backupRouted = true
+				break
+			}
+		}
+		if !backupRouted {
+			time.Sleep(10 * time.Millisecond)
 		}
 	}
 	if !backupRouted {

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -32,7 +32,14 @@ func (s *Server) handleGenericEndpointStreamingResponseWithError(
 		return
 	}
 	writeSSEResponseHeader(w, pr.RequestID)
-	emitter := newGenericEndpointStreamEmitter(w, flusher, pr)
+
+	// The emitter flushes after every event; defer those flushes so a burst of
+	// already-queued provider chunks reaches the wire in one Flush. Every
+	// return path performs the owed flush.
+	deferred := newDeferredFlusher(flusher)
+	defer deferred.flushNow()
+
+	emitter := newGenericEndpointStreamEmitter(w, deferred, pr)
 	emitter.start()
 	for _, chunk := range firstChunks {
 		if chunk != "" {
@@ -47,54 +54,92 @@ func (s *Server) handleGenericEndpointStreamingResponseWithError(
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(*initialError))
 		return
 	}
+	// The preamble (start event + dispatch-time chunks) goes on the wire
+	// before blocking on the provider.
+	deferred.flushNow()
 
 	timer := time.NewTimer(inferenceTimeout)
 	defer timer.Stop()
+
+	// emitProviderError settles and reports an in-band provider error.
+	emitProviderError := func(errMsg protocol.InferenceErrorMessage) {
+		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
+		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
+		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
+		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))
+	}
+
+	// finishStream runs once ChunkCh is observed closed — on the blocking
+	// receive or while draining already-queued chunks (after those were
+	// flushed). A provider error is delivered on ErrorCh just before the
+	// channels close, so it is checked first: a close must never turn a real
+	// provider error into "incomplete".
+	finishStream := func() {
+		select {
+		case errMsg, ok := <-pr.ErrorCh:
+			if ok && errMsg.Error != "" {
+				emitProviderError(errMsg)
+				return
+			}
+		default:
+		}
+		var usage protocol.UsageInfo
+		select {
+		case complete, completeOK := <-pr.CompleteCh:
+			if !completeOK {
+				s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
+				s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
+				emitter.emitError("provider_error", "provider ended without completion")
+				return
+			}
+			usage = complete
+		case <-time.After(2 * time.Second):
+			s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
+			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
+			emitter.emitError("provider_error", "provider ended without completion")
+			return
+		case <-r.Context().Done():
+			profileClientGone(pr, phaseAfterCommit)
+			return
+		}
+		s.noteInferenceSuccess(pr)
+		emitter.finish(usage)
+	}
+
+	relayChunk := func(chunk registry.ProviderChunk) {
+		emitter.handleChunk(sanitizeStreamCacheDetails(chunk.Data))
+		resetIdleTimer(timer, inferenceTimeout)
+	}
+
 	for {
 		select {
 		case providerChunk, ok := <-pr.ChunkCh:
 			if !ok {
-				var usage protocol.UsageInfo
-				select {
-				case complete, completeOK := <-pr.CompleteCh:
-					if !completeOK {
-						s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
-						s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
-						emitter.emitError("provider_error", "provider ended without completion")
-						return
-					}
-					usage = complete
-				case <-time.After(2 * time.Second):
-					s.refundReservedBalance(pr, "provider_incomplete:"+pr.RequestID)
-					s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderIncompleteOutcome(pr))
-					emitter.emitError("provider_error", "provider ended without completion")
-					return
-				case <-r.Context().Done():
-					profileClientGone(pr, phaseAfterCommit)
-					return
-				}
-				s.noteInferenceSuccess(pr)
-				emitter.finish(usage)
+				finishStream()
 				return
 			}
-			emitter.handleChunk(sanitizeStreamCacheDetails(providerChunk.Data))
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
+			relayChunk(providerChunk)
+			// Fold in whatever the provider already queued behind this chunk
+			// (never waiting for more), then flush the batch once. A close
+			// observed mid-drain is handled exactly like the blocking-receive
+			// close — after the drained chunks are on the wire.
+			closed := drainQueuedChunks(pr.ChunkCh, maxCoalescedChunks-1, relayChunk)
+			deferred.flushNow()
+			if closed {
+				finishStream()
+				return
 			}
-			timer.Reset(inferenceTimeout)
 
 		case errMsg, ok := <-pr.ErrorCh:
 			if !ok {
 				continue
 			}
-			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
-			s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
-			s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
-			emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))
+			// Forward chunks queued ahead of the error before the terminal
+			// event (see the chat relay for the rationale).
+			drainQueuedChunks(pr.ChunkCh, cap(pr.ChunkCh), relayChunk)
+			deferred.flushNow()
+			emitProviderError(errMsg)
 			return
 
 		case <-timer.C:

--- a/coordinator/api/inference_preprocess.go
+++ b/coordinator/api/inference_preprocess.go
@@ -10,6 +10,12 @@ package api
 // helpers preserve EXACT behavior — identical error types, messages, params, and
 // status codes — and write the terminal response themselves, signalling the
 // caller to return via ok=false / handled=true.
+//
+// The prelude parses the body exactly once. Every later rewrite (stop
+// normalization, alias resolution, reasoning policy, runtime defaults,
+// max_tokens bound, …) mutates the decoded map and marks the forwardBody
+// dirty; the bytes are serialized once, lazily, when the first consumer of
+// the provider-bound body asks for them.
 
 import (
 	"bytes"
@@ -19,6 +25,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/eigeninference/d-inference/coordinator/promptcontract"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -70,22 +77,68 @@ func marshalForwardBody(v any) ([]byte, error) {
 	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
 }
 
+// forwardBody is the provider-bound request as the handler reshapes it: the
+// decoded map every rewrite is applied to, plus the bytes that map was last
+// serialized to. bytes starts as the caller's verbatim input, so a request
+// that needs no rewrite at all reaches the provider byte-for-byte as sent;
+// after any mutation the handler marks the body dirty and current() serializes
+// once, however many rewrites preceded it.
+type forwardBody struct {
+	parsed map[string]any
+	bytes  []byte
+	dirty  bool
+	// serialized reports that bytes is a coordinator serialization of parsed
+	// (marshalForwardBody output) rather than the caller's verbatim input. Only
+	// such bytes may stand in for a candidateProviderBody: a verbatim body can
+	// differ from its re-serialization in whitespace, key order and string
+	// escapes, and the size verdicts must keep measuring the serialized form.
+	serialized bool
+}
+
+// markDirty records that parsed has diverged from bytes.
+func (b *forwardBody) markDirty() { b.dirty = true }
+
+// current returns bytes reflecting every mutation so far, serializing only when
+// something changed since the last serialization (or since the input was read).
+func (b *forwardBody) current() ([]byte, error) {
+	if !b.dirty {
+		return b.bytes, nil
+	}
+	out, err := marshalForwardBody(b.parsed)
+	if err != nil {
+		return nil, err
+	}
+	b.bytes, b.dirty, b.serialized = out, false, true
+	return out, nil
+}
+
+// replace adopts bytes a helper already serialized from parsed (remote media
+// inlining re-marshals after mutating parsed in place).
+func (b *forwardBody) replace(serialized []byte) {
+	b.bytes, b.dirty, b.serialized = serialized, false, true
+}
+
 // inferencePrelude carries the parsed request shape produced by the shared
-// prelude: the (tool-schema-normalized) raw body and its parsed map, plus the
-// consumer-requested model name (alias or raw build id, pre-resolution).
+// prelude: the forward body (decoded map + lazily serialized bytes), the
+// untouched input bytes, and the consumer-requested model name (alias or raw
+// build id, pre-resolution). originalTools is the caller's pre-normalization
+// tools value when the prelude repaired a tool schema (nil otherwise); the
+// tool-constraint validator must judge that view, never the repaired copy.
 type inferencePrelude struct {
-	rawBody         []byte
+	body            forwardBody
 	originalRawBody []byte
 	parsed          map[string]any
 	model           string
+	originalTools   []any
 }
 
 // parseInferencePrelude runs the request prelude shared verbatim by
-// handleChatCompletions and handleGenericInference: read the body, normalize tool
-// JSON-Schemas (so pre-0.6.3 providers never see chat-template-crashing shapes),
-// parse JSON, require a model, and enforce the per-key model allowlist. On any
-// failure it writes the exact OpenAI-compatible error response and returns
-// ok=false; the caller must then return immediately.
+// handleChatCompletions and handleGenericInference: read the body, parse JSON
+// (once), normalize tool JSON-Schemas on the decoded map (so pre-0.6.3
+// providers never see chat-template-crashing shapes), require a model, and
+// enforce the per-key model allowlist. On any failure it writes the exact
+// OpenAI-compatible error response and returns ok=false; the caller must then
+// return immediately.
 func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (inferencePrelude, bool) {
 	// Read the raw request body so we can forward it as-is to the provider.
 	// We only parse minimally to extract model/stream/messages for routing.
@@ -104,23 +157,23 @@ func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (
 		return inferencePrelude{}, false
 	}
 
-	originalRawBody := rawBody
-
-	// Normalize tool JSON-Schemas before parsing and dispatch so providers
-	// running binaries older than 0.6.3 (which normalize provider-side, #310)
-	// never see the schema shapes that crash Gemma-style chat templates
-	// ("upper filter requires string" — nullable array types, missing types).
-	// Centralizing this in the coordinator covers the whole fleet the moment
-	// the coordinator deploys, instead of waiting out provider update lag.
-	rawBody = NormalizeToolSchemas(rawBody)
-
 	parsed, ok := parseJSONBody(w, rawBody)
 	if !ok {
 		return inferencePrelude{}, false
 	}
+
+	// Normalize tool JSON-Schemas before dispatch so providers running binaries
+	// older than 0.6.3 (which normalize provider-side, #310) never see the
+	// schema shapes that crash Gemma-style chat templates ("upper filter
+	// requires string" — nullable array types, missing types). Centralizing
+	// this in the coordinator covers the whole fleet the moment the
+	// coordinator deploys, instead of waiting out provider update lag. The
+	// repair runs on the decoded map (one parse per request); the caller's
+	// original tools are kept for constraint validation.
+	originalTools, dirty := normalizeParsedToolSchemas(parsed, rawBody)
 	if stop, ok := parsed["stop"].(string); ok {
 		parsed["stop"] = []any{stop}
-		rawBody, _ = marshalForwardBody(parsed)
+		dirty = true
 	}
 
 	model, _ := parsed["model"].(string)
@@ -138,8 +191,11 @@ func (s *Server) parseInferencePrelude(w http.ResponseWriter, r *http.Request) (
 	}
 
 	return inferencePrelude{
-		rawBody: rawBody, originalRawBody: originalRawBody,
-		parsed: parsed, model: model,
+		body:            forwardBody{parsed: parsed, bytes: rawBody, dirty: dirty},
+		originalRawBody: rawBody,
+		parsed:          parsed,
+		model:           model,
+		originalTools:   originalTools,
 	}, true
 }
 
@@ -174,6 +230,70 @@ func decodeInferenceJSONObject(rawBody []byte) (map[string]any, error) {
 		return nil, err
 	}
 	return parsed, nil
+}
+
+// resolveRequestedBuild maps the consumer-requested model — which may be a
+// public alias like "gemma-4-26b" — to the concrete build id used for routing,
+// billing, and serving, returning the public name to echo back to the consumer.
+// When the request used an alias it rewrites parsed["model"] to the build and
+// reports rewrote=true so the caller marks its forward body dirty; it never
+// serializes (the chat handler marshals once, later). Raw build ids pass
+// through unchanged (publicModel == buildModel). ok=false means the alias
+// currently has no usable build; the caller should surface a model_unavailable
+// error. resolveRequestedModel is the body-threading variant the generic
+// handler still uses.
+func (s *Server) resolveRequestedBuild(
+	parsed map[string]any,
+	requested string,
+	allowedProviderSerials []string,
+	policy selfRoutePolicy,
+	traits registry.RequestTraits,
+) (buildModel, publicModel string, rewrote, ok bool) {
+	buildID, isAlias, resolved := s.registry.ResolveModelConstrainedWithTraits(
+		requested, allowedProviderSerials, policy.ownerAccountID,
+		policy.enabled, policy.prefer, traits)
+	if !resolved {
+		return "", requested, false, false
+	}
+	if !isAlias {
+		return requested, requested, false, true
+	}
+	parsed["model"] = buildID
+	return buildID, requested, true, true
+}
+
+// candidateProviderBody derives the provider-bound body the chat handler would
+// send for candidateModel — the alias fallback build the admission preflight
+// probes, or the resolved build itself — from the current parsed request:
+// model rewritten, that build's catalog runtime defaults reconciled, the
+// service reasoning policy applied, and (Responses surface) the input→chat
+// lowering. It works on a shallow copy so parsed is never mutated, serializes
+// once, and is memoized per request by providerBodyMemo.
+func (s *Server) candidateProviderBody(
+	parsed map[string]any,
+	runtimeDefaults modelRuntimeDefaults,
+	candidateModel string,
+	serviceConsumer, reasoningProvided, isResponsesAPI bool,
+) ([]byte, error) {
+	candidateParsed := make(map[string]any, len(parsed)+1)
+	for key, value := range parsed {
+		candidateParsed[key] = value
+	}
+	candidateParsed["model"] = candidateModel
+	if rec, err := s.store.GetModelRegistryRecord(candidateModel); err == nil {
+		runtimeDefaults.apply(candidateParsed, rec.RuntimeParameters)
+	} else {
+		runtimeDefaults.apply(candidateParsed, nil)
+	}
+	applyResolvedModelReasoningPolicy(candidateParsed, candidateModel, serviceConsumer, reasoningProvided)
+	candidateBody, err := marshalForwardBody(candidateParsed)
+	if err != nil {
+		return nil, err
+	}
+	if isResponsesAPI {
+		return promptcontract.LowerProviderBody(promptcontract.EndpointResponses, candidateBody)
+	}
+	return candidateBody, nil
 }
 
 // visionToolsFailFast is the shared media/tools capability fast-fail (mirrored

--- a/coordinator/api/inference_preprocess_bench_test.go
+++ b/coordinator/api/inference_preprocess_bench_test.go
@@ -1,0 +1,524 @@
+package api
+
+// Benchmarks for the consumer inference request preprocessing pipeline: the
+// prelude (read → tool-schema normalize → parse), request introspection
+// (media/tools/token estimates), tool-constraint validation, alias resolution,
+// reasoning/runtime-default/max_tokens rewrites, the provider-bound body
+// derivation, and the per-candidate routing-trait sizing.
+//
+// Two levels:
+//
+//   - BenchmarkChatPreprocessHelpers drives the helper functions in the same
+//     order handleChatCompletions calls them, without HTTP, billing, or
+//     dispatch — the precise ns/op, B/op, allocs/op view of the CPU and
+//     allocation churn per request shape.
+//   - BenchmarkChatCompletionsHTTP drives the real /v1/chat/completions handler
+//     through httptest against a fake WebSocket provider, so it includes
+//     encryption and transport. Its bytes/allocs are process-wide and the
+//     honest end-to-end before/after comparison; its ns/op is noisier.
+//
+// Bodies: a 2 KB single-turn chat, a 60 KB chat history, that history plus a
+// tool set (normalization + constraint validation), and a 3 MB inline-image
+// request.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+const (
+	benchAlias         = "bench-alias"
+	benchDesiredBuild  = "bench-build-desired"
+	benchPreviousBuild = "bench-build-previous"
+)
+
+var benchBodyNames = []string{"small_2KB", "history_60KB", "history_tools_60KB", "image_3MB"}
+
+// benchTurnText is ~1.4 KB of prose carrying the characters the forward
+// marshal must handle (quotes, backslashes, newlines, HTML-significant bytes).
+var benchTurnText = strings.Repeat(
+	`The quick "brown" fox <jumps> over the lazy dog & keeps running.\nIt said: `+
+		`"don't stop" — then paused for 3.5 seconds before continuing east. `,
+	10)
+
+func benchChatMessage(role, text string) map[string]any {
+	return map[string]any{"role": role, "content": text}
+}
+
+func benchTools() []any {
+	tools := make([]any, 0, 6)
+	for i := 0; i < 6; i++ {
+		tools = append(tools, map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        fmt.Sprintf("lookup_%d", i),
+				"description": "Look something up",
+				"parameters": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						// Missing `type` and a nullable union: both are shapes the
+						// coordinator-side normalizer repairs.
+						"query":  map[string]any{"description": "search text"},
+						"limit":  map[string]any{"type": []any{"integer", "null"}},
+						"filter": map[string]any{"type": "string", "enum": []any{"a", "b"}},
+					},
+					"required": []any{"query"},
+				},
+			},
+		})
+	}
+	return tools
+}
+
+// benchRequestBodies builds the request bodies keyed by benchBodyNames.
+func benchRequestBodies() map[string][]byte {
+	small := map[string]any{
+		"model":  benchAlias,
+		"stream": false,
+		"messages": []any{
+			benchChatMessage("system", "You are a concise assistant."),
+			benchChatMessage("user", benchTurnText),
+		},
+	}
+	history := make([]any, 0, 42)
+	history = append(history, benchChatMessage("system", "You are a concise assistant."))
+	for i := 0; i < 40; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		history = append(history, benchChatMessage(role, benchTurnText))
+	}
+	history = append(history, benchChatMessage("user", "Summarize the conversation."))
+	historyBody := map[string]any{"model": benchAlias, "stream": false, "messages": history}
+	historyTools := map[string]any{
+		"model": benchAlias, "stream": false, "messages": history,
+		"tools": benchTools(), "tool_choice": "auto",
+	}
+
+	// ~2.25 MB of incompressible bytes → ~3 MB of base64 in a data: URI.
+	rnd := rand.New(rand.NewPCG(7, 11))
+	raw := make([]byte, 2_250_000)
+	for i := 0; i+8 <= len(raw); i += 8 {
+		v := rnd.Uint64()
+		for j := 0; j < 8; j++ {
+			raw[i+j] = byte(v >> (8 * j))
+		}
+	}
+	image := map[string]any{
+		"model": benchAlias, "stream": false, "max_tokens": 64,
+		"messages": []any{map[string]any{"role": "user", "content": []any{
+			map[string]any{"type": "text", "text": "Describe this image."},
+			map[string]any{"type": "image_url", "image_url": map[string]any{
+				"url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(raw),
+			}},
+		}}},
+	}
+
+	bodies := make(map[string][]byte, 4)
+	for name, v := range map[string]any{
+		"small_2KB": small, "history_60KB": historyBody,
+		"history_tools_60KB": historyTools, "image_3MB": image,
+	} {
+		b, err := json.Marshal(v)
+		if err != nil {
+			panic(err)
+		}
+		bodies[name] = b
+	}
+	return bodies
+}
+
+func seedBenchModel(tb testing.TB, st store.Store, model string, runtimeParameters map[string]any) {
+	tb.Helper()
+	entry := &store.ModelRegistryEntry{
+		ID: model, DisplayName: model, Quantization: "4bit",
+		MaxContextLength: 131072, MaxOutputLength: 8192, MinRAMGB: 24,
+		Capabilities: []string{"chat", "vision"}, Status: "active",
+		RuntimeParameters: runtimeParameters,
+	}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := st.SetModelVersion(entry, &store.ModelVersion{
+		ModelID: model, Version: "v1", R2Prefix: modelR2Prefix(model, "v1"),
+		AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready",
+	}, files); err != nil {
+		tb.Fatal(err)
+	}
+	if err := st.PromoteModelVersion(model, "v1"); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+// newBenchServer builds a coordinator with the desired/previous builds in the
+// registry store (desired carries catalog runtime defaults so the
+// runtime-defaults rewrite fires) and the alias pointing at them.
+func newBenchServer(tb testing.TB) (*Server, *registry.Registry, *store.MemoryStore) {
+	tb.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	seedBenchModel(tb, st, benchDesiredBuild, map[string]any{
+		"reasoning_parser": "qwen3",
+		"tool_call_parser": "qwen3_coder",
+	})
+	seedBenchModel(tb, st, benchPreviousBuild, nil)
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = time.Hour
+	srv.SyncModelCatalog()
+	reg.SetModelAliases(map[string]registry.AliasTarget{
+		benchAlias: {Desired: benchDesiredBuild, Previous: benchPreviousBuild},
+	})
+	return srv, reg, st
+}
+
+// ---------------------------------------------------------------------------
+// Helper-level benchmark
+// ---------------------------------------------------------------------------
+
+// benchPreprocess mirrors handleChatCompletions from the prelude through the
+// routing-trait derivation: traits for the resolved build (handler, then again
+// in the admission preflight), the resolved build's size verdict, and the
+// alias-fallback build's traits — the probe the preflight issues only when the
+// desired build is saturated, included here so the fallback candidate's cost
+// is always measured.
+func benchPreprocess(b *testing.B, srv *Server, body []byte) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	prelude, ok := srv.parseInferencePrelude(w, r)
+	if !ok {
+		b.Fatalf("prelude failed: %s", w.Body.String())
+	}
+	fb := &prelude.body
+	parsed := prelude.parsed
+	model := prelude.model
+	runtimeDefaults := newModelRuntimeDefaults(parsed)
+	_, reasoningProvided := parsed["reasoning"]
+
+	if stripProviderRoutingFields(parsed) {
+		fb.markDirty()
+	}
+	if applyMetadataDetailsRequest(r, parsed) {
+		fb.markDirty()
+	}
+	shape := introspectRequest(parsed)
+	requiresVision := shape.requiresVision()
+	hasTools := shape.hasTools
+	validatedPolicy, err := validateParsedToolConstraintPolicy(
+		constraintView(parsed, prelude.originalTools))
+	if err != nil {
+		b.Fatalf("constraint validation: %v", err)
+	}
+	traits := registry.RequestTraits{
+		HasTools:          hasTools,
+		ToolChoiceMode:    string(validatedPolicy.mode),
+		ToolChoiceName:    validatedPolicy.name,
+		ParallelToolCalls: validatedPolicy.parallel,
+	}
+	buildModel, _, rewrote, ok := srv.resolveRequestedBuild(
+		parsed, model, nil, selfRoutePolicy{}, traits)
+	if !ok {
+		b.Fatal("alias did not resolve")
+	}
+	model = buildModel
+	if rewrote {
+		fb.markDirty()
+	}
+	if applyResolvedModelReasoningPolicy(parsed, model, false, reasoningProvided) {
+		fb.markDirty()
+	}
+	maxOutputBound := defaultMaxOutputTokens
+	if rec, err := srv.store.GetModelRegistryRecord(model); err == nil {
+		if runtimeDefaults.apply(parsed, rec.RuntimeParameters) {
+			fb.markDirty()
+		}
+		if rec.MaxOutputLength > 0 {
+			maxOutputBound = rec.MaxOutputLength
+		}
+	}
+	if ensureMaxTokensBound(parsed, false, maxOutputBound) {
+		fb.markDirty()
+	}
+	estimatedPromptTokens := shape.routingPromptTokens(parsed)
+	billingPromptTokens := shape.billingPromptTokens(parsed)
+	requestedMaxTokens := estimateRequestedMaxTokens(parsed)
+	if estimatedPromptTokens <= 0 || billingPromptTokens <= 0 || requestedMaxTokens <= 0 {
+		b.Fatal("estimates must be positive")
+	}
+
+	providerBody, err := fb.current()
+	if err != nil {
+		b.Fatal(err)
+	}
+	bodies := newProviderBodyMemo(func(candidateModel string) ([]byte, error) {
+		return srv.candidateProviderBody(parsed, runtimeDefaults, candidateModel,
+			false, reasoningProvided, false)
+	}, hasTools, requiresVision)
+	bodies.seed(model, providerBody)
+	// handleChatCompletions: routingTraits := routingTraitsForModel(model).
+	bodies.traits(model)
+	// runInferenceAdmission: modelTraits(model) for the capacity probe,
+	// fallbackTraits → traitsForModel(previous), providerBodyErrorForModel(model).
+	bodies.traits(model)
+	bodies.traits(benchPreviousBuild)
+	if err := bodies.sizeError(model); err != nil {
+		b.Fatal(err)
+	}
+	if shape.mediaParts < 0 || len(providerBody) == 0 {
+		b.Fatal("unexpected preprocessing state")
+	}
+}
+
+func BenchmarkChatPreprocessHelpers(b *testing.B) {
+	bodies := benchRequestBodies()
+	srv, _, _ := newBenchServer(b)
+	registerBuildsProvider(srv, "bench-provider", benchDesiredBuild, benchPreviousBuild)
+	for _, name := range benchBodyNames {
+		body := bodies[name]
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			for i := 0; i < b.N; i++ {
+				benchPreprocess(b, srv, body)
+			}
+		})
+	}
+}
+
+// BenchmarkRequestIntrospection measures the single-value wrappers the generic
+// handler calls individually (they must stay type-level walks, never
+// byte scans) against the fused pass and the billing byte count.
+func BenchmarkRequestIntrospection(b *testing.B) {
+	body := benchRequestBodies()["image_3MB"]
+	parsed, err := decodeInferenceJSONObject(body)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for name, fn := range map[string]func(map[string]any) int{
+		"detectMediaRequirement": func(p map[string]any) int {
+			if detectMediaRequirement(p) {
+				return 1
+			}
+			return 0
+		},
+		"countMediaParts":             countMediaParts,
+		"estimatePromptTokens":        estimatePromptTokens,
+		"estimateBillingPromptTokens": estimateBillingPromptTokens,
+		"introspectRequest":           func(p map[string]any) int { return introspectRequest(p).mediaParts },
+	} {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if fn(parsed) < 0 {
+					b.Fatal("negative")
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP-level benchmark
+// ---------------------------------------------------------------------------
+
+type benchEnv struct {
+	ts     *httptest.Server
+	conn   *websocket.Conn
+	cancel context.CancelFunc
+	client *http.Client
+}
+
+func (e *benchEnv) close() {
+	e.cancel()
+	_ = e.conn.Close(websocket.StatusNormalClosure, "bench done")
+	e.ts.Close()
+}
+
+// newBenchEnv starts the coordinator and one trusted, vision-capable fake
+// provider that answers challenges and serves every dispatch with a role
+// chunk, one content chunk, and a completion.
+func newBenchEnv(b *testing.B) *benchEnv {
+	b.Helper()
+	srv, reg, _ := newBenchServer(b)
+	ts := httptest.NewServer(srv.Handler())
+	ctx, cancel := context.WithCancel(context.Background())
+
+	pubKey := testPublicKeyB64()
+	value, ok := testProviderKeys.Load(pubKey)
+	if !ok {
+		b.Fatalf("missing cached provider keypair for %q", pubKey)
+	}
+	keypair := value.(testProviderKeyPair)
+
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		b.Fatalf("websocket dial: %v", err)
+	}
+	conn.SetReadLimit(64 << 20)
+	regMsg := protocol.RegisterMessage{
+		Type: protocol.TypeRegister,
+		Hardware: protocol.Hardware{
+			MachineModel: "Mac15,8", ChipName: "Apple M3 Max", MemoryGB: 64,
+		},
+		Models: []protocol.ModelInfo{
+			{ID: benchDesiredBuild, ModelType: "chat", Quantization: "4bit", IsVision: true},
+			{ID: benchPreviousBuild, ModelType: "chat", Quantization: "4bit", IsVision: true},
+		},
+		Backend:                 "mlx-swift",
+		Version:                 "0.8.0",
+		PublicKey:               pubKey,
+		EncryptedResponseChunks: true,
+		DecodeTPS:               100,
+		PrivacyCapabilities:     testPrivacyCaps(),
+	}
+	regData, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+		b.Fatalf("write register: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for len(reg.ProviderIDs()) == 0 {
+		if time.Now().After(deadline) {
+			b.Fatal("provider never registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+	go benchProviderLoop(ctx, conn, pubKey, keypair)
+	return &benchEnv{ts: ts, conn: conn, cancel: cancel, client: ts.Client()}
+}
+
+func benchEncryptedChunk(req protocol.InferenceRequestMessage, keypair testProviderKeyPair, sse string) ([]byte, error) {
+	if req.EncryptedBody == nil {
+		return nil, fmt.Errorf("inference request %s missing encrypted body", req.RequestID)
+	}
+	coordinatorPub, err := e2e.ParsePublicKey(req.EncryptedBody.EphemeralPublicKey)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := e2e.Encrypt([]byte(sse), coordinatorPub, &e2e.SessionKeys{
+		PublicKey: keypair.public, PrivateKey: keypair.private,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(protocol.InferenceResponseChunkMessage{
+		Type:      protocol.TypeInferenceResponseChunk,
+		RequestID: req.RequestID,
+		EncryptedData: &protocol.EncryptedPayload{
+			EphemeralPublicKey: payload.EphemeralPublicKey,
+			Ciphertext:         payload.Ciphertext,
+		},
+	})
+}
+
+func benchProviderLoop(ctx context.Context, conn *websocket.Conn, pubKey string, keypair testProviderKeyPair) {
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(data, &envelope) != nil {
+			continue
+		}
+		switch envelope.Type {
+		case protocol.TypeAttestationChallenge:
+			if err := conn.Write(ctx, websocket.MessageText, makeValidChallengeResponse(data, pubKey)); err != nil {
+				return
+			}
+		case protocol.TypeInferenceRequest:
+			var req protocol.InferenceRequestMessage
+			if json.Unmarshal(data, &req) != nil {
+				continue
+			}
+			// The body is deliberately NOT decrypted: the benchmark measures the
+			// coordinator, and a 3 MB NaCl open on the fake provider would only
+			// add provider-side noise to the process-wide allocation numbers.
+			for _, sse := range []string{
+				roleOnlyChunkSSE(benchDesiredBuild),
+				contentChunkSSE(benchDesiredBuild, "bench"),
+			} {
+				frame, err := benchEncryptedChunk(req, keypair, sse)
+				if err != nil {
+					return
+				}
+				if err := conn.Write(ctx, websocket.MessageText, frame); err != nil {
+					return
+				}
+			}
+			complete, _ := json.Marshal(protocol.InferenceCompleteMessage{
+				Type: protocol.TypeInferenceComplete, RequestID: req.RequestID,
+				Usage: protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 1},
+			})
+			if err := conn.Write(ctx, websocket.MessageText, complete); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (e *benchEnv) post(body []byte) (int, error) {
+	req, err := http.NewRequest(http.MethodPost, e.ts.URL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, fmt.Errorf("status %d: %s", resp.StatusCode, msg)
+	}
+	_, err = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, err
+}
+
+func BenchmarkChatCompletionsHTTP(b *testing.B) {
+	bodies := benchRequestBodies()
+	for _, name := range benchBodyNames {
+		body := bodies[name]
+		b.Run(name, func(b *testing.B) {
+			env := newBenchEnv(b)
+			defer env.close()
+			// Warm the path once (provider registration, alias catalog, HTTP
+			// keep-alive) before timing.
+			if _, err := env.post(body); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := env.post(body); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/coordinator/api/json_encoded_len.go
+++ b/coordinator/api/json_encoded_len.go
@@ -1,0 +1,162 @@
+package api
+
+// json_encoded_len.go computes len(json.Marshal(v)) for the value universe the
+// inference request decoder produces — map[string]any, []any, string,
+// json.Number, bool, nil — WITHOUT building the encoding. The billing prompt
+// estimate is a byte count of the marshaled messages (a guaranteed BPE upper
+// bound, see approximateTokenCountUpperBound), and marshaling a multi-MB
+// inline-image body just to measure it was one of the largest allocations on
+// the request path. The count mirrors encoding/json's encoder byte for byte
+// (escaping rules from encoding/json/encode.go appendString and tables.go);
+// anything outside the modeled universe reports ok=false so the caller falls
+// back to the real encoder and the value can never drift.
+
+import (
+	"encoding/json"
+	"unicode/utf8"
+)
+
+// jsonEncodedLen returns the exact length json.Marshal(v) would produce for a
+// decoder-shaped value. ok=false means v contains a type (or an invalid
+// json.Number) this counter does not model; the caller must then marshal.
+func jsonEncodedLen(v any) (int, bool) {
+	switch x := v.(type) {
+	case nil:
+		return len("null"), true
+	case bool:
+		if x {
+			return len("true"), true
+		}
+		return len("false"), true
+	case string:
+		return jsonStringEncodedLen(x, true), true
+	case json.Number:
+		// encoding/json writes the literal verbatim, substituting "0" for the
+		// zero-value Number and refusing anything that is not a JSON number.
+		s := string(x)
+		if s == "" {
+			return 1, true
+		}
+		if !jsonNumberLiteralValid(s) {
+			return 0, false
+		}
+		return len(s), true
+	case map[string]any:
+		if x == nil {
+			return len("null"), true
+		}
+		n := 2
+		if len(x) > 1 {
+			n += len(x) - 1 // commas
+		}
+		for key, value := range x {
+			m, ok := jsonEncodedLen(value)
+			if !ok {
+				return 0, false
+			}
+			n += jsonStringEncodedLen(key, true) + 1 + m // "key":value
+		}
+		return n, true
+	case []any:
+		if x == nil {
+			return len("null"), true
+		}
+		n := 2
+		if len(x) > 1 {
+			n += len(x) - 1
+		}
+		for _, value := range x {
+			m, ok := jsonEncodedLen(value)
+			if !ok {
+				return 0, false
+			}
+			n += m
+		}
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
+// jsonStringEncodedLen returns len(json.Marshal(s)) (quotes included) under
+// the encoder's escaping rules: `"` `\` and the five short escapes cost one
+// extra byte; other control bytes, and `<` `>` `&` when escapeHTML is set,
+// become 6-byte \u00XX forms; every invalid UTF-8 byte becomes the 6-byte
+// \ufffd; U+2028/U+2029 (3 bytes each) become 6-byte escapes unconditionally.
+func jsonStringEncodedLen(s string, escapeHTML bool) int {
+	n := 2 + len(s)
+	for i := 0; i < len(s); {
+		b := s[i]
+		if b < utf8.RuneSelf {
+			i++
+			if b >= 0x20 && b != '"' && b != '\\' {
+				if escapeHTML && (b == '<' || b == '>' || b == '&') {
+					n += 5
+				}
+				continue
+			}
+			switch b {
+			case '\\', '"', '\b', '\f', '\n', '\r', '\t':
+				n++
+			default:
+				n += 5
+			}
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			n += 5 // one invalid byte → `\ufffd`
+			i++
+			continue
+		}
+		if c == '\u2028' || c == '\u2029' {
+			n += 3 // three-byte rune → six-byte escape
+		}
+		i += size
+	}
+	return n
+}
+
+// jsonNumberLiteralValid reports whether s is a JSON number literal, matching
+// encoding/json's isValidNumber (RFC 8259 section 6 grammar).
+func jsonNumberLiteralValid(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] == '-' {
+		s = s[1:]
+		if s == "" {
+			return false
+		}
+	}
+	switch {
+	case s[0] == '0':
+		s = s[1:]
+	case '1' <= s[0] && s[0] <= '9':
+		s = s[1:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	default:
+		return false
+	}
+	if len(s) >= 2 && s[0] == '.' && '0' <= s[1] && s[1] <= '9' {
+		s = s[2:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+	if len(s) >= 2 && (s[0] == 'e' || s[0] == 'E') {
+		s = s[1:]
+		if s[0] == '+' || s[0] == '-' {
+			s = s[1:]
+			if s == "" {
+				return false
+			}
+		}
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+	return s == ""
+}

--- a/coordinator/api/json_encoded_len_test.go
+++ b/coordinator/api/json_encoded_len_test.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"encoding/json"
+	"math/rand/v2"
+	"strings"
+	"testing"
+)
+
+// jsonLenSpecialStrings are the string shapes whose encoded length differs
+// from their byte length: every short escape, every other control byte, the
+// HTML-significant bytes, DEL (safe), invalid UTF-8 (per-byte �),
+// U+2028/U+2029 (escaped unconditionally), a genuine U+FFFD (kept raw), and
+// multi-byte runes.
+var jsonLenSpecialStrings = []string{
+	"",
+	"plain ascii",
+	"quote\" backslash\\ ",
+	"\b\f\n\r\t",
+	"\x00\x01\x1f",
+	"<tag> & amp",
+	"\x7f del is safe",
+	"bad utf8 \xff\xfe end",
+	"truncated rune \xe2\x82",
+	"line\u2028sep\u2029par",
+	"replacement \uFFFD kept",
+	"émoji 🎉 日本語",
+	strings.Repeat("a\"b<c>&\n", 50),
+}
+
+func TestJSONStringEncodedLenMatchesEncoder(t *testing.T) {
+	for _, s := range jsonLenSpecialStrings {
+		want, err := json.Marshal(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := jsonStringEncodedLen(s, true); got != len(want) {
+			t.Errorf("escapeHTML=true %q: len = %d, want %d (%s)", s, got, len(want), want)
+		}
+		var buf strings.Builder
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if err := enc.Encode(s); err != nil {
+			t.Fatal(err)
+		}
+		if got, wantLen := jsonStringEncodedLen(s, false), buf.Len()-1; got != wantLen {
+			t.Errorf("escapeHTML=false %q: len = %d, want %d", s, got, wantLen)
+		}
+	}
+}
+
+func TestJSONEncodedLenLeafCases(t *testing.T) {
+	cases := map[string]any{
+		"nil":            nil,
+		"true":           true,
+		"false":          false,
+		"number":         json.Number("12.5e-3"),
+		"negative":       json.Number("-0"),
+		"empty number":   json.Number(""), // encodes as 0
+		"nil map":        map[string]any(nil),
+		"empty map":      map[string]any{},
+		"nil slice":      []any(nil),
+		"empty slice":    []any{},
+		"nested":         map[string]any{"a": []any{nil, true, json.Number("1"), "x"}, "b<": map[string]any{}},
+		"special key":    map[string]any{"k\"\n<": json.Number("1")},
+		"special values": map[string]any{"s": strings.Join(jsonLenSpecialStrings, "|")},
+	}
+	for name, v := range cases {
+		want, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := jsonEncodedLen(v)
+		if !ok || got != len(want) {
+			t.Errorf("%s: (%d, %v), want (%d, true) for %s", name, got, ok, len(want), want)
+		}
+	}
+	// Outside the decoder-shaped universe the counter must decline so the
+	// caller falls back to the real encoder.
+	for name, v := range map[string]any{
+		"int":            7,
+		"float":          1.5,
+		"[]string":       []string{"a"},
+		"nested int":     map[string]any{"n": 1},
+		"invalid number": json.Number("0x10"),
+		"leading plus":   json.Number("+1"),
+	} {
+		if n, ok := jsonEncodedLen(v); ok {
+			t.Errorf("%s: counter accepted unmodeled value (%d)", name, n)
+		}
+	}
+}
+
+// TestJSONValueLenMatchesMarshal is the property test: random decoder-shaped
+// trees seeded with the special strings must measure exactly like the encoder,
+// and the wrapper must agree with marshal-and-measure for everything else.
+func TestJSONValueLenMatchesMarshal(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(3, 9))
+	var gen func(depth int) any
+	gen = func(depth int) any {
+		switch k := rnd.IntN(8); {
+		case k == 0:
+			return nil
+		case k == 1:
+			return rnd.IntN(2) == 0
+		case k == 2:
+			return json.Number([]string{"0", "-1", "3.25", "1e10", "9007199254740993"}[rnd.IntN(5)])
+		case k <= 4 || depth > 3:
+			return jsonLenSpecialStrings[rnd.IntN(len(jsonLenSpecialStrings))]
+		case k == 5:
+			m := make(map[string]any)
+			for i := rnd.IntN(4); i > 0; i-- {
+				m[jsonLenSpecialStrings[rnd.IntN(len(jsonLenSpecialStrings))]+string(rune('a'+i))] = gen(depth + 1)
+			}
+			return m
+		default:
+			arr := make([]any, rnd.IntN(4))
+			for i := range arr {
+				arr[i] = gen(depth + 1)
+			}
+			return arr
+		}
+	}
+	for i := 0; i < 2000; i++ {
+		v := gen(0)
+		want, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := jsonValueLen(v); got != len(want) {
+			t.Fatalf("tree %d: len = %d, want %d for %s", i, got, len(want), want)
+		}
+	}
+	// Fallback path: values the counter declines still measure exactly, and an
+	// unencodable value reports 0 like the marshal-and-measure path.
+	if got := jsonValueLen(map[string]any{"n": 42, "f": 0.5}); got != len(`{"f":0.5,"n":42}`) {
+		t.Fatalf("fallback len = %d", got)
+	}
+	if got := jsonValueLen(map[string]any{"bad": json.Number("nope")}); got != 0 {
+		t.Fatalf("unencodable value len = %d, want 0", got)
+	}
+}
+
+func TestJSONNumberLiteralValid(t *testing.T) {
+	valid := []string{"0", "-0", "1", "-12", "1.5", "0.25", "1e5", "1E+5", "2.5e-3", "9007199254740993"}
+	invalid := []string{"", "-", "+1", "01", "1.", ".5", "1e", "1e+", "0x10", "nope", "1 ", "--1"}
+	for _, s := range valid {
+		if !jsonNumberLiteralValid(s) {
+			t.Errorf("%q rejected", s)
+		}
+		if _, err := json.Marshal(json.Number(s)); err != nil {
+			t.Errorf("%q: encoder disagrees: %v", s, err)
+		}
+	}
+	for _, s := range invalid {
+		if jsonNumberLiteralValid(s) {
+			t.Errorf("%q accepted", s)
+		}
+		if s == "" {
+			continue // the encoder substitutes "0" for the zero value
+		}
+		if _, err := json.Marshal(json.Number(s)); err == nil {
+			t.Errorf("%q: encoder disagrees (accepted)", s)
+		}
+	}
+}

--- a/coordinator/api/mdm_scheduler_cached_store_test.go
+++ b/coordinator/api/mdm_scheduler_cached_store_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Mirror of TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix
+// over store.NewCached(store.NewMemory(...)), the shape main.go hands the
+// server. The paged due-row scan is an optional verificationDuePageStore
+// capability that a direct type assertion cannot see through the decorator;
+// without store.As, loadDueRows silently falls back to re-reading page zero
+// and the live row behind the disconnected prefix is never reseeded.
+func TestMDMSchedulerDuePagingThroughCachedStore(t *testing.T) {
+	base := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	due := base.Add(time.Hour)
+	var clock atomic.Int64
+	clock.Store(base.UnixNano())
+	nowFn := func() time.Time { return time.Unix(0, clock.Load()).UTC() }
+
+	cached := store.NewCached(store.NewMemory(store.Config{}), store.CacheConfig{})
+	if _, direct := any(cached).(verificationDuePageStore); direct {
+		t.Fatal("direct assertion on CachedStore succeeded; this test no longer exercises the wrapped path")
+	}
+	srv, sch := newSchedulerTestServerWithStore(t, cached, MDMSchedulerConfig{
+		Workers: 1, QueueCapacity: 2,
+		InitialSpreadMin: time.Hour, InitialSpreadMax: time.Hour,
+	}, mdmSchedulerDeps{
+		now: nowFn,
+		jitter: func(time.Duration, time.Duration) time.Duration {
+			return time.Hour
+		},
+	})
+	withoutLiveDispatcher(sch)
+	if _, ok := store.As[verificationDuePageStore](sch.store); !ok {
+		t.Fatal("store.As cannot find verificationDuePageStore through the scheduler's cached store")
+	}
+
+	for i := range 5 {
+		_, err := cached.UpsertVerificationJob(context.Background(), store.VerificationJob{
+			SEPubKey:      fmt.Sprintf("a-disconnected-%02d", i),
+			Serial:        fmt.Sprintf("serial-disconnected-%02d", i),
+			Kind:          store.VerificationTaskSecurityInfo,
+			State:         store.VerificationStatePending,
+			Priority:      store.VerificationPriorityFirstOrExpired,
+			NextAttemptAt: due,
+			UpdatedAt:     base,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	first := schedulerTestProvider(t, srv, "paging-filler-1", "se-paging-filler-1")
+	second := schedulerTestProvider(t, srv, "paging-filler-2", "se-paging-filler-2")
+	firstGeneration := sch.Submit(
+		context.Background(), first.ID, first, store.VerificationPriorityRefresh,
+	)
+	secondGeneration := sch.Submit(
+		context.Background(), second.ID, second, store.VerificationPriorityRefresh,
+	)
+	live := schedulerTestProvider(t, srv, "paging-live", "z-se-paging-live")
+	sch.Submit(
+		context.Background(), live.ID, live, store.VerificationPriorityRefresh,
+	)
+	sch.ChallengeSettled(live, false)
+	sch.Unbind("se-paging-filler-1", firstGeneration)
+	sch.Unbind("se-paging-filler-2", secondGeneration)
+
+	clock.Store(due.UnixNano())
+	for range 4 {
+		sch.loadDueRows()
+	}
+	sch.mu.Lock()
+	offset := sch.dueScanOffset
+	sch.mu.Unlock()
+	found, reseededDue := schedulerJobDue(sch, "z-se-paging-live", store.VerificationTaskSecurityInfo)
+	if !found {
+		t.Fatalf("live queue-rejected row remained hidden behind the disconnected due-row prefix (dueScanOffset=%d): paged listing was not reached through the cached store", offset)
+	}
+	if !reseededDue.Equal(due) {
+		t.Fatalf("paged reseed due = %s, want %s", reseededDue, due)
+	}
+}

--- a/coordinator/api/mdm_scheduler_queue.go
+++ b/coordinator/api/mdm_scheduler_queue.go
@@ -298,7 +298,7 @@ func (s *mdmVerificationScheduler) loadDueRows() {
 		rows []store.VerificationJob
 		err  error
 	)
-	if paged, ok := s.store.(verificationDuePageStore); ok {
+	if paged, ok := store.As[verificationDuePageStore](s.store); ok {
 		rows, err = paged.ListDueVerificationJobsPage(
 			s.ctx, now, limit, offset,
 		)

--- a/coordinator/api/mdm_scheduler_test.go
+++ b/coordinator/api/mdm_scheduler_test.go
@@ -118,6 +118,29 @@ func waitSchedulerCondition(t *testing.T, condition func() bool, message string)
 	}
 }
 
+// withoutLiveDispatcher consumes the scheduler's start Once so Submit's Start
+// becomes a no-op and no dispatcher or worker goroutine ever runs. Tests that
+// drive loadDueRows by hand are then the only actor over sch.jobs and
+// dueScanOffset: nothing concurrently pages the same due rows, claims the
+// reseeded job (rewriting job.record) or completes and drops it. Close stays
+// safe because the WaitGroup is never armed.
+func withoutLiveDispatcher(sch *mdmVerificationScheduler) {
+	sch.start.Do(func() {})
+}
+
+// schedulerJobDue reports whether the scheduler currently holds the job and
+// its recorded due time, both read under sch.mu so a test never races the
+// dispatcher's claimAndDispatch, which rewrites job.record.
+func schedulerJobDue(sch *mdmVerificationScheduler, sePubKey string, kind store.VerificationTaskKind) (bool, time.Time) {
+	sch.mu.Lock()
+	defer sch.mu.Unlock()
+	job := sch.jobs[verificationSchedulerKey(sePubKey, kind)]
+	if job == nil {
+		return false, time.Time{}
+	}
+	return true, job.record.NextAttemptAt
+}
+
 func TestMDMSchedulerGlobalConcurrencyCap(t *testing.T) {
 	var active atomic.Int32
 	var maximum atomic.Int32
@@ -969,6 +992,7 @@ func TestMDMSchedulerQueueRejectedChallengeSettlesDurablyAndReseeds(t *testing.T
 	}, mdmSchedulerDeps{now: nowFn, jitter: func(time.Duration, time.Duration) time.Duration {
 		return 3 * time.Minute
 	}})
+	withoutLiveDispatcher(sch)
 	evicted := schedulerTestProvider(t, srv, "evicted-refresh", "se-evicted-refresh")
 	sch.Submit(context.Background(), evicted.ID, evicted, store.VerificationPriorityRefresh)
 	urgent := schedulerTestProvider(t, srv, "urgent-first", "se-urgent-first")
@@ -991,18 +1015,9 @@ func TestMDMSchedulerQueueRejectedChallengeSettlesDurablyAndReseeds(t *testing.T
 	sch.Unbind("se-urgent-first", urgentGeneration)
 	clock.Store(wantDue.UnixNano())
 	sch.loadDueRows()
-	sch.mu.Lock()
-	job := sch.jobs[verificationSchedulerKey(
-		"se-evicted-refresh", store.VerificationTaskSecurityInfo,
-	)]
-	var reseeded *store.VerificationJob
-	if job != nil {
-		record := job.record
-		reseeded = &record
-	}
-	sch.mu.Unlock()
-	if reseeded == nil || !reseeded.NextAttemptAt.Equal(wantDue) {
-		t.Fatalf("durable queue-pressure job was not reseeded at preserved due time: %+v", reseeded)
+	found, reseededDue := schedulerJobDue(sch, "se-evicted-refresh", store.VerificationTaskSecurityInfo)
+	if !found || !reseededDue.Equal(wantDue) {
+		t.Fatalf("durable queue-pressure job was not reseeded at preserved due time: found=%v due=%s", found, reseededDue)
 	}
 }
 
@@ -1021,6 +1036,7 @@ func TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix(t *tes
 			return time.Hour
 		},
 	})
+	withoutLiveDispatcher(sch)
 	for i := range 5 {
 		_, err := st.UpsertVerificationJob(context.Background(), store.VerificationJob{
 			SEPubKey:      fmt.Sprintf("a-disconnected-%02d", i),
@@ -1055,21 +1071,12 @@ func TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix(t *tes
 	for range 4 {
 		sch.loadDueRows()
 	}
-	sch.mu.Lock()
-	job := sch.jobs[verificationSchedulerKey(
-		"z-se-paging-live", store.VerificationTaskSecurityInfo,
-	)]
-	var reseeded *store.VerificationJob
-	if job != nil {
-		record := job.record
-		reseeded = &record
-	}
-	sch.mu.Unlock()
-	if reseeded == nil {
+	found, reseededDue := schedulerJobDue(sch, "z-se-paging-live", store.VerificationTaskSecurityInfo)
+	if !found {
 		t.Fatal("live queue-rejected row remained hidden behind disconnected due-row prefix")
 	}
-	if !reseeded.NextAttemptAt.Equal(due) {
-		t.Fatalf("paged reseed due = %s, want %s", reseeded.NextAttemptAt, due)
+	if !reseededDue.Equal(due) {
+		t.Fatalf("paged reseed due = %s, want %s", reseededDue, due)
 	}
 }
 

--- a/coordinator/api/media_resolve_test.go
+++ b/coordinator/api/media_resolve_test.go
@@ -734,7 +734,11 @@ func TestPreludeDefersRemoteMediaResolution(t *testing.T) {
 	if !ok {
 		t.Fatalf("prelude unexpectedly failed: %s", w.Body.String())
 	}
-	if !bytes.Contains(prelude.rawBody, []byte("http://")) {
+	rawBody, err := prelude.body.current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(rawBody, []byte("http://")) {
 		t.Errorf("prelude inlined the remote URL; media resolution must be deferred to post-billing")
 	}
 	if n := atomic.LoadInt32(&hits); n != 0 {

--- a/coordinator/api/model_hash_data_race_test.go
+++ b/coordinator/api/model_hash_data_race_test.go
@@ -69,8 +69,12 @@ func TestHandlersDoNotRaceModelHashRefresh(t *testing.T) {
 		// key each iteration so every call misses the cache and actually reads
 		// p.Models — otherwise reverting ONLY the stats fix would not reliably
 		// trip -race.
-		if path == "/v1/stats" {
+		switch path {
+		case "/v1/stats":
 			srv.readCache.Invalidate("stats:v1")
+		case "/v1/providers/attestation":
+			// Same reasoning: the attestation body is cached for 2s.
+			srv.readCache.Invalidate(providerAttestationCacheKey)
 		}
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()

--- a/coordinator/api/models_cache.go
+++ b/coordinator/api/models_cache.go
@@ -1,0 +1,72 @@
+package api
+
+// Read-cache wiring for the consumer model catalog endpoints (GET /v1/models,
+// GET /v1/models/{id}). The shared, caller-independent computation —
+// listModelEntries: the registry snapshot plus the alias/registry DB lookups —
+// is memoized for a short TTL. Anything per-caller (self-route owned-model
+// views, key allow-lists) is applied by the handlers after the shared step and
+// is never cached.
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+)
+
+// modelListCacheTTL bounds staleness of the public model list. It carries live
+// capacity fields (routable/warm providers, can_accept), so it matches the 2s
+// window GET /v1/models/capacity already uses. Catalog sync invalidates these
+// entries and prevents an older in-flight fill from publishing afterward.
+const modelListCacheTTL = 2 * time.Second
+
+func modelEntriesCacheKey(includeBuilds bool) string {
+	return "models:entries:v1:include_builds=" + strconv.FormatBool(includeBuilds)
+}
+
+func modelListBodyCacheKey(includeBuilds bool) string {
+	return "models:list:v1:include_builds=" + strconv.FormatBool(includeBuilds)
+}
+
+// cachedModelEntries returns the public catalog's consumer-facing entries,
+// memoized for modelListCacheTTL. The slice is shared between callers and
+// must not be mutated (handlers copy the entry they return).
+func (s *Server) cachedModelEntries(includeBuilds bool) ([]types.ModelEntry, error) {
+	key := modelEntriesCacheKey(includeBuilds)
+	if v, ok := s.readCacheGetValue(key); ok {
+		if entries, ok := v.([]types.ModelEntry); ok {
+			return entries, nil
+		}
+	}
+	generation := s.readCacheGeneration()
+	entries, err := s.listModelEntries(includeBuilds)
+	if err != nil {
+		return nil, err
+	}
+	s.readCacheSetEntryIfCurrent(key, ttlEntry{obj: entries}, modelListCacheTTL, generation)
+	return entries, nil
+}
+
+// cachedModelListBody returns the pre-serialized GET /v1/models response for
+// the public catalog, byte-identical to what writeJSON would produce. A body
+// miss recomputes the entries (refreshing the entries memo alongside) rather
+// than reusing an almost-expired memo, so the body is never older than
+// modelListCacheTTL.
+func (s *Server) cachedModelListBody(includeBuilds bool) ([]byte, error) {
+	key := modelListBodyCacheKey(includeBuilds)
+	if body, ok := s.readCacheGet(key); ok {
+		return body, nil
+	}
+	generation := s.readCacheGeneration()
+	entries, err := s.listModelEntries(includeBuilds)
+	if err != nil {
+		return nil, err
+	}
+	body, err := encodeCachedJSON(types.ModelListResponse{Object: "list", Data: entries})
+	if err != nil {
+		return nil, err
+	}
+	s.readCacheSetEntryIfCurrent(modelEntriesCacheKey(includeBuilds), ttlEntry{obj: entries}, modelListCacheTTL, generation)
+	s.readCacheSetEntryIfCurrent(key, ttlEntry{value: body}, modelListCacheTTL, generation)
+	return body, nil
+}

--- a/coordinator/api/models_cache_invalidate_test.go
+++ b/coordinator/api/models_cache_invalidate_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// An admin catalog mutation must be visible on the very next /v1/models and
+// /v1/models/openrouter request, not after the 2s/5s TTLs: every admin alias
+// and registry handler calls SyncModelCatalog, which drops the derived cache
+// entries after publishing the updated routing catalog.
+func TestCatalogSyncInvalidatesModelCaches(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const modelA, modelB = "invalidate-model-a", "invalidate-model-b"
+	h.seedCatalogModel(t, modelA)
+	h.connectProvider(t, ctx, modelA)
+
+	status, first := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, first)
+	if ids := modelIDs(t, first); !containsID(ids, modelA) || containsID(ids, modelB) {
+		t.Fatalf("initial list = %v, want only %s", ids, modelA)
+	}
+	status, feed := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, feed)
+	if _, ok := h.srv.readCacheGet(openRouterFeedCacheKey); !ok {
+		t.Fatal("openrouter feed should be cached after the first request")
+	}
+
+	// Catalog change inside the TTL, then the sync every admin mutation runs.
+	h.seedCatalogModel(t, modelB)
+	h.connectProvider(t, ctx, modelB)
+	h.srv.SyncModelCatalog()
+
+	if _, ok := h.srv.readCacheGet(openRouterFeedCacheKey); ok {
+		t.Fatal("openrouter feed cache survived SyncModelCatalog")
+	}
+	status, fresh := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, fresh)
+	if ids := modelIDs(t, fresh); !containsID(ids, modelA) || !containsID(ids, modelB) {
+		t.Fatalf("post-sync list = %v, want both models without waiting for the TTL", ids)
+	}
+}
+
+// Capture one catalog read before blocking. SyncModelCatalog can proceed with
+// its own read while the first request still holds a pre-mutation snapshot.
+type blockedCatalogSnapshotStore struct {
+	store.Store
+	blocked atomic.Bool
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *blockedCatalogSnapshotStore) ListActiveModelRegistryWithError() ([]store.ModelRegistryRecord, error) {
+	rows, err := s.Store.ListActiveModelRegistryWithError()
+	if s.blocked.CompareAndSwap(false, true) {
+		close(s.entered)
+		<-s.release
+	}
+	return rows, err
+}
+
+func TestCatalogSyncRejectsInflightCachePublication(t *testing.T) {
+	for _, view := range []string{"entries", "list", "openrouter"} {
+		t.Run(view, func(t *testing.T) {
+			h := newCachedEndpointHarness(t)
+			t.Cleanup(h.srv.Close)
+			h.seedCatalogModel(t, "catalog-before-sync")
+			st := &blockedCatalogSnapshotStore{
+				Store: h.srv.store, entered: make(chan struct{}), release: make(chan struct{}),
+			}
+			h.srv.store = st
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(st.release) }) }
+			t.Cleanup(release)
+			read := func() error {
+				switch view {
+				case "entries":
+					_, err := h.srv.cachedModelEntries(false)
+					return err
+				case "list":
+					_, err := h.srv.cachedModelListBody(false)
+					return err
+				default:
+					rr := httptest.NewRecorder()
+					h.srv.handleListModelsOpenRouter(rr, httptest.NewRequest(http.MethodGet, "/v1/models/openrouter", nil))
+					if rr.Code != http.StatusOK {
+						return fmt.Errorf("catalog status = %d, body = %s", rr.Code, rr.Body.String())
+					}
+					return nil
+				}
+			}
+			done := make(chan error, 1)
+			go func() { done <- read() }()
+			select {
+			case <-st.entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("catalog read did not start")
+			}
+			// This sync completes and evicts the catalog keys while the first
+			// request still holds the old one-model snapshot.
+			h.seedCatalogModel(t, "catalog-after-sync")
+			release()
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{modelEntriesCacheKey(false), modelListBodyCacheKey(false), openRouterFeedCacheKey} {
+				if _, ok := h.srv.readCache.lookup(key); ok {
+					t.Fatalf("pre-sync request repopulated %q after invalidation", key)
+				}
+			}
+			if err := read(); err != nil {
+				t.Fatal(err)
+			}
+			key := modelEntriesCacheKey(false)
+			if view == "list" {
+				key = modelListBodyCacheKey(false)
+			} else if view == "openrouter" {
+				key = openRouterFeedCacheKey
+			}
+			if _, ok := h.srv.readCache.lookup(key); !ok {
+				t.Fatalf("post-sync request did not cache %q", key)
+			}
+		})
+	}
+}

--- a/coordinator/api/models_endpoints.go
+++ b/coordinator/api/models_endpoints.go
@@ -201,17 +201,15 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Pass ?include_builds=1 (ops/debug) to also list the raw quant builds.
-	data, err := s.listModelEntries(r.URL.Query().Get("include_builds") == "1")
+	// The public catalog is the same for every caller (no per-key filtering
+	// applies to it), so the whole response is served from the read cache.
+	body, err := s.cachedModelListBody(r.URL.Query().Get("include_builds") == "1")
 	if err != nil {
 		s.logger.Error("model registry: failed to list active models", "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list models"))
 		return
 	}
-
-	writeJSON(w, http.StatusOK, types.ModelListResponse{
-		Object: "list",
-		Data:   data,
-	})
+	writeCachedJSON(w, body)
 }
 
 // selfRouteModelEntries assembles the /v1/models view for a self-route-only
@@ -338,7 +336,9 @@ func (s *Server) handleGetModel(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("model %q not found", id), withParam("model")))
 		return
 	}
-	data, err := s.listModelEntries(true)
+	// Shares the memoized public catalog with GET /v1/models; the per-id scan
+	// and the alias fallback below stay uncached.
+	data, err := s.cachedModelEntries(true)
 	if err != nil {
 		s.logger.Error("model registry: failed to list active models", "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list models"))

--- a/coordinator/api/openrouter_endpoint.go
+++ b/coordinator/api/openrouter_endpoint.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/api/types"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -20,12 +21,44 @@ import (
 // must not make the model vanish from the marketplace. Live provider data is
 // used only as supplemental signal (datacenters, and excluding a model whose
 // providers report a non-text aggregate type).
+//
+// The feed is the same for every caller and is polled by OpenRouter, so the
+// serialized response is served from the read cache for openRouterFeedCacheTTL.
 func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Request) {
-	catalogByID, registryByID, err := s.activeCatalogLookups()
+	if body, ok := s.readCacheGet(openRouterFeedCacheKey); ok {
+		writeCachedJSON(w, body)
+		return
+	}
+	generation := s.readCacheGeneration()
+	data, err := s.openRouterFeedEntries()
 	if err != nil {
 		s.logger.Error("openrouter models: failed to list active models", "error", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to list models"))
 		return
+	}
+	body, err := encodeCachedJSON(types.OpenRouterModelsResponse{Data: data})
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to encode models"))
+		return
+	}
+	s.readCacheSetEntryIfCurrent(openRouterFeedCacheKey, ttlEntry{value: body}, openRouterFeedCacheTTL, generation)
+	writeCachedJSON(w, body)
+}
+
+// openRouterFeedCacheTTL bounds staleness of the marketplace feed. The feed is
+// catalog-driven (DB), with live providers contributing only datacenters and
+// non-text exclusions. Catalog sync invalidates the feed immediately and
+// rejects any stale publication from an in-flight pre-sync read.
+const openRouterFeedCacheTTL = 5 * time.Second
+
+const openRouterFeedCacheKey = "models:openrouter:v1"
+
+// openRouterFeedEntries assembles the feed: public aliases first, then the
+// active concrete catalog models not hidden behind an alias, in stable order.
+func (s *Server) openRouterFeedEntries() ([]types.OpenRouterModel, error) {
+	catalogByID, registryByID, err := s.activeCatalogLookups()
+	if err != nil {
+		return nil, err
 	}
 
 	// Provider-reported model types override the catalog's text fallback so
@@ -57,8 +90,7 @@ func (s *Server) handleListModelsOpenRouter(w http.ResponseWriter, r *http.Reque
 		}
 		data = append(data, entry)
 	}
-
-	writeJSON(w, http.StatusOK, types.OpenRouterModelsResponse{Data: data})
+	return data, nil
 }
 
 // openRouterAliasEntries builds the OpenRouter feed entries for public model

--- a/coordinator/api/perf_e2e_test.go
+++ b/coordinator/api/perf_e2e_test.go
@@ -1,0 +1,279 @@
+package api
+
+// Gated end-to-end performance measurement for the inference hot path.
+//
+// Real HTTP server (httptest), real WebSocket providers (in-process fakes that
+// answer attestation challenges and stream encrypted chunks), real memory store,
+// real API key → user → billing-free path. Everything the coordinator does per
+// request runs — auth, parse, admission, routing, dispatch, relay, settlement —
+// with providers that answer instantly, so the numbers are coordinator overhead.
+//
+//	EIGENINFERENCE_PERF_E2E=1 go test ./api/ -run TestPerfE2E -v -count=1
+//
+// Knobs (env): PERF_E2E_PROVIDERS (100), PERF_E2E_REQUESTS (400),
+// PERF_E2E_CONCURRENCY (16), PERF_E2E_BODY_KB (16), PERF_E2E_CHUNKS (40).
+// Skipped unless EIGENINFERENCE_PERF_E2E=1 so CI never runs it.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func perfEnvInt(name string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(name)); err == nil && v > 0 {
+		return v
+	}
+	return def
+}
+
+type perfSample struct {
+	ttfb  time.Duration
+	total time.Duration
+	code  int
+}
+
+func perfPercentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(len(sorted)-1) * p)
+	return sorted[idx]
+}
+
+// perfChatBody builds a multi-turn chat body of roughly kb kilobytes.
+func perfChatBody(model string, kb int) string {
+	turn := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 12) // ~540 bytes
+	var sb strings.Builder
+	sb.WriteString(`{"model":`)
+	sb.WriteString(strconv.Quote(model))
+	sb.WriteString(`,"stream":true,"max_tokens":64,"messages":[{"role":"system","content":"You are terse."}`)
+	for sb.Len() < kb*1024 {
+		sb.WriteString(`,{"role":"user","content":`)
+		sb.WriteString(strconv.Quote(turn))
+		sb.WriteString(`},{"role":"assistant","content":`)
+		sb.WriteString(strconv.Quote(turn))
+		sb.WriteString(`}`)
+	}
+	sb.WriteString(`,{"role":"user","content":"Reply with one word."}]}`)
+	return sb.String()
+}
+
+// runPerfProviderLoop answers challenges and serves each inference request with
+// chunks encrypted SSE chunks followed by a completion. Returns served count.
+func runPerfProviderLoop(ctx context.Context, t *testing.T, conn *websocket.Conn, pubKey, model string, chunks int) int {
+	served := 0
+	for {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
+			return served
+		}
+		var env struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(data, &env) != nil {
+			continue
+		}
+		switch env.Type {
+		case protocol.TypeAttestationChallenge:
+			if err := conn.Write(ctx, websocket.MessageText, makeValidChallengeResponse(data, pubKey)); err != nil {
+				return served
+			}
+		case protocol.TypeInferenceRequest:
+			var inferReq protocol.InferenceRequestMessage
+			if err := json.Unmarshal(data, &inferReq); err != nil {
+				continue
+			}
+			for i := 0; i < chunks; i++ {
+				sse := fmt.Sprintf(`data: {"id":"chatcmpl-perf","object":"chat.completion.chunk","model":%q,"choices":[{"index":0,"delta":{"content":"tok%d "},"finish_reason":null}]}`+"\n\n", model, i)
+				writeEncryptedTestChunk(t, ctx, conn, inferReq, pubKey, sse)
+			}
+			complete := protocol.InferenceCompleteMessage{
+				Type:      protocol.TypeInferenceComplete,
+				RequestID: inferReq.RequestID,
+				Usage:     protocol.UsageInfo{PromptTokens: 400, CompletionTokens: chunks},
+			}
+			completeData, _ := json.Marshal(complete)
+			if err := conn.Write(ctx, websocket.MessageText, completeData); err != nil {
+				return served
+			}
+			served++
+		}
+	}
+}
+
+func TestPerfE2E_ChatCompletions(t *testing.T) {
+	if os.Getenv("EIGENINFERENCE_PERF_E2E") != "1" {
+		t.Skip("set EIGENINFERENCE_PERF_E2E=1 to run the end-to-end performance measurement")
+	}
+	providers := perfEnvInt("PERF_E2E_PROVIDERS", 100)
+	requests := perfEnvInt("PERF_E2E_REQUESTS", 400)
+	concurrency := perfEnvInt("PERF_E2E_CONCURRENCY", 16)
+	bodyKB := perfEnvInt("PERF_E2E_BODY_KB", 16)
+	chunks := perfEnvInt("PERF_E2E_CHUNKS", 40)
+
+	ts, reg, st := setupLoadTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// A real user + API key so requireAuth takes the key → user path.
+	if err := st.CreateUser(&store.User{AccountID: "perf-acct", PrivyUserID: "did:privy:perf"}); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	apiKey, _, err := st.CreateAPIKey("perf-acct", store.APIKeyCreate{Name: "perf"})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	const model = "perf-model-4bit"
+	models := []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+
+	providerCtx, providerCancel := context.WithCancel(ctx)
+	defer providerCancel()
+	var served atomic.Int64
+	var providerWg sync.WaitGroup
+	for i := 0; i < providers; i++ {
+		pk := testPublicKeyB64()
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial provider %d: %v", i, err)
+		}
+		// The real provider raises the read limit; nhooyr's 32 KB default
+		// would kill the socket on any request body larger than that.
+		conn.SetReadLimit(16 << 20)
+		defer conn.Close(websocket.StatusNormalClosure, "done")
+		regMsg := protocol.RegisterMessage{
+			Type: protocol.TypeRegister,
+			Hardware: protocol.Hardware{
+				MachineModel: "Mac15,8", ChipName: "Apple M3 Max", ChipFamily: "M3", ChipTier: "Max",
+				MemoryGB: 64, MemoryBandwidthGBs: 400,
+				CPUCores: protocol.CPUCores{Total: 16, Performance: 12, Efficiency: 4}, GPUCores: 40,
+			},
+			Models:                  models,
+			Backend:                 "mlx-swift",
+			Version:                 "0.8.15",
+			PublicKey:               pk,
+			EncryptedResponseChunks: true,
+			DecodeTPS:               float64(20 + i%25),
+			PrivacyCapabilities:     testPrivacyCaps(),
+		}
+		regData, _ := json.Marshal(regMsg)
+		if err := conn.Write(ctx, websocket.MessageText, regData); err != nil {
+			t.Fatalf("register provider %d: %v", i, err)
+		}
+		hb := protocol.HeartbeatMessage{
+			Type: protocol.TypeHeartbeat, Status: "idle",
+			SystemMetrics: protocol.SystemMetrics{MemoryPressure: 0.2, CPUUsage: 0.1, ThermalState: "nominal"},
+			BackendCapacity: &protocol.BackendCapacity{
+				TotalMemoryGB: 64,
+				Slots: []protocol.BackendSlotCapacity{{
+					Model: model, State: "running", MaxConcurrency: 8,
+					ObservedDecodeTPS: 25, ObservedPrefillTPS: 900,
+					ActiveTokenBudgetMax: 120000, KVBytesPerToken: 98304,
+				}},
+			},
+		}
+		hbData, _ := json.Marshal(hb)
+		if err := conn.Write(ctx, websocket.MessageText, hbData); err != nil {
+			t.Fatalf("heartbeat provider %d: %v", i, err)
+		}
+		providerWg.Add(1)
+		go func() {
+			defer providerWg.Done()
+			served.Add(int64(runPerfProviderLoop(providerCtx, t, conn, pk, model, chunks)))
+		}()
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for reg.OnlineCount() < int64(providers) {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d/%d providers online", reg.OnlineCount(), providers)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	for _, id := range reg.ProviderIDs() {
+		reg.SetTrustLevel(id, registry.TrustHardware)
+		reg.RecordChallengeSuccess(id)
+	}
+
+	body := perfChatBody(model, bodyKB)
+	client := &http.Client{Transport: &http.Transport{MaxIdleConnsPerHost: concurrency * 2}}
+	samples := make([]perfSample, requests)
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+	start := time.Now()
+	for i := 0; i < requests; i++ {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			reqStart := time.Now()
+			req, _ := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+"/v1/chat/completions", strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.Do(req)
+			if err != nil {
+				samples[idx] = perfSample{code: 0, total: time.Since(reqStart)}
+				return
+			}
+			defer resp.Body.Close()
+			r := bufio.NewReader(resp.Body)
+			ttfb := time.Duration(0)
+			for {
+				line, err := r.ReadString('\n')
+				if ttfb == 0 && len(strings.TrimSpace(line)) > 0 {
+					ttfb = time.Since(reqStart)
+				}
+				if err != nil {
+					break
+				}
+			}
+			samples[idx] = perfSample{code: resp.StatusCode, ttfb: ttfb, total: time.Since(reqStart)}
+		}(i)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	codes := map[int]int{}
+	var ttfbs, totals []time.Duration
+	for _, s := range samples {
+		codes[s.code]++
+		if s.code == http.StatusOK {
+			ttfbs = append(ttfbs, s.ttfb)
+			totals = append(totals, s.total)
+		}
+	}
+	sort.Slice(ttfbs, func(i, j int) bool { return ttfbs[i] < ttfbs[j] })
+	sort.Slice(totals, func(i, j int) bool { return totals[i] < totals[j] })
+
+	t.Logf("perf e2e: providers=%d requests=%d concurrency=%d body=%dKB chunks=%d", providers, requests, concurrency, bodyKB, chunks)
+	t.Logf("perf e2e: elapsed=%s throughput=%.1f req/s codes=%v", elapsed.Round(time.Millisecond), float64(requests)/elapsed.Seconds(), codes)
+	t.Logf("perf e2e: ttfb  p50=%s p95=%s p99=%s max=%s",
+		perfPercentile(ttfbs, 0.50).Round(time.Microsecond), perfPercentile(ttfbs, 0.95).Round(time.Microsecond),
+		perfPercentile(ttfbs, 0.99).Round(time.Microsecond), perfPercentile(ttfbs, 1).Round(time.Microsecond))
+	t.Logf("perf e2e: total p50=%s p95=%s p99=%s max=%s",
+		perfPercentile(totals, 0.50).Round(time.Microsecond), perfPercentile(totals, 0.95).Round(time.Microsecond),
+		perfPercentile(totals, 0.99).Round(time.Microsecond), perfPercentile(totals, 1).Round(time.Microsecond))
+
+	providerCancel()
+	if codes[http.StatusOK] != requests {
+		t.Fatalf("expected every request to succeed, got %v", codes)
+	}
+}

--- a/coordinator/api/profiler_dispatch.go
+++ b/coordinator/api/profiler_dispatch.go
@@ -202,7 +202,18 @@ func newRelayStamps(rp *registry.RequestProfile) *relayStamps {
 
 // flushed records one chunk written + flushed to the client.
 func (r *relayStamps) flushed(bytes int) {
-	if r == nil || r.rp == nil || bytes <= 0 {
+	r.flushedFrames(1, bytes)
+}
+
+// flushedFrames records one client flush that carried frames SSE frames:
+// chunks_out advances by the frame count (the relays coalesce already-queued
+// chunks into one write, and the field keeps meaning "frames delivered"),
+// bytes_out by the bytes accepted, and first_flush_us / max_chunk_gap_us are
+// stamped per call: per flush in the chat relay (when the bytes reach the
+// wire), per event write in the emitter relays (just ahead of their deferred
+// Flush).
+func (r *relayStamps) flushedFrames(frames, bytes int) {
+	if r == nil || r.rp == nil || bytes <= 0 || frames <= 0 {
 		return
 	}
 	now := time.Now()
@@ -215,7 +226,7 @@ func (r *relayStamps) flushed(bytes int) {
 		}
 	}
 	r.lastFlush = now
-	rp.ChunksOut.Add(1)
+	rp.ChunksOut.Add(int64(frames))
 	rp.BytesOut.Add(int64(bytes))
 }
 
@@ -245,6 +256,21 @@ func (r *relayStamps) wrote(n int, err error) {
 	}
 	if n > 0 {
 		r.flushed(n)
+	}
+}
+
+// wroteFrames records the outcome of one coalesced client write carrying
+// frames SSE frames (the chat relay's flush): the same contract as wrote,
+// with chunks_out advancing by the number of frames folded into the write.
+func (r *relayStamps) wroteFrames(frames, n int, err error) {
+	if r == nil || r.rp == nil {
+		return
+	}
+	if err != nil {
+		r.writeErr()
+	}
+	if n > 0 {
+		r.flushedFrames(frames, n)
 	}
 }
 

--- a/coordinator/api/profiler_sink.go
+++ b/coordinator/api/profiler_sink.go
@@ -65,7 +65,7 @@ func (p *profileSink) submit(rp *registry.RequestProfile, ap *registry.AttemptPr
 		return true
 	default:
 		n := p.dropped.Add(1)
-		if isPowerOfTen(n) && p.s != nil && p.s.logger != nil {
+		if crossesPowerOfTen(n-1, n) && p.s != nil && p.s.logger != nil {
 			p.s.logger.Warn("profile sink dropping records (buffer full) — inference is unaffected",
 				"dropped_total", n, "capacity", cap(p.ch))
 		}

--- a/coordinator/api/profiler_test.go
+++ b/coordinator/api/profiler_test.go
@@ -1266,3 +1266,62 @@ func TestRelayStampsCountOnlyWrittenBytes(t *testing.T) {
 		t.Fatal("clean stream must stamp done_flushed")
 	}
 }
+
+// TestRelayStampsCoalescedWriteCountsFrames pins the contract the chat relay's
+// batched flush relies on: one client write carrying several SSE frames
+// advances chunks_out by the frame count (the field keeps meaning "frames
+// delivered" whether or not chunks were coalesced), bytes_out by the accepted
+// bytes only, and a failed write flags client_write_err exactly as wrote does.
+func TestRelayStampsCoalescedWriteCountsFrames(t *testing.T) {
+	rp := registry.NewRequestProfile(time.Now(), "c", nil, 0)
+	rs := newRelayStamps(rp)
+	rs.wroteFrames(3, 100, nil)
+	if rp.ChunksOut.Load() != 3 || rp.BytesOut.Load() != 100 || rp.FirstFlushUS.Load() == 0 {
+		t.Fatalf("coalesced write: chunks=%d bytes=%d first_flush=%d, want 3/100/stamped",
+			rp.ChunksOut.Load(), rp.BytesOut.Load(), rp.FirstFlushUS.Load())
+	}
+	rs.wroteFrames(0, 0, nil) // an empty batch (relay.flush with nothing buffered) counts nothing
+	rs.wroteFrames(2, 0, errors.New("broken pipe"))
+	if rp.ChunksOut.Load() != 3 || rp.BytesOut.Load() != 100 || !rp.ClientWriteErr.Load() {
+		t.Fatalf("failed coalesced write must count nothing and flag client_write_err: chunks=%d bytes=%d err=%v",
+			rp.ChunksOut.Load(), rp.BytesOut.Load(), rp.ClientWriteErr.Load())
+	}
+	rs.wroteFrames(2, 10, errors.New("short")) // partial: the accepted bytes and the frames count, the error is kept
+	if rp.ChunksOut.Load() != 5 || rp.BytesOut.Load() != 110 || !rp.ClientWriteErr.Load() {
+		t.Fatalf("short coalesced write: chunks=%d bytes=%d err=%v",
+			rp.ChunksOut.Load(), rp.BytesOut.Load(), rp.ClientWriteErr.Load())
+	}
+	// wrote stays the one-frame case of the same accounting.
+	rs.wrote(4, nil)
+	if rp.ChunksOut.Load() != 6 || rp.BytesOut.Load() != 114 {
+		t.Fatalf("wrote after wroteFrames: chunks=%d bytes=%d, want 6/114", rp.ChunksOut.Load(), rp.BytesOut.Load())
+	}
+}
+
+// TestChatStreamRelayFlushReportsFramesAndBytes pins the relay side of the
+// same contract: flush records the number of frames in the batch and the bytes
+// the ResponseWriter accepted in the request profile, in one write and one
+// Flush, and an empty batch neither writes nor flushes.
+func TestChatStreamRelayFlushReportsFramesAndBytes(t *testing.T) {
+	w := newCapturingResponseWriter()
+	rp := registry.NewRequestProfile(time.Now(), "c", nil, 0)
+	relay := newChatStreamRelay(&registry.PendingRequest{}, w, w, newRelayStamps(rp))
+	relay.writeFrame(`data: {"a":1}`)
+	relay.writeFrame(`data: {"b":2}`)
+	relay.writeFrame("data: [DONE]")
+	relay.flush()
+	want := "data: {\"a\":1}\n\ndata: {\"b\":2}\n\ndata: [DONE]\n\n"
+	if w.body.String() != want || w.writes != 1 || w.flushes != 1 {
+		t.Fatalf("flush wrote %q in %d write(s) / %d flush(es); want %q in 1 / 1",
+			w.body.String(), w.writes, w.flushes, want)
+	}
+	if rp.ChunksOut.Load() != 3 || rp.BytesOut.Load() != int64(len(want)) || rp.ClientWriteErr.Load() {
+		t.Fatalf("profile chunks_out=%d bytes_out=%d client_write_err=%v; want 3 / %d / false",
+			rp.ChunksOut.Load(), rp.BytesOut.Load(), rp.ClientWriteErr.Load(), len(want))
+	}
+	relay.flush()
+	if w.writes != 1 || w.flushes != 1 || rp.ChunksOut.Load() != 3 || rp.BytesOut.Load() != int64(len(want)) {
+		t.Fatalf("empty flush must neither write nor flush nor count: writes=%d flushes=%d chunks_out=%d bytes_out=%d",
+			w.writes, w.flushes, rp.ChunksOut.Load(), rp.BytesOut.Load())
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -143,6 +143,17 @@ func (s *Server) handleProviderWS(w http.ResponseWriter, r *http.Request) {
 	s.providerReadLoop(r.Context(), conn, providerID, r)
 }
 
+// maxProviderVersionLength bounds the provider-reported binary version accepted
+// at registration. The Swift provider sends the compile-time constant
+// ProviderCore.version ("0.8.15"; release tags must equal it, dev builds are
+// published with the same exact-version contract), and the longest shape the
+// coordinator has ever handled is "0.8.15-rc.1+build" (17 bytes). 128 leaves
+// an order of magnitude of margin while keeping provider-controlled bytes out
+// of the registry's parse memos, metric tags and logs. Raising this must be
+// paired with the registry's memo bound (maxMemoizedVersionLen), which stops
+// caching above 64 bytes.
+const maxProviderVersionLength = 128
+
 // sessionDisconnectReason maps a provider read-loop exit to the disconnect
 // reason recorded on its provider_sessions row. Kept to a small, fixed
 // vocabulary so the column stays aggregatable:
@@ -332,6 +343,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				return
 			}
 			regMsg := msg.Payload.(*protocol.RegisterMessage)
+			// The version string is provider-controlled and flows into semver
+			// parsing memos, metric tags and logs; a legitimate build id is a
+			// few dozen bytes. Reject anything larger before it reaches the
+			// registry so a hostile client cannot retain multi-MiB keys.
+			if len(regMsg.Version) > maxProviderVersionLength {
+				s.logger.Warn("rejecting provider registration with oversized version",
+					"provider_id", providerID, "version_len", len(regMsg.Version))
+				s.ddIncr("providers.registration_rejected", []string{"reason:oversized_version"})
+				_ = conn.Close(websocket.StatusPolicyViolation, "version string too long")
+				return
+			}
 			if err := s.registry.ValidatePrefixCacheRegistration(regMsg); err != nil {
 				// Validation errors can quote provider-controlled model IDs.
 				s.logger.Warn("rejecting malformed provider cache capabilities",
@@ -3553,10 +3575,22 @@ func (s *Server) verifyAppleDeviceAttestation(ctx context.Context, providerID st
 	)
 }
 
+// providerAttestationCacheTTL bounds staleness of the public trust listing. It
+// reflects live connection state (trust level, status, models), so it uses the
+// same 2s window as GET /v1/models/capacity. The response is the same for every
+// caller (unauthenticated, no query parameters).
+const providerAttestationCacheTTL = 2 * time.Second
+
+const providerAttestationCacheKey = "providers:attestation:v1"
+
 // handleProviderAttestation returns privacy-redacted trust status for all providers.
 // Device identity and raw MDA certificates stay coordinator-private because
 // Apple's leaf certificate embeds the hardware serial number and UDID.
 func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Request) {
+	if body, ok := s.readCacheGet(providerAttestationCacheKey); ok {
+		writeCachedJSON(w, body)
+		return
+	}
 	type providerAttestation struct {
 		ProviderID    string `json:"provider_id"`
 		ChipName      string `json:"chip_name"`
@@ -3647,7 +3681,13 @@ func (s *Server) handleProviderAttestation(w http.ResponseWriter, r *http.Reques
 	})
 
 	resp := map[string]any{"providers": providers}
-	writeJSON(w, http.StatusOK, resp)
+	body, err := encodeCachedJSON(resp)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to encode attestation"))
+		return
+	}
+	s.readCacheSet(providerAttestationCacheKey, body, providerAttestationCacheTTL)
+	writeCachedJSON(w, body)
 }
 
 // sendTrustStatus sends the provider its current trust level and status over

--- a/coordinator/api/provider_body_identity_test.go
+++ b/coordinator/api/provider_body_identity_test.go
@@ -1,0 +1,408 @@
+package api
+
+// Byte-identity guards for the provider-bound body. The chat handler parses
+// the request once, applies its rewrites to the decoded map, and serializes
+// once; these tests drive real requests through httptest against a fake
+// provider and compare the RAW decrypted bytes the provider receives with an
+// oracle built independently (decode the original → apply the expected
+// rewrite → marshalForwardBody), or with the caller's exact input when no
+// rewrite applies.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/promptcontract"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// forwardOracle decodes body, applies mutate, and serializes the way the
+// handler does.
+func forwardOracle(t *testing.T, body string, mutate func(map[string]any)) []byte {
+	t.Helper()
+	parsed, err := decodeInferenceJSONObject([]byte(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mutate != nil {
+		mutate(parsed)
+	}
+	out, err := marshalForwardBody(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// postAndCapture posts body to path and returns the raw bytes the fake
+// provider decrypted for it.
+func postAndCapture(t *testing.T, ctx context.Context, ts *httptest.Server, fp *failoverProvider, path, apiKey, body string) []byte {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	respBody := new(bytes.Buffer)
+	respBody.ReadFrom(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, respBody.String())
+	}
+	select {
+	case got := <-fp.bodies:
+		if got == nil {
+			t.Fatal("provider could not decrypt the dispatched body")
+		}
+		return got
+	case <-time.After(10 * time.Second):
+		t.Fatal("provider never received the request")
+	}
+	return nil
+}
+
+func assertProviderBytes(t *testing.T, got, want []byte) {
+	t.Helper()
+	if !bytes.Equal(got, want) {
+		t.Fatalf("provider body diverged:\n got %s\nwant %s", got, want)
+	}
+}
+
+// setPrefixCacheProtocol pins the fake provider's prefix-cache protocol. At
+// protocol 0 every dispatch splices a per-attempt prompt_cache_key buster into
+// the sealed body (see PrepareCacheAttempt); protocol 1 providers receive the
+// handler's body untouched, which is what the byte-identity oracles describe.
+func setPrefixCacheProtocol(t *testing.T, reg *registry.Registry, fp *failoverProvider, protocol int) {
+	t.Helper()
+	p := reg.GetProvider(fp.registryID)
+	if p == nil {
+		t.Fatal("provider missing from registry")
+	}
+	p.Mu().Lock()
+	p.PrefixCacheProtocol = protocol
+	p.Mu().Unlock()
+}
+
+// legacyBustKey returns the protocol-0 prompt_cache_key buster a sealed body
+// carries, if any.
+func legacyBustKey(t *testing.T, sealed []byte) (string, bool) {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(sealed, &fields); err != nil {
+		t.Fatalf("decode sealed body: %v", err)
+	}
+	raw, ok := fields[legacyCacheBustField]
+	if !ok {
+		return "", false
+	}
+	var key string
+	if err := json.Unmarshal(raw, &key); err != nil {
+		t.Fatal(err)
+	}
+	return key, true
+}
+
+// assertSealedProviderBytes compares a protocol-0 provider's bytes with the
+// oracle sealed the way dispatch seals it (the buster spliced at its sorted
+// position), or with the bare oracle when no buster was attached.
+func assertSealedProviderBytes(t *testing.T, got, oracle []byte) {
+	t.Helper()
+	key, ok := legacyBustKey(t, got)
+	if !ok {
+		assertProviderBytes(t, got, oracle)
+		return
+	}
+	assertProviderBytes(t, got, legacySealCacheBust(t, oracle, key))
+}
+
+func createServiceKey(t *testing.T, st store.Store, account string) string {
+	t.Helper()
+	if err := st.CreateUser(&store.User{
+		AccountID: account, PrivyUserID: "did:privy:" + account, Role: store.RoleService,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	key, _, err := st.CreateAPIKey(account, store.APIKeyCreate{Name: "identity-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func TestProviderBodyByteIdentity(t *testing.T) {
+	reg, st, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const (
+		plainBuild     = "identity-plain-build"
+		defaultsBuild  = "identity-defaults-build"
+		alias          = "identity-alias"
+		serviceAccount = "identity-service-account"
+	)
+	seedRuntimeDefaultsModel(t, st, defaultsBuild, map[string]any{
+		"reasoning_parser": "catalog-reasoning",
+		"tool_call_parser": "qwen3_coder",
+	})
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "identity-provider", Version: "0.7.6", DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: plainBuild}, {ID: defaultsBuild}, {ID: serviceReasoningOptInModel}},
+		Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+			fp.serveFull(ctx, req, plainBuild, "ok")
+		},
+	})
+	setPrefixCacheProtocol(t, reg, fp, 1)
+	reg.SetModelAliases(map[string]registry.AliasTarget{alias: {Desired: plainBuild}})
+	serviceKey := createServiceKey(t, st, serviceAccount)
+
+	messages := `[{"role":"user","content":"hello <world> & \"friends\"\n"}]`
+
+	t.Run("verbatim passthrough", func(t *testing.T) {
+		// Raw build id, explicit max_tokens, no stop string, no catalog
+		// defaults, non-service key: nothing rewrites, so the caller's exact
+		// bytes — unsorted keys, whitespace, escapes and all — reach the provider.
+		body := "{\n  \"stream\": false,\n  \"model\": \"" + plainBuild + "\",\n  \"max_tokens\": 16,\n" +
+			"  \"messages\": " + messages + ",\n  \"temperature\": 0.10000000000000001,\n  \"note\": \"\\u003c kept \\u0041\"\n}"
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, []byte(body))
+	})
+
+	t.Run("alias resolution", func(t *testing.T) {
+		body := `{"model":"` + alias + `","messages":` + messages + `,"max_tokens":16}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) { p["model"] = plainBuild }))
+	})
+
+	t.Run("stop normalization", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","messages":` + messages + `,"max_tokens":16,"stop":"END"}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) { p["stop"] = []any{"END"} }))
+	})
+
+	t.Run("max_tokens bound injected", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","messages":` + messages + `}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) { p["max_tokens"] = defaultMaxOutputTokens }))
+	})
+
+	t.Run("max_completion_tokens mirrored to max_tokens", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","messages":` + messages + `,"max_completion_tokens":9}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) { p["max_tokens"] = 9 }))
+	})
+
+	t.Run("runtime defaults and catalog max_tokens", func(t *testing.T) {
+		body := `{"model":"` + defaultsBuild + `","messages":` + messages + `,"tool_call_parser":"caller-parser"}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) {
+			p["reasoning_parser"] = "catalog-reasoning" // injected; caller's tool_call_parser wins
+			p["max_tokens"] = 8192                      // seedRuntimeDefaultsModel's MaxOutputLength
+		}))
+	})
+
+	t.Run("service reasoning policy on", func(t *testing.T) {
+		body := `{"model":"` + serviceReasoningOptInModel + `","messages":` + messages + `,"max_tokens":16}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", serviceKey, body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) {
+			p["reasoning"] = map[string]any{"enabled": false}
+		}))
+	})
+
+	t.Run("service reasoning policy off", func(t *testing.T) {
+		// Same body, non-service key: no rewrite at all, verbatim passthrough.
+		body := `{"model":"` + serviceReasoningOptInModel + `", "messages":` + messages + `, "max_tokens":16}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, []byte(body))
+	})
+
+	t.Run("private routing field stripped", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","messages":` + messages + `,"max_tokens":16,"provider_serial":"C02ABC","metadata_details":true}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) {
+			delete(p, "provider_serial")
+			delete(p, "metadata_details")
+		}))
+	})
+
+	t.Run("tools normalized", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","messages":` + messages + `,"max_tokens":16,"tool_choice":"auto",` +
+			`"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"x"},"n":{"type":["integer","null"]}}}}}]}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+		// Oracle: the bytes path's normalization, then the same serialization.
+		assertProviderBytes(t, got, forwardOracle(t, string(NormalizeToolSchemas([]byte(body))), nil))
+	})
+
+	t.Run("responses lowering", func(t *testing.T) {
+		body := `{"model":"` + plainBuild + `","input":"hello","max_output_tokens":16}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/responses", "test-key", body)
+		want, err := promptcontract.LowerProviderBody(promptcontract.EndpointResponses, []byte(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertProviderBytes(t, got, want)
+	})
+
+	t.Run("responses lowering after rewrite", func(t *testing.T) {
+		body := `{"model":"` + alias + `","input":"hello"}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/responses", "test-key", body)
+		rewritten := forwardOracle(t, body, func(p map[string]any) {
+			p["model"] = plainBuild
+			p["max_output_tokens"] = defaultMaxOutputTokens
+		})
+		want, err := promptcontract.LowerProviderBody(promptcontract.EndpointResponses, rewritten)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertProviderBytes(t, got, want)
+	})
+
+	t.Run("protocol-0 cache isolation seal", func(t *testing.T) {
+		// A protocol-0 provider receives the handler's body with the per-attempt
+		// buster spliced in — through the splice fast path for the coordinator's
+		// own serialization and the decode/re-encode path for a verbatim body.
+		setPrefixCacheProtocol(t, reg, fp, 0)
+		defer setPrefixCacheProtocol(t, reg, fp, 1)
+		rewritten := `{"model":"` + alias + `","messages":` + messages + `,"max_tokens":16}`
+		got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", rewritten)
+		assertSealedProviderBytes(t, got, forwardOracle(t, rewritten, func(p map[string]any) { p["model"] = plainBuild }))
+
+		verbatim := "{\n  \"model\": \"" + plainBuild + "\",\n  \"max_tokens\": 16,\n  \"messages\": " + messages + "\n}"
+		got = postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", verbatim)
+		assertSealedProviderBytes(t, got, []byte(verbatim))
+	})
+}
+
+// The alias-capacity fallback rewrites the model and reconciles the fallback
+// build's runtime defaults; the provider must receive exactly that
+// serialization.
+func TestProviderBodyByteIdentityAliasFallback(t *testing.T) {
+	previousRuntime := map[string]any{
+		"reasoning_parser": "previous-reasoning",
+		"tool_call_parser": "previous-tools",
+	}
+	harness := newRuntimeDefaultsAliasHarness(t, map[string]any{
+		"reasoning_parser": "desired-reasoning",
+		"tool_call_parser": "desired-tools",
+	}, previousRuntime)
+	body := `{"model":"` + runtimeDefaultsAlias + `","messages":[{"role":"user","content":"hello"}],"max_tokens":32,"stream":true}`
+	postRuntimeDefaultsEndpoint(t, harness, "/v1/chat/completions", body)
+	var got []byte
+	select {
+	case got = <-harness.providers[0].bodies:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fallback provider never received the request")
+	}
+	// The harness's fallback provider is protocol 0, so dispatch splices the
+	// buster into the fallback serialization.
+	assertSealedProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) {
+		p["model"] = runtimeDefaultsPreviousModel
+		p["reasoning_parser"] = "previous-reasoning"
+		p["tool_call_parser"] = "previous-tools"
+	}))
+}
+
+// On the Responses surface the alias-capacity fallback rewrites the model and
+// the fallback build's runtime defaults, then re-lowers input→chat; the
+// provider must receive exactly that lowering of the rewritten map.
+func TestProviderBodyByteIdentityResponsesAliasFallback(t *testing.T) {
+	harness := newRuntimeDefaultsAliasHarness(t, map[string]any{
+		"reasoning_parser": "desired-reasoning",
+		"tool_call_parser": "desired-tools",
+	}, map[string]any{
+		"reasoning_parser": "previous-reasoning",
+		"tool_call_parser": "previous-tools",
+	})
+	body := `{"model":"` + runtimeDefaultsAlias + `","input":"hello","max_output_tokens":32,"stream":true}`
+	postRuntimeDefaultsEndpoint(t, harness, "/v1/responses", body)
+	var got []byte
+	select {
+	case got = <-harness.providers[0].bodies:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fallback provider never received the request")
+	}
+	rewritten := forwardOracle(t, body, func(p map[string]any) {
+		p["model"] = runtimeDefaultsPreviousModel
+		p["reasoning_parser"] = "previous-reasoning"
+		p["tool_call_parser"] = "previous-tools"
+	})
+	want, err := promptcontract.LowerProviderBody(promptcontract.EndpointResponses, rewritten)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSealedProviderBytes(t, got, want)
+}
+
+// Remote media inlining mutates parsed after the first serialization; the
+// provider must receive a fresh serialization of the inlined map.
+func TestProviderBodyByteIdentityMediaInlined(t *testing.T) {
+	t.Setenv("EIGENINFERENCE_MEDIA_FETCH_ALLOW_PRIVATE_IPS", "true")
+	t.Setenv("EIGENINFERENCE_MEDIA_FETCH_ALLOW_NONSTANDARD_PORTS", "true")
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	const model = "identity-media-model"
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "identity-vision", Version: "0.7.6", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}},
+		Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+			fp.serveFull(ctx, req, model, "ok")
+		},
+	})
+	p := reg.GetProvider(fp.registryID)
+	p.Mu().Lock()
+	for i := range p.Models {
+		p.Models[i].IsVision = true
+	}
+	p.PrefixCacheProtocol = 1
+	p.Mu().Unlock()
+
+	var hits int32
+	media := httptest.NewServer(pngHandler(t, &hits))
+	defer media.Close()
+	imageURL := media.URL + "/cat.png"
+	body := `{"model":"` + model + `","max_tokens":16,"messages":[{"role":"user","content":[` +
+		`{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"` + imageURL + `"}}]}]}`
+
+	got := postAndCapture(t, ctx, ts, fp, "/v1/chat/completions", "test-key", body)
+	if atomic.LoadInt32(&hits) != 1 {
+		t.Fatalf("origin hit %d times, want 1", hits)
+	}
+	// Recover the inlined data: URI from the provider body, then the oracle is
+	// the original request with only that URL substituted.
+	var dispatched struct {
+		Messages []struct {
+			Content []struct {
+				Type     string `json:"type"`
+				ImageURL struct {
+					URL string `json:"url"`
+				} `json:"image_url"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(got, &dispatched); err != nil {
+		t.Fatalf("decode provider body: %v", err)
+	}
+	inlined := dispatched.Messages[0].Content[1].ImageURL.URL
+	if !strings.HasPrefix(inlined, "data:image/png;base64,") {
+		t.Fatalf("image was not inlined: %.80s", inlined)
+	}
+	assertProviderBytes(t, got, forwardOracle(t, body, func(p map[string]any) {
+		part := p["messages"].([]any)[0].(map[string]any)["content"].([]any)[1].(map[string]any)
+		part["image_url"].(map[string]any)["url"] = inlined
+	}))
+}

--- a/coordinator/api/provider_body_memo.go
+++ b/coordinator/api/provider_body_memo.go
@@ -1,0 +1,104 @@
+package api
+
+// provider_body_memo.go memoizes, for ONE request, the provider-bound body of
+// each candidate model and the routing verdicts derived from it. The chat
+// handler needs that body for the resolved build (dispatch), for the alias
+// fallback build the admission preflight probes, and again for the size
+// verdict and routing traits of whichever build wins — and every one of those
+// used to rebuild and re-serialize the body from scratch. Building is a full
+// marshal (plus a parse+re-encode for the legacy cache-bust sizing), so a
+// single request paid it three to five times for the same bytes.
+
+import "github.com/eigeninference/d-inference/coordinator/registry"
+
+// providerBodyEntry is one memoized candidate: the serialized body (or the
+// error building it), and — computed lazily, once — the routing traits and
+// protocol-0 size verdict routingTraitsForProviderBody derives from it.
+type providerBodyEntry struct {
+	body    []byte
+	err     error
+	sized   bool
+	traits  registry.RequestTraits
+	sizeErr error
+}
+
+// providerBodyMemo caches candidate bodies per model for the life of one
+// request. It is single-goroutine (the handler's preprocessing runs inline).
+type providerBodyMemo struct {
+	build          func(model string) ([]byte, error)
+	hasTools       bool
+	requiresVision bool
+	entries        map[string]*providerBodyEntry
+}
+
+func newProviderBodyMemo(build func(model string) ([]byte, error), hasTools, requiresVision bool) *providerBodyMemo {
+	return &providerBodyMemo{
+		build:          build,
+		hasTools:       hasTools,
+		requiresVision: requiresVision,
+		entries:        make(map[string]*providerBodyEntry, 2),
+	}
+}
+
+// entry returns the memoized candidate for model, building it on first use.
+func (m *providerBodyMemo) entry(model string) *providerBodyEntry {
+	if e, ok := m.entries[model]; ok {
+		return e
+	}
+	e := &providerBodyEntry{}
+	e.body, e.err = m.build(model)
+	m.entries[model] = e
+	return e
+}
+
+// body returns the candidate body for model.
+func (m *providerBodyMemo) body(model string) ([]byte, error) {
+	e := m.entry(model)
+	return e.body, e.err
+}
+
+// seed records a body the handler already serialized for model (the dispatch
+// body itself, or the fallback body after an alias rewrite) so the routing
+// verdicts for that model reuse those exact bytes instead of rebuilding them.
+// Valid only while parsed is fully reconciled for model — which is exactly
+// when the handler holds such a body.
+func (m *providerBodyMemo) seed(model string, body []byte) {
+	m.entries[model] = &providerBodyEntry{body: body}
+}
+
+// reset forgets every candidate. Called whenever parsed is mutated in place
+// after bodies were built (remote media inlined, alias fallback applied).
+func (m *providerBodyMemo) reset() {
+	clear(m.entries)
+}
+
+// sizing computes the routing traits and protocol-0 size verdict once per
+// candidate.
+func (m *providerBodyMemo) sizing(model string) *providerBodyEntry {
+	e := m.entry(model)
+	if e.err == nil && !e.sized {
+		e.traits, e.sizeErr = routingTraitsForProviderBody(m.hasTools, e.body, m.requiresVision)
+		e.sized = true
+	}
+	return e
+}
+
+// traits returns the body-derived routing traits for model. ok=false means the
+// body could not be built; the caller falls back to constraint-only traits.
+func (m *providerBodyMemo) traits(model string) (registry.RequestTraits, bool) {
+	e := m.sizing(model)
+	if e.err != nil {
+		return registry.RequestTraits{}, false
+	}
+	return e.traits, true
+}
+
+// sizeError returns the protocol-0 cache-isolation size verdict for model, or
+// nil when the body could not be built (a build failure is not a size failure).
+func (m *providerBodyMemo) sizeError(model string) error {
+	e := m.sizing(model)
+	if e.err != nil {
+		return nil
+	}
+	return e.sizeErr
+}

--- a/coordinator/api/provider_body_memo_test.go
+++ b/coordinator/api/provider_body_memo_test.go
@@ -1,0 +1,224 @@
+package api
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/promptcontract"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// runChatRewrites replays handleChatCompletions' rewrites on a request body up
+// to the single serialization point and returns the provider body the handler
+// would seal for the resolved build, plus the state candidateProviderBody
+// needs to rebuild it.
+func runChatRewrites(t *testing.T, srv *Server, body string, service bool) (
+	providerBody []byte, parsed map[string]any, defaults modelRuntimeDefaults,
+	model string, reasoningProvided, isResponsesAPI, serialized bool,
+) {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(body)))
+	w := httptest.NewRecorder()
+	prelude, ok := srv.parseInferencePrelude(w, r)
+	if !ok {
+		t.Fatalf("prelude failed: %s", w.Body.String())
+	}
+	fb := &prelude.body
+	parsed = prelude.parsed
+	defaults = newModelRuntimeDefaults(parsed)
+	_, reasoningProvided = parsed["reasoning"]
+	messages, _ := parsed["messages"].([]any)
+	isResponsesAPI = parsed["input"] != nil && len(messages) == 0
+	if stripProviderRoutingFields(parsed) {
+		fb.markDirty()
+	}
+	if applyMetadataDetailsRequest(r, parsed) {
+		fb.markDirty()
+	}
+	shape := introspectRequest(parsed)
+	buildModel, _, rewrote, ok := srv.resolveRequestedBuild(
+		parsed, prelude.model, nil, selfRoutePolicy{}, registry.RequestTraits{HasTools: shape.hasTools})
+	if !ok {
+		t.Fatalf("model %q did not resolve", prelude.model)
+	}
+	model = buildModel
+	if rewrote {
+		fb.markDirty()
+	}
+	if applyResolvedModelReasoningPolicy(parsed, model, service, reasoningProvided) {
+		fb.markDirty()
+	}
+	maxOutputBound := defaultMaxOutputTokens
+	if rec, err := srv.store.GetModelRegistryRecord(model); err == nil {
+		if defaults.apply(parsed, rec.RuntimeParameters) {
+			fb.markDirty()
+		}
+		if rec.MaxOutputLength > 0 {
+			maxOutputBound = rec.MaxOutputLength
+		}
+	}
+	if ensureMaxTokensBound(parsed, isResponsesAPI, maxOutputBound) {
+		fb.markDirty()
+	}
+	rawBody, err := fb.current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerBody = rawBody
+	if isResponsesAPI {
+		if providerBody, err = promptcontract.LowerProviderBody(promptcontract.EndpointResponses, rawBody); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return providerBody, parsed, defaults, model, reasoningProvided, isResponsesAPI, fb.serialized
+}
+
+// Seeding the memo with the handler's own serialization is only valid if a
+// fresh candidateProviderBody for the resolved build produces the same bytes.
+// Every rewrite class must hold that invariant; a request that needed no
+// rewrite keeps the caller's verbatim bytes for dispatch and is not seeded.
+func TestProviderBodyMemoSeedMatchesFreshBuild(t *testing.T) {
+	srv, _, _ := newBenchServer(t)
+	registerBuildsProvider(srv, "memo-provider", benchDesiredBuild, benchPreviousBuild)
+	registerBuildsProvider(srv, "memo-qwen-provider", serviceReasoningOptInModel)
+
+	tests := []struct {
+		name    string
+		body    string
+		service bool
+		// verbatim: no rewrite applies, so the handler forwards the caller's
+		// bytes untouched and must not seed the memo with them.
+		verbatim bool
+	}{
+		{"alias + runtime defaults + injected max_tokens", `{"model":"` + benchAlias + `","messages":[{"role":"user","content":"hi"}]}`, false, false},
+		{"raw build, explicit max_completion_tokens alias field", `{"model":"` + benchDesiredBuild + `","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":7}`, false, false},
+		{"stop string normalized", `{"model":"` + benchDesiredBuild + `","messages":[{"role":"user","content":"hi"}],"stop":"END","max_tokens":3}`, false, false},
+		{"service reasoning injected", `{"model":"` + serviceReasoningOptInModel + `","messages":[{"role":"user","content":"hi"}],"max_tokens":3}`, true, false},
+		{"service reasoning explicit", `{"model":"` + serviceReasoningOptInModel + `","messages":[{"role":"user","content":"hi"}],"reasoning":{"enabled":true},"max_tokens":3}`, true, true},
+		{"non-service qwen untouched", `{"model":"` + serviceReasoningOptInModel + `", "messages":[{"role":"user","content":"hi"}], "max_tokens":3}`, false, true},
+		{"caller-provided parser default kept", `{"model":"` + benchAlias + `","messages":[{"role":"user","content":"hi"}],"tool_call_parser":"mine","max_tokens":3}`, false, false},
+		{"private routing field stripped", `{"model":"` + benchAlias + `","messages":[{"role":"user","content":"hi"}],"provider_serial":"C02XYZ","max_tokens":3}`, false, false},
+		{"responses lowered", `{"model":"` + benchAlias + `","input":"hello","max_output_tokens":5}`, false, false},
+		{"responses verbatim", `{"model":"` + serviceReasoningOptInModel + `","input":"hello","max_output_tokens":5}`, false, true},
+		{"tools normalized", `{"model":"` + benchAlias + `","messages":[{"role":"user","content":"hi"}],"max_tokens":3,"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"x"}}}}}]}`, false, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			providerBody, parsed, defaults, model, reasoningProvided, isResponsesAPI, serialized :=
+				runChatRewrites(t, srv, test.body, test.service)
+			if serialized == test.verbatim {
+				t.Fatalf("serialized = %v, want %v", serialized, !test.verbatim)
+			}
+			fresh, err := srv.candidateProviderBody(parsed, defaults, model, test.service, reasoningProvided, isResponsesAPI)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.verbatim {
+				if isResponsesAPI {
+					want, err := promptcontract.LowerProviderBody(promptcontract.EndpointResponses, []byte(test.body))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !bytes.Equal(providerBody, want) {
+						t.Fatalf("verbatim Responses body was not lowered from the caller's bytes:\n got %s\nwant %s", providerBody, want)
+					}
+				} else if string(providerBody) != test.body {
+					t.Fatalf("verbatim request was re-serialized:\n got %s\nwant %s", providerBody, test.body)
+				}
+				return
+			}
+			if !bytes.Equal(fresh, providerBody) {
+				t.Fatalf("fresh candidate body diverged from the handler's serialization:\n got %s\nwant %s", fresh, providerBody)
+			}
+			// A fallback candidate rebuilt after the handler's own rewrites must
+			// equal the same candidate built from the pristine map — the invariant
+			// the admission preflight relies on when it probes Previous before the
+			// alias fallback mutates parsed.
+			if !isResponsesAPI && model == benchDesiredBuild {
+				before, err := srv.candidateProviderBody(parsed, defaults, benchPreviousBuild, test.service, reasoningProvided, false)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Simulate the fallback the handler applies: model rewritten, defaults
+				// reconciled for the new build, reasoning policy re-applied, then a
+				// fresh serialization — which the memo would be seeded with.
+				parsed["model"] = benchPreviousBuild
+				if rec, err := srv.store.GetModelRegistryRecord(benchPreviousBuild); err == nil {
+					defaults.apply(parsed, rec.RuntimeParameters)
+				} else {
+					defaults.apply(parsed, nil)
+				}
+				applyResolvedModelReasoningPolicy(parsed, benchPreviousBuild, test.service, reasoningProvided)
+				after, err := marshalForwardBody(parsed)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(before, after) {
+					t.Fatalf("fallback candidate differs from the post-fallback serialization:\n got %s\nwant %s", before, after)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderBodyMemoBuildsOncePerModel(t *testing.T) {
+	builds := map[string]int{}
+	memo := newProviderBodyMemo(func(model string) ([]byte, error) {
+		builds[model]++
+		if model == "broken" {
+			return nil, errors.New("cannot build")
+		}
+		return []byte(`{"model":"` + model + `"}`), nil
+	}, true, false)
+
+	memo.seed("seeded", []byte(`{"model":"seeded","seeded":true}`))
+	if body, err := memo.body("seeded"); err != nil || !bytes.Contains(body, []byte(`"seeded":true`)) {
+		t.Fatalf("seeded body = %s, %v", body, err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, ok := memo.traits("seeded"); !ok {
+			t.Fatal("seeded traits unavailable")
+		}
+		if err := memo.sizeError("seeded"); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := memo.traits("fresh"); !ok {
+			t.Fatal("fresh traits unavailable")
+		}
+		if _, err := memo.body("fresh"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if builds["seeded"] != 0 || builds["fresh"] != 1 {
+		t.Fatalf("builds = %v, want seeded:0 fresh:1", builds)
+	}
+	traits, _ := memo.traits("fresh")
+	if !traits.HasTools {
+		t.Fatalf("traits lost HasTools: %+v", traits)
+	}
+
+	// A build failure yields no traits and no size error (a build failure is
+	// not a size verdict), and is not retried.
+	if _, ok := memo.traits("broken"); ok {
+		t.Fatal("broken candidate reported traits")
+	}
+	if err := memo.sizeError("broken"); err != nil {
+		t.Fatalf("broken candidate reported size error %v", err)
+	}
+	memo.sizeError("broken")
+	if builds["broken"] != 1 {
+		t.Fatalf("broken rebuilt %d times", builds["broken"])
+	}
+
+	// reset forgets everything, including seeds.
+	memo.reset()
+	if _, err := memo.body("seeded"); err != nil {
+		t.Fatal(err)
+	}
+	if builds["seeded"] != 1 {
+		t.Fatalf("seeded not rebuilt after reset: %v", builds)
+	}
+}

--- a/coordinator/api/provider_body_seal.go
+++ b/coordinator/api/provider_body_seal.go
@@ -1,0 +1,63 @@
+package api
+
+// provider_body_seal.go seals a provider body for a protocol-0 cache
+// isolation attempt (the per-attempt prompt_cache_key buster) and sizes the
+// result without necessarily building it. Both take the splice fast path of
+// provider_body_splice.go for bodies proven canonical and fall back to the
+// decode/re-encode path otherwise; bodyForCacheAttempt (consumer.go) is the
+// dispatch-time caller, the sizing probes behind routingTraitsForProviderBody
+// are the pre-dispatch ones.
+
+import "encoding/json"
+
+// legacyCacheBustField is the request field a protocol-0 provider reads its
+// per-attempt cache isolation key from.
+const legacyCacheBustField = "prompt_cache_key"
+
+// sealLegacyCacheBust is the decode/re-encode path for bodies the splice fast
+// path cannot prove canonical.
+func sealLegacyCacheBust(body, keyJSON []byte) ([]byte, error) {
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, err
+	}
+	parsed[legacyCacheBustField] = keyJSON
+	return marshalForwardBody(parsed)
+}
+
+// cacheAttemptSealedSize returns the length bodyForCacheAttempt's sealed body
+// would have for a provider-specific body and (possibly empty) legacy
+// cache-bust key, computed arithmetically for canonical bodies and by the
+// decode/re-encode path otherwise — never building the sealed bytes on the
+// arithmetic path.
+func cacheAttemptSealedSize(body []byte, legacyKey string) (int, error) {
+	if legacyKey == "" {
+		return len(body), nil
+	}
+	keyJSON, err := json.Marshal(legacyKey)
+	if err != nil {
+		return 0, err
+	}
+	if size, ok := splicedTopLevelMemberSize(body, legacyCacheBustField, keyJSON); ok {
+		return size, nil
+	}
+	sealed, err := sealLegacyCacheBust(body, keyJSON)
+	if err != nil {
+		return 0, err
+	}
+	return len(sealed), nil
+}
+
+// cacheAttemptSizeError mirrors bodyForCacheAttempt's verdict from a size:
+// (0, nil) when the sealed body fits, (size, errProviderBodyTooLarge) when it
+// does not, and (0, err) for a body that cannot be sealed at all.
+func cacheAttemptSizeError(body []byte, legacyKey string) (int, error) {
+	size, err := cacheAttemptSealedSize(body, legacyKey)
+	if err != nil {
+		return 0, err
+	}
+	if size > maxInferenceBodyBytes {
+		return size, &providerBodyTooLargeError{size: size}
+	}
+	return 0, nil
+}

--- a/coordinator/api/provider_body_splice.go
+++ b/coordinator/api/provider_body_splice.go
@@ -1,0 +1,455 @@
+package api
+
+// provider_body_splice.go is the allocation-free fast path behind the
+// protocol-0 cache-isolation sizing and sealing (bodyForCacheAttempt and its
+// size-only callers, see provider_body_seal.go) and the legacy vision penalty
+// strip (bodyForProvider).
+//
+// Those helpers used to decode the whole provider body into
+// map[string]json.RawMessage and re-encode it — twice per candidate model per
+// request, and again per dispatch attempt — just to add one top-level member
+// (or check whether a few exist). For a body the coordinator itself serialized
+// (marshalForwardBody: compact, keys sorted, canonical string escaping) the
+// re-encode is the identity on every existing member, so the sealed body is
+// the input with `"prompt_cache_key":<value>` spliced in at its sorted
+// position, and its size is plain arithmetic.
+//
+// Exactness argument (encoding/json, escapeHTML=false): a RawMessage value is
+// re-emitted through compact, which only drops whitespace outside strings;
+// object keys are decoded and re-encoded with appendString, then sorted by
+// strings.Compare. So the re-encode is byte-identical to a splice iff (1) the
+// body carries no insignificant whitespace anywhere, (2) every top-level key
+// is escape-free printable ASCII without `"`/`\` (decoded == raw, and
+// re-encoding is the identity), and (3) the keys are strictly increasing
+// (already sorted, no duplicates to collapse). Anything else — a caller's
+// verbatim pretty-printed body, non-ASCII keys, duplicates — takes the
+// decode/re-encode path exactly as before.
+//
+// The scanner is a complete structural validator of the JSON grammar
+// encoding/json's scanner accepts (object/array structure, string escapes and
+// control bytes, number and literal syntax, nesting bounded well below the
+// decoder's limit), so a body it indexes is one the decode path would have
+// accepted; it does not check UTF-8 validity, which the decoder does not
+// reject either (RawMessage values are copied verbatim).
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+)
+
+// maxSpliceNestingDepth bounds the recursive scan. It sits well under
+// encoding/json's own limit (10000), so a body nested deeper is simply handed
+// to the decode path, which stays the authority on whether it is accepted.
+const maxSpliceNestingDepth = 8192
+
+// topLevelMember locates one member of a JSON object body.
+type topLevelMember struct {
+	keyStart, keyEnd     int // body[keyStart:keyEnd] is the quoted key, quotes included
+	valueStart, valueEnd int // body[valueStart:valueEnd] is the raw value
+}
+
+// topLevelIndex describes the top-level members of a JSON object body and the
+// properties the fast paths rely on.
+type topLevelIndex struct {
+	members []topLevelMember
+	// compact: no whitespace outside strings anywhere in the body.
+	compact bool
+	// plainKeys: every top-level key is escape-free printable ASCII without
+	// `"` or `\`, so its decoded form is exactly its raw bytes.
+	plainKeys bool
+	// sorted: the keys are strictly increasing in byte order.
+	sorted bool
+}
+
+// canonical reports whether re-encoding the body's members is the identity.
+func (idx topLevelIndex) canonical() bool {
+	return idx.compact && idx.plainKeys && idx.sorted
+}
+
+// rawKey returns the unquoted raw key bytes of a member.
+func (idx topLevelIndex) rawKey(body []byte, m topLevelMember) []byte {
+	return body[m.keyStart+1 : m.keyEnd-1]
+}
+
+// find returns the position of the first member whose raw key equals key.
+func (idx topLevelIndex) find(body []byte, key string) (int, bool) {
+	for i, m := range idx.members {
+		if string(idx.rawKey(body, m)) == key {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// noteMember records a top-level member and folds its key into the
+// plainKeys / sorted verdicts.
+func (idx *topLevelIndex) noteMember(body []byte, m topLevelMember) {
+	key := body[m.keyStart+1 : m.keyEnd-1]
+	for _, b := range key {
+		if !isPlainKeyByte(b) {
+			idx.plainKeys = false
+			break
+		}
+	}
+	if n := len(idx.members); n > 0 {
+		previous := idx.rawKey(body, idx.members[n-1])
+		if bytes.Compare(previous, key) >= 0 {
+			idx.sorted = false
+		}
+	}
+	idx.members = append(idx.members, m)
+}
+
+func isJSONWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+func isPlainKeyByte(b byte) bool {
+	return b >= 0x20 && b < 0x7f && b != '"' && b != '\\'
+}
+
+func isHexDigit(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F')
+}
+
+// skipJSONSpace advances past insignificant whitespace and reports whether
+// any was present.
+func skipJSONSpace(body []byte, i int) (int, bool) {
+	start := i
+	for i < len(body) && isJSONWhitespace(body[i]) {
+		i++
+	}
+	return i, i != start
+}
+
+// indexTopLevelObject scans body as a single JSON object, validating the full
+// grammar on the way. ok=false when body is not a valid object (the caller
+// then decodes it for real, which reports the same verdict).
+func indexTopLevelObject(body []byte) (topLevelIndex, bool) {
+	idx := topLevelIndex{compact: true, plainKeys: true, sorted: true}
+	i, ws := skipJSONSpace(body, 0)
+	if ws {
+		idx.compact = false
+	}
+	if i >= len(body) || body[i] != '{' {
+		return topLevelIndex{}, false
+	}
+	end, compact, ok := scanJSONObject(body, i, 1, &idx)
+	if !ok {
+		return topLevelIndex{}, false
+	}
+	if !compact {
+		idx.compact = false
+	}
+	i, ws = skipJSONSpace(body, end)
+	if ws {
+		idx.compact = false
+	}
+	if i != len(body) {
+		return topLevelIndex{}, false // trailing content
+	}
+	return idx, true
+}
+
+// scanJSONValue validates the value starting at body[i] and returns the index
+// just past it, plus whether it carried no whitespace outside strings.
+func scanJSONValue(body []byte, i, depth int) (end int, compact bool, ok bool) {
+	if i >= len(body) {
+		return 0, false, false
+	}
+	switch body[i] {
+	case '"':
+		end, ok = scanJSONString(body, i)
+		return end, true, ok
+	case '{':
+		return scanJSONObject(body, i, depth+1, nil)
+	case '[':
+		return scanJSONArray(body, i, depth+1)
+	default:
+		return scanJSONScalar(body, i)
+	}
+}
+
+// scanJSONObject validates an object starting at body[i] == '{'. idx, when
+// non-nil, receives the object's members (only the top level asks).
+func scanJSONObject(body []byte, i, depth int, idx *topLevelIndex) (end int, compact bool, ok bool) {
+	if depth > maxSpliceNestingDepth {
+		return 0, false, false
+	}
+	compact = true
+	i++ // '{'
+	var ws bool
+	if i, ws = skipJSONSpace(body, i); ws {
+		compact = false
+	}
+	if i < len(body) && body[i] == '}' {
+		return i + 1, compact, true
+	}
+	for {
+		if i >= len(body) || body[i] != '"' {
+			return 0, false, false
+		}
+		var m topLevelMember
+		m.keyStart = i
+		if i, ok = scanJSONString(body, i); !ok {
+			return 0, false, false
+		}
+		m.keyEnd = i
+		if i, ws = skipJSONSpace(body, i); ws {
+			compact = false
+		}
+		if i >= len(body) || body[i] != ':' {
+			return 0, false, false
+		}
+		i++
+		if i, ws = skipJSONSpace(body, i); ws {
+			compact = false
+		}
+		m.valueStart = i
+		var valueCompact bool
+		if i, valueCompact, ok = scanJSONValue(body, i, depth); !ok {
+			return 0, false, false
+		}
+		if !valueCompact {
+			compact = false
+		}
+		m.valueEnd = i
+		if idx != nil {
+			idx.noteMember(body, m)
+		}
+		if i, ws = skipJSONSpace(body, i); ws {
+			compact = false
+		}
+		if i >= len(body) {
+			return 0, false, false
+		}
+		switch body[i] {
+		case ',':
+			i++
+			if i, ws = skipJSONSpace(body, i); ws {
+				compact = false
+			}
+		case '}':
+			return i + 1, compact, true
+		default:
+			return 0, false, false
+		}
+	}
+}
+
+// scanJSONArray validates an array starting at body[i] == '['.
+func scanJSONArray(body []byte, i, depth int) (end int, compact bool, ok bool) {
+	if depth > maxSpliceNestingDepth {
+		return 0, false, false
+	}
+	compact = true
+	i++ // '['
+	var ws bool
+	if i, ws = skipJSONSpace(body, i); ws {
+		compact = false
+	}
+	if i < len(body) && body[i] == ']' {
+		return i + 1, compact, true
+	}
+	for {
+		var valueCompact bool
+		if i, valueCompact, ok = scanJSONValue(body, i, depth); !ok {
+			return 0, false, false
+		}
+		if !valueCompact {
+			compact = false
+		}
+		if i, ws = skipJSONSpace(body, i); ws {
+			compact = false
+		}
+		if i >= len(body) {
+			return 0, false, false
+		}
+		switch body[i] {
+		case ',':
+			i++
+			if i, ws = skipJSONSpace(body, i); ws {
+				compact = false
+			}
+		case ']':
+			return i + 1, compact, true
+		default:
+			return 0, false, false
+		}
+	}
+}
+
+// scanJSONString validates the string starting at body[start] == '"' and
+// returns the index just past its closing quote: no raw control bytes, only
+// the escapes the grammar allows (\" \\ \/ \b \f \n \r \t \uXXXX). The
+// closing-quote search is SIMD-assisted and every byte is examined once, so
+// a long string with many escapes stays linear.
+func scanJSONString(body []byte, start int) (int, bool) {
+	j := start + 1
+	quotePos := -1
+	for {
+		if quotePos < j {
+			q := bytes.IndexByte(body[j:], '"')
+			if q < 0 {
+				return 0, false
+			}
+			quotePos = j + q
+		}
+		escape := bytes.IndexByte(body[j:quotePos], '\\')
+		if escape < 0 {
+			if hasControlByte(body[j:quotePos]) {
+				return 0, false
+			}
+			return quotePos + 1, true
+		}
+		e := j + escape
+		if hasControlByte(body[j:e]) || e+1 >= len(body) {
+			return 0, false
+		}
+		switch body[e+1] {
+		case '"', '\\', '/', 'b', 'f', 'n', 'r', 't':
+			j = e + 2
+		case 'u':
+			if e+6 > len(body) {
+				return 0, false
+			}
+			for _, h := range body[e+2 : e+6] {
+				if !isHexDigit(h) {
+					return 0, false
+				}
+			}
+			j = e + 6
+		default:
+			return 0, false
+		}
+	}
+}
+
+// hasControlByte reports whether b contains any byte below 0x20, eight bytes
+// at a time.
+func hasControlByte(b []byte) bool {
+	const (
+		ones = 0x0101010101010101
+		high = 0x8080808080808080
+	)
+	for len(b) >= 8 {
+		v := binary.LittleEndian.Uint64(b)
+		if (v-ones*0x20)&^v&high != 0 {
+			return true
+		}
+		b = b[8:]
+	}
+	for _, c := range b {
+		if c < 0x20 {
+			return true
+		}
+	}
+	return false
+}
+
+// scanJSONScalar accepts the literals true/false/null and JSON numbers.
+func scanJSONScalar(body []byte, start int) (end int, compact bool, ok bool) {
+	end = start
+	for end < len(body) {
+		b := body[end]
+		if b == ',' || b == '}' || b == ']' || isJSONWhitespace(b) {
+			break
+		}
+		end++
+	}
+	literal := body[start:end]
+	switch string(literal) {
+	case "true", "false", "null":
+		return end, true, true
+	}
+	if jsonNumberLiteralValid(string(literal)) {
+		return end, true, true
+	}
+	return 0, false, false
+}
+
+// spliceTopLevelMember returns body with key set to valueJSON — replacing an
+// existing member or inserting at the sorted position — when body is
+// canonical, so the result is byte-identical to decoding body into
+// map[string]json.RawMessage, setting the key, and marshalForwardBody-ing it.
+// ok=false means the caller must take that decode path.
+func spliceTopLevelMember(body []byte, key string, valueJSON []byte) ([]byte, bool) {
+	idx, ok := indexTopLevelObject(body)
+	if !ok || !idx.canonical() {
+		return nil, false
+	}
+	if pos, exists := idx.find(body, key); exists {
+		m := idx.members[pos]
+		out := make([]byte, 0, len(body)-(m.valueEnd-m.valueStart)+len(valueJSON))
+		out = append(out, body[:m.valueStart]...)
+		out = append(out, valueJSON...)
+		out = append(out, body[m.valueEnd:]...)
+		return out, true
+	}
+	at, insertBefore := insertionPoint(body, idx, key)
+	out := make([]byte, 0, len(body)+len(key)+3+len(valueJSON)+1)
+	out = append(out, body[:at]...)
+	if !insertBefore && len(idx.members) > 0 {
+		out = append(out, ',')
+	}
+	out = append(out, '"')
+	out = append(out, key...)
+	out = append(out, '"', ':')
+	out = append(out, valueJSON...)
+	if insertBefore {
+		out = append(out, ',')
+	}
+	out = append(out, body[at:]...)
+	return out, true
+}
+
+// splicedTopLevelMemberSize is the arithmetic twin of spliceTopLevelMember:
+// the length the spliced body would have, without building it.
+func splicedTopLevelMemberSize(body []byte, key string, valueJSON []byte) (int, bool) {
+	idx, ok := indexTopLevelObject(body)
+	if !ok || !idx.canonical() {
+		return 0, false
+	}
+	if pos, exists := idx.find(body, key); exists {
+		m := idx.members[pos]
+		return len(body) - (m.valueEnd - m.valueStart) + len(valueJSON), true
+	}
+	size := len(body) + len(key) + 3 + len(valueJSON) // "key": + value
+	if len(idx.members) > 0 {
+		size++ // separating comma
+	}
+	return size, true
+}
+
+// insertionPoint returns where a new member with key belongs in a sorted
+// canonical body: before the first member whose key sorts after it
+// (insertBefore=true, the new member gets a trailing comma) or, when no such
+// member exists, at the closing brace (a leading comma unless the object is
+// empty).
+func insertionPoint(body []byte, idx topLevelIndex, key string) (at int, insertBefore bool) {
+	pos := sort.Search(len(idx.members), func(i int) bool {
+		return string(idx.rawKey(body, idx.members[i])) > key
+	})
+	if pos < len(idx.members) {
+		return idx.members[pos].keyStart, true
+	}
+	return len(body) - 1, false
+}
+
+// topLevelObjectHasAnyKey reports whether body carries any of keys as a
+// top-level member. ok=false when body is not a valid object or a key is
+// not plain (an escaped spelling could decode to a listed key), in which case
+// the caller must decode for real.
+func topLevelObjectHasAnyKey(body []byte, keys []string) (has bool, ok bool) {
+	idx, ok := indexTopLevelObject(body)
+	if !ok || !idx.plainKeys {
+		return false, false
+	}
+	for _, key := range keys {
+		if _, exists := idx.find(body, key); exists {
+			return true, true
+		}
+	}
+	return false, true
+}

--- a/coordinator/api/provider_body_splice_test.go
+++ b/coordinator/api/provider_body_splice_test.go
@@ -1,0 +1,329 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// legacySealCacheBust is the pre-fast-path implementation of the protocol-0
+// cache-bust seal: decode into RawMessages, set the key, re-encode.
+func legacySealCacheBust(t *testing.T, body []byte, key string) []byte {
+	t.Helper()
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("legacy seal decode: %v", err)
+	}
+	keyJSON, _ := json.Marshal(key)
+	parsed["prompt_cache_key"] = keyJSON
+	sealed, err := marshalForwardBody(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sealed
+}
+
+// legacyStripPenalties is the pre-fast-path vision penalty strip.
+func legacyStripPenalties(t *testing.T, body []byte) []byte {
+	t.Helper()
+	parsed, err := decodeInferenceJSONObject(body)
+	if err != nil {
+		return body
+	}
+	changed := false
+	for _, key := range visionPenaltyFields {
+		if _, ok := parsed[key]; ok {
+			delete(parsed, key)
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+	out, err := marshalForwardBody(parsed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func forwardBytes(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := marshalForwardBody(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+type spliceCase struct {
+	body []byte
+	// fast reports whether the splice fast path must fire (canonical body).
+	fast bool
+}
+
+func spliceCases(t *testing.T) map[string]spliceCase {
+	t.Helper()
+	nested := map[string]any{
+		"messages": []any{map[string]any{"role": "user", "content": "a <b> & \"c\"\n\t\\   end"}},
+		"model":    "m",
+		"tools": []any{map[string]any{"type": "function", "function": map[string]any{
+			"name": "f", "parameters": map[string]any{"type": "object", "properties": map[string]any{}, "required": []any{}},
+		}}},
+		"temperature": json.Number("0.5"),
+		"stream":      true,
+		"stop":        nil,
+		"metadata":    map[string]any{"exact": json.Number("9007199254740993"), "arr": []any{json.Number("1"), false, nil, "x"}},
+	}
+	return map[string]spliceCase{
+		"canonical nested":            {forwardBytes(t, nested), true},
+		"canonical empty object":      {[]byte(`{}`), true},
+		"canonical single member":     {[]byte(`{"model":"m"}`), true},
+		"canonical key sorts first":   {[]byte(`{"a":1,"b":[1,2,{"c":"d"}]}`), true},
+		"canonical key sorts last":    {[]byte(`{"prompt":"x","z":"y"}`), true},
+		"canonical key sorts between": {[]byte(`{"messages":[],"prompt":"x","temperature":1}`), true},
+		"canonical existing key":      {forwardBytes(t, map[string]any{"model": "m", "prompt_cache_key": "old-key", "z": json.Number("1")}), true},
+		"canonical existing key last": {[]byte(`{"model":"m","prompt_cache_key":"old"}`), true},
+		"canonical invalid utf8":      {forwardBytes(t, map[string]any{"model": "m", "text": "bad \xff\xfe bytes"}), true},
+		"canonical escapes in values": {[]byte(`{"a":"quote \" backslash \\ A \\\"","b":"{not an object}","c":"[nor array],"}`), true},
+		// Raw (not coordinator-serialized) canonical bodies: values are copied
+		// verbatim by both paths, whatever they contain.
+		"canonical raw line separators": {[]byte("{\"a\":\"x\u2028y\u2029z\",\"b\":\"\\u2028 escaped\"}"), true},
+		"canonical raw invalid utf8":    {[]byte("{\"a\":\"bad \xff\xfe\xc0 bytes\",\"b\":1}"), true},
+		"canonical number forms":        {[]byte(`{"a":1e5,"b":-0,"c":1.0,"d":1E+5,"e":` + strings.Repeat("9", 300) + `,"f":[0.5e-7,-12.25E3,0]}`), true},
+		"canonical html and slashes":    {[]byte(`{"a":"<b>&amp;</b> http:\/\/x <"}`), true},
+		"canonical del in key":          {[]byte("{\"k\x7f\":1}"), false},
+		"pretty printed":                {[]byte("{\n  \"model\": \"m\",\n  \"messages\": []\n}"), false},
+		"whitespace inside nested":      {[]byte(`{"a":[1, 2],"b":"x"}`), false},
+		"unsorted keys":                 {[]byte(`{"z":1,"a":2}`), false},
+		"duplicate keys":                {[]byte(`{"a":1,"a":2}`), false},
+		"escaped key":                   {[]byte(`{"pro\u006dpt":"x"}`), false},
+		"non-ascii key":                 {[]byte(`{"ключ":"x"}`), false},
+		"key with quote escape":         {[]byte(`{"a\"b":"x"}`), false},
+		"leading whitespace":            {[]byte(` {"a":1}`), false},
+		"trailing newline":              {[]byte("{\"a\":1}\n"), false},
+	}
+}
+
+// Every case must seal to exactly what the decode/re-encode path produced,
+// and the arithmetic size must equal the sealed length — whether or not the
+// fast path fired, and the fast path must fire exactly for canonical bodies.
+func TestCacheBustSpliceMatchesReencode(t *testing.T) {
+	const key = "darkbloom-uncached-0123456789abcdefghijkl"
+	keyJSON, _ := json.Marshal(key)
+	for name, tc := range spliceCases(t) {
+		t.Run(name, func(t *testing.T) {
+			want := legacySealCacheBust(t, tc.body, key)
+			got, err := bodyForCacheAttempt(tc.body, false, nil, &registry.PendingRequest{LegacyCacheBustKey: key})
+			if err != nil {
+				t.Fatalf("bodyForCacheAttempt: %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("sealed body diverged:\n got %s\nwant %s", got, want)
+			}
+			size, err := cacheAttemptSealedSize(tc.body, key)
+			if err != nil || size != len(want) {
+				t.Fatalf("sealed size = %d (%v), want %d", size, err, len(want))
+			}
+			if _, fast := spliceTopLevelMember(tc.body, legacyCacheBustField, keyJSON); fast != tc.fast {
+				t.Fatalf("fast path fired = %v, want %v", fast, tc.fast)
+			}
+			if _, fast := splicedTopLevelMemberSize(tc.body, legacyCacheBustField, keyJSON); fast != tc.fast {
+				t.Fatalf("size fast path fired = %v, want %v", fast, tc.fast)
+			}
+			// A second seal of the sealed body (the key already present) also matches.
+			resealed, err := bodyForCacheAttempt(want, false, nil, &registry.PendingRequest{LegacyCacheBustKey: "second-key"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if wantResealed := legacySealCacheBust(t, want, "second-key"); !bytes.Equal(resealed, wantResealed) {
+				t.Fatalf("resealed body diverged:\n got %s\nwant %s", resealed, wantResealed)
+			}
+		})
+	}
+}
+
+// TestCacheBustSplicePropertyMatchesReencode is the property test: random
+// decoder-shaped objects serialized by marshalForwardBody (canonical unless a
+// key is not plain ASCII) and their json.Indent perturbations (never
+// canonical, except the empty object) must seal and size exactly like the
+// decode/re-encode reference, and the fast path must fire exactly when the
+// body is canonical.
+func TestCacheBustSplicePropertyMatchesReencode(t *testing.T) {
+	rnd := rand.New(rand.NewPCG(5, 8))
+	keys := []string{"a", "model", "messages", "prompt_cache_key", "zeta", "x<y>", "k\"q", "ключ", "tab\there", "prompt_cache_key2", "", "Z"}
+	values := []string{"", "plain", "quote\" backslash\\", "\n\t\b", "<html>&", "line\u2028sep", "bad\xffutf8", "emoji 🎉", "}{][,:"}
+	var gen func(depth int) any
+	gen = func(depth int) any {
+		switch k := rnd.IntN(8); {
+		case k == 0:
+			return nil
+		case k == 1:
+			return rnd.IntN(2) == 0
+		case k == 2:
+			return json.Number([]string{"0", "-0", "1.0", "1e5", "1E+5", "-12.25E3", strings.Repeat("7", 40)}[rnd.IntN(7)])
+		case k <= 4 || depth > 3:
+			return values[rnd.IntN(len(values))]
+		case k == 5:
+			m := make(map[string]any)
+			for i := rnd.IntN(4); i > 0; i-- {
+				m[keys[rnd.IntN(len(keys))]] = gen(depth + 1)
+			}
+			return m
+		default:
+			arr := make([]any, rnd.IntN(4))
+			for i := range arr {
+				arr[i] = gen(depth + 1)
+			}
+			return arr
+		}
+	}
+	check := func(i int, body []byte, key string, expectFast bool) {
+		t.Helper()
+		want := legacySealCacheBust(t, body, key)
+		got, err := bodyForCacheAttempt(body, false, nil, &registry.PendingRequest{LegacyCacheBustKey: key})
+		if err != nil {
+			t.Fatalf("tree %d: seal: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("tree %d: sealed body diverged:\n body %s\n got %s\nwant %s", i, body, got, want)
+		}
+		if size, err := cacheAttemptSealedSize(body, key); err != nil || size != len(want) {
+			t.Fatalf("tree %d: size = %d (%v), want %d", i, size, err, len(want))
+		}
+		keyJSON, _ := json.Marshal(key)
+		if _, fast := spliceTopLevelMember(body, legacyCacheBustField, keyJSON); fast != expectFast {
+			t.Fatalf("tree %d: fast path fired = %v, want %v for %s", i, fast, expectFast, body)
+		}
+	}
+	for i := 0; i < 500; i++ {
+		obj := make(map[string]any)
+		for n := rnd.IntN(7); n > 0; n-- {
+			obj[keys[rnd.IntN(len(keys))]] = gen(0)
+		}
+		plain := true
+		for k := range obj {
+			for _, b := range []byte(k) {
+				if !isPlainKeyByte(b) {
+					plain = false
+				}
+			}
+		}
+		key := fmt.Sprintf("darkbloom-uncached-%03d", i)
+		canonical := forwardBytes(t, obj)
+		check(i, canonical, key, plain)
+		var indented bytes.Buffer
+		if err := json.Indent(&indented, canonical, "", "  "); err != nil {
+			t.Fatal(err)
+		}
+		// Indentation adds whitespace outside strings unless the object is empty.
+		check(i, indented.Bytes(), key, plain && len(obj) == 0)
+	}
+}
+
+// The size-only verdict must match the byte-building verdict at the cap.
+func TestCacheAttemptSizeErrorMatchesSeal(t *testing.T) {
+	key := strings.Repeat("x", registry.LegacyCacheBustKeyLength)
+	sealedOverhead := len(`,"prompt_cache_key":""`) + len(key)
+	for _, delta := range []int{-1, 0, 1} {
+		fill := maxInferenceBodyBytes - sealedOverhead - len(`{"payload":""}`) + delta
+		body := []byte(`{"payload":"` + strings.Repeat("x", fill) + `"}`)
+		_, sealErr := bodyForCacheAttempt(body, false, nil, &registry.PendingRequest{LegacyCacheBustKey: key})
+		size, sizeErr := cacheAttemptSizeError(body, key)
+		if (sealErr == nil) != (sizeErr == nil) {
+			t.Fatalf("delta %d: seal err %v, size err %v", delta, sealErr, sizeErr)
+		}
+		if sealErr != nil && size != oversizedProviderBodyBytes(sealErr) {
+			t.Fatalf("delta %d: size %d, seal reported %d", delta, size, oversizedProviderBodyBytes(sealErr))
+		}
+		if sealErr == nil && size != 0 {
+			t.Fatalf("delta %d: fitting body reported size %d", delta, size)
+		}
+	}
+	if _, err := cacheAttemptSizeError([]byte(`not json`), key); err == nil {
+		t.Fatal("unsealable body reported no error")
+	}
+}
+
+func TestBodyForProviderPenaltyFastPath(t *testing.T) {
+	legacy := &registry.Provider{Version: "0.6.6"}
+	cases := map[string][]byte{
+		"no penalties canonical":  forwardBytes(t, map[string]any{"model": "m", "messages": []any{}, "temperature": json.Number("1")}),
+		"no penalties pretty":     []byte("{\n \"model\": \"m\"\n}"),
+		"presence penalty":        forwardBytes(t, map[string]any{"model": "m", "presence_penalty": json.Number("0.5")}),
+		"all penalties unsorted":  []byte(`{"repetition_penalty":1.1,"model":"m","frequency_penalty":0,"presence_penalty":0}`),
+		"escaped penalty key":     []byte(`{"model":"m","presence\u005fpenalty":0.5}`),
+		"penalty nested only":     []byte(`{"model":"m","x":{"presence_penalty":1}}`),
+		"not an object":           []byte(`[1,2]`),
+		"invalid json":            []byte(`{"model":`),
+		"duplicate penalty":       []byte(`{"presence_penalty":1,"presence_penalty":2,"model":"m"}`),
+		"penalty value has quote": []byte(`{"model":"m","presence_penalty":"a\"b"}`),
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			want := legacyStripPenalties(t, body)
+			got := bodyForProvider(body, true, legacy)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("legacy provider body diverged:\n got %s\nwant %s", got, want)
+			}
+			if bytes.Equal(want, body) && len(body) > 0 && &got[0] != &body[0] {
+				t.Fatal("unchanged body was copied")
+			}
+			// Fixed providers and text requests never strip.
+			if out := bodyForProvider(body, true, &registry.Provider{Version: penaltySafeProviderVersion}); !bytes.Equal(out, body) {
+				t.Fatal("fixed provider body changed")
+			}
+			if out := bodyForProvider(body, false, legacy); !bytes.Equal(out, body) {
+				t.Fatal("text request body changed")
+			}
+		})
+	}
+}
+
+func TestIndexTopLevelObjectRejectsMalformedBodies(t *testing.T) {
+	for _, body := range []string{
+		``, `[1,2]`, `{"a":1`, `{"a" 1}`, `{"a":1}x`, `{"a":tru}`, `{"a":01}`, `{"a":1,}`,
+		`{,"a":1}`, `{"a":"unterminated}`, `{"a":[1,2}`, `{"a":{"b":1]}`, `{a:1}`, `{"a":1 "b":2}`,
+		`{"a":1}}`, `{"a":"x\"}`,
+		// Nested grammar: the scanner must reject what encoding/json rejects, or
+		// the splice would succeed where the decode path errors.
+		`{"a":[1,,2]}`, `{"a":[1,]}`, `{"a":{"b":}}`, `{"a":{"b":1,}}`, `{"a":[1 2]}`, `{"a":{"b" 1}}`,
+		`{"a":[tru]}`, `{"a":{1:2}}`, `{"a":[01]}`, `{"a":[1.]}`, `{"a":[.5]}`, `{"a":[-]}`, `{"a":[1e]}`,
+		`{"a":"\x"}`, `{"a":"\u12G4"}`, `{"a":"\u123"}`, "{\"a\":\"tab\there\"}", "{\"a\":[\"nl\nhere\"]}",
+		`{"a":["unterminated]}`, `{"a":{"b":"c"}`, `{"a":[[1]}`, `{"a":{"b":[1}}`, `{"a":[]]}`,
+	} {
+		if _, ok := indexTopLevelObject([]byte(body)); ok {
+			t.Errorf("accepted malformed body %q", body)
+		}
+		if err := json.Unmarshal([]byte(body), new(map[string]json.RawMessage)); err == nil {
+			t.Errorf("fixture %q is valid JSON; the scanner would be right to accept it", body)
+		}
+	}
+	idx, ok := indexTopLevelObject([]byte(`{"b":{"x":[1,{"y":"}"}]},"a":"\"","c":null}`))
+	if !ok || len(idx.members) != 3 || idx.sorted || !idx.compact || !idx.plainKeys {
+		t.Fatalf("index = %+v ok=%v", idx, ok)
+	}
+}
+
+// Nesting deeper than the scanner's bound is handed to the decode path (which
+// stays the authority), never accepted by the fast path.
+func TestIndexTopLevelObjectBoundsNesting(t *testing.T) {
+	deep := []byte(`{"a":` + strings.Repeat("[", maxSpliceNestingDepth+8) + strings.Repeat("]", maxSpliceNestingDepth+8) + `}`)
+	if _, ok := indexTopLevelObject(deep); ok {
+		t.Fatal("scanner accepted nesting beyond its bound")
+	}
+	shallow := []byte(`{"a":` + strings.Repeat("[", 64) + strings.Repeat("]", 64) + `}`)
+	if idx, ok := indexTopLevelObject(shallow); !ok || !idx.canonical() {
+		t.Fatalf("scanner rejected shallow nesting: ok=%v idx=%+v", ok, idx)
+	}
+	// Valid escapes, literals and number forms nested anywhere are accepted.
+	valid := []byte(`{"a":["\"\\\/\b\f\n\r\té",true,false,null,0,-0,1.5,1e5,1E+5,2.5e-3,{"b":[[]],"c":{}}]}`)
+	if idx, ok := indexTopLevelObject(valid); !ok || !idx.canonical() {
+		t.Fatalf("scanner rejected valid nested body: ok=%v idx=%+v", ok, idx)
+	}
+}

--- a/coordinator/api/provider_heartbeat_bench_test.go
+++ b/coordinator/api/provider_heartbeat_bench_test.go
@@ -1,0 +1,206 @@
+package api
+
+// Benchmarks for the API-side heartbeat branch of providerReadLoop
+// (case protocol.TypeHeartbeat): everything that runs per provider per
+// heartbeat AFTER the frame is decoded. providerReadLoop itself needs a live
+// WebSocket, so the branch body is reproduced here step for step against a
+// registered provider carrying a realistic three-slot BackendCapacity with MLX
+// cache reclaimer telemetry — the shape every current provider reports.
+//
+//	go test ./api/ -run '^$' -bench 'HeartbeatBranch' -benchmem
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/eigeninference/d-inference/coordinator/datadog"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+const benchHeartbeatProviderID = "bench-heartbeat-provider"
+
+var benchHeartbeatModels = []string{
+	"mlx-community/bench-model-00-4bit",
+	"mlx-community/bench-model-01-4bit",
+	"mlx-community/bench-model-02-4bit",
+}
+
+func benchHeartbeatServer(tb testing.TB) (*Server, *registry.Provider) {
+	tb.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	// NewServer starts the telemetry worker and the trust-coverage loop; only
+	// Close stops them, so every benchmark server must be closed.
+	tb.Cleanup(srv.Close)
+
+	infos := make([]protocol.ModelInfo, 0, len(benchHeartbeatModels))
+	for _, m := range benchHeartbeatModels {
+		infos = append(infos, protocol.ModelInfo{ID: m, ModelType: "chat", Quantization: "4bit"})
+	}
+	p := reg.Register(benchHeartbeatProviderID, nil, &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{ChipFamily: "M3", ChipTier: "Max", MemoryGB: 128},
+		Models:                  infos,
+		Backend:                 registry.BackendMLXSwift,
+		Version:                 "0.8.15",
+		PublicKey:               "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+		EncryptedResponseChunks: true,
+	})
+	reg.Heartbeat(benchHeartbeatProviderID, benchHeartbeatMessage())
+	return srv, p
+}
+
+// benchHeartbeatMessage is a baseline (non-event) heartbeat: no prefix-cache
+// fields, three resident slots with engine-health counters, reclaimer stats.
+func benchHeartbeatMessage() *protocol.HeartbeatMessage {
+	slots := make([]protocol.BackendSlotCapacity, 0, 3)
+	for i, m := range benchHeartbeatModels {
+		kv := "paged"
+		slots = append(slots, protocol.BackendSlotCapacity{
+			Model:                 m,
+			State:                 "running",
+			NumRunning:            i,
+			MaxConcurrency:        8,
+			ObservedDecodeTPS:     20 + float64(i),
+			ObservedPrefillTPS:    900,
+			ActiveTokenBudgetUsed: int64(i) * 1400,
+			ActiveTokenBudgetMax:  120000,
+			KVBytesPerToken:       98304,
+			KVBackend:             &kv,
+			StepsExecuted:         int64(1000 + i),
+			Admits:                int64(50 + i),
+			FirstTokensEmitted:    int64(50 + i),
+		})
+	}
+	active := benchHeartbeatModels[0]
+	free := 30.0
+	return &protocol.HeartbeatMessage{
+		Type:        protocol.TypeHeartbeat,
+		Status:      "idle",
+		ActiveModel: &active,
+		WarmModels:  benchHeartbeatModels,
+		SystemMetrics: protocol.SystemMetrics{
+			MemoryPressure: 0.3,
+			CPUUsage:       0.2,
+			ThermalState:   "nominal",
+		},
+		BackendCapacity: &protocol.BackendCapacity{
+			Slots:             slots,
+			GPUMemoryActiveGB: 48,
+			GPUMemoryPeakGB:   52,
+			GPUMemoryCacheGB:  3,
+			TotalMemoryGB:     128,
+			FreeForLoadGB:     &free,
+			MLXCacheReclaimer: &protocol.MLXCacheReclaimerTelemetry{
+				CacheLimitBytes:       8 << 30,
+				SweepSignals:          120,
+				Reclaims:              12,
+				ReclaimedBytes:        3 << 30,
+				LastReclaimedBytes:    256 << 20,
+				LastReclaimDurationMS: 14,
+			},
+		},
+	}
+}
+
+// benchLocalStatsd wires a real DogStatsD client at a throwaway local UDP
+// socket so the benchmark pays the real client-side cost instead of the
+// nil-client no-op. datadog-go v5 aggregates gauges client-side, so what the
+// timed loop pays per call is the aggregator insert (metric/tag context key +
+// map update); formatting and the UDP write happen on the client's flush
+// goroutine. Nothing reads the socket; UDP just drops the datagrams.
+func benchLocalStatsd(tb testing.TB) *datadog.Client {
+	tb.Helper()
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("listen udp: %v", err)
+	}
+	tb.Cleanup(func() { _ = conn.Close() })
+	sd, err := statsd.New(conn.LocalAddr().String(), statsd.WithNamespace("bench."))
+	if err != nil {
+		tb.Fatalf("statsd client: %v", err)
+	}
+	tb.Cleanup(func() { _ = sd.Close() })
+	return &datadog.Client{Statsd: sd}
+}
+
+// runHeartbeatBranch mirrors the post-decode heartbeat branch of
+// providerReadLoop for a baseline heartbeat (no prefix-cache fields, so
+// UpdatePrefixCacheSnapshot is skipped exactly as in production).
+func runHeartbeatBranch(ctx context.Context, s *Server, providerID string, provider *registry.Provider, hb *protocol.HeartbeatMessage) {
+	s.registry.Heartbeat(providerID, hb)
+	runHeartbeatTail(ctx, s, providerID, provider, hb)
+}
+
+// runHeartbeatTail is the API-side tail after registry ingest, exactly as the
+// branch runs it today.
+func runHeartbeatTail(ctx context.Context, s *Server, providerID string, provider *registry.Provider, hb *protocol.HeartbeatMessage) {
+	capacity := provider.BackendCapacitySnapshot()
+	s.recordBackendWedgeTelemetry(capacity)
+	s.recordMLXCacheTelemetry(providerID, capacity)
+	s.maybeRearmCodeAttest(ctx, providerID, provider, hb)
+}
+
+// BenchmarkHeartbeatBranchNoDD is the whole branch with Datadog unconfigured
+// (metric calls are no-ops): registry ingest + snapshot + telemetry extraction.
+func BenchmarkHeartbeatBranchNoDD(b *testing.B) {
+	s, p := benchHeartbeatServer(b)
+	hb := benchHeartbeatMessage()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runHeartbeatBranch(ctx, s, benchHeartbeatProviderID, p, hb)
+	}
+}
+
+// BenchmarkHeartbeatBranchStatsd is the same branch with a real DogStatsD
+// client attached, so the nine per-heartbeat gauge emissions are paid.
+func BenchmarkHeartbeatBranchStatsd(b *testing.B) {
+	s, p := benchHeartbeatServer(b)
+	s.SetDatadog(benchLocalStatsd(b))
+	hb := benchHeartbeatMessage()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runHeartbeatBranch(ctx, s, benchHeartbeatProviderID, p, hb)
+	}
+}
+
+// BenchmarkHeartbeatBranchTelemetryOnly isolates the API-side tail (snapshot
+// + wedge + MLX cache telemetry + code-attest re-arm check) from the registry
+// ingest, with Datadog unconfigured.
+func BenchmarkHeartbeatBranchTelemetryOnly(b *testing.B) {
+	s, p := benchHeartbeatServer(b)
+	hb := benchHeartbeatMessage()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, hb)
+	}
+}
+
+// BenchmarkHeartbeatBranchTelemetryOnlyStatsd is the API-side tail with a real
+// DogStatsD client attached.
+func BenchmarkHeartbeatBranchTelemetryOnlyStatsd(b *testing.B) {
+	s, p := benchHeartbeatServer(b)
+	s.SetDatadog(benchLocalStatsd(b))
+	hb := benchHeartbeatMessage()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, hb)
+	}
+}

--- a/coordinator/api/provider_registration_test.go
+++ b/coordinator/api/provider_registration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
@@ -182,102 +183,109 @@ func TestProviderRegistrationBindsProtectedRuntimeClaims(t *testing.T) {
 
 func TestProviderRegistrationAttestationFreshnessVersionGate(t *testing.T) {
 	cases := []struct {
-		name      string
-		version   string
-		timestamp time.Time
-		accepted  bool
+		name            string
+		version         string
+		timestampOffset time.Duration
+		accepted        bool
 	}{
 		{
-			name:      "missing version retains legacy reconnect semantics",
-			timestamp: time.Now().Add(-10 * time.Minute),
-			accepted:  true,
+			name:            "missing version retains legacy reconnect semantics",
+			timestampOffset: -10 * time.Minute,
+			accepted:        true,
 		},
 		{
-			name:      "last legacy release accepts reconnect replay",
-			version:   "0.8.14",
-			timestamp: time.Now().Add(-10 * time.Minute),
-			accepted:  true,
+			name:            "last legacy release accepts reconnect replay",
+			version:         "0.8.14",
+			timestampOffset: -10 * time.Minute,
+			accepted:        true,
 		},
 		{
-			name:      "capability release rejects stale replay",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(-10 * time.Minute),
+			name:            "capability release rejects stale replay",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: -10 * time.Minute,
 		},
 		{
-			name:      "newer release rejects stale replay",
-			version:   "0.8.16",
-			timestamp: time.Now().Add(-10 * time.Minute),
+			name:            "newer release rejects stale replay",
+			version:         "0.8.16",
+			timestampOffset: -10 * time.Minute,
 		},
 		{
-			name:      "capability release accepts future skew just under boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew - time.Second),
-			accepted:  true,
+			name:            "capability release accepts future skew just under boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew - time.Second,
+			accepted:        true,
 		},
 		{
-			name:      "capability release accepts future skew at boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew),
-			accepted:  true,
+			name:            "capability release accepts future skew at boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew,
+			accepted:        true,
 		},
 		{
-			name:      "capability release rejects future skew over boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew + time.Second),
+			name:            "capability release rejects future skew just over boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew + time.Second,
 		},
 		{
-			name:      "capability release accepts fresh reconnect",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now(),
-			accepted:  true,
+			name:     "capability release accepts fresh reconnect",
+			version:  minProviderVersionForReconnectAttestation,
+			accepted: true,
 		},
 	}
 
 	for index, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			reg := registry.New(logger)
-			srv := NewServer(
-				reg,
-				store.NewMemory(store.Config{AdminKey: "test-key"}),
-				ServerConfig{},
-				logger,
-			)
-			publicKey := testPublicKeyB64()
-			regMsg := &protocol.RegisterMessage{
-				Type:      protocol.TypeRegister,
-				Version:   tc.version,
-				PublicKey: publicKey,
-				Attestation: buildTestAttestationJSONWithFields(
-					t, publicKey, "", "", tc.timestamp, nil),
-			}
-			provider := reg.Register(fmt.Sprintf("reconnect-%d", index), nil, regMsg)
-			srv.verifyProviderAttestation(provider.ID, provider, regMsg)
+			synctest.Test(t, func(t *testing.T) {
+				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+				reg := registry.New(logger)
+				srv := NewServer(
+					reg,
+					store.NewMemory(store.Config{AdminKey: "test-key"}),
+					ServerConfig{},
+					logger,
+				)
+				defer srv.Close()
+				publicKey := testPublicKeyB64()
+				// The bubble freezes time at a whole-second instant while this
+				// synchronous verification runs, so the signed fixture keeps exact
+				// below/at/one-second-over boundary coverage without aging between
+				// construction and CheckTimestamp. Production clocks are untouched.
+				timestamp := time.Now().Add(tc.timestampOffset)
+				regMsg := &protocol.RegisterMessage{
+					Type:      protocol.TypeRegister,
+					Version:   tc.version,
+					PublicKey: publicKey,
+					Attestation: buildTestAttestationJSONWithFields(
+						t, publicKey, "", "", timestamp, nil),
+				}
+				provider := reg.Register(fmt.Sprintf("reconnect-%d", index), nil, regMsg)
+				srv.verifyProviderAttestation(provider.ID, provider, regMsg)
 
-			provider.Mu().Lock()
-			defer provider.Mu().Unlock()
-			if tc.accepted {
-				if provider.Status == registry.StatusUntrusted ||
+				provider.Mu().Lock()
+				defer provider.Mu().Unlock()
+				if tc.accepted {
+					if provider.Status == registry.StatusUntrusted ||
+						provider.AttestationResult == nil ||
+						!provider.AttestationResult.Valid {
+						t.Fatalf("freshness-compatible registration rejected: status=%s result=%+v",
+							provider.Status, provider.AttestationResult)
+					}
+					if provider.LastChallengeVerified.IsZero() {
+						t.Fatal("accepted registration did not initialize periodic challenge freshness")
+					}
+					return
+				}
+				if provider.Status != registry.StatusUntrusted ||
 					provider.AttestationResult == nil ||
-					!provider.AttestationResult.Valid {
-					t.Fatalf("freshness-compatible registration rejected: status=%s result=%+v",
+					provider.AttestationResult.Error != "attestation timestamp outside freshness window" {
+					t.Fatalf("replayed attestation state = status=%s result=%+v",
 						provider.Status, provider.AttestationResult)
 				}
-				if provider.LastChallengeVerified.IsZero() {
-					t.Fatal("accepted registration did not initialize periodic challenge freshness")
+				if len(provider.RuntimeCapabilities) != 0 {
+					t.Fatalf("replayed attestation retained capabilities: %v",
+						provider.RuntimeCapabilities)
 				}
-				return
-			}
-			if provider.Status != registry.StatusUntrusted ||
-				provider.AttestationResult == nil ||
-				provider.AttestationResult.Error != "attestation timestamp outside freshness window" {
-				t.Fatalf("replayed attestation state = status=%s result=%+v",
-					provider.Status, provider.AttestationResult)
-			}
-			if len(provider.RuntimeCapabilities) != 0 {
-				t.Fatalf("replayed attestation retained capabilities: %v",
-					provider.RuntimeCapabilities)
-			}
+			})
 		})
 	}
 }

--- a/coordinator/api/provider_version_length_test.go
+++ b/coordinator/api/provider_version_length_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"nhooyr.io/websocket"
+)
+
+// A provider whose version string exceeds maxProviderVersionLength is refused
+// at registration with a policy-violation close and never enters the registry;
+// a normal version registers as before.
+func TestProviderRegistrationRejectsOversizedVersion(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	register := func(version string) (*websocket.Conn, error) {
+		wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		regMsg := protocol.RegisterMessage{
+			Type:                    protocol.TypeRegister,
+			Hardware:                protocol.Hardware{MachineModel: "Mac15,8", ChipName: "Apple M3 Max", MemoryGB: 64},
+			Models:                  []protocol.ModelInfo{{ID: "version-len-model", ModelType: "chat"}},
+			Backend:                 "mlx-swift",
+			Version:                 version,
+			PublicKey:               testPublicKeyB64(),
+			EncryptedResponseChunks: true,
+			PrivacyCapabilities:     testPrivacyCaps(),
+		}
+		data, _ := json.Marshal(regMsg)
+		if err := conn.Write(ctx, websocket.MessageText, data); err != nil {
+			t.Fatalf("write register: %v", err)
+		}
+		// The coordinator either closes the socket (rejection) or starts the
+		// challenge loop (accepted): read one frame to observe which.
+		_, _, err = conn.Read(ctx)
+		return conn, err
+	}
+
+	conn, err := register(strings.Repeat("9.", maxProviderVersionLength) + "0")
+	if err == nil {
+		t.Fatal("oversized version was accepted")
+	}
+	if status := websocket.CloseStatus(err); status != websocket.StatusPolicyViolation {
+		t.Fatalf("close status = %v, want policy violation (err=%v)", status, err)
+	}
+	conn.Close(websocket.StatusNormalClosure, "")
+	if got := reg.OnlineCount(); got != 0 {
+		t.Fatalf("rejected provider is online: count=%d", got)
+	}
+
+	conn, err = register("0.8.15")
+	if err != nil {
+		t.Fatalf("normal version rejected: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	if got := reg.OnlineCount(); got != 1 {
+		t.Fatalf("normal provider not registered: count=%d", got)
+	}
+}

--- a/coordinator/api/read_cache_endpoints_test.go
+++ b/coordinator/api/read_cache_endpoints_test.go
@@ -1,0 +1,458 @@
+package api
+
+// Read-cache coverage for the public catalog/trust endpoints, through the
+// real HTTP path: a repeat request within the TTL is served without
+// recomputing (store read counters stay flat, bytes identical), a mutation
+// inside the TTL is not yet visible, expiry recomputes, and per-caller views
+// (self-route owned models, key allow-lists) bypass the shared cache.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// catalogReadCountingStore wraps the real memory store and counts the DB reads the
+// cached catalog endpoints depend on.
+type catalogReadCountingStore struct {
+	store.Store
+	aliases  atomic.Int64
+	registry atomic.Int64
+}
+
+func (c *catalogReadCountingStore) ListModelAliases() ([]store.ModelAlias, error) {
+	c.aliases.Add(1)
+	return c.Store.ListModelAliases()
+}
+
+func (c *catalogReadCountingStore) ListActiveModelRegistryWithError() ([]store.ModelRegistryRecord, error) {
+	c.registry.Add(1)
+	return c.Store.ListActiveModelRegistryWithError()
+}
+
+func (c *catalogReadCountingStore) reads() int64 { return c.aliases.Load() + c.registry.Load() }
+
+// expireAllForTest backdates every entry so the next lookup misses —
+// deterministic TTL expiry without sleeping.
+func (c *ttlCache) expireAllForTest() {
+	c.mu.Lock()
+	for k, e := range c.data {
+		e.expiresAt = time.Now().Add(-time.Second)
+		c.data[k] = e
+	}
+	c.mu.Unlock()
+}
+
+type cachedEndpointHarness struct {
+	srv *Server
+	reg *registry.Registry
+	mem *store.MemoryStore
+	st  *catalogReadCountingStore
+	ts  *httptest.Server
+}
+
+func newCachedEndpointHarness(t *testing.T) *cachedEndpointHarness {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mem := store.NewMemory(store.Config{AdminKey: "test-key"})
+	st := &catalogReadCountingStore{Store: mem}
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+	srv.challengeInterval = 500 * time.Millisecond
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return &cachedEndpointHarness{srv: srv, reg: reg, mem: mem, st: st, ts: ts}
+}
+
+// seedCatalogModel registers an active catalog model with platform pricing
+// and syncs the routing catalog.
+func (h *cachedEndpointHarness) seedCatalogModel(t *testing.T, modelID string) {
+	t.Helper()
+	entry := &store.ModelRegistryEntry{
+		ID:               modelID,
+		DisplayName:      modelID + " display",
+		Family:           "test",
+		Quantization:     "4bit",
+		MaxContextLength: 8192,
+		MaxOutputLength:  1024,
+		MinRAMGB:         8,
+		Capabilities:     []string{"tools"},
+		Status:           "active",
+		CreatedAt:        time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	version := &store.ModelVersion{ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready"}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := h.mem.SetModelVersion(entry, version, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.mem.PromoteModelVersion(modelID, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	h.srv.SyncModelCatalog()
+	if err := h.mem.SetModelPrice("platform", modelID, 50_000, 200_000); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// connectProvider connects a routable provider serving modelID and keeps it
+// answering attestation challenges for the life of the test.
+func (h *cachedEndpointHarness) connectProvider(t *testing.T, ctx context.Context, modelID string) *websocket.Conn {
+	t.Helper()
+	pubKey := testPublicKeyB64()
+	conn := connectAndPrepareProvider(t, ctx, h.ts.URL, h.reg, modelID, pubKey, 50.0)
+	go handleProviderMessages(ctx, t, conn, func(msgType string, data []byte) []byte {
+		if msgType == protocol.TypeAttestationChallenge {
+			return makeValidChallengeResponse(data, pubKey)
+		}
+		return nil
+	})
+	t.Cleanup(func() { conn.Close(websocket.StatusNormalClosure, "") })
+	return conn
+}
+
+func (h *cachedEndpointHarness) get(t *testing.T, ctx context.Context, path, bearer string) (int, []byte) {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, h.ts.URL+path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+func mustOK(t *testing.T, status int, body []byte) {
+	t.Helper()
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, body)
+	}
+}
+
+func modelIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var resp types.ModelListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode model list: %v\n%s", err, body)
+	}
+	ids := make([]string, 0, len(resp.Data))
+	for _, m := range resp.Data {
+		ids = append(ids, m.ID)
+	}
+	return ids
+}
+
+func containsID(ids []string, id string) bool {
+	for _, v := range ids {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}
+
+// GET /v1/models: a repeat within the TTL is byte-identical and skips the
+// store; a provider that connects inside the TTL is not visible until the
+// entry expires, after which the list is recomputed.
+func TestModelsListCache_RepeatHitThenExpiry(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const modelA, modelB = "cache-model-a", "cache-model-b"
+	h.seedCatalogModel(t, modelA)
+	h.seedCatalogModel(t, modelB)
+	h.connectProvider(t, ctx, modelA)
+
+	status, first := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, first)
+	if ids := modelIDs(t, first); !containsID(ids, modelA) || containsID(ids, modelB) {
+		t.Fatalf("initial list = %v, want only %s", ids, modelA)
+	}
+	if !bytes.HasSuffix(first, []byte("}\n")) {
+		t.Fatalf("cached body must keep writeJSON's trailing newline: %q", first[len(first)-3:])
+	}
+	reads := h.st.reads()
+
+	status, second := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, second)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("cache hit diverged from the miss:\n%s\n%s", first, second)
+	}
+	if got := h.st.reads(); got != reads {
+		t.Fatalf("cache hit recomputed: store reads %d -> %d", reads, got)
+	}
+
+	// Registry mutation inside the TTL: a second provider serving model B.
+	h.connectProvider(t, ctx, modelB)
+	status, stale := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, stale)
+	if !bytes.Equal(first, stale) {
+		t.Fatalf("list changed inside the TTL; expected the cached body")
+	}
+
+	h.srv.readCache.expireAllForTest()
+	status, fresh := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, fresh)
+	if ids := modelIDs(t, fresh); !containsID(ids, modelA) || !containsID(ids, modelB) {
+		t.Fatalf("post-expiry list = %v, want both models", ids)
+	}
+	if got := h.st.reads(); got <= reads {
+		t.Fatalf("expiry did not recompute: store reads %d -> %d", reads, got)
+	}
+
+	// include_builds is part of the key: it is computed and cached separately.
+	reads = h.st.reads()
+	status, builds := h.get(t, ctx, "/v1/models?include_builds=1", "test-key")
+	mustOK(t, status, builds)
+	if got := h.st.reads(); got <= reads {
+		t.Fatal("include_builds=1 must not be served from the default key")
+	}
+	reads = h.st.reads()
+	status, builds2 := h.get(t, ctx, "/v1/models?include_builds=1", "test-key")
+	mustOK(t, status, builds2)
+	if !bytes.Equal(builds, builds2) || h.st.reads() != reads {
+		t.Fatal("include_builds=1 repeat should be a cache hit")
+	}
+}
+
+// GET /v1/models/{id} shares the memoized entry list: repeats (found and
+// not-found) do not re-read the catalog, and expiry recomputes.
+func TestModelsGetCache_SharesMemoizedEntries(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const modelA = "cache-get-model"
+	h.seedCatalogModel(t, modelA)
+	h.connectProvider(t, ctx, modelA)
+
+	status, first := h.get(t, ctx, "/v1/models/"+modelA, "test-key")
+	mustOK(t, status, first)
+	var entry types.ModelEntry
+	if err := json.Unmarshal(first, &entry); err != nil || entry.ID != modelA {
+		t.Fatalf("retrieve = %s (%v)", first, err)
+	}
+	reads := h.st.reads()
+
+	status, second := h.get(t, ctx, "/v1/models/"+modelA, "test-key")
+	mustOK(t, status, second)
+	if !bytes.Equal(first, second) || h.st.reads() != reads {
+		t.Fatalf("retrieve repeat recomputed (reads %d -> %d)", reads, h.st.reads())
+	}
+	if status, body := h.get(t, ctx, "/v1/models/does-not-exist", "test-key"); status != http.StatusNotFound {
+		t.Fatalf("unknown id status = %d body = %s", status, body)
+	}
+	if h.st.reads() != reads {
+		t.Fatalf("404 path re-read the catalog (reads %d -> %d)", reads, h.st.reads())
+	}
+
+	h.srv.readCache.expireAllForTest()
+	status, third := h.get(t, ctx, "/v1/models/"+modelA, "test-key")
+	mustOK(t, status, third)
+	if h.st.reads() <= reads {
+		t.Fatal("expiry did not recompute the entry list")
+	}
+}
+
+// The self-route (owned-model) view is never cached: it re-reads on every
+// request, and the key's allow-list is applied to the live result even while
+// the public list is cache-warm.
+func TestModelsList_SelfRouteViewBypassesCacheAndFiltersByKey(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const modelA = "owned-model-a"
+	const owner = "owner-acct"
+	h.seedCatalogModel(t, modelA)
+	h.connectProvider(t, ctx, modelA)
+	setOwnedProvider(h.srv, owner)
+
+	// Warm the public cache.
+	status, public := h.get(t, ctx, "/v1/models", "test-key")
+	mustOK(t, status, public)
+	if !containsID(modelIDs(t, public), modelA) {
+		t.Fatalf("public list missing %s: %s", modelA, public)
+	}
+
+	restricted, _, err := h.mem.CreateAPIKey(owner, store.APIKeyCreate{Name: "restricted", SelfRouteOnly: true, AllowedModels: []string{"some-other-model"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrestricted, _, err := h.mem.CreateAPIKey(owner, store.APIKeyCreate{Name: "mine", SelfRouteOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reads := h.st.reads()
+	status, body := h.get(t, ctx, "/v1/models", restricted)
+	mustOK(t, status, body)
+	if ids := modelIDs(t, body); len(ids) != 0 {
+		t.Fatalf("allow-listed self-route key must not see %v", ids)
+	}
+	if h.st.reads() == reads {
+		t.Fatal("self-route view must be computed live (no store read happened)")
+	}
+
+	reads = h.st.reads()
+	status, body = h.get(t, ctx, "/v1/models", unrestricted)
+	mustOK(t, status, body)
+	var owned types.ModelListResponse
+	if err := json.Unmarshal(body, &owned); err != nil {
+		t.Fatal(err)
+	}
+	if len(owned.Data) != 1 || owned.Data[0].ID != modelA || owned.Data[0].OwnedBy != "self" {
+		t.Fatalf("owned view = %+v, want one self-owned %s", owned.Data, modelA)
+	}
+	if h.st.reads() == reads {
+		t.Fatal("second self-route view must also be computed live")
+	}
+	if bytes.Equal(body, public) {
+		t.Fatal("self-route view must not be the cached public body")
+	}
+}
+
+// GET /v1/models/openrouter: repeat within the TTL is byte-identical and
+// skips the store; an admin catalog change (which runs SyncModelCatalog) is
+// visible on the next request because the sync invalidates the feed entry,
+// and the refreshed entry is again served from cache until it expires.
+func TestOpenRouterFeedCache_RepeatHitThenExpiry(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	const modelA, modelB = "or-model-a", "or-model-b"
+	h.seedCatalogModel(t, modelA)
+
+	status, first := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, first)
+	if !strings.Contains(string(first), modelA) {
+		t.Fatalf("feed missing %s: %s", modelA, first)
+	}
+	reads := h.st.reads()
+
+	status, second := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, second)
+	if !bytes.Equal(first, second) || h.st.reads() != reads {
+		t.Fatalf("feed repeat recomputed (reads %d -> %d)", reads, h.st.reads())
+	}
+
+	h.seedCatalogModel(t, modelB) // SyncModelCatalog runs and invalidates the feed
+	reads = h.st.reads()
+	status, fresh := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, fresh)
+	if !strings.Contains(string(fresh), modelB) {
+		t.Fatalf("post-sync feed missing %s without waiting for the TTL: %s", modelB, fresh)
+	}
+	if h.st.reads() <= reads {
+		t.Fatal("catalog sync did not recompute the feed")
+	}
+
+	// The refreshed entry is cached again until it expires.
+	reads = h.st.reads()
+	status, again := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, again)
+	if !bytes.Equal(fresh, again) || h.st.reads() != reads {
+		t.Fatalf("refreshed feed repeat recomputed (reads %d -> %d)", reads, h.st.reads())
+	}
+	h.srv.readCache.expireAllForTest()
+	reads = h.st.reads()
+	status, expired := h.get(t, ctx, "/v1/models/openrouter", "test-key")
+	mustOK(t, status, expired)
+	if h.st.reads() <= reads {
+		t.Fatal("expiry did not recompute the feed")
+	}
+}
+
+// GET /v1/providers/attestation: repeat within the TTL is byte-identical; a
+// trust-level change inside the TTL is not visible until the entry expires.
+func TestProviderAttestationCache_RepeatHitThenExpiry(t *testing.T) {
+	h := newCachedEndpointHarness(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	h.connectProvider(t, ctx, "attest-model")
+	ids := h.reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("providers = %v", ids)
+	}
+
+	status, first := h.get(t, ctx, "/v1/providers/attestation", "")
+	mustOK(t, status, first)
+	if !strings.Contains(string(first), `"trust_level":"hardware"`) {
+		t.Fatalf("expected hardware trust: %s", first)
+	}
+	status, second := h.get(t, ctx, "/v1/providers/attestation", "")
+	mustOK(t, status, second)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("repeat diverged:\n%s\n%s", first, second)
+	}
+
+	h.reg.SetTrustLevel(ids[0], registry.TrustSelfSigned)
+	status, stale := h.get(t, ctx, "/v1/providers/attestation", "")
+	mustOK(t, status, stale)
+	if !bytes.Equal(first, stale) {
+		t.Fatal("attestation changed inside the TTL; expected the cached body")
+	}
+
+	h.srv.readCache.expireAllForTest()
+	status, fresh := h.get(t, ctx, "/v1/providers/attestation", "")
+	mustOK(t, status, fresh)
+	if !strings.Contains(string(fresh), `"trust_level":"self_signed"`) {
+		t.Fatalf("post-expiry attestation still stale: %s", fresh)
+	}
+}
+
+// encodeCachedJSON renders exactly what writeJSON writes, so hits and misses
+// are byte-identical.
+func TestEncodeCachedJSONMatchesWriteJSON(t *testing.T) {
+	v := map[string]any{"b": []int{1, 2}, "a": "x<y&z", "n": nil}
+	rec := httptest.NewRecorder()
+	writeJSON(rec, http.StatusOK, v)
+	body, err := encodeCachedJSON(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), body) {
+		t.Fatalf("encodeCachedJSON = %q, writeJSON = %q", body, rec.Body.Bytes())
+	}
+}
+
+// Typed values share the map with byte entries: independent keys, TTL
+// expiry, and Get/GetValue never return the other kind.
+func TestTTLCacheTypedValues(t *testing.T) {
+	c := newTTLCache()
+	c.SetValue("entries", []string{"a"}, time.Minute)
+	c.Set("body", []byte("{}"), time.Minute)
+	if v, ok := c.GetValue("entries"); !ok || len(v.([]string)) != 1 {
+		t.Fatalf("GetValue = %v, %v", v, ok)
+	}
+	if _, ok := c.Get("entries"); ok {
+		t.Fatal("Get must not return a typed entry as bytes")
+	}
+	if _, ok := c.GetValue("body"); ok {
+		t.Fatal("GetValue must not return a byte entry as a value")
+	}
+	c.SetValue("stale", 1, -time.Second)
+	if _, ok := c.GetValue("stale"); ok {
+		t.Fatal("expired typed value returned")
+	}
+	c.PurgeExpired()
+	if c.Len() != 2 {
+		t.Fatalf("Len after purge = %d, want 2", c.Len())
+	}
+}

--- a/coordinator/api/reasoning_request_policy.go
+++ b/coordinator/api/reasoning_request_policy.go
@@ -4,42 +4,29 @@ const serviceReasoningOptInModel = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
 
 // applyResolvedModelReasoningPolicy makes reasoning opt-in for service traffic
 // to the Qwen build. Gemma defaults thinking off, while the production Qwen
-// template defaults it on when reasoning is absent.
+// template defaults it on when reasoning is absent. It mutates parsed in place
+// and reports whether it did, so the caller marks its forward body dirty; it
+// is idempotent for a given resolved model, which lets the per-request body
+// memo reuse the handler's own serialization for that model.
 func applyResolvedModelReasoningPolicy(
 	parsed map[string]any,
-	rawBody []byte,
 	resolvedModel string,
 	serviceConsumer bool,
 	reasoningProvided bool,
-) ([]byte, bool, error) {
+) (changed bool) {
 	if reasoningProvided {
-		return rawBody, false, nil
+		return false
 	}
 
 	_, hasReasoning := parsed["reasoning"]
 	shouldDisable := serviceConsumer && resolvedModel == serviceReasoningOptInModel
 	if hasReasoning == shouldDisable {
-		return rawBody, false, nil
-	}
-
-	updated := make(map[string]any, len(parsed)+1)
-	for key, value := range parsed {
-		updated[key] = value
+		return false
 	}
 	if shouldDisable {
-		updated["reasoning"] = map[string]any{"enabled": false}
-	} else {
-		delete(updated, "reasoning")
-	}
-
-	body, err := marshalForwardBody(updated)
-	if err != nil {
-		return rawBody, false, err
-	}
-	if shouldDisable {
-		parsed["reasoning"] = updated["reasoning"]
+		parsed["reasoning"] = map[string]any{"enabled": false}
 	} else {
 		delete(parsed, "reasoning")
 	}
-	return body, true, nil
+	return true
 }

--- a/coordinator/api/reasoning_request_policy_test.go
+++ b/coordinator/api/reasoning_request_policy_test.go
@@ -344,16 +344,25 @@ func TestApplyResolvedModelReasoningPolicyPreservesExplicitValuesAndUntouchedByt
 			if err != nil {
 				t.Fatal(err)
 			}
-			got, changed, err := applyResolvedModelReasoningPolicy(
-				parsed, []byte(test.body), test.model, test.service, test.provided)
+			before, err := marshalForwardBody(parsed)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if changed {
+			if applyResolvedModelReasoningPolicy(parsed, test.model, test.service, test.provided) {
 				t.Fatal("policy reported a mutation")
 			}
-			if string(got) != test.body {
-				t.Fatalf("body changed: got %q, want original %q", got, test.body)
+			after, err := marshalForwardBody(parsed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != string(before) {
+				t.Fatalf("parsed changed: got %s, want %s", after, before)
+			}
+			// A no-op policy leaves the forward body clean, so the caller's exact
+			// bytes reach the provider.
+			body := forwardBody{parsed: parsed, bytes: []byte(test.body)}
+			if got, _ := body.current(); string(got) != test.body {
+				t.Fatalf("forward body changed: got %q, want original %q", got, test.body)
 			}
 		})
 	}

--- a/coordinator/api/request_introspection.go
+++ b/coordinator/api/request_introspection.go
@@ -9,6 +9,13 @@ package api
 // off *Server only to record rejection telemetry. Split out of consumer.go
 // to keep the request-handling orchestrator thin.
 //
+// The estimates and media/tool detection share ONE walk of the message tree
+// (introspectRequest → requestShape); estimatePromptTokens,
+// estimateBillingPromptTokens, detectMediaRequirement, countMediaParts and
+// requestHasTools are thin wrappers over it, so the handler can take every
+// value from a single pass while callers that need just one keep their
+// signature.
+//
 // Remote-media flow note: on the chat-completions surface the media resolver
 // (media_resolve.go / coordinator/mediafetch) FETCHES remote image_url/video_url
 // links and inlines them as data: URIs, so rejectRemoteMediaURLs only fires
@@ -58,6 +65,20 @@ func intFromRequestValue(v any) (int, bool) {
 	}
 }
 
+// jsonValueLen returns len(json.Marshal(v)), counting decoder-shaped values
+// without allocating the encoding and marshaling anything else. A value the
+// encoder rejects reports 0, exactly as the marshal-and-measure path did.
+func jsonValueLen(v any) int {
+	if n, ok := jsonEncodedLen(v); ok {
+		return n
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
 // approximateTokenCount returns a rough token estimate for routing and queue
 // admission. The len/4 heuristic is a reasonable average for English text
 // with GPT-style BPE tokenizers. This value feeds into the scheduler's
@@ -72,25 +93,30 @@ func approximateTokenCount(v any) int {
 	}
 	switch x := v.(type) {
 	case string:
-		if x == "" {
-			return 0
-		}
-		tokens := len(x) / 4
-		if tokens < 1 {
-			tokens = 1
-		}
-		return tokens
+		return textPromptTokens(x)
 	default:
-		b, err := json.Marshal(v)
-		if err != nil {
+		n := jsonValueLen(v)
+		if n == 0 {
 			return 0
 		}
-		tokens := len(b) / 4
+		tokens := n / 4
 		if tokens < 1 {
 			tokens = 1
 		}
 		return tokens
 	}
+}
+
+// textPromptTokens is the len/4 routing heuristic for one text string: empty
+// text costs nothing, any other text at least one token.
+func textPromptTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	if t := len(s) / 4; t > 0 {
+		return t
+	}
+	return 1
 }
 
 // approximateTokenCountUpperBound returns a guaranteed upper bound on the
@@ -111,29 +137,102 @@ func approximateTokenCountUpperBound(v any) int {
 	case string:
 		return len(x)
 	default:
-		b, err := json.Marshal(v)
-		if err != nil {
-			return 0
-		}
-		return len(b)
+		return jsonValueLen(v)
 	}
 }
 
-func estimatePromptTokens(parsed map[string]any) int {
-	total := 0
+// requestShape is everything the handlers derive from one walk of the
+// messages / input / prompt tree: the media-aware routing token estimate, the
+// byte-length billing bound, the count of image/video parts, and whether a
+// non-empty tools array is declared.
+//
+// routingTokens and billingTokens are the field-level totals BEFORE the
+// whole-body fallback: a request whose messages/input/prompt all estimate to
+// zero is measured over the entire parsed body instead, and that fallback
+// depends on fields the handler mutates after introspection (model,
+// max_tokens, runtime defaults), so it is applied lazily by
+// routingPromptTokens / billingPromptTokens at the call site.
+type requestShape struct {
+	routingTokens int
+	billingTokens int
+	mediaParts    int
+	hasTools      bool
+}
+
+// introspectRequest composes the two passes below: the routing/media walk
+// (type-level, never scans string contents) and the billing byte count (scans
+// every string once). Handlers that need everything call this once; the
+// single-value wrappers call only the pass they need.
+func introspectRequest(parsed map[string]any) requestShape {
+	routingTokens, mediaParts := routingShape(parsed)
+	return requestShape{
+		routingTokens: routingTokens,
+		billingTokens: billingBytes(parsed),
+		mediaParts:    mediaParts,
+		hasTools:      requestHasTools(parsed),
+	}
+}
+
+// routingShape walks messages[], input[] and prompt once for the media-aware
+// routing estimate and the image/video part count.
+func routingShape(parsed map[string]any) (routingTokens, mediaParts int) {
 	if v, ok := parsed["messages"]; ok {
-		total += messagesPromptTokens(v)
+		tokens, media := messagesShape(v)
+		routingTokens += tokens
+		mediaParts += media
 	}
 	if v, ok := parsed["input"]; ok {
-		total += inputPromptTokens(v)
+		tokens, media := inputShape(v)
+		routingTokens += tokens
+		mediaParts += media
 	}
 	if v, ok := parsed["prompt"]; ok {
-		total += approximateTokenCount(v)
+		routingTokens += approximateTokenCount(v)
 	}
-	if total == 0 {
-		total = approximateTokenCount(parsed)
+	return routingTokens, mediaParts
+}
+
+// billingBytes is the byte-length reservation bound over the same fields.
+// Billing MUST stay a guaranteed upper bound (len(bytes) >= tokens for any BPE
+// tokenizer), so it counts full message bytes — including a base64 image's
+// bytes and every non-content field (role, tool_calls, name). Switching to the
+// media-aware flat count here would DROP those fields and under-reserve for
+// tool-calling requests. Over-reservation on a large image is safe (it is
+// refunded after inference); the routing/ITPM estimate is the media-aware one.
+func billingBytes(parsed map[string]any) int {
+	total := 0
+	for _, field := range []string{"messages", "input", "prompt"} {
+		if v, ok := parsed[field]; ok {
+			total += approximateTokenCountUpperBound(v)
+		}
 	}
 	return total
+}
+
+// routingPromptTokens is the routing/ITPM estimate, falling back to the whole
+// body when no prompt-bearing field contributed.
+func (s requestShape) routingPromptTokens(parsed map[string]any) int {
+	if s.routingTokens == 0 {
+		return approximateTokenCount(parsed)
+	}
+	return s.routingTokens
+}
+
+// billingPromptTokens is the reservation upper bound, falling back to the
+// whole body when no prompt-bearing field contributed.
+func (s requestShape) billingPromptTokens(parsed map[string]any) int {
+	if s.billingTokens == 0 {
+		return approximateTokenCountUpperBound(parsed)
+	}
+	return s.billingTokens
+}
+
+// requiresVision reports whether the request carries any image/video part.
+func (s requestShape) requiresVision() bool { return s.mediaParts > 0 }
+
+func estimatePromptTokens(parsed map[string]any) int {
+	routingTokens, _ := routingShape(parsed)
+	return requestShape{routingTokens: routingTokens}.routingPromptTokens(parsed)
 }
 
 // estimateBillingPromptTokens returns a guaranteed upper bound on prompt
@@ -141,27 +240,7 @@ func estimatePromptTokens(parsed map[string]any) int {
 // pre-flight reservation always covers actual cost. This value must NOT
 // be used for routing — see estimatePromptTokens for that.
 func estimateBillingPromptTokens(parsed map[string]any) int {
-	total := 0
-	if v, ok := parsed["messages"]; ok {
-		// Billing MUST stay a guaranteed upper bound (len(bytes) >= tokens for any
-		// BPE tokenizer), so it keeps counting full message bytes — including a
-		// base64 image's bytes and every non-content field (role, tool_calls,
-		// name). Switching to the media-aware flat count here would DROP those
-		// fields and under-reserve for tool-calling requests. Over-reservation on a
-		// large image is safe (it is refunded after inference); the routing/ITPM
-		// estimate (estimatePromptTokens) is the media-aware one.
-		total += approximateTokenCountUpperBound(v)
-	}
-	if v, ok := parsed["input"]; ok {
-		total += approximateTokenCountUpperBound(v)
-	}
-	if v, ok := parsed["prompt"]; ok {
-		total += approximateTokenCountUpperBound(v)
-	}
-	if total == 0 {
-		total = approximateTokenCountUpperBound(parsed)
-	}
-	return total
+	return requestShape{billingTokens: billingBytes(parsed)}.billingPromptTokens(parsed)
 }
 
 // isMediaPartType reports whether an OpenAI/OpenRouter content-part type denotes
@@ -176,26 +255,19 @@ func isMediaPartType(t string) bool {
 	return false
 }
 
-// messageContentTokens estimates ROUTING prompt tokens for one message's
-// `content`, counting text parts as text (len/4) and each image/video part as a
-// flat media cost (never the base64 length). Used only for the routing/ITPM
-// estimate; billing uses approximateTokenCountUpperBound (a guaranteed upper
-// bound that intentionally still counts the base64 bytes).
-func messageContentTokens(content any) int {
-	textTokens := func(s string) int {
-		if s == "" {
-			return 0
-		}
-		if t := len(s) / 4; t > 0 {
-			return t
-		}
-		return 1
-	}
+// contentShape estimates ROUTING prompt tokens for one message's `content`
+// and counts its image/video parts in the same pass. Text parts count as text
+// (len/4); each image/video part costs a flat media price (never the base64
+// length) and counts as one media part; other part shapes count their JSON
+// length. Non-object parts are skipped, exactly as the media detection always
+// did. Used only for the routing/ITPM estimate; billing uses
+// approximateTokenCountUpperBound (a guaranteed upper bound that intentionally
+// still counts the base64 bytes).
+func contentShape(content any) (tokens, mediaParts int) {
 	switch c := content.(type) {
 	case string:
-		return textTokens(c)
+		return textPromptTokens(c), 0
 	case []any:
-		total := 0
 		for _, part := range c {
 			pm, ok := part.(map[string]any)
 			if !ok {
@@ -205,94 +277,75 @@ func messageContentTokens(content any) int {
 			switch {
 			case typ == "text" || typ == "input_text":
 				if s, ok := pm["text"].(string); ok {
-					total += textTokens(s)
+					tokens += textPromptTokens(s)
 				}
 			case typ == "image_url" || typ == "input_image" || typ == "image":
-				total += imagePromptTokenCost
+				tokens += imagePromptTokenCost
+				mediaParts++
 			case typ == "video_url" || typ == "input_video" || typ == "video":
-				total += videoPromptTokenCost
+				tokens += videoPromptTokenCost
+				mediaParts++
 			default:
-				if b, err := json.Marshal(pm); err == nil {
-					total += len(b) / 4
-				}
+				tokens += jsonValueLen(pm) / 4
 			}
 		}
-		return total
+		return tokens, mediaParts
 	default:
-		return approximateTokenCount(content)
+		return approximateTokenCount(content), 0
 	}
 }
 
-// messagesPromptTokens sums media-aware routing content tokens across a messages
-// array. Falls back to the len/4 heuristic when messages isn't the standard
-// array shape.
-func messagesPromptTokens(messages any) int {
+// messagesShape sums media-aware routing content tokens and media parts across
+// a messages array. Falls back to the len/4 heuristic (and no media) when
+// messages isn't the standard array shape.
+func messagesShape(messages any) (tokens, mediaParts int) {
 	arr, ok := messages.([]any)
 	if !ok {
-		return approximateTokenCount(messages)
+		return approximateTokenCount(messages), 0
 	}
-	total := 0
 	for _, m := range arr {
 		mm, ok := m.(map[string]any)
 		if !ok {
-			total += approximateTokenCount(m)
+			tokens += approximateTokenCount(m)
 			continue
 		}
-		total += 4 // small per-message framing (role + delimiters)
-		total += messageContentTokens(mm["content"])
+		t, media := contentShape(mm["content"])
+		tokens += 4 + t // small per-message framing (role + delimiters)
+		mediaParts += media
 	}
-	return total
+	return tokens, mediaParts
 }
 
-// inputPromptTokens estimates the Responses API `input` field. A string input
-// is plain text (len/4). Structured input is an array of message-like items with
+// inputShape estimates the Responses API `input` field. A string input is
+// plain text (len/4). Structured input is an array of message-like items with
 // `content` parts, so reuse the same media-aware content estimator as chat
 // messages instead of counting JSON wrapper bytes.
-func inputPromptTokens(input any) int {
+func inputShape(input any) (tokens, mediaParts int) {
 	switch x := input.(type) {
 	case string:
-		return approximateTokenCount(x)
+		return approximateTokenCount(x), 0
 	case []any:
-		total := 0
 		for _, item := range x {
 			switch m := item.(type) {
 			case string:
-				total += approximateTokenCount(m)
+				tokens += approximateTokenCount(m)
 			case map[string]any:
 				content, ok := m["content"]
 				if !ok {
-					total += approximateTokenCount(m)
+					tokens += approximateTokenCount(m)
 					continue
 				}
-				total += 4 // role/type framing, matching messagesPromptTokens.
-				total += messageContentTokens(content)
+				t, media := contentShape(content)
+				tokens += 4 + t // role/type framing, matching messagesShape.
+				mediaParts += media
 			default:
-				total += approximateTokenCount(item)
+				tokens += approximateTokenCount(item)
 			}
 		}
-		return total
+		return tokens, mediaParts
 	default:
-		return approximateTokenCount(input)
+		return approximateTokenCount(input), 0
 	}
-}
-
-// contentPartsHaveMedia reports whether a `content` value (a content-part array)
-// carries any image/video part.
-func contentPartsHaveMedia(content any) bool {
-	parts, ok := content.([]any)
-	if !ok {
-		return false
-	}
-	for _, part := range parts {
-		pm, ok := part.(map[string]any)
-		if !ok {
-			continue
-		}
-		if typ, _ := pm["type"].(string); isMediaPartType(typ) {
-			return true
-		}
-	}
-	return false
 }
 
 // detectMediaRequirement reports whether the request carries image/video input.
@@ -302,63 +355,18 @@ func contentPartsHaveMedia(content any) bool {
 // `messages[].content` parts and the Responses API `input[].content` parts so a
 // media request on either surface is gated (never silently routed text-blind).
 func detectMediaRequirement(parsed map[string]any) bool {
-	if messages, ok := parsed["messages"].([]any); ok {
-		for _, m := range messages {
-			if mm, ok := m.(map[string]any); ok && contentPartsHaveMedia(mm["content"]) {
-				return true
-			}
-		}
-	}
-	// Responses API: `input` may be a string (no media) or an array of items,
-	// each carrying `content` parts in the same image_url/input_image shape.
-	if input, ok := parsed["input"].([]any); ok {
-		for _, item := range input {
-			if im, ok := item.(map[string]any); ok && contentPartsHaveMedia(im["content"]) {
-				return true
-			}
-		}
-	}
-	return false
+	return countMediaParts(parsed) > 0
 }
 
 // countMediaParts counts the image/video content parts across a chat
 // (messages[]) or Responses API (input[]) body — the count-only vision shape
 // term a capacity probe carries (protocol.CapacityProbeMessage
 // VisionImageCount: counts, never bytes or content-derived dimensions).
-// Same traversal as detectMediaRequirement so the two can never disagree on
+// Same traversal as the routing estimate so the two can never disagree on
 // what constitutes a media part.
 func countMediaParts(parsed map[string]any) int {
-	count := 0
-	countContent := func(content any) {
-		parts, ok := content.([]any)
-		if !ok {
-			return
-		}
-		for _, part := range parts {
-			pm, ok := part.(map[string]any)
-			if !ok {
-				continue
-			}
-			if typ, _ := pm["type"].(string); isMediaPartType(typ) {
-				count++
-			}
-		}
-	}
-	if messages, ok := parsed["messages"].([]any); ok {
-		for _, m := range messages {
-			if mm, ok := m.(map[string]any); ok {
-				countContent(mm["content"])
-			}
-		}
-	}
-	if input, ok := parsed["input"].([]any); ok {
-		for _, item := range input {
-			if im, ok := item.(map[string]any); ok {
-				countContent(im["content"])
-			}
-		}
-	}
-	return count
+	_, mediaParts := routingShape(parsed)
+	return mediaParts
 }
 
 // isInlineDataURI reports whether a media reference is an inline base64 data: URI

--- a/coordinator/api/request_introspection_test.go
+++ b/coordinator/api/request_introspection_test.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// introspectionBodies are request shapes that exercise every branch of the
+// fused walk: plain chat, multimodal chat parts, Responses string/structured
+// input, completions prompt, Anthropic source blocks, degenerate shapes that
+// hit the whole-body fallback, and non-array messages.
+var introspectionBodies = map[string]string{
+	"chat text": `{"model":"m","messages":[{"role":"system","content":"be brief"},{"role":"user","content":"hello <world> & \"friends\"\n"}],"max_tokens":8}`,
+	"chat multimodal": `{"model":"m","messages":[{"role":"user","content":[
+		{"type":"text","text":"what is this"},
+		{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}},
+		{"type":"video_url","video_url":{"url":"data:video/mp4;base64,BBBB"}},
+		{"type":"mystery","payload":{"deep":[1,2,3]}},
+		"stray string part"]}],"tools":[{"type":"function","function":{"name":"f"}}]}`,
+	"chat tool history":    `{"model":"m","messages":[{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":"{\"a\":1}"}}]},{"role":"tool","tool_call_id":"c1","content":"42"}],"tools":[]}`,
+	"responses string":     `{"model":"m","input":"translate this please"}`,
+	"responses structured": `{"model":"m","input":[{"role":"user","content":[{"type":"input_text","text":"hi"},{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]},"bare item",{"type":"message","no_content":true},7]}`,
+	"completions prompt":   `{"model":"m","prompt":"Once upon a time","max_tokens":4}`,
+	"anthropic image":      `{"model":"m","messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","data":"AAAA"}},{"type":"text","text":"describe"}]}]}`,
+	"messages not array":   `{"model":"m","messages":"just a string"}`,
+	"messages non-map":     `{"model":"m","messages":["a",1,null,{"role":"user","content":"x"}]}`,
+	"empty prompt":         `{"model":"m","messages":[],"input":"","prompt":"","max_tokens":9}`,
+	"no prompt fields":     `{"model":"m","temperature":0.5}`,
+	"content unusual":      `{"model":"m","messages":[{"role":"user","content":{"nested":"object"}},{"role":"user","content":12}]}`,
+}
+
+// legacyEstimates re-implements the pre-fusion estimators (independent walks,
+// json.Marshal for the billing byte count) so the fused walk is pinned to them.
+func legacyEstimates(parsed map[string]any) (routing, billing, media int) {
+	textTokens := func(s string) int {
+		if s == "" {
+			return 0
+		}
+		if t := len(s) / 4; t > 0 {
+			return t
+		}
+		return 1
+	}
+	marshalLen := func(v any) int {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return 0
+		}
+		return len(b)
+	}
+	legacyCount := func(v any) int {
+		if v == nil {
+			return 0
+		}
+		if s, ok := v.(string); ok {
+			return textTokens(s)
+		}
+		n := marshalLen(v)
+		if n == 0 {
+			return 0
+		}
+		if n/4 < 1 {
+			return 1
+		}
+		return n / 4
+	}
+	legacyUpper := func(v any) int {
+		if v == nil {
+			return 0
+		}
+		if s, ok := v.(string); ok {
+			return len(s)
+		}
+		return marshalLen(v)
+	}
+	contentTokens := func(content any) int {
+		switch c := content.(type) {
+		case string:
+			return textTokens(c)
+		case []any:
+			total := 0
+			for _, part := range c {
+				pm, ok := part.(map[string]any)
+				if !ok {
+					continue
+				}
+				typ, _ := pm["type"].(string)
+				switch {
+				case typ == "text" || typ == "input_text":
+					if s, ok := pm["text"].(string); ok {
+						total += textTokens(s)
+					}
+				case typ == "image_url" || typ == "input_image" || typ == "image":
+					total += imagePromptTokenCost
+				case typ == "video_url" || typ == "input_video" || typ == "video":
+					total += videoPromptTokenCost
+				default:
+					total += marshalLen(pm) / 4
+				}
+			}
+			return total
+		default:
+			return legacyCount(content)
+		}
+	}
+	countMedia := func(content any) int {
+		parts, ok := content.([]any)
+		if !ok {
+			return 0
+		}
+		n := 0
+		for _, part := range parts {
+			if pm, ok := part.(map[string]any); ok {
+				if typ, _ := pm["type"].(string); isMediaPartType(typ) {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	if v, ok := parsed["messages"]; ok {
+		if arr, ok := v.([]any); ok {
+			for _, m := range arr {
+				mm, ok := m.(map[string]any)
+				if !ok {
+					routing += legacyCount(m)
+					continue
+				}
+				routing += 4 + contentTokens(mm["content"])
+				media += countMedia(mm["content"])
+			}
+		} else {
+			routing += legacyCount(v)
+		}
+		billing += legacyUpper(v)
+	}
+	if v, ok := parsed["input"]; ok {
+		switch x := v.(type) {
+		case string:
+			routing += legacyCount(x)
+		case []any:
+			for _, item := range x {
+				switch m := item.(type) {
+				case string:
+					routing += legacyCount(m)
+				case map[string]any:
+					content, ok := m["content"]
+					if !ok {
+						routing += legacyCount(m)
+						continue
+					}
+					routing += 4 + contentTokens(content)
+					media += countMedia(content)
+				default:
+					routing += legacyCount(item)
+				}
+			}
+		default:
+			routing += legacyCount(v)
+		}
+		billing += legacyUpper(v)
+	}
+	if v, ok := parsed["prompt"]; ok {
+		routing += legacyCount(v)
+		billing += legacyUpper(v)
+	}
+	if routing == 0 {
+		routing = legacyCount(parsed)
+	}
+	if billing == 0 {
+		billing = legacyUpper(parsed)
+	}
+	return routing, billing, media
+}
+
+func TestIntrospectRequestMatchesIndependentWalks(t *testing.T) {
+	for name, body := range introspectionBodies {
+		t.Run(name, func(t *testing.T) {
+			parsed, err := decodeInferenceJSONObject([]byte(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantRouting, wantBilling, wantMedia := legacyEstimates(parsed)
+			shape := introspectRequest(parsed)
+			if got := shape.routingPromptTokens(parsed); got != wantRouting {
+				t.Errorf("routing = %d, want %d", got, wantRouting)
+			}
+			if got := shape.billingPromptTokens(parsed); got != wantBilling {
+				t.Errorf("billing = %d, want %d", got, wantBilling)
+			}
+			if shape.mediaParts != wantMedia {
+				t.Errorf("media parts = %d, want %d", shape.mediaParts, wantMedia)
+			}
+			tools, _ := parsed["tools"].([]any)
+			if shape.hasTools != (len(tools) > 0) {
+				t.Errorf("hasTools = %v", shape.hasTools)
+			}
+			// The thin wrappers must agree with the fused walk.
+			if estimatePromptTokens(parsed) != wantRouting ||
+				estimateBillingPromptTokens(parsed) != wantBilling ||
+				countMediaParts(parsed) != wantMedia ||
+				detectMediaRequirement(parsed) != (wantMedia > 0) ||
+				requestHasTools(parsed) != shape.hasTools {
+				t.Errorf("wrapper drift: routing=%d billing=%d media=%d vision=%v tools=%v",
+					estimatePromptTokens(parsed), estimateBillingPromptTokens(parsed),
+					countMediaParts(parsed), detectMediaRequirement(parsed), requestHasTools(parsed))
+			}
+		})
+	}
+}
+
+// The whole-body fallback must observe mutations made AFTER introspection
+// (the handler injects max_tokens and rewrites the model between the two
+// call sites), so it is evaluated lazily at the call site.
+func TestRequestShapeFallbackIsLazy(t *testing.T) {
+	parsed := map[string]any{"model": "m", "messages": nil}
+	shape := introspectRequest(parsed)
+	before := shape.routingPromptTokens(parsed)
+	beforeBilling := shape.billingPromptTokens(parsed)
+	parsed["model"] = "a-much-longer-concrete-build-identifier"
+	parsed["max_tokens"] = 8192
+	if got := shape.routingPromptTokens(parsed); got <= before {
+		t.Fatalf("routing fallback ignored later mutations: %d <= %d", got, before)
+	}
+	if got := shape.billingPromptTokens(parsed); got <= beforeBilling {
+		t.Fatalf("billing fallback ignored later mutations: %d <= %d", got, beforeBilling)
+	}
+	if got := estimatePromptTokens(parsed); got != shape.routingPromptTokens(parsed) {
+		t.Fatalf("wrapper = %d, shape = %d", got, shape.routingPromptTokens(parsed))
+	}
+}

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -151,19 +151,9 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 	}
 	s.emitInferenceErrorMetric(model, outcome)
 	s.emitTimingDecompositionMetric(model, outcome.FinalStatus, outcome)
-	s.submitTelemetry("updateInferenceRoute", func() {
-		if err := s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome); err != nil && s.logger != nil {
-			s.logger.Error("inference_routes outcome update failed",
-				"request_id", requestID,
-				"attempt", attempt,
-				"model", model,
-				"final_status", outcome.FinalStatus,
-				"error_class", outcome.ErrorClass,
-				"error_reason", outcome.ErrorReason,
-				"error", err,
-			)
-		}
-	})
+	// Off the request path: the batching sink pipelines this update with its
+	// neighbours after the group's route inserts (route_telemetry_submit.go).
+	s.submitRouteOutcome(requestID, attempt, model, outcome)
 }
 
 func (s *Server) emitInferenceErrorMetric(model string, outcome *store.InferenceRouteOutcome) {

--- a/coordinator/api/route_telemetry_submit.go
+++ b/coordinator/api/route_telemetry_submit.go
@@ -1,0 +1,83 @@
+package api
+
+// Server entry points for inference_routes telemetry writes. They hand typed
+// ops to the batching sink when the Server has one, and otherwise fall back
+// to the historical per-write panic-safe goroutine so a Server built directly
+// (e.g. &Server{} in tests, which never runs NewServer) keeps working.
+
+import (
+	"log/slog"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// submitRouteRecord persists a routing-decision snapshot off the request
+// path. It never blocks: with a sink the record is enqueued (or dropped and
+// counted when the buffer is full); without one it is written by its own
+// goroutine.
+func (s *Server) submitRouteRecord(record *store.InferenceRouteRecord) {
+	if s == nil || record == nil {
+		return
+	}
+	if t := s.routeTelemetry; t != nil {
+		t.bind(s.store)
+		t.submitRoute(record)
+		return
+	}
+	saferun.Go(s.logger, "recordInferenceRoute", func() {
+		logRouteRecordWriteError(s.logger, record, s.store.RecordInferenceRoute(record))
+	})
+}
+
+// submitRouteOutcome persists an outcome merge for (requestID, attempt) off
+// the request path with the same never-block contract as submitRouteRecord.
+// Callers must have submitted the matching route record first (dispatch
+// precedes every commit/terminal), which is what the sink's insert-before-
+// update grouping relies on.
+func (s *Server) submitRouteOutcome(requestID string, attempt int, model string, outcome *store.InferenceRouteOutcome) {
+	if s == nil || outcome == nil {
+		return
+	}
+	if t := s.routeTelemetry; t != nil {
+		t.bind(s.store)
+		t.submitOutcome(requestID, attempt, model, outcome)
+		return
+	}
+	saferun.Go(s.logger, "updateInferenceRoute", func() {
+		logRouteOutcomeWriteError(s.logger, requestID, attempt, model, outcome,
+			s.store.UpdateInferenceRouteOutcome(requestID, attempt, outcome))
+	})
+}
+
+// logRouteRecordWriteError is the single diagnostic line for a failed route
+// snapshot write; a nil err is a no-op.
+func logRouteRecordWriteError(logger *slog.Logger, record *store.InferenceRouteRecord, err error) {
+	if err == nil || logger == nil || record == nil {
+		return
+	}
+	logger.Error("inference_routes record write failed",
+		"request_id", record.RequestID,
+		"attempt", record.Attempt,
+		"provider_id", record.ProviderID,
+		"model", record.Model,
+		"error", err,
+	)
+}
+
+// logRouteOutcomeWriteError is the single diagnostic line for a failed
+// outcome update; a nil err is a no-op.
+func logRouteOutcomeWriteError(logger *slog.Logger, requestID string, attempt int, model string, outcome *store.InferenceRouteOutcome, err error) {
+	if err == nil || logger == nil || outcome == nil {
+		return
+	}
+	logger.Error("inference_routes outcome update failed",
+		"request_id", requestID,
+		"attempt", attempt,
+		"model", model,
+		"final_status", outcome.FinalStatus,
+		"error_class", outcome.ErrorClass,
+		"error_reason", outcome.ErrorReason,
+		"error", err,
+	)
+}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -957,7 +957,16 @@ func (s *Server) Close() {
 		s.promptArtifacts.Close()
 	}
 	if s.routeTelemetry != nil {
-		s.routeTelemetry.close()
+		// Bounded flush: buffered route rows are written before main's deferred
+		// store Close (registered earlier, so it runs after this) tears down the
+		// pool. A stuck store cannot hold shutdown past the deadline; whatever
+		// is still unwritten then is counted as dropped by the sink.
+		if !s.routeTelemetry.closeAndWait(telemetrySinkShutdownFlush) && s.logger != nil {
+			s.logger.Warn("routing telemetry sink did not finish flushing before the shutdown deadline",
+				"deadline", telemetrySinkShutdownFlush,
+				"dropped_total", s.routeTelemetry.dropped.Load(),
+			)
+		}
 	}
 	s.trustAuthorityMu.Lock()
 	if s.trustAuthority != nil {
@@ -1289,6 +1298,15 @@ func (s *Server) invalidateCatalogCache() {
 			s.readCache.Invalidate(modelCatalogCacheKey(typeFilter, includeAliases))
 		}
 	}
+	// /v1/models entry memo + list bodies (both include_builds values) and the
+	// OpenRouter feed are derived from the same catalog; drop them too so an
+	// admin alias/registry change is visible on the next request instead of
+	// after their 2s/5s TTLs (which remain the bound for out-of-band DB edits).
+	for _, includeBuilds := range []bool{false, true} {
+		s.readCache.Invalidate(modelEntriesCacheKey(includeBuilds))
+		s.readCache.Invalidate(modelListBodyCacheKey(includeBuilds))
+	}
+	s.readCache.Invalidate(openRouterFeedCacheKey)
 	// stats:v1 is deliberately NOT evicted here: the stats refresher recomputes
 	// it every minute, and evicting it made every concurrent /v1/stats request
 	// rerun the multi-second usage analytics statements.
@@ -3049,6 +3067,7 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 				s.ddGauge("request_queue.depth", float64(q.TotalSize()), nil)
 			}
 			s.emitExactCacheDDGauges()
+			s.emitStoreCacheGauges()
 			// Network utilization — demand/capacity across the warm-serving and
 			// token-budget axes, plus a per-model breakdown.
 			util := s.registry.NetworkUtilizationSnapshot()

--- a/coordinator/api/sse_normalize_gate.go
+++ b/coordinator/api/sse_normalize_gate.go
@@ -1,0 +1,57 @@
+package api
+
+// Cheap pre-gates for normalizeSSEChunk. Every streamed token passes through
+// the relay, so deciding whether a chunk needs the JSON round-trip must cost a
+// scan or two, not one strings.Contains per fixable field.
+
+import "strings"
+
+// sseNullFixKeys are the JSON keys whose null values normalizeSSEChunk
+// rewrites (delta fields become ""/[], top-level fields are dropped). Each is
+// matched as `<key>:null` — exactly the substrings the gate has always looked
+// for — so `"finish_reason":null`, present on every delta, never triggers a
+// round-trip.
+var sseNullFixKeys = [...]string{
+	`"content":`,
+	`"tool_calls":`,
+	`"usage":`,
+	`"reasoning":`,
+	`"reasoning_content":`,
+	`"refusal":`,
+	`"system_fingerprint":`,
+}
+
+// sseChunkNeedsNullFix reports whether line contains `<key>:null` for any key
+// in sseNullFixKeys, in a single pass: it walks the `null` literals and checks
+// the bytes immediately before each one. This is equivalent to OR-ing
+// strings.Contains over the seven `"<key>":null` patterns, substring semantics
+// included (a match inside a string value counts, and the round-trip is then
+// a no-op that returns the chunk unchanged).
+func sseChunkNeedsNullFix(line string) bool {
+	rest := line
+	for {
+		i := strings.Index(rest, "null")
+		if i < 0 {
+			return false
+		}
+		head := rest[:i]
+		for _, key := range sseNullFixKeys {
+			if strings.HasSuffix(head, key) {
+				return true
+			}
+		}
+		rest = rest[i+len("null"):]
+	}
+}
+
+// sseChunkHasReasoningField reports whether line names a `"reasoning"` or
+// `"reasoning_content"` key. One scan for the shared `"reasoning` prefix
+// gates the two exact checks, so chunks carrying only `"reasoning_details"`
+// or `"reasoning_tokens"` (the common no-op shapes) cost one scan and never
+// round-trip.
+func sseChunkHasReasoningField(line string) bool {
+	if !strings.Contains(line, `"reasoning`) {
+		return false
+	}
+	return strings.Contains(line, `"reasoning"`) || strings.Contains(line, `"reasoning_content"`)
+}

--- a/coordinator/api/sse_normalize_gate_test.go
+++ b/coordinator/api/sse_normalize_gate_test.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// legacyNormalizeGate is the gate normalizeSSEChunk used before the
+// single-pass scan: seven strings.Contains for `"<key>":null` plus two for
+// the reasoning aliases. The single-pass gate must agree with it on every
+// input so normalizeSSEChunk's output stays byte-identical.
+func legacyNormalizeGate(line string) (needsNullFix, needsReasoning bool) {
+	needsNullFix = strings.Contains(line, `"content":null`) ||
+		strings.Contains(line, `"tool_calls":null`) ||
+		strings.Contains(line, `"usage":null`) ||
+		strings.Contains(line, `"reasoning":null`) ||
+		strings.Contains(line, `"reasoning_content":null`) ||
+		strings.Contains(line, `"refusal":null`) ||
+		strings.Contains(line, `"system_fingerprint":null`)
+	needsReasoning = strings.Contains(line, `"reasoning"`) ||
+		strings.Contains(line, `"reasoning_content"`)
+	return needsNullFix, needsReasoning
+}
+
+// sseGateCorpus covers the shapes that distinguish the gates: every fixable
+// key, the finish_reason:null present on every delta (must not trigger),
+// reasoning aliases vs reasoning_details / reasoning_tokens, spaced and
+// quoted nulls, nulls inside string values, key look-alikes, non-JSON lines.
+var sseGateCorpus = []struct {
+	name  string
+	chunk string
+}{
+	{"content delta, finish_reason null only",
+		`data: {"id":"c","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`},
+	{"role-only preamble",
+		`data: {"id":"c","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`},
+	{"all fixable nulls",
+		`data: {"id":"c","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":null,"reasoning_content":null,"reasoning":null,"refusal":null},"finish_reason":null}],"usage":null,"system_fingerprint":null}`},
+	{"content null only", `data: {"choices":[{"delta":{"content":null},"finish_reason":null}]}`},
+	{"tool_calls null only", `data: {"choices":[{"delta":{"tool_calls":null},"finish_reason":null}]}`},
+	{"usage null only", `data: {"choices":[],"usage":null}`},
+	{"refusal null only", `data: {"choices":[{"delta":{"refusal":null}}]}`},
+	{"system_fingerprint null only", `data: {"choices":[],"system_fingerprint":null}`},
+	{"reasoning null only", `data: {"choices":[{"delta":{"reasoning":null}}]}`},
+	{"reasoning_content null only", `data: {"choices":[{"delta":{"reasoning_content":null}}]}`},
+	{"finish null before content null",
+		`data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":null}}]}`},
+	{"usage object final chunk",
+		`data: {"id":"c","choices":[],"usage":{"prompt_tokens":150,"completion_tokens":83,"total_tokens":233}}`},
+	{"usage with reasoning_tokens detail (no alias)",
+		`data: {"id":"c","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2,"completion_tokens_details":{"reasoning_tokens":7}}}`},
+	{"reasoning_content delta",
+		`data: {"choices":[{"index":0,"delta":{"reasoning_content":"think"},"finish_reason":null}]}`},
+	{"reasoning delta",
+		`data: {"choices":[{"index":0,"delta":{"reasoning":"think"},"finish_reason":null}]}`},
+	{"both aliases, differing",
+		`data: {"choices":[{"index":0,"delta":{"reasoning":"a","reasoning_content":"b"},"finish_reason":null}]}`},
+	{"reasoning_details only (no alias)",
+		`data: {"choices":[{"index":0,"delta":{"content":"x","reasoning_details":[{"type":"reasoning.text","text":"t"}]},"finish_reason":null}]}`},
+	{"reasoning_details with content null",
+		`data: {"choices":[{"index":0,"delta":{"content":null,"reasoning_details":[]},"finish_reason":null}]}`},
+	{"spaced null (pretty JSON) must not trigger",
+		`data: {"choices": [{"delta": {"content": null}, "finish_reason": null}]}`},
+	{"string value \"null\"", `data: {"choices":[{"delta":{"content":"null"},"finish_reason":null}]}`},
+	{"null pattern inside string value",
+		`data: {"choices":[{"delta":{"content":"see \"usage\":null here"},"finish_reason":null}]}`},
+	{"key look-alike xcontent", `data: {"choices":[{"delta":{"xcontent":null},"finish_reason":null}]}`},
+	{"key look-alike contents", `data: {"choices":[{"delta":{"contents":null},"finish_reason":null}]}`},
+	{"reasoning look-alike reasonings", `data: {"choices":[{"delta":{"reasonings":"x"},"finish_reason":null}]}`},
+	{"content mentioning reasoning word", `data: {"choices":[{"delta":{"content":"my reasoning is"},"finish_reason":null}]}`},
+	{"done marker", `data: [DONE]`},
+	{"empty", ``},
+	{"no data prefix", `{"choices":[{"delta":{"content":null}}]}`},
+	{"garbage with null key", `data: not json "content":null`},
+	{"garbage without keys", `data: nullnullnull`},
+	{"trailing null literal", `data: {"a":null`},
+	{"null at very start", `null`},
+	{"finish chunk", `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`},
+	{"tool call delta",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"f","arguments":"{"}}]},"finish_reason":null}]}`},
+	{"responses event", `data: {"type":"response.output_text.delta","delta":"hi","sequence_number":3}`},
+	{"multiline SSE group with event field",
+		"event: message\ndata: {\"choices\":[{\"delta\":{\"content\":null},\"finish_reason\":null}]}"},
+}
+
+// The single-pass gate agrees with the legacy nine-Contains gate on the whole
+// corpus, and normalizeSSEChunk's output is exactly what the legacy gate
+// would have produced (unchanged chunk when gated off, the parsed rewrite
+// when gated on).
+func TestSSENormalizeGateMatchesLegacy(t *testing.T) {
+	for _, tc := range sseGateCorpus {
+		t.Run(tc.name, func(t *testing.T) {
+			line := strings.TrimPrefix(tc.chunk, "data: ")
+			wantNull, wantReasoning := legacyNormalizeGate(line)
+			if got := sseChunkNeedsNullFix(line); got != wantNull {
+				t.Errorf("sseChunkNeedsNullFix = %v, legacy = %v", got, wantNull)
+			}
+			if got := sseChunkHasReasoningField(line); got != wantReasoning {
+				t.Errorf("sseChunkHasReasoningField = %v, legacy = %v", got, wantReasoning)
+			}
+			want := tc.chunk
+			if wantNull || wantReasoning {
+				want = rewriteSSEChunkFields(tc.chunk, line)
+			}
+			if got := normalizeSSEChunk(tc.chunk); got != want {
+				t.Errorf("normalizeSSEChunk output diverged from legacy-gated output:\n got: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
+// legacyNormalizeSSEChunk is normalizeSSEChunk with the pre-change gate, for
+// a same-binary before/after benchmark.
+func legacyNormalizeSSEChunk(chunk string) string {
+	line := strings.TrimPrefix(chunk, "data: ")
+	needsNullFix, needsReasoning := legacyNormalizeGate(line)
+	if !needsNullFix && !needsReasoning {
+		return chunk
+	}
+	return rewriteSSEChunkFields(chunk, line)
+}
+
+// BenchmarkNormalizeSSEChunkGate compares the legacy nine-Contains gate with
+// the single-pass gate on the benchmark corpus (fast-path cases are where the
+// gate dominates; slow-path cases are dominated by the JSON round-trip).
+func BenchmarkNormalizeSSEChunkGate(b *testing.B) {
+	cases := []struct {
+		name  string
+		chunk string
+	}{
+		{"content_delta", `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"content":"Hello world"},"finish_reason":null}]}`},
+		{"usage_final", `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[],"usage":{"prompt_tokens":150,"completion_tokens":83,"total_tokens":233}}`},
+		{"reasoning_details_passthrough", `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"content":"Hello","reasoning_details":[{"type":"reasoning.text","text":"t","index":0}]},"finish_reason":null}]}`},
+		{"with_nulls", `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":null,"reasoning_content":null},"finish_reason":null}],"usage":null,"system_fingerprint":null}`},
+		{"reasoning_delta", `data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"qwen3.5-27b","choices":[{"index":0,"delta":{"reasoning_content":"Let me think about this"},"finish_reason":null}]}`},
+	}
+	impls := []struct {
+		name string
+		fn   func(string) string
+	}{
+		{"legacy", legacyNormalizeSSEChunk},
+		{"single_pass", normalizeSSEChunk},
+	}
+	for _, tc := range cases {
+		for _, impl := range impls {
+			b.Run(tc.name+"/"+impl.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					_ = impl.fn(tc.chunk)
+				}
+			})
+		}
+	}
+}
+
+// Nulls that are not the first `null` in the line are still found: the scan
+// must continue past finish_reason:null rather than stop at the first hit.
+func TestSSENullFixScanContinuesPastFirstNull(t *testing.T) {
+	line := `{"choices":[{"finish_reason":null,"logprobs":null,"index":0,"delta":{"role":"assistant","content":null}}]}`
+	if !sseChunkNeedsNullFix(line) {
+		t.Fatal("content:null after two other nulls was not detected")
+	}
+	if sseChunkNeedsNullFix(`{"choices":[{"finish_reason":null,"logprobs":null,"delta":{"content":"x"}}]}`) {
+		t.Fatal("non-fixable nulls must not trigger")
+	}
+}

--- a/coordinator/api/store_cache_http_test.go
+++ b/coordinator/api/store_cache_http_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// The production store is wrapped in the read-through cache (store.NewCached,
+// see cmd/coordinator/main.go). This exercises the cache through the real HTTP
+// path: the admin runtime-parameters action READS the model record, merges,
+// and WRITES it back — so a second update must observe the first one. With a
+// stale cache the second response would silently drop the first parameter.
+func TestStoreCacheInvalidatesThroughAdminModelAction(t *testing.T) {
+	t.Setenv("MODEL_REGISTRY_PUBLISHING_KEY", "publish-secret")
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	cached := store.NewCached(store.NewMemory(store.Config{}), store.DefaultCacheConfig())
+	reg := registry.New(logger)
+	srv := NewServer(reg, cached, ServerConfig{}, logger)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	const modelID = "mlx-community/cache-probe-4bit"
+	entry := &store.ModelRegistryEntry{
+		ID: modelID, DisplayName: "Cache Probe", Quantization: "4bit",
+		MaxContextLength: 32768, MaxOutputLength: 4096, MinRAMGB: 16,
+		Capabilities: []string{"chat"}, Status: "active",
+	}
+	files := []store.ModelVersionFile{{Path: "config.json", SizeBytes: 1, SHA256: testHash, Role: "config"}}
+	if err := cached.SetModelVersion(entry, &store.ModelVersion{ModelID: modelID, Version: "v1", R2Prefix: modelR2Prefix(modelID, "v1"), AggregateSHA256: testHash, TotalSizeBytes: 1, FileCount: 1, Status: "ready"}, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := cached.PromoteModelVersion(modelID, "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Warm the cache with a read through the store, exactly as the chat path does.
+	if _, err := cached.GetModelRegistryRecord(modelID); err != nil {
+		t.Fatalf("warm read: %v", err)
+	}
+
+	post := func(params map[string]any) map[string]any {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{"runtime_parameters": params})
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/admin/models/"+modelID+"/runtime-parameters", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer publish-secret")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("runtime-parameters status = %d", resp.StatusCode)
+		}
+		var out struct {
+			RuntimeParameters map[string]any `json:"runtime_parameters"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		return out.RuntimeParameters
+	}
+
+	post(map[string]any{"temperature": 0.2})
+	got := post(map[string]any{"top_p": 0.9})
+	if _, ok := got["temperature"]; !ok {
+		t.Fatalf("second update lost the first parameter — stale cached record served through HTTP: %v", got)
+	}
+	if _, ok := got["top_p"]; !ok {
+		t.Fatalf("second update missing its own parameter: %v", got)
+	}
+
+	// The store view agrees, and the cache is serving hits again after the writes.
+	rec, err := cached.GetModelRegistryRecord(modelID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.RuntimeParameters["temperature"] == nil || rec.RuntimeParameters["top_p"] == nil {
+		t.Fatalf("store record = %v", rec.RuntimeParameters)
+	}
+	stats := cached.Stats()
+	if stats.Models.Invalidations == 0 {
+		t.Fatalf("expected model-domain invalidations from the admin writes, stats = %+v", stats.Models)
+	}
+	if stats.Models.Hits == 0 {
+		t.Fatalf("expected cache hits after warm read, stats = %+v", stats.Models)
+	}
+}

--- a/coordinator/api/store_cache_metrics.go
+++ b/coordinator/api/store_cache_metrics.go
@@ -1,0 +1,39 @@
+package api
+
+import "github.com/eigeninference/d-inference/coordinator/store"
+
+// storeCacheStatsProvider is implemented by store.CachedStore (the production
+// store wrapper, see cmd/coordinator/main.go). Discovered by assertion so the
+// Server keeps depending only on store.Store.
+type storeCacheStatsProvider interface {
+	Stats() store.CacheStats
+}
+
+// emitStoreCacheGauges publishes the read-through store cache counters as
+// DogStatsD gauges, tagged by domain (users / models). The hit ratio is the
+// number that proves the cache is removing the per-request user and
+// model-registry round trips; without it the cache is dark in production.
+// Called from StartDDGaugeLoop every 15s; a no-op when the store is not
+// wrapped (tests, bare stores) or Datadog is not configured.
+func (s *Server) emitStoreCacheGauges() {
+	if s.dd == nil {
+		return
+	}
+	provider, ok := s.store.(storeCacheStatsProvider)
+	if !ok {
+		return
+	}
+	stats := provider.Stats()
+	s.emitStoreCacheDomainGauges("users", stats.Users)
+	s.emitStoreCacheDomainGauges("models", stats.Models)
+}
+
+func (s *Server) emitStoreCacheDomainGauges(domain string, c store.CacheCounters) {
+	tags := []string{"domain:" + domain}
+	s.ddGauge("store.cache.hits", float64(c.Hits), tags)
+	s.ddGauge("store.cache.misses", float64(c.Misses), tags)
+	s.ddGauge("store.cache.negative_hits", float64(c.NegativeHits), tags)
+	s.ddGauge("store.cache.evictions", float64(c.Evictions), tags)
+	s.ddGauge("store.cache.invalidations", float64(c.Invalidations), tags)
+	s.ddGauge("store.cache.entries", float64(c.Entries), tags)
+}

--- a/coordinator/api/store_cache_metrics_test.go
+++ b/coordinator/api/store_cache_metrics_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// The cache counters must reach DogStatsD, tagged by domain, so the hit ratio
+// is observable in production; a bare (unwrapped) store emits nothing.
+func TestEmitStoreCacheGauges(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	cached := store.NewCached(store.NewMemory(store.Config{}), store.DefaultCacheConfig())
+	if err := cached.CreateUser(&store.User{AccountID: "acct-gauge", PrivyUserID: "did:privy:gauge"}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := cached.GetUserByAccountID("acct-gauge"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	srv := NewServer(registry.New(logger), cached, ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+
+	srv.emitStoreCacheGauges()
+	ddClient.Statsd.Flush()
+	packets := collector.drain()
+
+	for _, want := range []string{
+		"store.cache.hits:2|g|#",
+		"store.cache.misses:1|g|#",
+		"domain:users",
+		"domain:models",
+		"store.cache.invalidations",
+		"store.cache.entries",
+	} {
+		if !hasMetric(packets, want) {
+			t.Errorf("missing %q in %v", want, packets)
+		}
+	}
+
+	// Unwrapped store: nothing emitted, no panic.
+	bare := NewServer(registry.New(logger), store.NewMemory(store.Config{}), ServerConfig{}, logger)
+	bare.SetDatadog(ddClient)
+	bare.emitStoreCacheGauges()
+	ddClient.Statsd.Flush()
+	if got := findMetrics(collector.drain(), "store.cache."); len(got) != 0 {
+		t.Errorf("bare store emitted %v", got)
+	}
+}

--- a/coordinator/api/stream_burst_helpers_test.go
+++ b/coordinator/api/stream_burst_helpers_test.go
@@ -1,0 +1,182 @@
+package api
+
+// Shared harness for the streaming-relay burst tests: a fake WebSocket
+// provider that answers attestation challenges and, on the inference request,
+// runs a scripted burst (chunks, then completion / error / wait-for-cancel),
+// plus a consumer that captures the raw SSE byte stream over real HTTP.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"nhooyr.io/websocket"
+)
+
+const burstTestModel = "burst-model"
+
+// burstProvider is a scripted fake provider. script runs on the provider's
+// read goroutine when the inference request arrives; it may write chunks
+// synchronously or spawn its own goroutine. cancelled is closed when the
+// coordinator sends a cancel for the request.
+type burstProvider struct {
+	conn      *websocket.Conn
+	pubKey    string
+	cancelled chan struct{}
+	once      sync.Once
+	done      chan struct{}
+}
+
+func (p *burstProvider) cancelledOnce() {
+	p.once.Do(func() { close(p.cancelled) })
+}
+
+// startBurstProvider connects a routable provider serving burstTestModel and
+// drives it with script. The returned provider's done channel closes when the
+// read loop exits (connection closed).
+func startBurstProvider(t *testing.T, ctx context.Context, ts *httptest.Server, reg *registry.Registry,
+	script func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage)) *burstProvider {
+	t.Helper()
+	pubKey := testPublicKeyB64()
+	models := []protocol.ModelInfo{{ID: burstTestModel, ModelType: "test", Quantization: "4bit"}}
+	conn := connectProvider(t, ctx, ts.URL, models, pubKey)
+	makeProviderRoutable(reg)
+	p := &burstProvider{conn: conn, pubKey: pubKey, cancelled: make(chan struct{}), done: make(chan struct{})}
+	go func() {
+		defer close(p.done)
+		handleProviderMessages(ctx, t, conn, func(msgType string, data []byte) []byte {
+			switch msgType {
+			case protocol.TypeAttestationChallenge:
+				return makeValidChallengeResponse(data, pubKey)
+			case protocol.TypeInferenceRequest:
+				var req protocol.InferenceRequestMessage
+				if err := json.Unmarshal(data, &req); err != nil {
+					t.Errorf("unmarshal inference request: %v", err)
+					return nil
+				}
+				script(ctx, p, req)
+			case protocol.TypeCancel:
+				p.cancelledOnce()
+			}
+			return nil
+		})
+	}()
+	return p
+}
+
+func (p *burstProvider) writeChunk(t *testing.T, ctx context.Context, req protocol.InferenceRequestMessage, sse string) {
+	t.Helper()
+	writeEncryptedTestChunk(t, ctx, p.conn, req, p.pubKey, sse)
+}
+
+func (p *burstProvider) writeComplete(t *testing.T, ctx context.Context, req protocol.InferenceRequestMessage, usage protocol.UsageInfo) {
+	t.Helper()
+	complete := protocol.InferenceCompleteMessage{
+		Type:      protocol.TypeInferenceComplete,
+		RequestID: req.RequestID,
+		Usage:     usage,
+	}
+	data, _ := json.Marshal(complete)
+	if err := p.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Errorf("write complete: %v", err)
+	}
+}
+
+func (p *burstProvider) writeError(t *testing.T, ctx context.Context, req protocol.InferenceRequestMessage, msg protocol.InferenceErrorMessage) {
+	t.Helper()
+	msg.Type = protocol.TypeInferenceError
+	msg.RequestID = req.RequestID
+	data, _ := json.Marshal(msg)
+	if err := p.conn.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Errorf("write error: %v", err)
+	}
+}
+
+// chatContentChunk is one chat.completion.chunk content delta, framed the way
+// the Swift provider frames it (SSE line + blank line).
+func chatContentChunk(text string) string {
+	return `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"` +
+		burstTestModel + `","choices":[{"index":0,"delta":{"content":"` + text + `"},"finish_reason":null}]}` + "\n\n"
+}
+
+// chatReasoningNullContentChunk exercises normalizeSSEChunk's slow path inside
+// a burst: a null content alongside a reasoning delta.
+func chatReasoningNullContentChunk(reasoning string) string {
+	return `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"` +
+		burstTestModel + `","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"` + reasoning + `"},"finish_reason":null}],"usage":null}` + "\n\n"
+}
+
+func chatFinishChunk(reason string) string {
+	return `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"` +
+		burstTestModel + `","choices":[{"index":0,"delta":{},"finish_reason":"` + reason + `"}]}` + "\n\n"
+}
+
+func chatUsageChunk(prompt, completion int) string {
+	return `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1700000000,"model":"` +
+		burstTestModel + `","choices":[],"usage":{"prompt_tokens":` + strconv.Itoa(prompt) + `,"completion_tokens":` + strconv.Itoa(completion) +
+		`,"total_tokens":` + strconv.Itoa(prompt+completion) + `}}` + "\n\n"
+}
+
+// burstChatChunks is the canonical 50-content-delta burst plus the terminal
+// finish / usage / provider-[DONE] frames used by the golden tests.
+func burstChatChunks(n int) []string {
+	chunks := make([]string, 0, n+3)
+	for i := 0; i < n; i++ {
+		if i%17 == 5 {
+			chunks = append(chunks, chatReasoningNullContentChunk("think"+strconv.Itoa(i)))
+			continue
+		}
+		chunks = append(chunks, chatContentChunk("t"+strconv.Itoa(i)+" "))
+	}
+	chunks = append(chunks, chatFinishChunk("stop"))
+	chunks = append(chunks, chatUsageChunk(10, n))
+	chunks = append(chunks, "data: [DONE]\n\n")
+	return chunks
+}
+
+// streamRequest posts a streaming request and returns the status and the raw
+// SSE body. The body is read to EOF (or ctx cancellation).
+func streamRequest(t *testing.T, ctx context.Context, ts *httptest.Server, path, body string) (int, http.Header, []byte) {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, resp.Header, out
+}
+
+// sseEvents splits a raw SSE body into non-empty event groups.
+func sseEvents(body []byte) []string {
+	var events []string
+	for _, group := range strings.Split(string(body), "\n\n") {
+		if strings.TrimSpace(group) == "" {
+			continue
+		}
+		events = append(events, group)
+	}
+	return events
+}
+
+// waitClosed fails the test if ch is not closed within d.
+func waitClosed(t *testing.T, ch <-chan struct{}, d time.Duration, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(d):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}

--- a/coordinator/api/stream_burst_test.go
+++ b/coordinator/api/stream_burst_test.go
@@ -1,0 +1,548 @@
+package api
+
+// Streaming-relay burst tests (real HTTP + fake WebSocket provider). The relay
+// coalesces chunks that are already queued when it wakes; these tests pin the
+// consumer-visible byte stream so coalescing can never reorder, drop,
+// duplicate, or reframe a chunk, and pin the terminal semantics (held
+// finish/usage frames, single [DONE], in-band provider error, cancel on client
+// disconnect) across all three streaming variants.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+const burstChatRequest = `{"model":"` + burstTestModel + `","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":1000}`
+
+// chatBurstGolden is the exact SSE byte stream the pre-coalescing relay
+// produced for burstChatChunks(50) followed by inference_complete with
+// prompt=10 / completion=50 / reasoning=7. Captured from the baseline code
+// path (commit 37d0f181c) and pinned verbatim: any change to per-chunk
+// transforms, ordering, framing, or terminal events must update this golden
+// deliberately.
+var chatBurstGolden = func() string {
+	var b strings.Builder
+	for i := 0; i < 50; i++ {
+		if i%17 == 5 {
+			// normalizeSSEChunk: content null -> "", reasoning aliases mirrored,
+			// reasoning_details synthesised, top-level usage:null dropped.
+			b.WriteString(`data: {"choices":[{"delta":{"content":"","reasoning":"think` + strconv.Itoa(i) +
+				`","reasoning_content":"think` + strconv.Itoa(i) + `","reasoning_details":[{"type":"reasoning.text","text":"think` +
+				strconv.Itoa(i) + `","id":"reasoning-text-0","format":"unknown","index":0,"signature":null}]},"finish_reason":null,"index":0}],"created":1700000000,"id":"chatcmpl-1","model":"` +
+				burstTestModel + `","object":"chat.completion.chunk"}` + "\n\n")
+			continue
+		}
+		b.WriteString(chatContentChunk("t"+strconv.Itoa(i)+" ") + "\n\n")
+	}
+	// Held finish chunk, re-emitted at stream end (finish_reason preserved:
+	// 50 completion tokens < max_tokens 1000).
+	b.WriteString(`data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1700000000,"id":"chatcmpl-1","model":"` +
+		burstTestModel + `","object":"chat.completion.chunk"}` + "\n\n")
+	// Held usage chunk with the provider's reasoning breakdown spliced in.
+	b.WriteString(`data: {"choices":[],"created":1700000000,"id":"chatcmpl-1","model":"` + burstTestModel +
+		`","object":"chat.completion.chunk","usage":{"completion_tokens":50,"completion_tokens_details":{"reasoning_tokens":7},"prompt_tokens":10,"total_tokens":60}}` + "\n\n")
+	// Exactly one terminator; the provider's own [DONE] was swallowed.
+	b.WriteString("data: [DONE]\n\n")
+	return b.String()
+}()
+
+// TestStreamRelay_ChatBurstByteIdentical: a provider that bursts 50 chunks
+// (plus finish, usage and its own [DONE]) then completes yields exactly the
+// pre-coalescing byte stream, and the persisted request profile accounts for
+// it in SSE frames (chunks_out = 53, not the handful of coalesced flushes).
+func TestStreamRelay_ChatBurstByteIdentical(t *testing.T) {
+	// A clean single-attempt success is sampled at defaultProfileSample (10%);
+	// the profile assertions below need this request's row persisted.
+	t.Setenv(envProfileSampleRate, "1")
+	srv, reg, st, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		for _, c := range burstChatChunks(50) {
+			p.writeChunk(t, ctx, req, c)
+		}
+		p.writeComplete(t, ctx, req, protocol.UsageInfo{PromptTokens: 10, CompletionTokens: 50, ReasoningTokens: 7})
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	status, hdr, body := streamRequest(t, ctx, ts, "/v1/chat/completions", burstChatRequest)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, body)
+	}
+	if ct := hdr.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content-type = %q", ct)
+	}
+	if got := string(body); got != chatBurstGolden {
+		t.Fatalf("SSE stream diverged from golden.\n--- got ---\n%q\n--- want ---\n%q", got, chatBurstGolden)
+	}
+	// Terminal semantics, spelled out: finish, usage, then exactly one [DONE].
+	events := sseEvents(body)
+	if n := len(events); n != 53 {
+		t.Fatalf("events = %d, want 53 (50 deltas + finish + usage + [DONE])", n)
+	}
+	if !strings.Contains(events[50], `"finish_reason":"stop"`) {
+		t.Errorf("event 50 should be the held finish chunk: %s", events[50])
+	}
+	if !strings.Contains(events[51], `"reasoning_tokens":7`) {
+		t.Errorf("event 51 should be the held usage chunk with reasoning spliced: %s", events[51])
+	}
+	if events[52] != "data: [DONE]" {
+		t.Errorf("event 52 = %q, want data: [DONE]", events[52])
+	}
+	if strings.Count(string(body), "[DONE]") != 1 {
+		t.Errorf("stream must carry exactly one [DONE]: %q", body)
+	}
+
+	// The profiler's relay stamps under coalescing: every frame counts once
+	// (53 events over ~9 flushes), bytes_out is the exact byte stream the
+	// client received, the terminal flush is stamped and no write failed.
+	if !srv.profilerEnabled() {
+		t.Fatal("profiler must be on by default with a store")
+	}
+	var recs []store.RequestProfileRecord
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); time.Sleep(20 * time.Millisecond) {
+		if recs = st.RequestProfilesSince(time.Time{}); len(recs) == 1 {
+			break
+		}
+	}
+	if len(recs) != 1 {
+		t.Fatalf("persisted request profiles = %d, want 1", len(recs))
+	}
+	rec := recs[0]
+	if rec.ChunksOut != 53 || rec.BytesOut != int64(len(chatBurstGolden)) {
+		t.Fatalf("profile chunks_out=%d bytes_out=%d, want 53 frames / %d bytes (frames, not flushes)",
+			rec.ChunksOut, rec.BytesOut, len(chatBurstGolden))
+	}
+	if rec.DoneFlushedUS == nil || rec.ClientWriteErr {
+		t.Fatalf("profile done_flushed_us=%v client_write_err=%v, want stamped / false", rec.DoneFlushedUS, rec.ClientWriteErr)
+	}
+}
+
+// TestStreamRelay_ChatBurstThenProviderError: chunks queued ahead of a
+// mid-stream provider error are all delivered, then the in-band error event,
+// and no [DONE].
+func TestStreamRelay_ChatBurstThenProviderError(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const n = 20
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		for i := 0; i < n; i++ {
+			p.writeChunk(t, ctx, req, chatContentChunk("w"+strconv.Itoa(i)))
+		}
+		p.writeError(t, ctx, req, protocol.InferenceErrorMessage{
+			Error:       "engine crashed mid-generation",
+			StatusCode:  http.StatusInternalServerError,
+			FailureCode: protocol.FailureCodeGenerationFailure,
+		})
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	status, _, body := streamRequest(t, ctx, ts, "/v1/chat/completions", burstChatRequest)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, body)
+	}
+	events := sseEvents(body)
+	if len(events) != n+1 {
+		t.Fatalf("events = %d, want %d chunks + 1 error: %q", len(events), n, body)
+	}
+	for i := 0; i < n; i++ {
+		if want := chatContentChunk("w" + strconv.Itoa(i)); strings.TrimSpace(want) != events[i] {
+			t.Fatalf("event %d = %q, want %q", i, events[i], strings.TrimSpace(want))
+		}
+	}
+	var errEvent struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(events[n], "data: ")), &errEvent); err != nil {
+		t.Fatalf("last event is not an error object: %q (%v)", events[n], err)
+	}
+	if errEvent.Error.Type != "provider_error" || errEvent.Error.Message == "" {
+		t.Errorf("error event = %+v, want type provider_error with a message", errEvent.Error)
+	}
+	if strings.Contains(string(body), "[DONE]") {
+		t.Errorf("an errored stream must not be terminated with [DONE]: %q", body)
+	}
+}
+
+// TestStreamRelay_EmitterVariantsBurstThenProviderError: for the Responses,
+// completions and Messages relays, a provider error that lands right behind a
+// burst (the provider enqueues ErrorCh and then closes ChunkCh, so the relay
+// may observe the close mid-drain) is still reported as an in-band error —
+// never as a completed/incomplete stream — after every queued delta.
+func TestStreamRelay_EmitterVariantsBurstThenProviderError(t *testing.T) {
+	const n = 20
+	variants := []struct {
+		name, path, body string
+		// deltas extracts the content deltas in order.
+		deltas func(t *testing.T, raw []byte) []string
+		// completedMarkers must be absent from an errored stream.
+		completedMarkers []string
+		// errorMarker must be present in the last frame.
+		errorMarker string
+	}{
+		{
+			name: "responses", path: "/v1/responses",
+			body: `{"model":"` + burstTestModel + `","input":"hi","stream":true,"max_output_tokens":1000}`,
+			deltas: func(t *testing.T, raw []byte) []string {
+				var out []string
+				for _, ev := range parseTypedSSE(t, raw) {
+					if ev.Type == "response.output_text.delta" {
+						out = append(out, ev.Delta)
+					}
+				}
+				return out
+			},
+			completedMarkers: []string{"response.completed", "response.incomplete"},
+			errorMarker:      "event: error",
+		},
+		{
+			name: "completions", path: "/v1/completions",
+			body: `{"model":"` + burstTestModel + `","prompt":"hi","stream":true,"max_tokens":1000}`,
+			deltas: func(t *testing.T, raw []byte) []string {
+				var out []string
+				for _, ev := range sseEvents(raw) {
+					var frame struct {
+						Choices []struct {
+							Text string `json:"text"`
+						} `json:"choices"`
+					}
+					if json.Unmarshal([]byte(strings.TrimPrefix(ev, "data: ")), &frame) == nil && len(frame.Choices) == 1 {
+						out = append(out, frame.Choices[0].Text)
+					}
+				}
+				return out
+			},
+			completedMarkers: []string{"[DONE]", `"finish_reason":"stop"`},
+			errorMarker:      `"error":{`,
+		},
+		{
+			name: "messages", path: "/v1/messages",
+			body: `{"model":"` + burstTestModel + `","max_tokens":1000,"messages":[{"role":"user","content":"hi"}],"stream":true}`,
+			deltas: func(t *testing.T, raw []byte) []string {
+				var out []string
+				for _, ev := range parseTypedSSE(t, raw) {
+					if ev.Type == "content_block_delta" {
+						out = append(out, ev.DeltaText)
+					}
+				}
+				return out
+			},
+			completedMarkers: []string{"message_stop", "message_delta"},
+			errorMarker:      "event: error",
+		},
+	}
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			_, reg, _, ts := setupTestServer(t)
+			defer ts.Close()
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+				for i := 0; i < n; i++ {
+					p.writeChunk(t, ctx, req, chatContentChunk("e"+strconv.Itoa(i)+" "))
+				}
+				p.writeError(t, ctx, req, protocol.InferenceErrorMessage{
+					Error:       "engine crashed mid-generation",
+					StatusCode:  http.StatusInternalServerError,
+					FailureCode: protocol.FailureCodeGenerationFailure,
+				})
+			})
+			defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+			status, _, raw := streamRequest(t, ctx, ts, v.path, v.body)
+			if status != http.StatusOK {
+				t.Fatalf("status = %d body = %s", status, raw)
+			}
+			deltas := v.deltas(t, raw)
+			if len(deltas) != n {
+				t.Fatalf("deltas = %d, want %d: %q", len(deltas), n, raw)
+			}
+			for i, d := range deltas {
+				if want := "e" + strconv.Itoa(i) + " "; d != want {
+					t.Fatalf("delta %d = %q, want %q", i, d, want)
+				}
+			}
+			events := sseEvents(raw)
+			if last := events[len(events)-1]; !strings.Contains(last, v.errorMarker) {
+				t.Fatalf("last frame should be the provider error: %q", last)
+			}
+			if strings.Contains(string(raw), "provider ended without completion") {
+				t.Fatalf("provider error misreported as incomplete: %q", raw)
+			}
+			for _, marker := range v.completedMarkers {
+				if strings.Contains(string(raw), marker) {
+					t.Fatalf("errored stream must not carry %q: %q", marker, raw)
+				}
+			}
+		})
+	}
+}
+
+// TestStreamRelay_ChatClientDisconnectDuringBurst: when the consumer drops the
+// connection while the provider is still bursting, the relay returns and the
+// provider receives a cancel.
+func TestStreamRelay_ChatClientDisconnectDuringBurst(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	burstStarted := make(chan struct{})
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		// Keep bursting on a side goroutine so the read loop stays free to
+		// observe the cancel; stop once cancelled (or the test ends).
+		go func() {
+			for i := 0; ; i++ {
+				select {
+				case <-p.cancelled:
+					return
+				case <-ctx.Done():
+					return
+				default:
+				}
+				chunk := testEncryptedChunk(t, req, p.pubKey, chatContentChunk("d"+strconv.Itoa(i)))
+				data, _ := json.Marshal(chunk)
+				if err := p.conn.Write(ctx, websocket.MessageText, data); err != nil {
+					return
+				}
+				if i == 3 {
+					close(burstStarted)
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}()
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	reqCtx, cancelReq := context.WithCancel(ctx)
+	req, _ := http.NewRequestWithContext(reqCtx, http.MethodPost, ts.URL+"/v1/chat/completions", strings.NewReader(burstChatRequest))
+	req.Header.Set("Authorization", "Bearer test-key")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request: %v", err)
+	}
+	// Read a little of the stream, then drop the connection mid-burst.
+	buf := make([]byte, 64)
+	if _, err := resp.Body.Read(buf); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	waitClosed(t, burstStarted, 5*time.Second, "provider burst to start")
+	cancelReq()
+	resp.Body.Close()
+
+	waitClosed(t, p.cancelled, 10*time.Second, "provider cancel after consumer disconnect")
+}
+
+// TestStreamRelay_ResponsesBurstSequence: the Responses API variant delivers
+// every burst delta in order as output_text.delta events, then completes.
+func TestStreamRelay_ResponsesBurstSequence(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const n = 50
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		for i := 0; i < n; i++ {
+			p.writeChunk(t, ctx, req, chatContentChunk("r"+strconv.Itoa(i)+" "))
+		}
+		p.writeChunk(t, ctx, req, chatFinishChunk("stop"))
+		p.writeComplete(t, ctx, req, protocol.UsageInfo{PromptTokens: 10, CompletionTokens: n})
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	body := `{"model":"` + burstTestModel + `","input":"hi","stream":true,"max_output_tokens":1000}`
+	status, _, raw := streamRequest(t, ctx, ts, "/v1/responses", body)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, raw)
+	}
+	events := parseTypedSSE(t, raw)
+	var deltas []string
+	for _, ev := range events {
+		if ev.Type == "response.output_text.delta" {
+			deltas = append(deltas, ev.Delta)
+		}
+	}
+	if len(deltas) != n {
+		t.Fatalf("output_text.delta events = %d, want %d", len(deltas), n)
+	}
+	for i, d := range deltas {
+		if want := "r" + strconv.Itoa(i) + " "; d != want {
+			t.Fatalf("delta %d = %q, want %q", i, d, want)
+		}
+	}
+	if last := events[len(events)-1]; last.Type != "response.completed" {
+		t.Fatalf("last event = %s, want response.completed", last.Type)
+	}
+	assertSequenceNumbers(t, events)
+}
+
+// TestStreamRelay_CompletionsBurstSequence: the legacy completions variant
+// delivers every burst delta in order, then a finish event and [DONE].
+func TestStreamRelay_CompletionsBurstSequence(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const n = 50
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		for i := 0; i < n; i++ {
+			p.writeChunk(t, ctx, req, chatContentChunk("c"+strconv.Itoa(i)+" "))
+		}
+		p.writeChunk(t, ctx, req, chatFinishChunk("stop"))
+		p.writeComplete(t, ctx, req, protocol.UsageInfo{PromptTokens: 10, CompletionTokens: n})
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	body := `{"model":"` + burstTestModel + `","prompt":"hi","stream":true,"max_tokens":1000}`
+	status, _, raw := streamRequest(t, ctx, ts, "/v1/completions", body)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, raw)
+	}
+	events := sseEvents(raw)
+	if len(events) != n+2 {
+		t.Fatalf("events = %d, want %d deltas + finish + [DONE]: %q", len(events), n, raw)
+	}
+	for i := 0; i < n; i++ {
+		var ev struct {
+			Choices []struct {
+				Text string `json:"text"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(events[i], "data: ")), &ev); err != nil || len(ev.Choices) != 1 {
+			t.Fatalf("event %d unparsable: %q (%v)", i, events[i], err)
+		}
+		if want := "c" + strconv.Itoa(i) + " "; ev.Choices[0].Text != want {
+			t.Fatalf("delta %d = %q, want %q", i, ev.Choices[0].Text, want)
+		}
+	}
+	if !strings.Contains(events[n], `"finish_reason":"stop"`) {
+		t.Errorf("finish event = %q", events[n])
+	}
+	if events[n+1] != "data: [DONE]" {
+		t.Errorf("terminator = %q", events[n+1])
+	}
+}
+
+// TestStreamRelay_MessagesBurstSequence: the Anthropic Messages variant
+// delivers every burst delta in order inside one text block, then stops.
+func TestStreamRelay_MessagesBurstSequence(t *testing.T) {
+	_, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const n = 50
+	p := startBurstProvider(t, ctx, ts, reg, func(ctx context.Context, p *burstProvider, req protocol.InferenceRequestMessage) {
+		for i := 0; i < n; i++ {
+			p.writeChunk(t, ctx, req, chatContentChunk("m"+strconv.Itoa(i)+" "))
+		}
+		p.writeChunk(t, ctx, req, chatFinishChunk("stop"))
+		p.writeComplete(t, ctx, req, protocol.UsageInfo{PromptTokens: 10, CompletionTokens: n})
+	})
+	defer p.conn.Close(websocket.StatusNormalClosure, "")
+
+	body := `{"model":"` + burstTestModel + `","max_tokens":1000,"messages":[{"role":"user","content":"hi"}],"stream":true}`
+	status, _, raw := streamRequest(t, ctx, ts, "/v1/messages", body)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d body = %s", status, raw)
+	}
+	events := parseTypedSSE(t, raw)
+	var deltas []string
+	for _, ev := range events {
+		if ev.Type == "content_block_delta" {
+			deltas = append(deltas, ev.DeltaText)
+		}
+	}
+	if len(deltas) != n {
+		t.Fatalf("content_block_delta events = %d, want %d", len(deltas), n)
+	}
+	for i, d := range deltas {
+		if want := "m" + strconv.Itoa(i) + " "; d != want {
+			t.Fatalf("delta %d = %q, want %q", i, d, want)
+		}
+	}
+	types := make([]string, 0, len(events))
+	for _, ev := range events {
+		types = append(types, ev.Type)
+	}
+	if types[0] != "message_start" || types[len(types)-1] != "message_stop" {
+		t.Fatalf("event envelope = %v", types)
+	}
+}
+
+// typedSSEEvent is the subset of an `event:`-typed SSE frame these tests
+// inspect.
+type typedSSEEvent struct {
+	Type      string
+	Seq       int
+	Delta     string // Responses: output_text.delta payload
+	DeltaText string // Messages: content_block_delta text
+}
+
+var sseEventLine = regexp.MustCompile(`(?m)^event: (\S+)$`)
+
+func parseTypedSSE(t *testing.T, raw []byte) []typedSSEEvent {
+	t.Helper()
+	var out []typedSSEEvent
+	for _, group := range sseEvents(raw) {
+		m := sseEventLine.FindStringSubmatch(group)
+		if m == nil {
+			t.Fatalf("frame without event line: %q", group)
+		}
+		dataIdx := strings.Index(group, "data: ")
+		if dataIdx < 0 {
+			t.Fatalf("frame without data line: %q", group)
+		}
+		var payload struct {
+			Type  string `json:"type"`
+			Seq   int    `json:"sequence_number"`
+			Delta any    `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(group[dataIdx+len("data: "):]), &payload); err != nil {
+			t.Fatalf("frame data unparsable: %q (%v)", group, err)
+		}
+		ev := typedSSEEvent{Type: m[1], Seq: payload.Seq}
+		switch d := payload.Delta.(type) {
+		case string:
+			ev.Delta = d
+		case map[string]any:
+			ev.DeltaText, _ = d["text"].(string)
+		}
+		if ev.Type != payload.Type {
+			t.Fatalf("event line %q disagrees with payload type %q", ev.Type, payload.Type)
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// assertSequenceNumbers checks Responses events are numbered 0..n-1 in order.
+func assertSequenceNumbers(t *testing.T, events []typedSSEEvent) {
+	t.Helper()
+	for i, ev := range events {
+		if ev.Seq != i {
+			t.Fatalf("event %d (%s) has sequence_number %d", i, ev.Type, ev.Seq)
+		}
+	}
+}

--- a/coordinator/api/stream_coalesce.go
+++ b/coordinator/api/stream_coalesce.go
@@ -1,0 +1,92 @@
+package api
+
+// Streaming-relay coalescing primitives shared by the chat, Responses and
+// generic-endpoint relays. When a relay wakes on one provider chunk, chunks
+// that are ALREADY queued behind it are folded into the same write + Flush
+// instead of costing one syscall each. The drain never waits for more chunks,
+// so it adds no latency: a lone chunk is still flushed immediately.
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// maxCoalescedChunks bounds how many provider chunks one relay wake-up folds
+// into a single flush (the chunk that woke the relay plus up to
+// maxCoalescedChunks-1 already-queued ones). ChunkCh is buffered at 256; the
+// bound keeps a badly backed-up stream from starving the error/timeout/context
+// arms of the select for more than a handful of chunks.
+const maxCoalescedChunks = 32
+
+// maxCoalescedBatchBytes bounds the bytes one coalesced batch may hold before
+// it is written and flushed. maxCoalescedChunks alone bounds only the count:
+// the provider WebSocket read limit is 10 MiB (handleProviderWS), so one
+// decrypted chunk can approach 7.5 MiB, and a 32-chunk batch could reach
+// ~240 MiB — or ~1.9 GiB on the whole-channel drain (chunkBufferSize = 256)
+// ahead of a provider error — held in a single buffer per stream. Healthy
+// deltas are a few hundred bytes (32 of them ≈ 10 KiB), so the byte cap never
+// fires on a normal stream; it exists so a faulty or hostile provider cannot
+// turn concurrent streams into coordinator memory exhaustion. Only the chat
+// relay buffers frames itself (chatStreamRelay.buf); the emitter relays write
+// each event straight to the ResponseWriter and defer only the Flush.
+const maxCoalescedBatchBytes = 256 << 10
+
+// drainQueuedChunks non-blockingly pulls up to budget chunks that are already
+// queued in ch, handing each to fn in arrival order. It returns closed=true when
+// it observed the channel closed instead of a chunk; fn is not called for the
+// close, and the caller runs its normal end-of-stream handling only AFTER
+// flushing what was drained (so a close never delays already-received chunks).
+func drainQueuedChunks(ch <-chan registry.ProviderChunk, budget int, fn func(registry.ProviderChunk)) (closed bool) {
+	for i := 0; i < budget; i++ {
+		select {
+		case c, ok := <-ch:
+			if !ok {
+				return true
+			}
+			fn(c)
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// deferredFlusher lets per-event emitters keep calling Flush while the relay
+// loop decides when bytes actually reach the wire: Flush only marks the writer
+// dirty, and flushNow performs one real flush if anything was marked. Writes
+// themselves still go straight to the http.ResponseWriter (net/http buffers
+// them until the flush).
+type deferredFlusher struct {
+	inner http.Flusher
+	dirty bool
+}
+
+func newDeferredFlusher(inner http.Flusher) *deferredFlusher {
+	return &deferredFlusher{inner: inner}
+}
+
+// Flush implements http.Flusher by recording that a flush is owed.
+func (f *deferredFlusher) Flush() { f.dirty = true }
+
+// flushNow performs the owed flush, if any.
+func (f *deferredFlusher) flushNow() {
+	if f.dirty {
+		f.dirty = false
+		f.inner.Flush()
+	}
+}
+
+// resetIdleTimer re-arms the relay's idle timeout after a chunk arrived. Every
+// chunk is a liveness signal, including ones the relay holds rather than
+// forwards, so the caller resets once per chunk (drained chunks included).
+func resetIdleTimer(timer *time.Timer, d time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(d)
+}

--- a/coordinator/api/stream_coalesce_test.go
+++ b/coordinator/api/stream_coalesce_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// drainQueuedChunks pulls only what is already queued, in order, never more
+// than the budget, and reports a close it runs into without invoking fn.
+func TestDrainQueuedChunks(t *testing.T) {
+	t.Run("stops at budget and preserves order", func(t *testing.T) {
+		ch := make(chan registry.ProviderChunk, 8)
+		for i := 0; i < 5; i++ {
+			ch <- registry.ProviderChunk{Data: string(rune('a' + i))}
+		}
+		var got []string
+		closed := drainQueuedChunks(ch, 3, func(c registry.ProviderChunk) { got = append(got, c.Data) })
+		if closed {
+			t.Fatal("open channel reported closed")
+		}
+		if want := []string{"a", "b", "c"}; len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+			t.Fatalf("drained %v, want %v", got, want)
+		}
+		if len(ch) != 2 {
+			t.Fatalf("channel should retain the 2 chunks beyond the budget, has %d", len(ch))
+		}
+	})
+
+	t.Run("empty channel drains nothing without blocking", func(t *testing.T) {
+		ch := make(chan registry.ProviderChunk, 1)
+		done := make(chan struct{})
+		var n int
+		go func() {
+			defer close(done)
+			if drainQueuedChunks(ch, 31, func(registry.ProviderChunk) { n++ }) {
+				t.Error("open empty channel reported closed")
+			}
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("drain blocked on an empty channel")
+		}
+		if n != 0 {
+			t.Fatalf("drained %d chunks from an empty channel", n)
+		}
+	})
+
+	t.Run("close mid-drain is reported after the queued chunks", func(t *testing.T) {
+		ch := make(chan registry.ProviderChunk, 8)
+		ch <- registry.ProviderChunk{Data: "x"}
+		ch <- registry.ProviderChunk{Data: "y"}
+		close(ch)
+		var got []string
+		closed := drainQueuedChunks(ch, 31, func(c registry.ProviderChunk) { got = append(got, c.Data) })
+		if !closed {
+			t.Fatal("closed channel not reported")
+		}
+		if len(got) != 2 || got[0] != "x" || got[1] != "y" {
+			t.Fatalf("drained %v before the close, want [x y]", got)
+		}
+	})
+}
+
+type countingFlusher struct{ n int }
+
+func (f *countingFlusher) Flush() { f.n++ }
+
+// deferredFlusher collapses any number of emitter flushes into one real flush
+// and flushes nothing when nothing was written.
+func TestDeferredFlusher(t *testing.T) {
+	inner := &countingFlusher{}
+	d := newDeferredFlusher(inner)
+
+	d.flushNow()
+	if inner.n != 0 {
+		t.Fatalf("flushNow with nothing owed flushed %d times", inner.n)
+	}
+	for i := 0; i < 40; i++ {
+		d.Flush()
+	}
+	d.flushNow()
+	d.flushNow()
+	if inner.n != 1 {
+		t.Fatalf("40 deferred flushes should cost exactly 1 real flush, got %d", inner.n)
+	}
+	d.Flush()
+	d.flushNow()
+	if inner.n != 2 {
+		t.Fatalf("a new owed flush after flushNow should flush again, got %d", inner.n)
+	}
+}
+
+// A provider error delivered just before the channels close (the provider
+// side does `ErrorCh <- msg` and then closes ChunkCh) must be reported by
+// every relay as the in-band provider error — even when the close is observed
+// while draining queued chunks — never as an incomplete or completed stream,
+// and only after every queued delta has been forwarded.
+func TestStreamRelay_BufferedErrorBeforeCloseIsReported(t *testing.T) {
+	const n = 5
+	s := newRelayBenchServer()
+	for _, variant := range relayVariants {
+		t.Run(variant, func(t *testing.T) {
+			pr := &registry.PendingRequest{
+				RequestID:  "err-req",
+				Model:      burstTestModel,
+				ChunkCh:    make(chan registry.ProviderChunk, 16),
+				CompleteCh: make(chan protocol.UsageInfo, 1),
+				ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+			}
+			switch variant {
+			case "responses":
+				pr.IsResponsesAPI = true
+			case "completions":
+				pr.ConsumerEndpoint = completionsEndpoint
+			case "messages":
+				pr.ConsumerEndpoint = messagesEndpoint
+			}
+			for i := 0; i < n; i++ {
+				pr.ChunkCh <- registry.ProviderChunk{Data: chatContentChunk("x" + strconv.Itoa(i) + "z")}
+			}
+			pr.ErrorCh <- protocol.InferenceErrorMessage{
+				Type:        protocol.TypeInferenceError,
+				RequestID:   pr.RequestID,
+				Error:       "engine crashed mid-generation",
+				StatusCode:  http.StatusInternalServerError,
+				FailureCode: protocol.FailureCodeGenerationFailure,
+			}
+			close(pr.ChunkCh)
+			close(pr.CompleteCh)
+
+			rec := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			s.handleStreamingResponseWithFirstChunkAndError(rec, r, pr, nil, nil)
+
+			body := rec.Body.String()
+			for i := 0; i < n; i++ {
+				if !strings.Contains(body, "x"+strconv.Itoa(i)+"z") {
+					t.Fatalf("delta %d missing from stream: %q", i, body)
+				}
+			}
+			events := sseEvents(rec.Body.Bytes())
+			last := events[len(events)-1]
+			if !strings.Contains(last, `"error"`) {
+				t.Fatalf("last frame should be the provider error: %q", last)
+			}
+			for _, marker := range []string{
+				"[DONE]", "response.completed", "response.incomplete", "message_stop",
+				"provider ended without completion",
+			} {
+				if strings.Contains(body, marker) {
+					t.Fatalf("errored stream must not carry %q: %q", marker, body)
+				}
+			}
+		})
+	}
+}
+
+// A 200-chunk prefilled burst (the worst case for per-chunk flushing) costs
+// at most ceil(chunks/maxCoalescedChunks) batch flushes plus the header and
+// terminal flushes, for every streaming variant — and the byte count is
+// unchanged from one-flush-per-chunk relaying.
+func TestStreamRelay_FlushCountBounded(t *testing.T) {
+	const n = 200
+	s := newRelayBenchServer()
+	// n content chunks + 1 finish chunk, in batches of maxCoalescedChunks.
+	batches := (n + 1 + maxCoalescedChunks - 1) / maxCoalescedChunks
+	// header/preamble flush + batch flushes + terminal flush.
+	maxFlushes := batches + 2
+	for _, variant := range relayVariants {
+		t.Run(variant, func(t *testing.T) {
+			w := relayBurstCounts(s, n, variant)
+			if w.status != 200 {
+				t.Fatalf("status = %d", w.status)
+			}
+			if w.flushes > maxFlushes {
+				t.Fatalf("flushes = %d, want <= %d for %d chunks", w.flushes, maxFlushes, n+1)
+			}
+			if w.flushes < batches {
+				t.Fatalf("flushes = %d, fewer than the %d batches (a flush was skipped)", w.flushes, batches)
+			}
+			if w.bytes == 0 {
+				t.Fatal("no bytes written")
+			}
+		})
+	}
+}

--- a/coordinator/api/stream_flush_bench_test.go
+++ b/coordinator/api/stream_flush_bench_test.go
@@ -1,0 +1,113 @@
+package api
+
+// Flush/write accounting for the streaming relay. A counting ResponseWriter
+// drives each streaming variant directly with a PendingRequest whose chunk
+// channel is already full (the worst case for per-chunk flushing: every chunk
+// is ready the moment the relay wakes), so the benchmark reports how many
+// Flush() syscalls and Write() calls a 200-chunk burst costs.
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// countingResponseWriter records writes and flushes without buffering the
+// body (the bytes themselves are discarded; only counts matter here).
+type countingResponseWriter struct {
+	header  http.Header
+	status  int
+	writes  int
+	bytes   int
+	flushes int
+}
+
+func newCountingResponseWriter() *countingResponseWriter {
+	return &countingResponseWriter{header: make(http.Header)}
+}
+
+func (w *countingResponseWriter) Header() http.Header  { return w.header }
+func (w *countingResponseWriter) WriteHeader(code int) { w.status = code }
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	w.writes++
+	w.bytes += len(p)
+	return len(p), nil
+}
+func (w *countingResponseWriter) Flush() { w.flushes++ }
+
+// newPrefilledBurstRequest builds a PendingRequest whose ChunkCh already holds
+// n content chunks (plus a finish chunk) and is closed, with the completion
+// usage already delivered, so the relay drains it without ever blocking.
+func newPrefilledBurstRequest(n int, variant string) *registry.PendingRequest {
+	pr := &registry.PendingRequest{
+		RequestID:  "bench-req",
+		Model:      burstTestModel,
+		ChunkCh:    make(chan registry.ProviderChunk, n+8),
+		CompleteCh: make(chan protocol.UsageInfo, 1),
+		ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+	}
+	switch variant {
+	case "responses":
+		pr.IsResponsesAPI = true
+	case "completions":
+		pr.ConsumerEndpoint = completionsEndpoint
+	case "messages":
+		pr.ConsumerEndpoint = messagesEndpoint
+	}
+	for i := 0; i < n; i++ {
+		pr.ChunkCh <- registry.ProviderChunk{Data: chatContentChunk("b" + strconv.Itoa(i))}
+	}
+	pr.ChunkCh <- registry.ProviderChunk{Data: chatFinishChunk("stop")}
+	close(pr.ChunkCh)
+	pr.CompleteCh <- protocol.UsageInfo{PromptTokens: 10, CompletionTokens: n}
+	close(pr.CompleteCh)
+	return pr
+}
+
+func newRelayBenchServer() *Server {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	return NewServer(registry.New(logger), st, ServerConfig{}, logger)
+}
+
+var relayVariants = []string{"chat", "responses", "completions", "messages"}
+
+// relayBurstCounts runs one prefilled 200-chunk burst through the relay and
+// returns the writer's counters.
+func relayBurstCounts(s *Server, n int, variant string) *countingResponseWriter {
+	w := newCountingResponseWriter()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	pr := newPrefilledBurstRequest(n, variant)
+	s.handleStreamingResponseWithFirstChunkAndError(w, r, pr, nil, nil)
+	return w
+}
+
+// BenchmarkStreamRelayFlushes reports flushes/op, writes/op and bytes/op for a
+// 200-chunk burst per streaming variant.
+func BenchmarkStreamRelayFlushes(b *testing.B) {
+	const n = 200
+	s := newRelayBenchServer()
+	for _, variant := range relayVariants {
+		b.Run(variant, func(b *testing.B) {
+			b.ReportAllocs()
+			var flushes, writes, bytes int
+			for i := 0; i < b.N; i++ {
+				w := relayBurstCounts(s, n, variant)
+				flushes += w.flushes
+				writes += w.writes
+				bytes += w.bytes
+			}
+			b.ReportMetric(float64(flushes)/float64(b.N), "flushes/op")
+			b.ReportMetric(float64(writes)/float64(b.N), "writes/op")
+			b.ReportMetric(float64(bytes)/float64(b.N), "bytes/op")
+		})
+	}
+}

--- a/coordinator/api/telemetry_sink.go
+++ b/coordinator/api/telemetry_sink.go
@@ -1,6 +1,6 @@
 package api
 
-// Non-blocking sink for best-effort routing-telemetry persistence.
+// Non-blocking, batching sink for best-effort routing-telemetry persistence.
 //
 // Routing telemetry (inference-route records, outcome updates, rejection ledger
 // rows) is observability data: useful, but it must NEVER add latency or
@@ -10,144 +10,308 @@ package api
 // write. When the store fell behind, those goroutines (each pinning the captured
 // record) piled up unboundedly.
 //
-// telemetrySink replaces that with a single bounded, non-blocking queue: the
-// request path enqueues a closure via submit (which never blocks), a small fixed
-// pool of long-lived workers drains the queue, and when the buffer is full the
-// write is DROPPED and counted. Goroutines and memory are therefore bounded by
-// construction, and inference latency is fully decoupled from store latency.
+// telemetrySink is a single bounded, non-blocking queue: the request path
+// enqueues an op (which never blocks), ONE long-lived worker drains the queue,
+// and when the buffer is full the write is DROPPED and counted. Goroutines and
+// memory are therefore bounded by construction, and inference latency is fully
+// decoupled from store latency.
+//
+// Ops are TYPED so the worker can coalesce them: it gathers up to maxBatch ops
+// (waiting at most window for more), writes every route record in the group
+// with ONE multi-row store call and every run of outcome updates with ONE
+// pipelined call, and runs generic closures (rejections) inline at their queue
+// position. See telemetry_sink_batch.go for the ordering argument.
+//
+// Shutdown: close marks the sink closed (later submits are rejected and
+// counted as drops) and signals the worker, which finishes its group, writes
+// whatever was buffered at that instant, and exits. closeAndWait bounds how
+// long a caller waits for that final drain; Server.Close uses it so the rows
+// are flushed before the process closes the database pool.
 
 import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
-	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
 // Sink defaults. The buffer absorbs brief store stalls without dropping, while
-// one worker preserves route insert -> outcome update ordering for a given
-// request without adding request latency: callers still only enqueue work into
-// the bounded channel. Telemetry is best-effort and must not compete with
-// inference for resources.
+// the single worker preserves route insert -> outcome update ordering for a
+// given request without adding request latency: callers still only enqueue
+// work into the bounded channel. Telemetry is best-effort and must not compete
+// with inference for resources.
+//
+// maxBatch/window bound one worker group: at most 256 ops per group, and a
+// group is flushed no later than 100ms after its first op even when the queue
+// is quiet. 256 records × 57 columns stays well inside one INSERT statement.
 const (
-	defaultTelemetrySinkCapacity = 4096
-	defaultTelemetrySinkWorkers  = 1
+	defaultTelemetrySinkCapacity    = 4096
+	defaultTelemetrySinkWorkers     = 1
+	defaultTelemetrySinkMaxBatch    = 256
+	defaultTelemetrySinkBatchWindow = 100 * time.Millisecond
+
+	// telemetrySinkShutdownFlush bounds how long Server.Close waits for the
+	// sink's final drain. main defers the store's Close before Server.Close,
+	// so this flush runs while the pool is still open; a stuck store cannot
+	// hold shutdown past the deadline.
+	telemetrySinkShutdownFlush = 2 * time.Second
 )
 
+// telemetryOp is one queued unit of telemetry work. Exactly one of fn, record,
+// or update is set.
+type telemetryOp struct {
+	// fn is a generic best-effort closure (rejection ledger rows, ...). It runs
+	// at its queue position and is never reordered relative to other closures.
+	fn func()
+	// record is an inference_routes snapshot insert (upsert on request/attempt).
+	record *store.InferenceRouteRecord
+	// update is an outcome merge onto an existing inference_routes row.
+	update *store.InferenceRouteOutcomeUpdate
+	// model tags the update's failure log line; it is diagnostic only.
+	model string
+}
+
 // telemetrySink is a bounded, non-blocking work queue for best-effort telemetry
-// persistence. submit enqueues a closure without blocking; a fixed pool of
-// long-lived workers drains the queue and runs each closure inside a panic-safe
-// wrapper. When the buffer is full the write is dropped and counted, so the
-// inference path can never be slowed or blocked by telemetry — even if the store
-// is slow or down — and goroutine/memory growth is bounded.
+// persistence. submit* enqueue without blocking; the worker drains the queue
+// in coalesced groups, running each store call inside a panic-safe wrapper.
+// When the buffer is full the write is dropped and counted, so the inference
+// path can never be slowed or blocked by telemetry — even if the store is slow
+// or down — and goroutine/memory growth is bounded.
 type telemetrySink struct {
-	ch      chan func()
-	done    chan struct{}
-	logger  *slog.Logger
+	ch     chan telemetryOp
+	done   chan struct{}
+	logger *slog.Logger
+	// dropped counts every op that was not persisted: rejected at the buffer
+	// (full or closed) or dropped by the worker (unavailable store, closing).
 	dropped atomic.Int64
 	// closeOnce makes close idempotent: done is closed exactly once even when
 	// close is reached from more than one shutdown path.
 	closeOnce sync.Once
+	// stateMu orders close against enqueue: enqueue holds the read lock while
+	// it checks closed and offers the op; close takes the write lock to set
+	// closed. Once close returns no further op can enter the buffer, so the
+	// final drain is bounded by what was buffered at that instant.
+	stateMu sync.RWMutex
+	closed  bool
+
+	// maxBatch caps the ops gathered into one worker group; window caps how
+	// long the worker waits for more ops after the group's first one.
+	maxBatch int
+	window   time.Duration
+
+	// store persists typed ops (records, updates). It is bound once by the
+	// first typed submit (bind); the channel send/receive orders that write
+	// before any worker read, so no lock is needed on the read side.
+	store    store.TelemetryStore
+	bindOnce sync.Once
+
+	// workers counts live worker goroutines so closeAndWait can observe the
+	// final drain. workerCount is what the constructor actually started
+	// (always 1: the ordering guarantee depends on a single consumer).
+	workers     sync.WaitGroup
+	workerCount int
 }
 
-// newTelemetrySink starts workers long-lived goroutines, each draining the
-// buffered work channel until the sink is closed. capacity and workers fall back
-// to the package defaults when non-positive.
+// newTelemetrySink starts the worker with the default batching parameters.
+// capacity falls back to the package default when non-positive; workers is
+// clamped to 1 (see newBatchingTelemetrySink).
 func newTelemetrySink(logger *slog.Logger, capacity, workers int) *telemetrySink {
+	return newBatchingTelemetrySink(logger, capacity, workers, defaultTelemetrySinkMaxBatch, defaultTelemetrySinkBatchWindow)
+}
+
+// newBatchingTelemetrySink is newTelemetrySink with explicit group bounds.
+// maxBatch 1 disables coalescing (every op is its own group, no window wait).
+// Non-positive values fall back to the package defaults.
+//
+// The sink runs exactly ONE worker: the per-request insert -> update ordering
+// (telemetry_sink_batch.go) holds only with a single FIFO consumer. A request
+// for more workers is clamped and logged rather than honoured.
+func newBatchingTelemetrySink(logger *slog.Logger, capacity, workers, maxBatch int, window time.Duration) *telemetrySink {
 	if capacity <= 0 {
 		capacity = defaultTelemetrySinkCapacity
 	}
 	if workers <= 0 {
 		workers = defaultTelemetrySinkWorkers
 	}
-	t := &telemetrySink{
-		ch:     make(chan func(), capacity),
-		done:   make(chan struct{}),
-		logger: logger,
+	if workers != 1 {
+		if logger != nil {
+			logger.Warn("routing telemetry sink runs exactly one worker (per-request ordering); clamping",
+				"requested_workers", workers,
+			)
+		}
+		workers = 1
 	}
+	if maxBatch <= 0 {
+		maxBatch = defaultTelemetrySinkMaxBatch
+	}
+	if window <= 0 {
+		window = defaultTelemetrySinkBatchWindow
+	}
+	t := &telemetrySink{
+		ch:          make(chan telemetryOp, capacity),
+		done:        make(chan struct{}),
+		logger:      logger,
+		maxBatch:    maxBatch,
+		window:      window,
+		workerCount: workers,
+	}
+	t.workers.Add(workers)
 	for i := 0; i < workers; i++ {
 		go t.worker()
 	}
 	return t
 }
 
-// worker drains the work channel until the sink is closed. The worker IS the
-// long-lived goroutine — it runs each task inline (inside a panic-safe wrapper)
-// and never spawns a goroutine per task.
-func (t *telemetrySink) worker() {
-	for {
-		select {
-		case fn := <-t.ch:
-			t.run(fn)
-		case <-t.done:
-			return
-		}
+// bind sets the store that persists typed ops. The first call wins; later
+// calls are no-ops. Callers must bind before their first typed submit (the
+// Server helpers in route_telemetry_submit.go do this on every submit, which
+// is a cheap sync.Once check after the first).
+func (t *telemetrySink) bind(st store.TelemetryStore) {
+	if t == nil {
+		return
 	}
+	t.bindOnce.Do(func() { t.store = st })
 }
 
-// run executes one telemetry closure with saferun's recover semantics (log +
-// observe a panic, never propagate it). It reuses saferun.Recover rather than
-// saferun.Go precisely so no new goroutine is spawned per task.
-func (t *telemetrySink) run(fn func()) {
-	defer saferun.Recover(t.logger, "telemetrySink")
-	if fn != nil {
-		fn()
-	}
-}
-
-// submit enqueues fn without ever blocking. It returns true when the work was
-// accepted, or false when the buffer was full — in which case the write is
-// dropped and the drop counter is incremented. The inference request path calls
+// submit enqueues a generic closure without ever blocking. It returns true
+// when the work was accepted, or false when it was dropped and counted — the
+// buffer was full, or the sink is closed. The inference request path calls
 // this, so it must never block.
 func (t *telemetrySink) submit(fn func()) bool {
 	if t == nil || fn == nil {
 		return false
 	}
+	return t.enqueue(telemetryOp{fn: fn})
+}
+
+// submitRoute enqueues an inference_routes snapshot insert. Same non-blocking
+// accept/drop contract as submit.
+func (t *telemetrySink) submitRoute(record *store.InferenceRouteRecord) bool {
+	if t == nil || record == nil {
+		return false
+	}
+	return t.enqueue(telemetryOp{record: record})
+}
+
+// submitOutcome enqueues an outcome merge for (requestID, attempt). Same
+// non-blocking accept/drop contract as submit. The caller guarantees the
+// matching submitRoute happened-before this call (dispatch precedes every
+// commit/terminal), which is what lets the worker write records before
+// updates inside one group.
+func (t *telemetrySink) submitOutcome(requestID string, attempt int, model string, outcome *store.InferenceRouteOutcome) bool {
+	if t == nil || outcome == nil {
+		return false
+	}
+	return t.enqueue(telemetryOp{
+		update: &store.InferenceRouteOutcomeUpdate{RequestID: requestID, Attempt: attempt, Outcome: outcome},
+		model:  model,
+	})
+}
+
+// enqueue is the single non-blocking entry into the buffer: accept, or drop
+// and count (full buffer, or closed sink). The read lock is held only across
+// the closed check and a non-blocking send, so it never waits on the store.
+func (t *telemetrySink) enqueue(op telemetryOp) bool {
+	t.stateMu.RLock()
+	defer t.stateMu.RUnlock()
+	if t.closed {
+		t.countDrops(1)
+		return false
+	}
 	select {
-	case t.ch <- fn:
+	case t.ch <- op:
 		return true
 	default:
-		n := t.dropped.Add(1)
-		t.maybeLogDrop(n)
+		t.countDrops(1)
 		return false
 	}
 }
 
-// close signals the workers to stop and is idempotent. It never blocks on
-// in-flight telemetry writes: a stuck store call (the exact failure this sink
-// guards against) must not be able to stall coordinator shutdown. Workers return
-// on their next loop iteration once done is closed; any buffered-but-unrun
-// telemetry is best-effort and discarded.
+// close marks the sink closed and signals the worker; it is idempotent and
+// never blocks on in-flight telemetry writes: a stuck store call (the exact
+// failure this sink guards against) must not be able to stall coordinator
+// shutdown. After close returns no new op can be accepted; the worker
+// finishes the group it holds, writes what was buffered, and exits.
 func (t *telemetrySink) close() {
 	if t == nil {
 		return
 	}
 	t.closeOnce.Do(func() {
+		t.stateMu.Lock()
+		t.closed = true
 		close(t.done)
+		t.stateMu.Unlock()
 	})
+}
+
+// closeAndWait closes the sink and waits up to timeout for the worker to
+// finish its final drain, reporting whether it did. Server.Close uses it so
+// buffered route rows reach the store before the process closes the pool;
+// tests use it to observe the flush. Because close rejects further submits,
+// the drain cannot be prolonged by refills.
+func (t *telemetrySink) closeAndWait(timeout time.Duration) bool {
+	if t == nil {
+		return true
+	}
+	t.close()
+	stopped := make(chan struct{})
+	go func() {
+		t.workers.Wait()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// isClosed reports whether close has been called (the worker is draining).
+func (t *telemetrySink) isClosed() bool {
+	select {
+	case <-t.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// countDrops adds n unpersisted ops to the drop counter and emits the
+// throttled warning when the cumulative count crosses a power of ten.
+func (t *telemetrySink) countDrops(n int) {
+	if n <= 0 {
+		return
+	}
+	after := t.dropped.Add(int64(n))
+	t.maybeLogDrop(after-int64(n), after)
 }
 
 // maybeLogDrop emits a throttled warning so operators notice sustained drops
 // without flooding logs: it logs only when the cumulative drop count crosses a
-// power of ten (1, 10, 100, 1000, …).
-func (t *telemetrySink) maybeLogDrop(total int64) {
-	if t.logger == nil || !isPowerOfTen(total) {
+// power of ten (1, 10, 100, 1000, …) between before and after.
+func (t *telemetrySink) maybeLogDrop(before, after int64) {
+	if t.logger == nil || !crossesPowerOfTen(before, after) {
 		return
 	}
-	t.logger.Warn("routing telemetry sink dropping writes (buffer full) — inference is unaffected",
-		"dropped_total", total,
+	t.logger.Warn("routing telemetry sink dropping writes — inference is unaffected",
+		"dropped_total", after,
 		"capacity", cap(t.ch),
 	)
 }
 
-// isPowerOfTen reports whether n is 1, 10, 100, 1000, … It is the throttle key
-// for drop logging.
-func isPowerOfTen(n int64) bool {
-	if n < 1 {
-		return false
+// crossesPowerOfTen reports whether some power of ten p (1, 10, 100, …)
+// satisfies before < p <= after. It is the throttle key for drop logging and
+// works for multi-op drops, where a single increment could skip a threshold.
+// The p > 0 guard stops the walk when p*10 overflows int64 past 10^18, so an
+// after near math.MaxInt64 terminates instead of spinning.
+func crossesPowerOfTen(before, after int64) bool {
+	for p := int64(1); p > 0 && p <= after; p *= 10 {
+		if p > before {
+			return true
+		}
 	}
-	for n%10 == 0 {
-		n /= 10
-	}
-	return n == 1
+	return false
 }

--- a/coordinator/api/telemetry_sink_batch.go
+++ b/coordinator/api/telemetry_sink_batch.go
@@ -1,0 +1,370 @@
+package api
+
+// Worker-side grouping for telemetrySink: gather a bounded run of queued ops,
+// then persist it with as few store calls as its contents allow.
+//
+// INVARIANT: exactly one worker consumes the queue (newBatchingTelemetrySink
+// clamps workers to 1). Everything below assumes a single FIFO consumer.
+//
+// Ordering guarantee. The only order the store depends on is PER ROUTE KEY
+// (request_id, attempt): a row's insert must be written before any outcome
+// update for it (an UPDATE on a missing row is a silent no-op on both
+// backends), later updates must land after earlier ones, and a re-record of
+// the same key (dispatch.go records "queued", then "selected") must land after
+// the first insert and after any update that preceded it in the queue.
+//
+// Submission order already satisfies all of that: dispatch records the route
+// before the provider can produce a commit or terminal, and the single worker
+// consumes the queue FIFO. execute keeps it while coalescing by
+//
+//   - writing every record of a group FIRST (one multi-row upsert), then
+//     walking the rest of the group in queue order — updates coalesced into
+//     pipelined runs, generic closures inline;
+//   - refusing to add a record to a group whose key already has an insert OR
+//     an update in that group (telemetryGroup.conflicts): such a record starts
+//     the next group, so moving inserts to the front of a group can never move
+//     one across a same-key op. Distinct keys are independent rows, so their
+//     relative order is free.
+//
+// Groups execute sequentially on the one worker, so cross-group order is FIFO.
+//
+// Failure policy. A batch call runs under its own recover; a panic or error
+// is a failed batch. When the failure is a ROW fault (constraint, type, ...)
+// and the sink is still open, every row is replayed on its own — each under
+// its own recover — so one poison row cannot discard its neighbours and every
+// failure keeps the per-row diagnostic the single-write path always logged.
+// When the store is UNAVAILABLE (deadline, connection, closed pool, server
+// shutdown) or the sink is closing (the pool is about to go away), the group
+// is dropped and counted instead: N sequential replays would only be N more
+// timeouts and N error lines.
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// telemetryGroup is one gathered run of ops, executed together.
+type telemetryGroup struct {
+	ops        []telemetryOp
+	records    []*store.InferenceRouteRecord
+	insertKeys map[string]struct{}
+	updateKeys map[string]struct{}
+}
+
+func newTelemetryGroup(capacity int) *telemetryGroup {
+	return &telemetryGroup{
+		ops:        make([]telemetryOp, 0, capacity),
+		insertKeys: map[string]struct{}{},
+		updateKeys: map[string]struct{}{},
+	}
+}
+
+func routeTelemetryKey(requestID string, attempt int) string {
+	return requestID + "/" + strconv.Itoa(attempt)
+}
+
+// conflicts reports whether op must NOT join this group: it is a route record
+// whose key already has an insert (a single multi-row upsert cannot touch one
+// row twice, and the later record must land after the earlier one) or an
+// update (which must stay before this re-record) in the group.
+func (g *telemetryGroup) conflicts(op telemetryOp) bool {
+	if op.record == nil {
+		return false
+	}
+	key := routeTelemetryKey(op.record.RequestID, op.record.Attempt)
+	if _, dup := g.insertKeys[key]; dup {
+		return true
+	}
+	_, afterUpdate := g.updateKeys[key]
+	return afterUpdate
+}
+
+func (g *telemetryGroup) add(op telemetryOp) {
+	g.ops = append(g.ops, op)
+	switch {
+	case op.record != nil:
+		g.records = append(g.records, op.record)
+		g.insertKeys[routeTelemetryKey(op.record.RequestID, op.record.Attempt)] = struct{}{}
+	case op.update != nil:
+		g.updateKeys[routeTelemetryKey(op.update.RequestID, op.update.Attempt)] = struct{}{}
+	}
+}
+
+// worker drains the queue until the sink is closed. The worker IS the
+// long-lived goroutine — it runs each group inline (inside panic-safe
+// wrappers) and never spawns a goroutine per op. carry holds an op that
+// conflicted with the previous group and therefore opens the next one.
+func (t *telemetrySink) worker() {
+	defer t.workers.Done()
+	var carry *telemetryOp
+	for {
+		var first telemetryOp
+		if carry != nil {
+			first = *carry
+		} else {
+			select {
+			case first = <-t.ch:
+			case <-t.done:
+				t.drainOnClose(nil)
+				return
+			}
+		}
+		g, next := t.gather(first, t.liveNext())
+		t.execute(g)
+		carry = next
+		select {
+		case <-t.done:
+			t.drainOnClose(carry)
+			return
+		default:
+		}
+	}
+}
+
+// liveNext returns the op source for a live group: it blocks for the next op
+// until the group window elapses or the sink is closed.
+func (t *telemetrySink) liveNext() func() (telemetryOp, bool) {
+	var timer *time.Timer
+	return func() (telemetryOp, bool) {
+		if timer == nil {
+			timer = time.NewTimer(t.window)
+		}
+		select {
+		case op := <-t.ch:
+			return op, true
+		case <-timer.C:
+			return telemetryOp{}, false
+		case <-t.done:
+			timer.Stop()
+			return telemetryOp{}, false
+		}
+	}
+}
+
+// bufferedNext returns the op source for a closing drain: whatever is already
+// buffered, without waiting.
+func (t *telemetrySink) bufferedNext() func() (telemetryOp, bool) {
+	return func() (telemetryOp, bool) {
+		select {
+		case op := <-t.ch:
+			return op, true
+		default:
+			return telemetryOp{}, false
+		}
+	}
+}
+
+// gather builds a group starting with first, pulling from next until the
+// group is full, next runs dry, or an op conflicts with the group — in which
+// case that op is returned as the carry for the following group.
+func (t *telemetrySink) gather(first telemetryOp, next func() (telemetryOp, bool)) (*telemetryGroup, *telemetryOp) {
+	g := newTelemetryGroup(t.maxBatch)
+	g.add(first)
+	for len(g.ops) < t.maxBatch {
+		op, ok := next()
+		if !ok {
+			return g, nil
+		}
+		if g.conflicts(op) {
+			return g, &op
+		}
+		g.add(op)
+	}
+	return g, nil
+}
+
+// drainOnClose writes everything buffered at close time, in groups, without
+// waiting for more. It runs on the worker goroutine after done is closed, so
+// close itself never blocks on it; closeAndWait bounds how long a caller
+// waits for it. Because close rejects new submits, the buffer only shrinks.
+func (t *telemetrySink) drainOnClose(carry *telemetryOp) {
+	next := t.bufferedNext()
+	for {
+		var first telemetryOp
+		if carry != nil {
+			first = *carry
+		} else {
+			op, ok := next()
+			if !ok {
+				return
+			}
+			first = op
+		}
+		g, more := t.gather(first, next)
+		t.execute(g)
+		carry = more
+	}
+}
+
+// execute persists one group: all records first (one store call), then the
+// remaining ops in queue order with runs of updates pipelined (one store call
+// per run) and generic closures inline. Every store call and closure runs in
+// its own panic-safe unit so one failure cannot skip the rest of the group.
+func (t *telemetrySink) execute(g *telemetryGroup) {
+	if len(g.records) > 0 {
+		records := g.records
+		t.runUnit(func() { t.persistRoutes(records) })
+	}
+	var pending []telemetryOp
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		batch := pending
+		pending = nil
+		t.runUnit(func() { t.persistOutcomes(batch) })
+	}
+	for _, op := range g.ops {
+		switch {
+		case op.update != nil:
+			pending = append(pending, op)
+		case op.fn != nil:
+			flush()
+			t.runUnit(op.fn)
+		}
+	}
+	flush()
+}
+
+// runUnit executes fn with saferun's recover semantics (log + observe a panic,
+// never propagate it). It reuses saferun.Recover rather than saferun.Go
+// precisely so no new goroutine is spawned per unit.
+func (t *telemetrySink) runUnit(fn func()) {
+	defer saferun.Recover(t.logger, "telemetrySink")
+	fn()
+}
+
+// tryBatch runs one batch store call and reports a panic as an error, so the
+// caller handles it as a failed batch (replay or drop) instead of losing the
+// rest of the group. The panic is re-raised inside saferun.Recover while the
+// panicking frames are still on this stack, so it is logged and observed
+// exactly like any other telemetry unit.
+func (t *telemetrySink) tryBatch(name string, fn func() error) (err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		func() {
+			defer saferun.Recover(t.logger, "telemetrySink."+name)
+			panic(r)
+		}()
+		err = fmt.Errorf("telemetry batch %s panicked: %v", name, r)
+	}()
+	return fn()
+}
+
+// rowFault reports whether a failed write should be handled per row: the
+// sink is still open and the error describes the rows rather than the
+// store's availability. Otherwise the caller drops and counts.
+func (t *telemetrySink) rowFault(err error) bool {
+	return !t.isClosed() && !store.IsTransientWriteError(err)
+}
+
+// dropGroup counts rows that will not be persisted and says why, once.
+func (t *telemetrySink) dropGroup(kind string, rows int, err error) {
+	t.countDrops(rows)
+	if t.logger != nil {
+		t.logger.Warn("routing telemetry group dropped",
+			"kind", kind,
+			"rows", rows,
+			"closing", t.isClosed(),
+			"error", err,
+		)
+	}
+}
+
+// persistRoutes writes a group's records with one multi-row call, then applies
+// the failure policy from the file header.
+func (t *telemetrySink) persistRoutes(records []*store.InferenceRouteRecord) {
+	st := t.store
+	if st == nil {
+		return
+	}
+	writeOne := func(r *store.InferenceRouteRecord) {
+		t.runUnit(func() {
+			err := st.RecordInferenceRoute(r)
+			switch {
+			case err == nil:
+			case t.rowFault(err):
+				logRouteRecordWriteError(t.logger, r, err)
+			default:
+				t.dropGroup("inference_routes", 1, err)
+			}
+		})
+	}
+	if len(records) == 1 {
+		writeOne(records[0])
+		return
+	}
+	err := t.tryBatch("recordInferenceRoutes", func() error { return st.RecordInferenceRoutes(records) })
+	if err == nil {
+		return
+	}
+	if !t.rowFault(err) {
+		t.dropGroup("inference_routes", len(records), err)
+		return
+	}
+	if t.logger != nil {
+		t.logger.Warn("inference_routes batch write failed — retrying rows individually",
+			"rows", len(records),
+			"error", err,
+		)
+	}
+	for _, r := range records {
+		writeOne(r)
+	}
+}
+
+// persistOutcomes applies a run of outcome updates with one pipelined call,
+// then applies the failure policy from the file header. Outcome merges are
+// idempotent ("set when non-zero"), so a replay after a rolled-back pipeline
+// is safe.
+func (t *telemetrySink) persistOutcomes(ops []telemetryOp) {
+	st := t.store
+	if st == nil {
+		return
+	}
+	writeOne := func(op telemetryOp) {
+		t.runUnit(func() {
+			u := op.update
+			err := st.UpdateInferenceRouteOutcome(u.RequestID, u.Attempt, u.Outcome)
+			switch {
+			case err == nil:
+			case t.rowFault(err):
+				logRouteOutcomeWriteError(t.logger, u.RequestID, u.Attempt, op.model, u.Outcome, err)
+			default:
+				t.dropGroup("inference_routes_outcome", 1, err)
+			}
+		})
+	}
+	if len(ops) == 1 {
+		writeOne(ops[0])
+		return
+	}
+	updates := make([]store.InferenceRouteOutcomeUpdate, 0, len(ops))
+	for _, op := range ops {
+		updates = append(updates, *op.update)
+	}
+	err := t.tryBatch("updateInferenceRouteOutcomes", func() error { return st.UpdateInferenceRouteOutcomes(updates) })
+	if err == nil {
+		return
+	}
+	if !t.rowFault(err) {
+		t.dropGroup("inference_routes_outcome", len(ops), err)
+		return
+	}
+	if t.logger != nil {
+		t.logger.Warn("inference_routes outcome batch update failed — retrying rows individually",
+			"rows", len(ops),
+			"error", err,
+		)
+	}
+	for _, op := range ops {
+		writeOne(op)
+	}
+}

--- a/coordinator/api/telemetry_sink_failure_test.go
+++ b/coordinator/api/telemetry_sink_failure_test.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// faultingTelemetryStore layers injectable batch errors / panics and a
+// per-row panic onto countingTelemetryStore (which still applies every
+// successful call to a real memory store).
+type faultingTelemetryStore struct {
+	*countingTelemetryStore
+
+	mu          sync.Mutex
+	batchErr    error  // returned by both batch methods when non-nil
+	panicBatch  bool   // both batch methods panic
+	panicRecord string // RecordInferenceRoute panics for this request id
+}
+
+func newFaultingTelemetryStore() *faultingTelemetryStore {
+	return &faultingTelemetryStore{countingTelemetryStore: newCountingTelemetryStore()}
+}
+
+// waitForCalls polls until the store has seen n calls with the given log
+// prefix. The failure-policy tests size their groups to fill by count so the
+// group executes while the sink is still OPEN (a close-time execution would
+// take the closing branch instead), then observe the resulting store calls.
+func waitForCalls(t *testing.T, st *countingTelemetryStore, prefix string, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls, _ := st.count(prefix); calls >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	calls, _ := st.count(prefix)
+	t.Fatalf("waited for %d %q calls, saw %d; log=%v", n, prefix, calls, st.callLog())
+}
+
+// waitForDrops polls until the sink's drop counter reaches n.
+func waitForDrops(t *testing.T, sink *telemetrySink, n int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if sink.dropped.Load() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("waited for dropped >= %d, got %d", n, sink.dropped.Load())
+}
+
+func (f *faultingTelemetryStore) fault() (error, bool, string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.batchErr, f.panicBatch, f.panicRecord
+}
+
+func (f *faultingTelemetryStore) RecordInferenceRoutes(rs []*store.InferenceRouteRecord) error {
+	f.note(fmt.Sprintf("records:%d", len(rs)))
+	err, panics, _ := f.fault()
+	if panics {
+		panic("injected batch panic")
+	}
+	if err != nil {
+		return err
+	}
+	return f.MemoryStore.RecordInferenceRoutes(rs)
+}
+
+func (f *faultingTelemetryStore) RecordInferenceRoute(r *store.InferenceRouteRecord) error {
+	if _, _, id := f.fault(); id != "" && r.RequestID == id {
+		f.note("record")
+		panic("injected row panic")
+	}
+	return f.countingTelemetryStore.RecordInferenceRoute(r)
+}
+
+func (f *faultingTelemetryStore) UpdateInferenceRouteOutcomes(us []store.InferenceRouteOutcomeUpdate) error {
+	f.note(fmt.Sprintf("updates:%d", len(us)))
+	err, panics, _ := f.fault()
+	if panics {
+		panic("injected batch panic")
+	}
+	if err != nil {
+		return err
+	}
+	return f.MemoryStore.UpdateInferenceRouteOutcomes(us)
+}
+
+func TestCrossesPowerOfTen(t *testing.T) {
+	cases := []struct {
+		before, after int64
+		want          bool
+	}{
+		{0, 0, false}, {0, 1, true}, {1, 2, false}, {9, 10, true}, {10, 11, false},
+		{5, 12, true}, {99, 100, true}, {100, 1000, true}, {101, 999, false}, {0, 256, true},
+		// Near math.MaxInt64 the power-of-ten walk must stop at 10^18 instead
+		// of overflowing and spinning: 10^18 is the last threshold.
+		{1<<63 - 2, 1<<63 - 1, false}, {1e18 - 1, 1<<63 - 1, true}, {0, 1<<63 - 1, true},
+	}
+	for _, tc := range cases {
+		if got := crossesPowerOfTen(tc.before, tc.after); got != tc.want {
+			t.Fatalf("crossesPowerOfTen(%d, %d) = %v, want %v", tc.before, tc.after, got, tc.want)
+		}
+	}
+}
+
+func TestTelemetrySinkClampsWorkersToOne(t *testing.T) {
+	sink := newBatchingTelemetrySink(quietLogger(), 8, 4, 256, time.Second)
+	defer sink.closeAndWait(time.Second)
+	if sink.workerCount != 1 {
+		t.Fatalf("workerCount = %d, want 1 (ordering depends on a single consumer)", sink.workerCount)
+	}
+	if got := newTelemetrySink(quietLogger(), 8, 0); got.workerCount != 1 {
+		t.Fatalf("default workers = %d, want 1", got.workerCount)
+	}
+}
+
+func TestTelemetrySinkRejectsSubmitsAfterClose(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+	mustCloseAndWait(t, sink)
+
+	if sink.submitRoute(routeRec("late-1", 1, "p")) {
+		t.Fatal("submitRoute after close must be rejected")
+	}
+	if sink.submitOutcome("late-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"}) {
+		t.Fatal("submitOutcome after close must be rejected")
+	}
+	if sink.submit(func() {}) {
+		t.Fatal("submit after close must be rejected")
+	}
+	if got := sink.dropped.Load(); got != 3 {
+		t.Fatalf("dropped = %d, want 3 (every post-close submit counts)", got)
+	}
+	if len(sink.ch) != 0 {
+		t.Fatalf("post-close submits must not enter the buffer: %d buffered", len(sink.ch))
+	}
+	if st.route("late-1", 1) != nil {
+		t.Fatal("post-close submit must not be persisted")
+	}
+}
+
+// TestTelemetrySinkTransientBatchFailureDropsGroup: a batch that fails because
+// the store is unavailable (deadline, connection, closed pool) is dropped and
+// counted — never replayed row by row.
+func TestTelemetrySinkTransientBatchFailureDropsGroup(t *testing.T) {
+	st := newFaultingTelemetryStore()
+	st.batchErr = fmt.Errorf("store: record inference routes (5 rows): %w", context.DeadlineExceeded)
+	const n = 5
+	// Groups fill by size (n) so each executes while the sink is open.
+	sink := newTestSink(t, st, 1024, n, 10*time.Second)
+
+	for i := 0; i < n; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("tr-%d", i), 1, "p"))
+	}
+	for i := 0; i < n; i++ {
+		sink.submitOutcome(fmt.Sprintf("tr-%d", i), 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	}
+	waitForDrops(t, sink, 2*n)
+	flushAndWait(t, sink)
+
+	if calls, _ := st.count("record"); calls != 0 {
+		t.Fatalf("transient failure must not replay rows: %d single record writes, log=%v", calls, st.callLog())
+	}
+	if calls, _ := st.count("update"); calls != 0 {
+		t.Fatalf("transient failure must not replay updates: %d single update writes, log=%v", calls, st.callLog())
+	}
+	if got := sink.dropped.Load(); got != 2*n {
+		t.Fatalf("dropped = %d, want %d (records + updates)", got, 2*n)
+	}
+	if st.route("tr-0", 1) != nil {
+		t.Fatal("nothing must be persisted")
+	}
+}
+
+// TestTelemetrySinkClosingDrainDoesNotReplayRows: once close has been called
+// the pool is about to go away, so even a row-fault-shaped batch error must
+// not fan out into N per-row attempts (each of which would log an error).
+func TestTelemetrySinkClosingDrainDoesNotReplayRows(t *testing.T) {
+	st := newCountingTelemetryStore()
+	st.failBatchRecords.Store(true)
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("cd-%d", i), 1, "p"))
+	}
+	// The window never fires, so the group (all n ops, once the worker holds
+	// them) is executed by the close-time drain — i.e. after done is closed.
+	flushAndWait(t, sink)
+
+	if calls, _ := st.count("record"); calls != 0 {
+		t.Fatalf("closing drain must not replay rows: %d single writes, log=%v", calls, st.callLog())
+	}
+	if got := sink.dropped.Load(); got != n {
+		t.Fatalf("dropped = %d, want %d", got, n)
+	}
+}
+
+// TestTelemetrySinkBatchPanicReplaysRowsWithIsolation: a panic inside the
+// batch call is a failed batch (replayed row by row while open), and a panic
+// inside one replayed row does not take its neighbours or the worker down.
+func TestTelemetrySinkBatchPanicReplaysRowsWithIsolation(t *testing.T) {
+	st := newFaultingTelemetryStore()
+	st.panicBatch = true
+	st.panicRecord = "pp-2"
+	const n = 5
+	// The group fills by size (n) so it executes while the sink is open.
+	sink := newTestSink(t, st, 1024, n, 10*time.Second)
+
+	for i := 0; i < n; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("pp-%d", i), 1, "p"))
+	}
+	waitForCalls(t, st.countingTelemetryStore, "record", n)
+	flushAndWait(t, sink)
+
+	if calls, _ := st.count("records"); calls != 1 {
+		t.Fatalf("batch must be attempted once, got %d; log=%v", calls, st.callLog())
+	}
+	if calls, _ := st.count("record"); calls != n {
+		t.Fatalf("every row must be replayed after a batch panic: %d single writes, log=%v", calls, st.callLog())
+	}
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("pp-%d", i)
+		rec := st.route(id, 1)
+		if i == 2 {
+			if rec != nil {
+				t.Fatalf("panicking row must not be written: %+v", rec)
+			}
+			continue
+		}
+		if rec == nil {
+			t.Fatalf("row %s must survive its neighbour's panic", id)
+		}
+	}
+}
+
+// TestServerCloseFlushesRouteTelemetryBeforeReturning covers the production
+// shutdown path: Server.Close waits (bounded) for the sink's final drain, so
+// rows are in the store when Close returns — before main closes the pool —
+// and anything submitted afterwards is rejected and counted.
+func TestServerCloseFlushesRouteTelemetryBeforeReturning(t *testing.T) {
+	srv, st := testServer(t)
+	srv.submitRouteRecord(routeRec("shut-1", 1, "p"))
+	srv.updateInferenceRouteOutcomeWithModel("shut-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: 2, CompletionTokensSet: true})
+
+	srv.Close()
+
+	var found *store.InferenceRouteRecord
+	for _, r := range st.InferenceRouteRecordsSince(time.Time{}) {
+		if r.RequestID == "shut-1" {
+			rec := r
+			found = &rec
+		}
+	}
+	if found == nil || found.FinalStatus != "success" || found.CompletionTokens != 2 {
+		t.Fatalf("Close must flush the buffered route record and its outcome before returning: %+v", found)
+	}
+
+	srv.submitRouteRecord(routeRec("shut-2", 1, "p"))
+	if got := srv.routeTelemetry.dropped.Load(); got != 1 {
+		t.Fatalf("post-Close submit must be rejected and counted: dropped=%d", got)
+	}
+	for _, r := range st.InferenceRouteRecordsSince(time.Time{}) {
+		if r.RequestID == "shut-2" {
+			t.Fatal("post-Close submit must not be persisted")
+		}
+	}
+}
+
+// TestTelemetrySinkCloseIsBoundedByStuckStore: a store call that never returns
+// cannot hold closeAndWait past its deadline.
+func TestTelemetrySinkCloseIsBoundedByStuckStore(t *testing.T) {
+	st := newCountingTelemetryStore()
+	st.gate = make(chan struct{})
+	sink := newBatchingTelemetrySink(quietLogger(), 8, 1, 1, time.Millisecond)
+	sink.bind(st)
+	sink.submitRoute(routeRec("stuck-1", 1, "p"))
+
+	start := time.Now()
+	if sink.closeAndWait(50 * time.Millisecond) {
+		t.Fatal("closeAndWait must report a timeout while the store is stuck")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("closeAndWait took %v, want ~50ms", elapsed)
+	}
+	close(st.gate)
+	if !sink.closeAndWait(time.Second) {
+		t.Fatal("worker must exit once the store unblocks")
+	}
+}

--- a/coordinator/api/telemetry_sink_test.go
+++ b/coordinator/api/telemetry_sink_test.go
@@ -1,0 +1,473 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// countingTelemetryStore wraps a REAL memory store: every call is applied to
+// it (so row state is asserted through the real reader) while the wrapper
+// records which store method the sink chose and in what order.
+type countingTelemetryStore struct {
+	*store.MemoryStore
+
+	mu    sync.Mutex
+	calls []string // "record", "records:N", "update", "updates:N", "fn"
+
+	failBatchRecords atomic.Bool
+	failBatchUpdates atomic.Bool
+	// gate, when non-nil, blocks every single-record write until it is closed
+	// (simulates a stuck store while the worker holds one op).
+	gate chan struct{}
+}
+
+func newCountingTelemetryStore() *countingTelemetryStore {
+	return &countingTelemetryStore{MemoryStore: store.NewMemory(store.Config{})}
+}
+
+func (c *countingTelemetryStore) note(call string) {
+	c.mu.Lock()
+	c.calls = append(c.calls, call)
+	c.mu.Unlock()
+}
+
+func (c *countingTelemetryStore) callLog() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.calls...)
+}
+
+func (c *countingTelemetryStore) count(prefix string) (calls, rows int) {
+	for _, call := range c.callLog() {
+		var n int
+		if call == prefix {
+			calls++
+			rows++
+			continue
+		}
+		if _, err := fmt.Sscanf(call, prefix+":%d", &n); err == nil {
+			calls++
+			rows += n
+		}
+	}
+	return calls, rows
+}
+
+func (c *countingTelemetryStore) RecordInferenceRoute(r *store.InferenceRouteRecord) error {
+	if c.gate != nil {
+		<-c.gate
+	}
+	c.note("record")
+	return c.MemoryStore.RecordInferenceRoute(r)
+}
+
+func (c *countingTelemetryStore) RecordInferenceRoutes(rs []*store.InferenceRouteRecord) error {
+	c.note(fmt.Sprintf("records:%d", len(rs)))
+	if c.failBatchRecords.Load() {
+		return errors.New("injected batch insert failure")
+	}
+	return c.MemoryStore.RecordInferenceRoutes(rs)
+}
+
+func (c *countingTelemetryStore) UpdateInferenceRouteOutcome(id string, attempt int, o *store.InferenceRouteOutcome) error {
+	c.note("update")
+	return c.MemoryStore.UpdateInferenceRouteOutcome(id, attempt, o)
+}
+
+func (c *countingTelemetryStore) UpdateInferenceRouteOutcomes(us []store.InferenceRouteOutcomeUpdate) error {
+	c.note(fmt.Sprintf("updates:%d", len(us)))
+	if c.failBatchUpdates.Load() {
+		return errors.New("injected batch update failure")
+	}
+	return c.MemoryStore.UpdateInferenceRouteOutcomes(us)
+}
+
+func (c *countingTelemetryStore) route(id string, attempt int) *store.InferenceRouteRecord {
+	for _, r := range c.InferenceRouteRecordsSince(time.Time{}) {
+		if r.RequestID == id && r.Attempt == attempt {
+			rec := r
+			return &rec
+		}
+	}
+	return nil
+}
+
+func routeRec(id string, attempt int, provider string) *store.InferenceRouteRecord {
+	return &store.InferenceRouteRecord{RequestID: id, Attempt: attempt, ProviderID: provider, Outcome: "selected", Model: "m"}
+}
+
+// newTestSink returns a bound sink with a window long enough that a group only
+// ends by size, conflict, or close — making grouping deterministic.
+func newTestSink(t *testing.T, st store.TelemetryStore, capacity, maxBatch int, window time.Duration) *telemetrySink {
+	t.Helper()
+	sink := newBatchingTelemetrySink(quietLogger(), capacity, 1, maxBatch, window)
+	sink.bind(st)
+	t.Cleanup(func() { sink.closeAndWait(5 * time.Second) })
+	return sink
+}
+
+func mustCloseAndWait(t *testing.T, sink *telemetrySink) {
+	t.Helper()
+	if !sink.closeAndWait(5 * time.Second) {
+		t.Fatal("sink worker did not stop after close")
+	}
+}
+
+// flushAndWait waits until the worker has pulled every buffered op into its
+// current group (the test sinks use a window long enough that a group only
+// ends by size, conflict, or close), then closes so that group is written.
+// Closing earlier lets the close race the gather and split the group — correct
+// behaviour, but it makes exact grouping assertions timing-dependent.
+func flushAndWait(t *testing.T, sink *telemetrySink) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for len(sink.ch) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(sink.ch) != 0 {
+		t.Fatalf("worker did not drain the queue: %d ops still buffered", len(sink.ch))
+	}
+	mustCloseAndWait(t, sink)
+}
+
+func TestTelemetrySinkCoalescesRecordsAndUpdates(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("req-%d", i)
+		if !sink.submitRoute(routeRec(id, 1, "p")) {
+			t.Fatalf("submitRoute %d rejected", i)
+		}
+		// Interleaved: an update for the row just recorded lands in the same
+		// group; the insert must still be written first.
+		if !sink.submitOutcome(id, 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: i + 1}) {
+			t.Fatalf("submitOutcome %d rejected", i)
+		}
+	}
+	// Close flushes the held group (the window never fired).
+	flushAndWait(t, sink)
+
+	if calls, rows := st.count("records"); calls != 1 || rows != n {
+		t.Fatalf("record batches: calls=%d rows=%d, want 1/%d; log=%v", calls, rows, n, st.callLog())
+	}
+	if calls, rows := st.count("updates"); calls != 1 || rows != n {
+		t.Fatalf("update batches: calls=%d rows=%d, want 1/%d; log=%v", calls, rows, n, st.callLog())
+	}
+	if c, _ := st.count("record"); c != 0 {
+		t.Fatalf("no single-row record writes expected; log=%v", st.callLog())
+	}
+	if log := st.callLog(); len(log) != 2 || log[0] != fmt.Sprintf("records:%d", n) || log[1] != fmt.Sprintf("updates:%d", n) {
+		t.Fatalf("inserts must precede updates: %v", log)
+	}
+	for i := 0; i < n; i++ {
+		rec := st.route(fmt.Sprintf("req-%d", i), 1)
+		if rec == nil || rec.FinalStatus != "success" || rec.CompletionTokens != i+1 {
+			t.Fatalf("row %d missing or without outcome: %+v", i, rec)
+		}
+	}
+}
+
+func TestTelemetrySinkWindowFlushesQuietQueue(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 30*time.Millisecond)
+
+	sink.submitRoute(routeRec("win-1", 1, "p"))
+	sink.submitOutcome("win-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if rec := st.route("win-1", 1); rec != nil && rec.FinalStatus == "success" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("group was not flushed by the window; log=%v", st.callLog())
+}
+
+func TestTelemetrySinkMaxBatchSplitsGroups(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 4, 10*time.Second)
+
+	for i := 0; i < 10; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("mb-%d", i), 1, "p"))
+	}
+	flushAndWait(t, sink)
+
+	if calls, rows := st.count("records"); calls != 3 || rows != 10 {
+		t.Fatalf("expected groups of 4/4/2: calls=%d rows=%d log=%v", calls, rows, st.callLog())
+	}
+	for i := 0; i < 10; i++ {
+		if st.route(fmt.Sprintf("mb-%d", i), 1) == nil {
+			t.Fatalf("row %d missing", i)
+		}
+	}
+}
+
+// TestTelemetrySinkReRecordKeepsPerKeyOrder is the live dispatch.go pattern:
+// the same (request, attempt) is recorded as "queued", updated, then
+// re-recorded as "selected" and finalised — all inside one window. The
+// re-record must open a new group so inserts-first coalescing cannot hoist it
+// above the earlier update.
+func TestTelemetrySinkReRecordKeepsPerKeyOrder(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	queued := routeRec("rr-1", 1, "")
+	queued.Outcome = "queued"
+	sink.submitRoute(queued)
+	sink.submitOutcome("rr-1", 1, "m", &store.InferenceRouteOutcome{ActualTTFTMs: 5, UsedBackup: true})
+	sink.submitRoute(routeRec("rr-1", 1, "p-final"))
+	sink.submitOutcome("rr-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: 9})
+	// Unrelated key in the same window: free to coalesce with either group.
+	sink.submitRoute(routeRec("rr-2", 1, "p2"))
+	flushAndWait(t, sink)
+
+	rec := st.route("rr-1", 1)
+	if rec == nil {
+		t.Fatal("row missing")
+	}
+	if rec.ProviderID != "p-final" || rec.Outcome != "selected" {
+		t.Fatalf("re-record must win the snapshot: %+v", rec)
+	}
+	if rec.FinalStatus != "success" || rec.CompletionTokens != 9 || rec.ActualTTFTMs != 5 || !rec.UsedBackup {
+		t.Fatalf("both updates must survive in order: %+v", rec)
+	}
+	if st.route("rr-2", 1) == nil {
+		t.Fatal("unrelated row missing")
+	}
+	// Two groups: [queued, ttft-update, (rr-2 joins group 2)] and
+	// [selected, success-update]. The first group's insert is a single record
+	// write; the second group's insert is either single or a 2-row batch
+	// depending on where rr-2 landed. Total record rows must be 3, and no
+	// group may have held two rr-1 inserts.
+	singleCalls, singleRows := st.count("record")
+	batchCalls, batchRows := st.count("records")
+	if singleRows+batchRows != 3 || singleCalls+batchCalls != 2 {
+		t.Fatalf("expected two insert groups covering three records: log=%v", st.callLog())
+	}
+}
+
+// TestTelemetrySinkUpdateBeforeInsertStaysNoOp pins baseline parity for the
+// pathological queue order (an update racing ahead of its insert): the update
+// is a silent no-op and the insert still lands — coalescing must not "fix" it
+// by reordering the insert ahead.
+func TestTelemetrySinkUpdateBeforeInsertStaysNoOp(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	sink.submitOutcome("ub-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	sink.submitRoute(routeRec("ub-1", 1, "p"))
+	flushAndWait(t, sink)
+
+	rec := st.route("ub-1", 1)
+	if rec == nil {
+		t.Fatal("row missing")
+	}
+	if rec.FinalStatus != "" {
+		t.Fatalf("update that preceded its insert must not apply: %+v", rec)
+	}
+	if log := st.callLog(); len(log) != 2 || log[0] != "update" || log[1] != "record" {
+		t.Fatalf("queue order must be preserved for a same-key update->insert: %v", log)
+	}
+}
+
+func TestTelemetrySinkGenericClosureKeepsQueuePosition(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	sink.submitRoute(routeRec("g-1", 1, "p"))
+	sink.submitRoute(routeRec("g-2", 1, "p"))
+	sink.submitOutcome("g-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	sink.submit(func() { st.note("fn") })
+	sink.submitOutcome("g-2", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "error", CompletionTokensSet: true})
+	flushAndWait(t, sink)
+
+	want := []string{"records:2", "update", "fn", "update"}
+	got := st.callLog()
+	if len(got) != len(want) {
+		t.Fatalf("call log = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("call log = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestTelemetrySinkDropsAndCountsWhenFull(t *testing.T) {
+	st := newCountingTelemetryStore()
+	st.gate = make(chan struct{})
+	sink := newTestSink(t, st, 2, 1, time.Millisecond)
+
+	// Op 1 is taken by the worker and blocks in the store; ops 2 and 3 fill
+	// the buffer; op 4 must be dropped without blocking.
+	if !sink.submitRoute(routeRec("d-1", 1, "p")) {
+		t.Fatal("op 1 rejected")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for len(sink.ch) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !sink.submitRoute(routeRec("d-2", 1, "p")) || !sink.submitRoute(routeRec("d-3", 1, "p")) {
+		t.Fatal("ops 2/3 should fit the buffer")
+	}
+	done := make(chan bool, 1)
+	go func() { done <- sink.submitRoute(routeRec("d-4", 1, "p")) }()
+	select {
+	case accepted := <-done:
+		if accepted {
+			t.Fatal("op 4 must be dropped when the buffer is full")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("submit blocked on a full buffer")
+	}
+	if got := sink.dropped.Load(); got != 1 {
+		t.Fatalf("dropped = %d, want 1", got)
+	}
+
+	close(st.gate)
+	mustCloseAndWait(t, sink)
+	for _, id := range []string{"d-1", "d-2", "d-3"} {
+		if st.route(id, 1) == nil {
+			t.Fatalf("accepted op %s must be written", id)
+		}
+	}
+	if st.route("d-4", 1) != nil {
+		t.Fatal("dropped op must not be written")
+	}
+}
+
+func TestTelemetrySinkCloseFlushesBufferedOps(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	const n = 300 // more than one group: the close-time drain must loop
+	for i := 0; i < n; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("cf-%d", i), 1, "p"))
+	}
+	for i := 0; i < n; i++ {
+		sink.submitOutcome(fmt.Sprintf("cf-%d", i), 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	}
+	// Close while ops are still buffered: the worker's close-time drain must
+	// write them (in groups) before it exits.
+	mustCloseAndWait(t, sink)
+
+	for i := 0; i < n; i++ {
+		rec := st.route(fmt.Sprintf("cf-%d", i), 1)
+		if rec == nil || rec.FinalStatus != "success" {
+			t.Fatalf("row %d not flushed on close: %+v", i, rec)
+		}
+	}
+	// close is idempotent and a second closeAndWait returns immediately.
+	if !sink.closeAndWait(time.Second) {
+		t.Fatal("second closeAndWait must not block")
+	}
+}
+
+func TestTelemetrySinkBatchFailureFallsBackToSingleWrites(t *testing.T) {
+	st := newCountingTelemetryStore()
+	st.failBatchRecords.Store(true)
+	st.failBatchUpdates.Store(true)
+	const n = 5
+	// Groups fill by size (n) so each executes while the sink is OPEN — the
+	// per-row replay is only taken while open; a closing drain drops instead.
+	sink := newTestSink(t, st, 1024, n, 10*time.Second)
+
+	for i := 0; i < n; i++ {
+		sink.submitRoute(routeRec(fmt.Sprintf("fb-%d", i), 1, "p"))
+	}
+	waitForCalls(t, st, "record", n)
+	for i := 0; i < n; i++ {
+		sink.submitOutcome(fmt.Sprintf("fb-%d", i), 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	}
+	waitForCalls(t, st, "update", n)
+	flushAndWait(t, sink)
+
+	if calls, _ := st.count("records"); calls != 1 {
+		t.Fatalf("batch insert should be attempted once, got %d", calls)
+	}
+	if calls, _ := st.count("record"); calls != n {
+		t.Fatalf("every record must be retried individually: got %d single writes, log=%v", calls, st.callLog())
+	}
+	if calls, _ := st.count("update"); calls != n {
+		t.Fatalf("every update must be retried individually: got %d single writes, log=%v", calls, st.callLog())
+	}
+	for i := 0; i < n; i++ {
+		rec := st.route(fmt.Sprintf("fb-%d", i), 1)
+		if rec == nil || rec.FinalStatus != "success" {
+			t.Fatalf("row %d must be written by the fallback: %+v", i, rec)
+		}
+	}
+}
+
+func TestTelemetrySinkPanicInOneUnitDoesNotSkipTheRest(t *testing.T) {
+	st := newCountingTelemetryStore()
+	sink := newTestSink(t, st, 1024, 256, 10*time.Second)
+
+	sink.submitRoute(routeRec("pn-1", 1, "p"))
+	sink.submit(func() { panic("telemetry closure panic") })
+	sink.submitOutcome("pn-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	flushAndWait(t, sink)
+
+	if rec := st.route("pn-1", 1); rec == nil || rec.FinalStatus != "success" {
+		t.Fatalf("units after a panicking closure must still run: %+v", rec)
+	}
+}
+
+// TestServerRouteTelemetryWithoutSinkFallsBackToGoroutine covers a Server
+// built directly (no NewServer, no sink): writes still land, one goroutine
+// per write as before.
+func TestServerRouteTelemetryWithoutSinkFallsBackToGoroutine(t *testing.T) {
+	st := store.NewMemory(store.Config{})
+	s := &Server{store: st, logger: quietLogger()}
+
+	s.submitRouteRecord(routeRec("ns-1", 1, "p"))
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(st.InferenceRouteRecordsSince(time.Time{})) == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	s.submitRouteOutcome("ns-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success"})
+	for time.Now().Before(deadline) {
+		recs := st.InferenceRouteRecordsSince(time.Time{})
+		if len(recs) == 1 && recs[0].FinalStatus == "success" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("fallback path did not persist: %+v", st.InferenceRouteRecordsSince(time.Time{}))
+}
+
+// TestServerRouteTelemetryThroughSink wires the production path: NewServer's
+// sink, the dispatch-side record helper, and the outcome funnel every
+// terminal uses (updateInferenceRouteOutcomeWithModel).
+func TestServerRouteTelemetryThroughSink(t *testing.T) {
+	srv, st := testServer(t)
+	if srv.routeTelemetry == nil {
+		t.Fatal("NewServer must install the telemetry sink")
+	}
+
+	srv.submitRouteRecord(routeRec("ts-1", 1, "p"))
+	srv.updateInferenceRouteOutcomeWithModel("ts-1", 1, "m", &store.InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: 4, CompletionTokensSet: true})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, r := range st.InferenceRouteRecordsSince(time.Time{}) {
+			if r.RequestID == "ts-1" && r.FinalStatus == "success" && r.CompletionTokens == 4 {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("sink path did not persist within the window: %+v", st.InferenceRouteRecordsSince(time.Time{}))
+}

--- a/coordinator/api/tool_constraints.go
+++ b/coordinator/api/tool_constraints.go
@@ -46,6 +46,12 @@ func validateToolConstraintRequest(body []byte) (toolChoiceMode, error) {
 	return policy.mode, err
 }
 
+// validateToolConstraintPolicy validates the tool policy of a JSON request
+// body. It is the bytes-in entry point for bodies that only exist as bytes —
+// the endpoint-lowered constraint view of Responses / completions / Anthropic
+// requests and the unit tests; the chat handler validates its already-parsed
+// map through validateParsedToolConstraintPolicy instead of paying a second
+// full-body parse.
 func validateToolConstraintPolicy(body []byte) (validatedToolConstraintPolicy, error) {
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
@@ -54,6 +60,16 @@ func validateToolConstraintPolicy(body []byte) (validatedToolConstraintPolicy, e
 		return validatedToolConstraintPolicy{},
 			invalidToolConstraint("invalid request body", "")
 	}
+	return validateParsedToolConstraintPolicy(root)
+}
+
+// validateParsedToolConstraintPolicy validates tool_choice /
+// parallel_tool_calls / tool_call_parser / stop / tools / messages on a decoded
+// request object. root must be the PRE-normalization view of the tools (see
+// rejectReservedSchemaMetadata: a normalization marker present here is
+// client-forged); the chat prelude keeps that view aside when it repairs
+// schemas in place.
+func validateParsedToolConstraintPolicy(root map[string]any) (validatedToolConstraintPolicy, error) {
 	mode, selected, err := parseToolChoice(root["tool_choice"])
 	if err != nil {
 		return validatedToolConstraintPolicy{}, err

--- a/coordinator/api/tool_constraints_test.go
+++ b/coordinator/api/tool_constraints_test.go
@@ -55,8 +55,15 @@ func TestInferencePreludeNormalizesSingleStopForSwiftProtocol(t *testing.T) {
 	if !ok {
 		t.Fatalf("prelude failed: %s", response.Body.String())
 	}
+	if !prelude.body.dirty {
+		t.Fatal("stop normalization did not mark the forward body dirty")
+	}
+	rawBody, err := prelude.body.current()
+	if err != nil {
+		t.Fatal(err)
+	}
 	var forwarded map[string]any
-	if err := json.Unmarshal(prelude.rawBody, &forwarded); err != nil {
+	if err := json.Unmarshal(rawBody, &forwarded); err != nil {
 		t.Fatal(err)
 	}
 	stops, ok := forwarded["stop"].([]any)
@@ -64,8 +71,8 @@ func TestInferencePreludeNormalizesSingleStopForSwiftProtocol(t *testing.T) {
 		t.Fatalf("forwarded stop = %#v", forwarded["stop"])
 	}
 	for _, literal := range []string{"9007199254740993", "0.10000000000000001"} {
-		if !bytes.Contains(prelude.rawBody, []byte(literal)) {
-			t.Fatalf("forwarded body lost exact numeric literal %s: %s", literal, prelude.rawBody)
+		if !bytes.Contains(rawBody, []byte(literal)) {
+			t.Fatalf("forwarded body lost exact numeric literal %s: %s", literal, rawBody)
 		}
 	}
 }

--- a/coordinator/api/toolschema_parsed.go
+++ b/coordinator/api/toolschema_parsed.go
@@ -1,0 +1,87 @@
+package api
+
+// toolschema_parsed.go is the parsed-map twin of NormalizeToolSchemas
+// (toolschema.go). The inference prelude used to normalize tool schemas on the
+// raw bytes (parse → repair → re-encode) and then parse the result again for
+// the handler, and the tool-constraint validator parsed the ORIGINAL bytes a
+// third time because it must see the pre-normalization schemas. Normalizing
+// the already-decoded body instead makes the request cost one parse: the
+// tools subtree is deep-copied first (the repair walk mutates in place), the
+// copy is repaired, and the caller's untouched tools value is handed back for
+// constraint validation.
+//
+// Byte-identity with the bytes path holds because encoding/json's decoder
+// already produces a well-formed tree — it coerces invalid UTF-8 in strings
+// and keys to U+FFFD while unquoting — so the repaired map serializes to
+// exactly what decoding the bytes path's re-encoded output would have
+// produced. The gates are the same two the bytes path applies, measured on
+// the caller's input.
+
+import "bytes"
+
+// normalizeParsedToolSchemas repairs the tool JSON-Schemas of an already
+// decoded request in place, with the same gates as NormalizeToolSchemas,
+// measured against rawBody (the caller's input bytes): bodies over
+// maxToolNormalizationBytes, bodies without the literal `"tools"` key bytes
+// (an escaped spelling of the key is forwarded verbatim, exactly as the bytes
+// path always did), and bodies whose "tools" is not an array are left
+// untouched. When a repair was made it returns the caller's original tools
+// value (never mutated) and changed=true; otherwise (nil, false) and parsed is
+// exactly as it was.
+func normalizeParsedToolSchemas(parsed map[string]any, rawBody []byte) (originalTools []any, changed bool) {
+	if len(rawBody) > maxToolNormalizationBytes || !bytes.Contains(rawBody, toolsKeyNeedle) {
+		return nil, false
+	}
+	tools, ok := parsed["tools"].([]any)
+	if !ok {
+		return nil, false
+	}
+	repaired, _ := cloneJSONValue(tools).([]any)
+	for i, tool := range repaired {
+		repaired[i] = normalizeToolEntry(tool, &changed)
+	}
+	if !changed {
+		return nil, false
+	}
+	parsed["tools"] = repaired
+	return tools, true
+}
+
+// constraintView returns the request object the tool-constraint validator must
+// see: parsed itself when no schema was repaired, otherwise a shallow copy of
+// parsed with the caller's original tools restored, so validation judges the
+// schemas the client actually sent (and refuses a client-forged normalization
+// marker) without a second parse of the original bytes.
+func constraintView(parsed map[string]any, originalTools []any) map[string]any {
+	if originalTools == nil {
+		return parsed
+	}
+	view := make(map[string]any, len(parsed))
+	for key, value := range parsed {
+		view[key] = value
+	}
+	view["tools"] = originalTools
+	return view
+}
+
+// cloneJSONValue deep-copies a decoder-shaped value (objects, arrays, and
+// immutable scalars). Non-JSON leaf types are shared, which is safe because
+// the repair walk only ever rewrites map entries and array slots.
+func cloneJSONValue(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for key, value := range x {
+			out[key] = cloneJSONValue(value)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, value := range x {
+			out[i] = cloneJSONValue(value)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/coordinator/api/toolschema_parsed_test.go
+++ b/coordinator/api/toolschema_parsed_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// toolNormalizationParityBodies cover every schema home and repair class the
+// normalizer handles, plus the gates it must respect. Each is paired with a
+// message history so the whole-body round trip (not just the tools) is
+// compared.
+var toolNormalizationParityBodies = map[string]string{
+	"chat missing type": `{"model":"m","messages":[{"role":"user","content":"x <y> & z"}],
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"text"}}}}}]}`,
+	"chat nullable union": `{"model":"m","messages":[{"role":"user","content":"x"}],
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"n":{"type":["integer","null"]}}}}}]}`,
+	"chat boolean positional": `{"model":"m","messages":[{"role":"user","content":"x"}],
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"any":true,"none":{}}}}}]}`,
+	"responses flat shape": `{"model":"m","input":"hi","tools":[{"type":"function","name":"f","parameters":{"type":"object","properties":{"q":{"description":"text"}}}}]}`,
+	"anthropic input_schema": `{"model":"m","messages":[{"role":"user","content":"x"}],
+		"tools":[{"name":"f","input_schema":{"type":"object","properties":{"q":{"enum":["a","b"]}}}}]}`,
+	"already normalized": `{"model":"m","messages":[{"role":"user","content":"x"}],
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"type":"string"}}}}}]}`,
+	"no tools": `{"model":"m","messages":[{"role":"user","content":"the word \"tools\" in text"}]}`,
+	// The bytes path gates on the literal `"tools"` bytes: an escaped spelling of
+	// the key is forwarded verbatim (schemas unrepaired), and so must this path.
+	"escaped tools key": `{"model":"m","messages":[{"role":"user","content":"x"}],"to\u006fls":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"text"}}}}}]}`,
+	"tools not array":   `{"model":"m","messages":[{"role":"user","content":"x"}],"tools":{"type":"function"}}`,
+	"scalar tool":       `{"model":"m","messages":[{"role":"user","content":"x"}],"tools":["nope",1,null]}`,
+	"numbers preserved": `{"model":"m","messages":[{"role":"user","content":"x"}],"metadata":{"exact":9007199254740993,"decimal":0.10000000000000001},
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"text","default":1e400}}}}}]}`,
+	"invalid utf8 in messages and keys": "{\"model\":\"m\",\"messages\":[{\"role\":\"user\",\"content\":\"bad \xff\xfe bytes\",\"na\xffme\":\"v\xe2\x82\"}]," +
+		`"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"q":{"description":"text"}}}}}]}`,
+}
+
+func decodeForParity(t *testing.T, body string) map[string]any {
+	t.Helper()
+	parsed, err := decodeInferenceJSONObject([]byte(body))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return parsed
+}
+
+// The parsed-map normalization must leave the handler with exactly the map
+// the bytes path produced (decode(NormalizeToolSchemas(body))), marshal to the
+// same provider bytes, and hand back the caller's tools untouched.
+func TestNormalizeParsedToolSchemasMatchesBytesPath(t *testing.T) {
+	for name, body := range toolNormalizationParityBodies {
+		t.Run(name, func(t *testing.T) {
+			raw := []byte(body)
+			normalizedBytes := NormalizeToolSchemas(raw)
+			bytesChanged := !bytes.Equal(normalizedBytes, raw)
+			wantParsed := decodeForParity(t, string(normalizedBytes))
+			wantForward, err := marshalForwardBody(wantParsed)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			parsed := decodeForParity(t, body)
+			wantOriginalTools := decodeForParity(t, body)["tools"]
+			originalTools, changed := normalizeParsedToolSchemas(parsed, raw)
+			if changed != bytesChanged {
+				t.Fatalf("changed = %v, bytes path changed = %v", changed, bytesChanged)
+			}
+			if !reflect.DeepEqual(parsed, wantParsed) {
+				t.Fatalf("parsed tree diverged from bytes path:\n got %#v\nwant %#v", parsed, wantParsed)
+			}
+			gotForward, err := marshalForwardBody(parsed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotForward, wantForward) {
+				t.Fatalf("forward bytes diverged:\n got %s\nwant %s", gotForward, wantForward)
+			}
+			if !changed {
+				if originalTools != nil {
+					t.Fatalf("unchanged body returned original tools %#v", originalTools)
+				}
+				return
+			}
+			if !reflect.DeepEqual(any(originalTools), wantOriginalTools) {
+				t.Fatalf("original tools were mutated:\n got %#v\nwant %#v", originalTools, wantOriginalTools)
+			}
+		})
+	}
+}
+
+func TestNormalizeParsedToolSchemasRespectsSizeGate(t *testing.T) {
+	body := toolNormalizationParityBodies["chat missing type"]
+	parsed := decodeForParity(t, body)
+	before := cloneJSONValue(parsed)
+	padded := append([]byte(body), bytes.Repeat([]byte(" "), maxToolNormalizationBytes)...)
+	if _, changed := normalizeParsedToolSchemas(parsed, padded); changed {
+		t.Fatal("oversize body was normalized")
+	}
+	if !reflect.DeepEqual(parsed, before) {
+		t.Fatal("oversize body was mutated")
+	}
+	// The bytes path skips the same bodies.
+	if got := NormalizeToolSchemas(padded); !bytes.Equal(got, padded) {
+		t.Fatal("bytes path normalized an oversize body")
+	}
+}
+
+// The chat prelude validates constraints on the PRE-normalization tools: a
+// client-forged marker is refused, while the marker the normalizer itself
+// stamps (visible only in the repaired copy) never reaches the validator.
+func TestParsedConstraintValidationSeesPreNormalizationTools(t *testing.T) {
+	body := `{"model":"m","messages":[{"role":"user","content":"x"}],"tool_choice":"auto",
+		"tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object","properties":{"any":true}}}}]}`
+	parsed := decodeForParity(t, body)
+	originalTools, changed := normalizeParsedToolSchemas(parsed, []byte(body))
+	if !changed || originalTools == nil {
+		t.Fatal("boolean positional schema was not repaired")
+	}
+	// The repaired copy now carries the reserved marker …
+	repaired, _ := marshalForwardBody(parsed["tools"])
+	if !bytes.Contains(repaired, []byte(originalBooleanSchemaKey)) {
+		t.Fatalf("repaired tools lack the marker: %s", repaired)
+	}
+	// … so validating the repaired view would wrongly reject the request …
+	if _, err := validateParsedToolConstraintPolicy(parsed); err == nil {
+		t.Fatal("repaired view accepted (marker not detected); test premise broken")
+	}
+	// … while the original view (what the handler validates) accepts it.
+	view := constraintView(parsed, originalTools)
+	if _, err := validateParsedToolConstraintPolicy(view); err != nil {
+		t.Fatalf("original view rejected: %v", err)
+	}
+	// And a genuinely forged marker in the caller's body still fails closed.
+	forged := strings.Replace(body, `"any":true`, `"any":{"type":"string","`+originalBooleanSchemaKey+`":true}`, 1)
+	forgedParsed := decodeForParity(t, forged)
+	forgedTools, forgedChanged := normalizeParsedToolSchemas(forgedParsed, []byte(forged))
+	if _, err := validateParsedToolConstraintPolicy(constraintView(forgedParsed, forgedTools)); err == nil {
+		t.Fatalf("forged marker accepted (changed=%v)", forgedChanged)
+	}
+	// The bytes validator agrees with the map validator on the same input.
+	if _, err := validateToolConstraintPolicy([]byte(forged)); err == nil {
+		t.Fatal("bytes validator accepted the forged marker")
+	}
+}
+
+// The bytes and parsed validators must return identical verdicts for the
+// constraint test corpus.
+func TestParsedAndBytesConstraintValidatorsAgree(t *testing.T) {
+	bodies := []string{
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"weather"}}],"tool_choice":{"type":"function","function":{"name":"weather"}},"parallel_tool_calls":false}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"bad name"}}],"tool_choice":"required"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":[{"type":"function","function":{"name":"safe"}}],"tool_choice":{"type":"function","function":{"name":"missing"}}}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"stop":"END","tools":[{"type":"function","function":{"name":"f"}}],"tool_choice":"required"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"stop":["a","b","c","d","e"],"tools":[{"type":"function","function":{"name":"f"}}],"tool_choice":"required"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tool_call_parser":"unknown","tools":[{"type":"function","function":{"name":"f"}}],"tool_choice":"required"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}],"tools":"nope"}`,
+		`{"model":"m","messages":[{"role":"user","content":"x"}]}`,
+	}
+	for i, body := range bodies {
+		wantPolicy, wantErr := validateToolConstraintPolicy([]byte(body))
+		gotPolicy, gotErr := validateParsedToolConstraintPolicy(decodeForParity(t, body))
+		if gotPolicy != wantPolicy || !reflect.DeepEqual(gotErr, wantErr) {
+			t.Errorf("body %d: parsed=(%+v, %v) bytes=(%+v, %v)", i, gotPolicy, gotErr, wantPolicy, wantErr)
+		}
+	}
+	if _, err := validateToolConstraintPolicy([]byte(`not json`)); err == nil || err.Error() != "invalid request body" {
+		t.Fatalf("bytes validator lost its decode error: %v", err)
+	}
+}

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -131,6 +131,17 @@ func main() {
 		})
 	}
 
+	// Read-through cache for the per-request user and model-registry lookups
+	// (one Postgres round trip each, 4-5 per inference request). Wraps both
+	// backends so dev/test and prod behave identically. Invalidation is
+	// in-process -- correct because this single process serves every admin and
+	// publish mutation; the TTLs only bound staleness from out-of-band DB edits.
+	cacheCfg := store.DefaultCacheConfig()
+	st = store.NewCached(st, cacheCfg)
+	logger.Info("store read-through cache enabled",
+		"user_ttl", cacheCfg.UserTTL, "model_ttl", cacheCfg.ModelTTL, "negative_ttl", cacheCfg.NegativeTTL,
+		"max_users", cacheCfg.MaxUsers, "max_models", cacheCfg.MaxModels)
+
 	// Reconcile provider sessions left open by a previous coordinator process
 	// (durable uptime history). Best-effort + time-bounded — neither an error nor
 	// a slow/unresponsive DB must block startup. Only sessions whose last

--- a/coordinator/registry/reputation_persist_throttle_test.go
+++ b/coordinator/registry/reputation_persist_throttle_test.go
@@ -20,8 +20,11 @@ type reputationUpsertCounter struct {
 }
 
 func (c *reputationUpsertCounter) UpsertReputation(ctx context.Context, providerID string, rep store.ReputationRecord) error {
+	err := c.MemoryStore.UpsertReputation(ctx, providerID, rep)
+	// Waiters inspect the persisted row after observing this count, so publish
+	// completion only after the wrapped write has made that row visible.
 	c.upserts.Add(1)
-	return c.MemoryStore.UpsertReputation(ctx, providerID, rep)
+	return err
 }
 
 func waitForUpserts(t *testing.T, st *reputationUpsertCounter, want int64) {

--- a/coordinator/store/as.go
+++ b/coordinator/store/as.go
@@ -1,0 +1,30 @@
+package store
+
+// Unwrapper is implemented by Store decorators (CachedStore) so optional,
+// backend-only capabilities remain discoverable through the wrapper. A
+// decorator embeds the static Store method set, so a plain type assertion on
+// it can never see methods the concrete backend adds beyond Store.
+type Unwrapper interface {
+	Unwrap() Store
+}
+
+// As reports whether s -- or any Store it wraps -- implements T, returning the
+// innermost value that does. Use it instead of a direct type assertion when
+// probing for an optional capability (e.g. paged verification-job listing or
+// durable push budgets) so the probe keeps working once main.go wraps the
+// backend in CachedStore. s may be any Store slice (a narrow sub-interface
+// is fine); nil yields false.
+func As[T any](s any) (T, bool) {
+	var zero T
+	for s != nil {
+		if t, ok := s.(T); ok {
+			return t, true
+		}
+		u, ok := s.(Unwrapper)
+		if !ok {
+			return zero, false
+		}
+		s = u.Unwrap()
+	}
+	return zero, false
+}

--- a/coordinator/store/as_test.go
+++ b/coordinator/store/as_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Mirrors of the optional capabilities the api package probes for with
+// store.As (api/code_attest_throttle.go codeAttestPushBudgetStore and
+// api/mdm_scheduler.go verificationDuePageStore). Neither is part of Store;
+// both backends implement them.
+type pushBudgetCapability interface {
+	ListCodeAttestPushBudgets(ctx context.Context) ([]CodeAttestPushBudget, error)
+	ReserveCodeAttestPushBudget(ctx context.Context, seKey, tokenHash string, now, nextPushAt time.Time) (bool, error)
+	ClearCodeAttestPushFloor(ctx context.Context, seKey string, now time.Time, cooldown time.Duration) (time.Time, bool, error)
+}
+
+type duePageCapability interface {
+	ListDueVerificationJobsPage(ctx context.Context, now time.Time, limit, offset int) ([]VerificationJob, error)
+}
+
+// opaqueStore is a decorator that does NOT implement Unwrapper: As must stop
+// at it rather than guess.
+type opaqueStore struct{ Store }
+
+func TestAsFindsOptionalCapabilitiesThroughCachedStore(t *testing.T) {
+	for name, backend := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			if _, ok := backend.(pushBudgetCapability); !ok {
+				t.Fatalf("%s backend no longer implements the push-budget capability", name)
+			}
+			if _, ok := backend.(duePageCapability); !ok {
+				t.Fatalf("%s backend no longer implements the due-page capability", name)
+			}
+
+			cached := NewCached(backend, CacheConfig{})
+
+			// The bug shape: a direct assertion on the decorator fails ...
+			if _, ok := any(cached).(pushBudgetCapability); ok {
+				t.Fatal("direct assertion on CachedStore unexpectedly succeeded; this test no longer exercises the wrapped path")
+			}
+			if _, ok := any(cached).(duePageCapability); ok {
+				t.Fatal("direct assertion on CachedStore unexpectedly succeeded; this test no longer exercises the wrapped path")
+			}
+
+			// ... and As is the supported probe, returning the backend itself.
+			budgets, ok := As[pushBudgetCapability](cached)
+			if !ok {
+				t.Fatal("As did not find the push-budget capability through CachedStore")
+			}
+			if any(budgets) != any(backend) {
+				t.Fatalf("As returned %T, want the wrapped backend %T", budgets, backend)
+			}
+			paged, ok := As[duePageCapability](cached)
+			if !ok {
+				t.Fatal("As did not find the due-page capability through CachedStore")
+			}
+			if any(paged) != any(backend) {
+				t.Fatalf("As returned %T, want the wrapped backend %T", paged, backend)
+			}
+
+			// Through a narrow sub-interface value (the api fields are typed
+			// codeAttestStore / store.ProviderStore, not Store) and through
+			// nested decorators.
+			var narrow ProviderStore = cached
+			if _, ok := As[duePageCapability](narrow); !ok {
+				t.Fatal("As failed on a narrow sub-interface value")
+			}
+			if _, ok := As[pushBudgetCapability](NewCached(cached, CacheConfig{})); !ok {
+				t.Fatal("As failed through two decorator layers")
+			}
+
+			// The capability found through As reaches the same rows the
+			// wrapped store holds.
+			now := time.Now().UTC()
+			seKey := uniqueID("se-as")
+			if _, err := cached.UpsertVerificationJob(context.Background(), VerificationJob{
+				SEPubKey: seKey, Serial: "serial", Kind: VerificationTaskSecurityInfo,
+				State: VerificationStatePending, Priority: VerificationPriorityFirstOrExpired,
+				NextAttemptAt: now.Add(-time.Minute), UpdatedAt: now,
+			}); err != nil {
+				t.Fatalf("UpsertVerificationJob: %v", err)
+			}
+			rows, err := paged.ListDueVerificationJobsPage(context.Background(), now, 100, 0)
+			if err != nil {
+				t.Fatalf("ListDueVerificationJobsPage: %v", err)
+			}
+			found := false
+			for _, r := range rows {
+				found = found || r.SEPubKey == seKey
+			}
+			if !found {
+				t.Fatalf("capability reached via As does not see the wrapped store's rows: %+v", rows)
+			}
+		})
+	}
+}
+
+func TestAsStopsAtNonUnwrappingDecoratorsAndNil(t *testing.T) {
+	mem := NewMemory(Config{})
+	if _, ok := As[pushBudgetCapability](mem); !ok {
+		t.Fatal("As must succeed on the bare backend")
+	}
+	if _, ok := As[pushBudgetCapability](opaqueStore{mem}); ok {
+		t.Fatal("As must not see through a decorator that does not implement Unwrapper")
+	}
+	if _, ok := As[pushBudgetCapability](NewCached(opaqueStore{mem}, CacheConfig{})); ok {
+		t.Fatal("As must stop at the first non-unwrapping layer")
+	}
+	if _, ok := As[pushBudgetCapability](nil); ok {
+		t.Fatal("As(nil) must be false")
+	}
+	var nilStore Store
+	if _, ok := As[pushBudgetCapability](nilStore); ok {
+		t.Fatal("As(nil Store) must be false")
+	}
+	// Probing for something a backend genuinely lacks is false, not a panic.
+	type absent interface{ DefinitelyNotImplemented() }
+	if _, ok := As[absent](NewCached(mem, CacheConfig{})); ok {
+		t.Fatal("As found a capability nothing implements")
+	}
+}

--- a/coordinator/store/cached.go
+++ b/coordinator/store/cached.go
@@ -1,0 +1,227 @@
+package store
+
+import "time"
+
+// CachedStore is a read-through cache decorator over Store. It overrides only
+// the lookups that sit on the inference hot path and are otherwise a Postgres
+// round trip per call:
+//
+//   - GetUserByAccountID / GetUserByPrivyID (requireAuth on every request;
+//     handleCompleteAt on every settlement)
+//   - GetModelRegistryRecord / GetModelManifest (3-4 calls per chat request;
+//     the Postgres implementation issues two queries each)
+//
+// Every other method is delegated untouched via the embedded Store, including
+// the cold admin lookups GetUserByEmail and GetUserByStripeAccount.
+//
+// Consistency model -- SINGLE-PROCESS ASSUMPTION. Invalidation is in-process:
+// each Store mutator that can change a cached value (the four *User* writers,
+// the four model-registry writers) clears its whole domain after the inner
+// write, and a generation counter rejects loads that raced with that write.
+// This is only exact because one coordinator process serves every admin and
+// publish mutation. Anything written to the database out of band -- a manual
+// SQL edit, or a second coordinator sharing the DB during a blue-green cutover
+// -- is invisible until the TTL expires. The TTLs are therefore the staleness
+// bound for out-of-band writes, not the primary invalidation mechanism.
+//
+// A miss that the inner store reports as ErrNotFound is cached for
+// NegativeTTL; alias names reach GetModelRegistryRecord on every request and
+// would otherwise miss every time. Any other error is passed through uncached.
+// Returned values are deep copies; the cached value is never handed out.
+type CachedStore struct {
+	Store
+	users  *domainCache[User]
+	models *domainCache[ModelRegistryRecord]
+}
+
+// CacheConfig tunes CachedStore. Zero fields take DefaultCacheConfig values.
+type CacheConfig struct {
+	// UserTTL bounds staleness of a user's Role / PlatformFeePercent / Stripe
+	// fields after an out-of-band write. In-process writes invalidate at once.
+	UserTTL time.Duration
+	// ModelTTL bounds staleness of a model's active version and files. Kept
+	// tighter than UserTTL because a promoted version changes what providers
+	// are told to download.
+	ModelTTL time.Duration
+	// NegativeTTL bounds how long an ErrNotFound result is remembered. Short,
+	// so an entity created out of band appears quickly; in-process creation
+	// invalidates at once.
+	NegativeTTL time.Duration
+	// MaxUsers / MaxModels cap each domain's entry count (random eviction).
+	MaxUsers  int
+	MaxModels int
+	// Now is the clock; nil means time.Now. Tests inject a fake clock.
+	Now func() time.Time
+}
+
+// DefaultCacheConfig is the production tuning: users 30s, model records 10s,
+// negative entries 5s, 10k users and 1k models resident.
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{
+		UserTTL:     30 * time.Second,
+		ModelTTL:    10 * time.Second,
+		NegativeTTL: 5 * time.Second,
+		MaxUsers:    10_000,
+		MaxModels:   1_000,
+	}
+}
+
+func (c CacheConfig) withDefaults() CacheConfig {
+	d := DefaultCacheConfig()
+	if c.UserTTL <= 0 {
+		c.UserTTL = d.UserTTL
+	}
+	if c.ModelTTL <= 0 {
+		c.ModelTTL = d.ModelTTL
+	}
+	if c.NegativeTTL <= 0 {
+		c.NegativeTTL = d.NegativeTTL
+	}
+	if c.MaxUsers <= 0 {
+		c.MaxUsers = d.MaxUsers
+	}
+	if c.MaxModels <= 0 {
+		c.MaxModels = d.MaxModels
+	}
+	if c.Now == nil {
+		c.Now = time.Now
+	}
+	return c
+}
+
+// NewCached wraps inner (memory or Postgres) with the read-through cache.
+func NewCached(inner Store, cfg CacheConfig) *CachedStore {
+	cfg = cfg.withDefaults()
+	return &CachedStore{
+		Store:  inner,
+		users:  newDomainCache[User](cfg.UserTTL, cfg.NegativeTTL, cfg.MaxUsers, cfg.Now),
+		models: newDomainCache[ModelRegistryRecord](cfg.ModelTTL, cfg.NegativeTTL, cfg.MaxModels, cfg.Now),
+	}
+}
+
+// Unwrap exposes the wrapped backend so As can discover optional capabilities
+// (durable push budgets, paged verification listing) that the static Store
+// method set does not carry.
+func (c *CachedStore) Unwrap() Store { return c.Store }
+
+// Compile-time checks: the decorator still satisfies the full Store, and it
+// is transparent to store.As.
+var (
+	_ Store     = (*CachedStore)(nil)
+	_ Unwrapper = (*CachedStore)(nil)
+)
+
+// CacheCounters is one domain's counters since process start.
+type CacheCounters struct {
+	Hits          uint64 `json:"hits"`
+	Misses        uint64 `json:"misses"`
+	NegativeHits  uint64 `json:"negative_hits"`
+	Evictions     uint64 `json:"evictions"`
+	Invalidations uint64 `json:"invalidations"`
+	Entries       int    `json:"entries"`
+}
+
+// CacheStats is a point-in-time snapshot of both domains.
+type CacheStats struct {
+	Users  CacheCounters `json:"users"`
+	Models CacheCounters `json:"models"`
+}
+
+// Stats returns hit/miss/eviction counters for both domains.
+func (c *CachedStore) Stats() CacheStats {
+	return CacheStats{Users: c.users.counters(), Models: c.models.counters()}
+}
+
+// --- Users: cached lookups ---
+
+func (c *CachedStore) GetUserByAccountID(accountID string) (*User, error) {
+	return c.users.get("account\x00"+accountID, func() (*User, error) {
+		return c.Store.GetUserByAccountID(accountID)
+	}, cloneUser)
+}
+
+func (c *CachedStore) GetUserByPrivyID(privyUserID string) (*User, error) {
+	return c.users.get("privy\x00"+privyUserID, func() (*User, error) {
+		return c.Store.GetUserByPrivyID(privyUserID)
+	}, cloneUser)
+}
+
+// --- Users: every writer of the users table invalidates the whole domain.
+// Invalidation happens even when the inner write fails: GetOrCreateUser
+// re-reads by Privy ID after a duplicate-key CreateUser and must not be served
+// the negative entry it just recorded.
+
+func (c *CachedStore) CreateUser(user *User) error {
+	err := c.Store.CreateUser(user)
+	c.users.invalidate()
+	return err
+}
+
+func (c *CachedStore) SetUserStripeAccount(accountID, stripeAccountID, status, stripeAccountCountry, destinationType, destinationLast4 string, instantEligible bool) error {
+	err := c.Store.SetUserStripeAccount(accountID, stripeAccountID, status, stripeAccountCountry, destinationType, destinationLast4, instantEligible)
+	c.users.invalidate()
+	return err
+}
+
+func (c *CachedStore) SetUserRole(accountID, role string) error {
+	err := c.Store.SetUserRole(accountID, role)
+	c.users.invalidate()
+	return err
+}
+
+func (c *CachedStore) SetUserPlatformFeePercent(accountID string, feePercent *int64) error {
+	err := c.Store.SetUserPlatformFeePercent(accountID, feePercent)
+	c.users.invalidate()
+	return err
+}
+
+// --- Model registry: cached lookups ---
+
+func (c *CachedStore) GetModelRegistryRecord(modelID string) (*ModelRegistryRecord, error) {
+	return c.models.get(modelID, func() (*ModelRegistryRecord, error) {
+		return c.Store.GetModelRegistryRecord(modelID)
+	}, cloneModelRegistryRecord)
+}
+
+// GetModelManifest is derived from the cached record exactly as both inner
+// implementations derive it (manifestFromRecord builds a fresh value that
+// aliases nothing), so it needs no second cache and no defensive clone.
+func (c *CachedStore) GetModelManifest(modelID string) (*ModelManifest, error) {
+	rec, err := c.models.get(modelID, func() (*ModelRegistryRecord, error) {
+		return c.Store.GetModelRegistryRecord(modelID)
+	}, func(r *ModelRegistryRecord) *ModelRegistryRecord { return r })
+	if err != nil {
+		return nil, err
+	}
+	return manifestFromRecord(rec), nil
+}
+
+// --- Model registry: every writer that can change an active record (entry
+// fields, versions and their files, the active-version pointer, status)
+// invalidates the whole domain. Alias and publishing-key writers are left
+// alone: the record query joins only model_registry, model_active_versions and
+// model_versions.
+
+func (c *CachedStore) UpsertModelRegistryEntry(entry *ModelRegistryEntry) error {
+	err := c.Store.UpsertModelRegistryEntry(entry)
+	c.models.invalidate()
+	return err
+}
+
+func (c *CachedStore) SetModelVersion(entry *ModelRegistryEntry, version *ModelVersion, files []ModelVersionFile) error {
+	err := c.Store.SetModelVersion(entry, version, files)
+	c.models.invalidate()
+	return err
+}
+
+func (c *CachedStore) PromoteModelVersion(modelID, version string) error {
+	err := c.Store.PromoteModelVersion(modelID, version)
+	c.models.invalidate()
+	return err
+}
+
+func (c *CachedStore) SetModelStatus(modelID, status string) error {
+	err := c.Store.SetModelStatus(modelID, status)
+	c.models.invalidate()
+	return err
+}

--- a/coordinator/store/cached_clone.go
+++ b/coordinator/store/cached_clone.go
@@ -1,0 +1,92 @@
+package store
+
+// Deep-copy helpers for the values CachedStore hands out. The cached value is
+// the canonical copy; callers (e.g. the admin runtime_parameters PATCH, which
+// writes into rec.RuntimeParameters before upserting) must never be able to
+// reach it through a returned pointer.
+
+func cloneUser(u *User) *User {
+	if u == nil {
+		return nil
+	}
+	cp := *u
+	cp.PlatformFeePercent = cloneInt64Ptr(u.PlatformFeePercent)
+	return &cp
+}
+
+func cloneModelRegistryRecord(rec *ModelRegistryRecord) *ModelRegistryRecord {
+	if rec == nil {
+		return nil
+	}
+	cp := &ModelRegistryRecord{ModelRegistryEntry: cloneRegistryEntryForCache(&rec.ModelRegistryEntry)}
+	if rec.ActiveVersion != nil {
+		v := cloneModelVersionForCache(rec.ActiveVersion)
+		cp.ActiveVersion = &v
+	}
+	if rec.Files != nil {
+		cp.Files = make([]ModelVersionFile, len(rec.Files))
+		copy(cp.Files, rec.Files)
+	}
+	return cp
+}
+
+// cloneRegistryEntryForCache mirrors cloneModelRegistryEntry but copies the
+// JSON-shaped maps structurally instead of through a JSON round-trip: this
+// runs 3-4 times per inference request, and a structural copy preserves the
+// exact dynamic types the inner store produced (nil stays nil, numbers keep
+// their kind) rather than normalizing them.
+func cloneRegistryEntryForCache(entry *ModelRegistryEntry) ModelRegistryEntry {
+	cp := *entry
+	cp.Capabilities = cloneStrings(entry.Capabilities)
+	cp.RequiredProviderCapabilities = cloneStrings(entry.RequiredProviderCapabilities)
+	cp.RuntimeParameters = cloneJSONMap(entry.RuntimeParameters)
+	cp.Metadata = cloneJSONMap(entry.Metadata)
+	return cp
+}
+
+func cloneModelVersionForCache(version *ModelVersion) ModelVersion {
+	cp := *version
+	cp.PromotedAt = cloneTimePtr(version.PromotedAt)
+	cp.Metadata = cloneJSONMap(version.Metadata)
+	return cp
+}
+
+func cloneStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
+// cloneJSONMap deep-copies a map produced by JSON decoding (or by the memory
+// store's JSON-round-trip clone): nested map[string]any and []any are copied
+// recursively; every other value is an immutable scalar and is shared.
+func cloneJSONMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = cloneJSONValue(v)
+	}
+	return out
+}
+
+func cloneJSONValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return cloneJSONMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i := range t {
+			out[i] = cloneJSONValue(t[i])
+		}
+		return out
+	case []string:
+		return cloneStrings(t)
+	default:
+		return v
+	}
+}

--- a/coordinator/store/cached_domain.go
+++ b/coordinator/store/cached_domain.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// domainCache is the bounded TTL map behind one cached domain of CachedStore
+// (users, model-registry records). It is deliberately minimal: one mutex, one
+// map, a generation counter that orders reads against invalidations, and
+// random eviction at capacity.
+//
+// Entries are immutable once stored -- readers get clones, invalidation drops
+// entries rather than editing them -- so a value pointer taken under the lock
+// may be read after the lock is released.
+type domainCache[V any] struct {
+	ttl         time.Duration // positive-entry lifetime
+	negativeTTL time.Duration // "not found" entry lifetime
+	maxEntries  int           // hard cap; <= 0 means unbounded
+	now         func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]cacheEntry[V]
+	// gen is bumped by every invalidation. A read-through snapshots gen
+	// before calling the inner store and only publishes its result if gen is
+	// unchanged afterwards, so a value loaded concurrently with (and possibly
+	// older than) a write can never outlive that write's invalidation.
+	gen uint64
+
+	hits          atomic.Uint64
+	misses        atomic.Uint64
+	negativeHits  atomic.Uint64
+	evictions     atomic.Uint64
+	invalidations atomic.Uint64
+}
+
+type cacheEntry[V any] struct {
+	value     *V    // nil for a negative entry
+	err       error // non-nil for a negative entry
+	expiresAt time.Time
+}
+
+func newDomainCache[V any](ttl, negativeTTL time.Duration, maxEntries int, now func() time.Time) *domainCache[V] {
+	if now == nil {
+		now = time.Now
+	}
+	return &domainCache[V]{
+		ttl:         ttl,
+		negativeTTL: negativeTTL,
+		maxEntries:  maxEntries,
+		now:         now,
+		entries:     make(map[string]cacheEntry[V]),
+	}
+}
+
+// get is the read-through: serve from cache, else load from the inner store
+// and remember the result. Positive results are cached for ttl, ErrNotFound
+// results for negativeTTL, and any other error (timeouts, connection
+// failures) is passed through uncached so a DB blip is never pinned as a
+// miss. clone must return an independent copy; it is applied to every
+// positive result handed to the caller so the canonical cached value can
+// never be mutated through a returned pointer.
+func (c *domainCache[V]) get(key string, load func() (*V, error), clone func(*V) *V) (*V, error) {
+	if e, ok := c.lookup(key); ok {
+		if e.err != nil {
+			c.negativeHits.Add(1)
+			return nil, e.err
+		}
+		c.hits.Add(1)
+		return clone(e.value), nil
+	}
+	c.misses.Add(1)
+
+	gen := c.generation()
+	v, err := load()
+	switch {
+	case err == nil:
+		c.store(key, gen, v, nil)
+		return clone(v), nil
+	case errors.Is(err, ErrNotFound):
+		c.store(key, gen, nil, err)
+		return nil, err
+	default:
+		return nil, err
+	}
+}
+
+// lookup returns the live entry for key. Expired entries are dropped on the
+// way out so the map only ever holds entries that were valid at last touch.
+func (c *domainCache[V]) lookup(key string) (cacheEntry[V], bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return cacheEntry[V]{}, false
+	}
+	if !c.now().Before(e.expiresAt) {
+		delete(c.entries, key)
+		return cacheEntry[V]{}, false
+	}
+	return e, true
+}
+
+func (c *domainCache[V]) generation() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gen
+}
+
+// store publishes a loaded result unless an invalidation happened after gen
+// was snapshotted (see the gen field). At capacity it first sweeps expired
+// entries and, if that frees nothing, drops one arbitrary entry -- Go's
+// randomized map iteration gives a cheap random-replacement policy.
+func (c *domainCache[V]) store(key string, gen uint64, value *V, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.gen != gen {
+		return
+	}
+	ttl := c.ttl
+	if err != nil {
+		ttl = c.negativeTTL
+	}
+	if ttl <= 0 {
+		return
+	}
+	if _, present := c.entries[key]; !present && c.maxEntries > 0 && len(c.entries) >= c.maxEntries {
+		c.evictLocked()
+	}
+	c.entries[key] = cacheEntry[V]{value: value, err: err, expiresAt: c.now().Add(ttl)}
+}
+
+func (c *domainCache[V]) evictLocked() {
+	now := c.now()
+	removed := 0
+	victim, haveVictim := "", false
+	for k, e := range c.entries {
+		if !haveVictim {
+			victim, haveVictim = k, true
+		}
+		if !now.Before(e.expiresAt) {
+			delete(c.entries, k)
+			removed++
+		}
+	}
+	if removed == 0 && haveVictim {
+		delete(c.entries, victim)
+		removed = 1
+	}
+	c.evictions.Add(uint64(removed))
+}
+
+// invalidate drops every entry and bumps the generation so in-flight loads
+// that started before the corresponding write cannot repopulate the domain
+// with pre-write data.
+func (c *domainCache[V]) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gen++
+	clear(c.entries)
+	c.invalidations.Add(1)
+}
+
+func (c *domainCache[V]) size() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+func (c *domainCache[V]) counters() CacheCounters {
+	return CacheCounters{
+		Hits:          c.hits.Load(),
+		Misses:        c.misses.Load(),
+		NegativeHits:  c.negativeHits.Load(),
+		Evictions:     c.evictions.Load(),
+		Invalidations: c.invalidations.Load(),
+		Entries:       c.size(),
+	}
+}

--- a/coordinator/store/cached_domain_test.go
+++ b/coordinator/store/cached_domain_test.go
@@ -1,0 +1,227 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDomainCacheBoundedEviction(t *testing.T) {
+	clock := newFakeClock()
+	c := newDomainCache[User](time.Minute, time.Second, 2, clock.now)
+	load := func(id string) func() (*User, error) {
+		return func() (*User, error) { return &User{AccountID: id}, nil }
+	}
+	ident := func(u *User) *User { return u }
+
+	c.get("a", load("a"), ident)
+	c.get("b", load("b"), ident)
+	c.get("c", load("c"), ident) // over capacity: one live entry is evicted
+	if n := c.size(); n != 2 {
+		t.Fatalf("size after 3 inserts with cap 2 = %d, want 2", n)
+	}
+	if ev := c.counters().Evictions; ev != 1 {
+		t.Fatalf("evictions = %d, want 1", ev)
+	}
+	// Re-inserting an existing key never evicts.
+	c.invalidate()
+	c.get("a", load("a"), ident)
+	c.get("b", load("b"), ident)
+	c.get("a", load("a"), ident)
+	if ev := c.counters().Evictions; ev != 1 {
+		t.Fatalf("hit on an existing key evicted: evictions = %d", ev)
+	}
+
+	// Expired entries are reclaimed before any live one is dropped.
+	c.invalidate()
+	c.get("a", load("a"), ident)
+	c.get("b", load("b"), ident)
+	clock.advance(2 * time.Minute)
+	c.get("c", load("c"), ident)
+	if n := c.size(); n != 1 {
+		t.Fatalf("size after expiry sweep = %d, want 1 (only the new entry)", n)
+	}
+	if _, ok := c.lookup("c"); !ok {
+		t.Fatal("new entry missing after sweep")
+	}
+}
+
+func TestDomainCacheZeroTTLNeverStores(t *testing.T) {
+	c := newDomainCache[User](0, 0, 10, nil)
+	loads := 0
+	load := func() (*User, error) { loads++; return &User{AccountID: "a"}, nil }
+	ident := func(u *User) *User { return u }
+	c.get("a", load, ident)
+	c.get("a", load, ident)
+	if loads != 2 || c.size() != 0 {
+		t.Fatalf("zero TTL stored: loads=%d size=%d", loads, c.size())
+	}
+}
+
+// A read that fetched its value from the inner store BEFORE a write but tries
+// to publish it AFTER that write's invalidation must be rejected -- otherwise
+// the cache would serve pre-write data for a full TTL. Without the generation
+// guard in domainCache.store this test fails.
+func TestCachedStoreRejectsLoadThatRacedWithWrite(t *testing.T) {
+	cached, counting, _ := newCachedMemoryStore(t)
+	seedUser(t, cached, "acct-1")
+
+	loaded := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	counting.afterLoad = func() {
+		once.Do(func() {
+			close(loaded)
+			<-release
+		})
+	}
+
+	type result struct {
+		u   *User
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		u, err := cached.GetUserByAccountID("acct-1")
+		done <- result{u, err}
+	}()
+
+	<-loaded // reader holds the pre-write value, not yet published
+	if err := cached.SetUserRole("acct-1", RoleService); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	r := <-done
+	if r.err != nil || r.u.Role != "" {
+		t.Fatalf("racing reader should return what it loaded (pre-write): %+v %v", r.u, r.err)
+	}
+
+	// The pre-write value must not have been cached: this read goes to the
+	// inner store and sees the new role.
+	before := counting.count("GetUserByAccountID")
+	u, err := cached.GetUserByAccountID("acct-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Role != RoleService {
+		t.Fatalf("stale pre-write value served from cache: role %q", u.Role)
+	}
+	if got := counting.count("GetUserByAccountID"); got != before+1 {
+		t.Fatalf("expected a fresh inner read, inner calls %d -> %d", before, got)
+	}
+}
+
+// Run with -race: readers, writers and invalidations interleave on shared
+// keys; the cache must stay bounded and end up coherent with the inner store.
+func TestCachedStoreConcurrentReadersAndWriters(t *testing.T) {
+	cached, _, clock := newCachedMemoryStore(t)
+	const users, models = 6, 3
+	for i := 0; i < users; i++ {
+		seedUser(t, cached, fmt.Sprintf("acct-%d", i))
+	}
+	for i := 0; i < models; i++ {
+		seedActiveModel(t, cached, fmt.Sprintf("org/m%d", i), "v1")
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 64)
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				id := fmt.Sprintf("acct-%d", (g+i)%users)
+				if u, err := cached.GetUserByAccountID(id); err != nil || u.AccountID != id {
+					errs <- fmt.Errorf("user %s: %+v %v", id, u, err)
+					return
+				}
+				if _, err := cached.GetUserByPrivyID("did:privy:" + id); err != nil {
+					errs <- err
+					return
+				}
+				mid := fmt.Sprintf("org/m%d", (g+i)%models)
+				rec, err := cached.GetModelRegistryRecord(mid)
+				if err != nil || rec.ID != mid || rec.ActiveVersion == nil {
+					errs <- fmt.Errorf("model %s: %+v %v", mid, rec, err)
+					return
+				}
+				rec.RuntimeParameters["scribble"] = i // copies: must not race with other readers
+				if _, err := cached.GetModelManifest(mid); err != nil {
+					errs <- err
+					return
+				}
+				if _, err := cached.GetUserByAccountID("ghost"); !errors.Is(err, ErrNotFound) {
+					errs <- fmt.Errorf("ghost: %v", err)
+					return
+				}
+				if i%50 == 0 {
+					clock.advance(time.Second)
+				}
+			}
+		}(g)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fee := int64(3)
+		for i := 0; i < 60; i++ {
+			id := fmt.Sprintf("acct-%d", i%users)
+			role := ""
+			if i%2 == 0 {
+				role = RoleService
+			}
+			if err := cached.SetUserRole(id, role); err != nil {
+				errs <- err
+				return
+			}
+			if err := cached.SetUserPlatformFeePercent(id, &fee); err != nil {
+				errs <- err
+				return
+			}
+			mid := fmt.Sprintf("org/m%d", i%models)
+			entry, _, _ := registryFixture(mid, "v1")
+			entry.DisplayName = fmt.Sprintf("rev-%d", i)
+			if err := cached.UpsertModelRegistryEntry(entry); err != nil {
+				errs <- err
+				return
+			}
+			if err := cached.SetModelStatus(mid, "active"); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	// Coherence after quiescence: every cached read equals the inner store.
+	inner := cached.Store.(*countingStore).Store
+	for i := 0; i < users; i++ {
+		id := fmt.Sprintf("acct-%d", i)
+		want, _ := inner.GetUserByAccountID(id)
+		got, _ := cached.GetUserByAccountID(id)
+		if got.Role != want.Role || (got.PlatformFeePercent == nil) != (want.PlatformFeePercent == nil) {
+			t.Fatalf("user %s incoherent: cached %+v inner %+v", id, got, want)
+		}
+	}
+	for i := 0; i < models; i++ {
+		mid := fmt.Sprintf("org/m%d", i)
+		want, _ := inner.GetModelRegistryRecord(mid)
+		got, _ := cached.GetModelRegistryRecord(mid)
+		if got.DisplayName != want.DisplayName {
+			t.Fatalf("model %s incoherent: cached %q inner %q", mid, got.DisplayName, want.DisplayName)
+		}
+	}
+	st := cached.Stats()
+	if st.Users.Entries > DefaultCacheConfig().MaxUsers || st.Models.Entries > DefaultCacheConfig().MaxModels {
+		t.Fatalf("cache exceeded bounds: %+v", st)
+	}
+	if st.Users.Invalidations < 120 || st.Models.Invalidations < 120 {
+		t.Fatalf("expected every write to invalidate: %+v", st)
+	}
+}

--- a/coordinator/store/cached_postgres_test.go
+++ b/coordinator/store/cached_postgres_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Composes CachedStore over a real PostgresStore (throwaway DATABASE_URL, see
+// harness_test.go) and proves the decorator's invalidation tracks real SQL
+// writes, that a real pgx miss is negative-cached, and that an out-of-band
+// SQL write is only visible after the TTL -- the documented single-process
+// caveat.
+func TestCachedStoreOverPostgres(t *testing.T) {
+	pg := testPostgresStore(t)
+	counting := newCountingStore(pg)
+	clock := newFakeClock()
+	cfg := DefaultCacheConfig()
+	cfg.Now = clock.now
+	cached := NewCached(counting, cfg)
+
+	t.Run("users", func(t *testing.T) {
+		acct := uniqueID("acct")
+		u := &User{AccountID: acct, PrivyUserID: "did:privy:" + acct, Email: acct + "@example.test"}
+		if err := cached.CreateUser(u); err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		for i := 0; i < 3; i++ {
+			got, err := cached.GetUserByAccountID(acct)
+			if err != nil || got.AccountID != acct || got.Role != "" {
+				t.Fatalf("get %d: %+v %v", i, got, err)
+			}
+			if got, err := cached.GetUserByPrivyID("did:privy:" + acct); err != nil || got.AccountID != acct {
+				t.Fatalf("privy get %d: %+v %v", i, got, err)
+			}
+		}
+		if n := counting.count("GetUserByAccountID"); n != 1 {
+			t.Fatalf("inner GetUserByAccountID calls = %d, want 1", n)
+		}
+
+		// Real UPDATE through the decorator -> next read reflects it.
+		if err := cached.SetUserRole(acct, RoleService); err != nil {
+			t.Fatalf("SetUserRole: %v", err)
+		}
+		got, err := cached.GetUserByAccountID(acct)
+		if err != nil || got.Role != RoleService {
+			t.Fatalf("after SetUserRole: %+v %v", got, err)
+		}
+		if n := counting.count("GetUserByAccountID"); n != 2 {
+			t.Fatalf("inner calls after SetUserRole = %d, want 2", n)
+		}
+		fee := int64(0)
+		if err := cached.SetUserPlatformFeePercent(acct, &fee); err != nil {
+			t.Fatalf("SetUserPlatformFeePercent: %v", err)
+		}
+		if got, _ := cached.GetUserByAccountID(acct); got.PlatformFeePercent == nil || *got.PlatformFeePercent != 0 {
+			t.Fatalf("after SetUserPlatformFeePercent: %+v", got)
+		}
+		if err := cached.SetUserStripeAccount(acct, "acct_pg", "pending", "US", "card", "4242", true); err != nil {
+			t.Fatalf("SetUserStripeAccount: %v", err)
+		}
+		if got, _ := cached.GetUserByAccountID(acct); got.StripeAccountID != "acct_pg" || got.StripeAccountStatus != "pending" {
+			t.Fatalf("after SetUserStripeAccount: %+v", got)
+		}
+
+		// Out-of-band SQL write: invisible until UserTTL elapses.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if _, err := pg.pool.Exec(ctx, `UPDATE users SET role = '' WHERE account_id = $1`, acct); err != nil {
+			t.Fatalf("out-of-band update: %v", err)
+		}
+		if got, _ := cached.GetUserByAccountID(acct); got.Role != RoleService {
+			t.Fatalf("out-of-band write became visible before TTL: %+v", got)
+		}
+		clock.advance(cfg.UserTTL + time.Millisecond)
+		if got, _ := cached.GetUserByAccountID(acct); got.Role != "" {
+			t.Fatalf("out-of-band write still invisible after TTL: %+v", got)
+		}
+
+		// A real pgx.ErrNoRows miss is negative-cached with the sentinel.
+		before := counting.count("GetUserByAccountID")
+		for i := 0; i < 3; i++ {
+			if _, err := cached.GetUserByAccountID("acct-missing"); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("miss %d: %v", i, err)
+			}
+		}
+		if got := counting.count("GetUserByAccountID"); got != before+1 {
+			t.Fatalf("negative entry not cached over Postgres: inner calls %d -> %d", before, got)
+		}
+	})
+
+	t.Run("models", func(t *testing.T) {
+		modelID := uniqueID("mlx-community/cached")
+		entry, v, files := registryFixture(modelID, "v1")
+		if err := cached.SetModelVersion(entry, v, files); err != nil {
+			t.Fatalf("SetModelVersion: %v", err)
+		}
+		if err := cached.PromoteModelVersion(modelID, "v1"); err != nil {
+			t.Fatalf("PromoteModelVersion: %v", err)
+		}
+		for i := 0; i < 3; i++ {
+			rec, err := cached.GetModelRegistryRecord(modelID)
+			if err != nil || rec.ActiveVersion == nil || rec.ActiveVersion.Version != "v1" || len(rec.Files) != 1 {
+				t.Fatalf("record %d: %+v %v", i, rec, err)
+			}
+			if rec.RuntimeParameters["reasoning_parser"] != "qwen3" {
+				t.Fatalf("record %d runtime params: %+v", i, rec.RuntimeParameters)
+			}
+			m, err := cached.GetModelManifest(modelID)
+			if err != nil || m.Version != "v1" || m.AggregateSHA256 != cachedTestHash || len(m.Files) != 1 {
+				t.Fatalf("manifest %d: %+v %v", i, m, err)
+			}
+		}
+		if n := counting.count("GetModelRegistryRecord"); n != 1 {
+			t.Fatalf("inner GetModelRegistryRecord calls = %d, want 1 (two SQL queries each)", n)
+		}
+		if n := counting.count("GetModelManifest"); n != 0 {
+			t.Fatalf("inner GetModelManifest calls = %d, want 0", n)
+		}
+
+		// Real writes through the decorator, each followed by a fresh read.
+		entry.DisplayName = "Renamed"
+		if err := cached.UpsertModelRegistryEntry(entry); err != nil {
+			t.Fatalf("UpsertModelRegistryEntry: %v", err)
+		}
+		if rec, _ := cached.GetModelRegistryRecord(modelID); rec == nil || rec.DisplayName != "Renamed" {
+			t.Fatalf("after upsert: %+v", rec)
+		}
+		entry2, v2, files2 := registryFixture(modelID, "v2")
+		entry2.DisplayName = "Renamed"
+		if err := cached.SetModelVersion(entry2, v2, files2); err != nil {
+			t.Fatalf("SetModelVersion v2: %v", err)
+		}
+		if err := cached.PromoteModelVersion(modelID, "v2"); err != nil {
+			t.Fatalf("PromoteModelVersion v2: %v", err)
+		}
+		if m, err := cached.GetModelManifest(modelID); err != nil || m.Version != "v2" || m.R2Prefix != modelID+"/v2" {
+			t.Fatalf("after promote v2: %+v %v", m, err)
+		}
+		if err := cached.SetModelStatus(modelID, "retired"); err != nil {
+			t.Fatalf("SetModelStatus: %v", err)
+		}
+		before := counting.count("GetModelRegistryRecord")
+		for i := 0; i < 3; i++ {
+			rec, err := cached.GetModelRegistryRecord(modelID)
+			if rec != nil || !errors.Is(err, ErrNotFound) {
+				t.Fatalf("retired read %d: %+v %v", i, rec, err)
+			}
+		}
+		if got := counting.count("GetModelRegistryRecord"); got != before+1 {
+			t.Fatalf("retired miss not negative-cached: inner calls %d -> %d", before, got)
+		}
+	})
+}

--- a/coordinator/store/cached_test.go
+++ b/coordinator/store/cached_test.go
@@ -1,0 +1,656 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// countingStore forwards every call to a real Store and counts the inner
+// reads of the lookups CachedStore caches. It is not a mock of behavior: the
+// wrapped store answers every call. failWith and afterLoad exist so tests can
+// exercise the transient-error and read/write-race paths deterministically.
+type countingStore struct {
+	Store
+	mu        sync.Mutex
+	calls     map[string]int
+	failWith  error  // when set, cached lookups return it instead of forwarding
+	afterLoad func() // runs after the inner read, before returning (race test)
+}
+
+func newCountingStore(inner Store) *countingStore {
+	return &countingStore{Store: inner, calls: map[string]int{}}
+}
+
+func (c *countingStore) note(name string) {
+	c.mu.Lock()
+	c.calls[name]++
+	c.mu.Unlock()
+}
+
+func (c *countingStore) count(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls[name]
+}
+
+func (c *countingStore) GetUserByAccountID(accountID string) (*User, error) {
+	c.note("GetUserByAccountID")
+	if c.failWith != nil {
+		return nil, c.failWith
+	}
+	u, err := c.Store.GetUserByAccountID(accountID)
+	if c.afterLoad != nil {
+		c.afterLoad()
+	}
+	return u, err
+}
+
+func (c *countingStore) GetUserByPrivyID(privyUserID string) (*User, error) {
+	c.note("GetUserByPrivyID")
+	if c.failWith != nil {
+		return nil, c.failWith
+	}
+	return c.Store.GetUserByPrivyID(privyUserID)
+}
+
+func (c *countingStore) GetModelRegistryRecord(modelID string) (*ModelRegistryRecord, error) {
+	c.note("GetModelRegistryRecord")
+	if c.failWith != nil {
+		return nil, c.failWith
+	}
+	rec, err := c.Store.GetModelRegistryRecord(modelID)
+	if c.afterLoad != nil {
+		c.afterLoad()
+	}
+	return rec, err
+}
+
+func (c *countingStore) GetModelManifest(modelID string) (*ModelManifest, error) {
+	c.note("GetModelManifest")
+	return c.Store.GetModelManifest(modelID)
+}
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{t: time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)}
+}
+
+func (f *fakeClock) now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.t
+}
+
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	f.t = f.t.Add(d)
+	f.mu.Unlock()
+}
+
+// newCachedMemoryStore composes CachedStore -> countingStore -> MemoryStore
+// with a fake clock and the production TTLs.
+func newCachedMemoryStore(t *testing.T) (*CachedStore, *countingStore, *fakeClock) {
+	t.Helper()
+	clock := newFakeClock()
+	counting := newCountingStore(NewMemory(Config{}))
+	cfg := DefaultCacheConfig()
+	cfg.Now = clock.now
+	return NewCached(counting, cfg), counting, clock
+}
+
+func seedUser(t *testing.T, st Store, accountID string) *User {
+	t.Helper()
+	u := &User{AccountID: accountID, PrivyUserID: "did:privy:" + accountID, Email: accountID + "@example.test"}
+	if err := st.CreateUser(u); err != nil {
+		t.Fatalf("CreateUser(%s): %v", accountID, err)
+	}
+	return u
+}
+
+const cachedTestHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func registryFixture(modelID, version string) (*ModelRegistryEntry, *ModelVersion, []ModelVersionFile) {
+	entry := &ModelRegistryEntry{
+		ID: modelID, DisplayName: "Model " + modelID, Status: "active", MinRAMGB: 16,
+		MaxContextLength: 32768, MaxOutputLength: 8192,
+		Capabilities:                 []string{"chat"},
+		RequiredProviderCapabilities: []string{},
+		RuntimeParameters:            map[string]any{"reasoning_parser": "qwen3", "nested": map[string]any{"k": []any{"a", "b"}}},
+		Metadata:                     map[string]any{"hugging_face_id": "org/" + modelID},
+	}
+	v := &ModelVersion{ModelID: modelID, Version: version, R2Prefix: modelID + "/" + version,
+		AggregateSHA256: cachedTestHash, TotalSizeBytes: 3, FileCount: 1, Status: "ready"}
+	files := []ModelVersionFile{{Path: "config.json", SizeBytes: 3, SHA256: cachedTestHash, Role: "config"}}
+	return entry, v, files
+}
+
+// seedActiveModel registers and promotes one ready version so the model has
+// an active registry record.
+func seedActiveModel(t *testing.T, st Store, modelID, version string) {
+	t.Helper()
+	entry, v, files := registryFixture(modelID, version)
+	if err := st.SetModelVersion(entry, v, files); err != nil {
+		t.Fatalf("SetModelVersion(%s %s): %v", modelID, version, err)
+	}
+	if err := st.PromoteModelVersion(modelID, version); err != nil {
+		t.Fatalf("PromoteModelVersion(%s %s): %v", modelID, version, err)
+	}
+}
+
+// --- Users ---
+
+func TestCachedStoreUserHitAfterMiss(t *testing.T) {
+	cached, counting, _ := newCachedMemoryStore(t)
+	seedUser(t, cached, "acct-1")
+
+	for i := 0; i < 3; i++ {
+		u, err := cached.GetUserByAccountID("acct-1")
+		if err != nil || u.AccountID != "acct-1" || u.PrivyUserID != "did:privy:acct-1" {
+			t.Fatalf("get %d: user=%+v err=%v", i, u, err)
+		}
+		u, err = cached.GetUserByPrivyID("did:privy:acct-1")
+		if err != nil || u.AccountID != "acct-1" {
+			t.Fatalf("privy get %d: user=%+v err=%v", i, u, err)
+		}
+	}
+	if n := counting.count("GetUserByAccountID"); n != 1 {
+		t.Fatalf("inner GetUserByAccountID calls = %d, want 1", n)
+	}
+	if n := counting.count("GetUserByPrivyID"); n != 1 {
+		t.Fatalf("inner GetUserByPrivyID calls = %d, want 1", n)
+	}
+	st := cached.Stats()
+	if st.Users.Hits != 4 || st.Users.Misses != 2 || st.Users.Entries != 2 {
+		t.Fatalf("user stats = %+v, want 4 hits / 2 misses / 2 entries", st.Users)
+	}
+}
+
+func TestCachedStoreUserTTLExpiry(t *testing.T) {
+	cached, counting, clock := newCachedMemoryStore(t)
+	seedUser(t, cached, "acct-1")
+
+	cached.GetUserByAccountID("acct-1")
+	clock.advance(DefaultCacheConfig().UserTTL - time.Second)
+	cached.GetUserByAccountID("acct-1")
+	if n := counting.count("GetUserByAccountID"); n != 1 {
+		t.Fatalf("calls before expiry = %d, want 1", n)
+	}
+	clock.advance(2 * time.Second)
+	cached.GetUserByAccountID("acct-1")
+	if n := counting.count("GetUserByAccountID"); n != 2 {
+		t.Fatalf("calls after expiry = %d, want 2", n)
+	}
+}
+
+func TestCachedStoreNegativeUserCached(t *testing.T) {
+	cached, counting, clock := newCachedMemoryStore(t)
+
+	want := "user with account ID \"ghost\" not found"
+	for i := 0; i < 3; i++ {
+		u, err := cached.GetUserByAccountID("ghost")
+		if u != nil || !errors.Is(err, ErrNotFound) {
+			t.Fatalf("get %d: user=%v err=%v, want ErrNotFound", i, u, err)
+		}
+		if err.Error() != want {
+			t.Fatalf("get %d: message %q, want %q (must match inner store verbatim)", i, err.Error(), want)
+		}
+	}
+	if n := counting.count("GetUserByAccountID"); n != 1 {
+		t.Fatalf("inner calls for a cached miss = %d, want 1", n)
+	}
+	if st := cached.Stats(); st.Users.NegativeHits != 2 {
+		t.Fatalf("negative hits = %d, want 2", st.Users.NegativeHits)
+	}
+
+	clock.advance(DefaultCacheConfig().NegativeTTL + time.Millisecond)
+	cached.GetUserByAccountID("ghost")
+	if n := counting.count("GetUserByAccountID"); n != 2 {
+		t.Fatalf("inner calls after negative TTL = %d, want 2", n)
+	}
+}
+
+func TestCachedStoreUserMutatorsInvalidate(t *testing.T) {
+	fee := int64(0)
+	cases := []struct {
+		name   string
+		mutate func(*CachedStore) error
+		check  func(*User) error
+	}{
+		{"CreateUser", func(c *CachedStore) error {
+			return c.CreateUser(&User{AccountID: "acct-other", PrivyUserID: "did:privy:other"})
+		}, func(*User) error { return nil }},
+		{"SetUserRole", func(c *CachedStore) error {
+			return c.SetUserRole("acct-1", RoleService)
+		}, func(u *User) error {
+			if u.Role != RoleService {
+				return fmt.Errorf("role = %q, want %q", u.Role, RoleService)
+			}
+			return nil
+		}},
+		{"SetUserPlatformFeePercent", func(c *CachedStore) error {
+			return c.SetUserPlatformFeePercent("acct-1", &fee)
+		}, func(u *User) error {
+			if u.PlatformFeePercent == nil || *u.PlatformFeePercent != 0 {
+				return fmt.Errorf("fee = %v, want 0", u.PlatformFeePercent)
+			}
+			return nil
+		}},
+		{"SetUserStripeAccount", func(c *CachedStore) error {
+			return c.SetUserStripeAccount("acct-1", "acct_stripe", "pending", "US", "card", "4242", true)
+		}, func(u *User) error {
+			if u.StripeAccountID != "acct_stripe" || u.StripeAccountStatus != "pending" {
+				return fmt.Errorf("stripe = %q/%q, want acct_stripe/pending", u.StripeAccountID, u.StripeAccountStatus)
+			}
+			return nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cached, counting, _ := newCachedMemoryStore(t)
+			seedUser(t, cached, "acct-1")
+			cached.GetUserByAccountID("acct-1")
+			cached.GetUserByPrivyID("did:privy:acct-1")
+			before := counting.count("GetUserByAccountID") + counting.count("GetUserByPrivyID")
+
+			if err := tc.mutate(cached); err != nil {
+				t.Fatalf("mutate: %v", err)
+			}
+			u, err := cached.GetUserByAccountID("acct-1")
+			if err != nil {
+				t.Fatalf("get after mutate: %v", err)
+			}
+			if err := tc.check(u); err != nil {
+				t.Fatalf("stale read after %s: %v", tc.name, err)
+			}
+			if _, err := cached.GetUserByPrivyID("did:privy:acct-1"); err != nil {
+				t.Fatalf("privy get after mutate: %v", err)
+			}
+			after := counting.count("GetUserByAccountID") + counting.count("GetUserByPrivyID")
+			if after != before+2 {
+				t.Fatalf("inner reads after %s = %d, want %d (both user keys reloaded)", tc.name, after, before+2)
+			}
+		})
+	}
+}
+
+// GetOrCreateUser's race branch re-reads by Privy ID after a failed
+// CreateUser; both the miss recorded before creation and the failed create
+// must leave the cache pointing at the real row.
+func TestCachedStoreCreateUserClearsNegativeEntryEvenOnFailure(t *testing.T) {
+	cached, counting, _ := newCachedMemoryStore(t)
+
+	if _, err := cached.GetUserByPrivyID("did:privy:new"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected miss, got %v", err)
+	}
+	seedUser(t, cached, "new") // CreateUser through the decorator
+	if u, err := cached.GetUserByPrivyID("did:privy:new"); err != nil || u.AccountID != "new" {
+		t.Fatalf("after create: user=%+v err=%v", u, err)
+	}
+
+	// Warm, then a duplicate CreateUser fails -- it must still invalidate.
+	cached.GetUserByPrivyID("did:privy:new")
+	n := counting.count("GetUserByPrivyID")
+	if err := cached.CreateUser(&User{AccountID: "new", PrivyUserID: "did:privy:new"}); err == nil {
+		t.Fatal("duplicate CreateUser should fail")
+	}
+	cached.GetUserByPrivyID("did:privy:new")
+	if got := counting.count("GetUserByPrivyID"); got != n+1 {
+		t.Fatalf("failed CreateUser did not invalidate: inner calls %d, want %d", got, n+1)
+	}
+}
+
+func TestCachedStoreReturnsUserCopies(t *testing.T) {
+	cached, _, _ := newCachedMemoryStore(t)
+	seedUser(t, cached, "acct-1")
+	fee := int64(7)
+	if err := cached.SetUserPlatformFeePercent("acct-1", &fee); err != nil {
+		t.Fatal(err)
+	}
+
+	u1, _ := cached.GetUserByAccountID("acct-1")
+	u1.Role = "tampered"
+	*u1.PlatformFeePercent = 99
+	u1.Email = "tampered@example.test"
+
+	u2, _ := cached.GetUserByAccountID("acct-1")
+	if u2.Role != "" || *u2.PlatformFeePercent != 7 || u2.Email != "acct-1@example.test" {
+		t.Fatalf("caller mutation leaked into cache: %+v", u2)
+	}
+	if u1 == u2 {
+		t.Fatal("cache handed out the same pointer twice")
+	}
+}
+
+// --- Model registry ---
+
+func TestCachedStoreModelRecordAndManifestShareOneLoad(t *testing.T) {
+	cached, counting, _ := newCachedMemoryStore(t)
+	seedActiveModel(t, cached, "org/m1", "v1")
+
+	for i := 0; i < 3; i++ {
+		rec, err := cached.GetModelRegistryRecord("org/m1")
+		if err != nil || rec.ActiveVersion == nil || rec.ActiveVersion.Version != "v1" || len(rec.Files) != 1 {
+			t.Fatalf("record %d: %+v err=%v", i, rec, err)
+		}
+		m, err := cached.GetModelManifest("org/m1")
+		if err != nil || m == nil || m.Version != "v1" || m.ModelID != "org/m1" || len(m.Files) != 1 || m.Files[0].Path != "config.json" {
+			t.Fatalf("manifest %d: %+v err=%v", i, m, err)
+		}
+	}
+	if n := counting.count("GetModelRegistryRecord"); n != 1 {
+		t.Fatalf("inner GetModelRegistryRecord calls = %d, want 1", n)
+	}
+	if n := counting.count("GetModelManifest"); n != 0 {
+		t.Fatalf("inner GetModelManifest calls = %d, want 0 (derived from the cached record)", n)
+	}
+	if st := cached.Stats(); st.Models.Hits != 5 || st.Models.Misses != 1 || st.Models.Entries != 1 {
+		t.Fatalf("model stats = %+v", st.Models)
+	}
+}
+
+func TestCachedStoreModelTTLExpiry(t *testing.T) {
+	cached, counting, clock := newCachedMemoryStore(t)
+	seedActiveModel(t, cached, "org/m1", "v1")
+
+	cached.GetModelRegistryRecord("org/m1")
+	clock.advance(DefaultCacheConfig().ModelTTL - time.Second)
+	cached.GetModelRegistryRecord("org/m1")
+	if n := counting.count("GetModelRegistryRecord"); n != 1 {
+		t.Fatalf("calls before expiry = %d, want 1", n)
+	}
+	clock.advance(2 * time.Second)
+	cached.GetModelRegistryRecord("org/m1")
+	if n := counting.count("GetModelRegistryRecord"); n != 2 {
+		t.Fatalf("calls after expiry = %d, want 2", n)
+	}
+}
+
+// Alias names reach GetModelRegistryRecord on every request and always miss;
+// that miss must be remembered for NegativeTTL, and both the sentinel and the
+// exact message the API string-matches on must survive the cache.
+func TestCachedStoreNegativeModelCached(t *testing.T) {
+	cached, counting, clock := newCachedMemoryStore(t)
+
+	want := `model "qwen3-alias" not found`
+	for i := 0; i < 4; i++ {
+		if _, err := cached.GetModelRegistryRecord("qwen3-alias"); !errors.Is(err, ErrNotFound) || err.Error() != want {
+			t.Fatalf("record %d: err=%v want ErrNotFound %q", i, err, want)
+		}
+		if _, err := cached.GetModelManifest("qwen3-alias"); !errors.Is(err, ErrNotFound) || err.Error() != want {
+			t.Fatalf("manifest %d: err=%v want ErrNotFound %q", i, err, want)
+		}
+	}
+	if n := counting.count("GetModelRegistryRecord"); n != 1 {
+		t.Fatalf("inner calls for a cached miss = %d, want 1", n)
+	}
+	clock.advance(DefaultCacheConfig().NegativeTTL + time.Millisecond)
+	cached.GetModelRegistryRecord("qwen3-alias")
+	if n := counting.count("GetModelRegistryRecord"); n != 2 {
+		t.Fatalf("inner calls after negative TTL = %d, want 2", n)
+	}
+}
+
+func TestCachedStoreModelMutatorsInvalidate(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*CachedStore) error
+		check  func(*ModelRegistryRecord, error) error
+	}{
+		{"UpsertModelRegistryEntry", func(c *CachedStore) error {
+			entry, _, _ := registryFixture("org/m1", "v1")
+			entry.DisplayName = "Renamed"
+			entry.RuntimeParameters["reasoning_parser"] = "gemma"
+			return c.UpsertModelRegistryEntry(entry)
+		}, func(rec *ModelRegistryRecord, err error) error {
+			if err != nil || rec.DisplayName != "Renamed" || rec.RuntimeParameters["reasoning_parser"] != "gemma" {
+				return fmt.Errorf("rec=%+v err=%v", rec, err)
+			}
+			return nil
+		}},
+		{"SetModelVersion", func(c *CachedStore) error {
+			entry, v, files := registryFixture("org/m1", "v2")
+			entry.MaxOutputLength = 16384
+			return c.SetModelVersion(entry, v, files)
+		}, func(rec *ModelRegistryRecord, err error) error {
+			// v2 is uploaded but not promoted: entry fields changed, active stays v1.
+			if err != nil || rec.MaxOutputLength != 16384 || rec.ActiveVersion.Version != "v1" {
+				return fmt.Errorf("rec=%+v err=%v", rec, err)
+			}
+			return nil
+		}},
+		{"PromoteModelVersion", func(c *CachedStore) error {
+			entry, v, files := registryFixture("org/m1", "v2")
+			if err := c.SetModelVersion(entry, v, files); err != nil {
+				return err
+			}
+			c.GetModelRegistryRecord("org/m1") // re-warm so the promote is what invalidates
+			return c.PromoteModelVersion("org/m1", "v2")
+		}, func(rec *ModelRegistryRecord, err error) error {
+			if err != nil || rec.ActiveVersion.Version != "v2" || rec.ActiveVersion.R2Prefix != "org/m1/v2" {
+				return fmt.Errorf("rec=%+v err=%v", rec, err)
+			}
+			return nil
+		}},
+		{"SetModelStatus", func(c *CachedStore) error {
+			return c.SetModelStatus("org/m1", "retired")
+		}, func(rec *ModelRegistryRecord, err error) error {
+			if rec != nil || !errors.Is(err, ErrNotFound) {
+				return fmt.Errorf("retired model still served: rec=%+v err=%v", rec, err)
+			}
+			return nil
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cached, counting, _ := newCachedMemoryStore(t)
+			seedActiveModel(t, cached, "org/m1", "v1")
+			cached.GetModelRegistryRecord("org/m1")
+			cached.GetModelRegistryRecord("org/m1")
+			if n := counting.count("GetModelRegistryRecord"); n != 1 {
+				t.Fatalf("warm-up inner calls = %d, want 1", n)
+			}
+			if err := tc.mutate(cached); err != nil {
+				t.Fatalf("mutate: %v", err)
+			}
+			before := counting.count("GetModelRegistryRecord")
+			rec, err := cached.GetModelRegistryRecord("org/m1")
+			if err := tc.check(rec, err); err != nil {
+				t.Fatalf("stale read after %s: %v", tc.name, err)
+			}
+			if got := counting.count("GetModelRegistryRecord"); got != before+1 {
+				t.Fatalf("inner reads after %s = %d, want %d", tc.name, got, before+1)
+			}
+			// Manifest follows the same entry.
+			m, err := cached.GetModelManifest("org/m1")
+			if rec == nil {
+				if m != nil || !errors.Is(err, ErrNotFound) {
+					t.Fatalf("manifest for retired model: %+v err=%v", m, err)
+				}
+			} else if err != nil || m.Version != rec.ActiveVersion.Version {
+				t.Fatalf("manifest version %v vs record %v (err=%v)", m, rec.ActiveVersion.Version, err)
+			}
+		})
+	}
+}
+
+func TestCachedStoreReturnsRecordCopies(t *testing.T) {
+	cached, _, _ := newCachedMemoryStore(t)
+	seedActiveModel(t, cached, "org/m1", "v1")
+
+	r1, err := cached.GetModelRegistryRecord("org/m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exactly what api/model_registry_handlers.go does before an upsert, plus
+	// every other reference-typed field.
+	r1.RuntimeParameters["reasoning_parser"] = "tampered"
+	r1.RuntimeParameters["nested"].(map[string]any)["k"].([]any)[0] = "tampered"
+	r1.Metadata["hugging_face_id"] = "tampered"
+	r1.Capabilities[0] = "tampered"
+	r1.Files[0].Path = "tampered"
+	r1.ActiveVersion.Version = "tampered"
+	r1.DisplayName = "tampered"
+
+	r2, err := cached.GetModelRegistryRecord("org/m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1 == r2 || r1.ActiveVersion == r2.ActiveVersion {
+		t.Fatal("cache handed out the same pointer twice")
+	}
+	if r2.RuntimeParameters["reasoning_parser"] != "qwen3" ||
+		r2.RuntimeParameters["nested"].(map[string]any)["k"].([]any)[0] != "a" ||
+		r2.Metadata["hugging_face_id"] != "org/org/m1" ||
+		r2.Capabilities[0] != "chat" ||
+		r2.Files[0].Path != "config.json" ||
+		r2.ActiveVersion.Version != "v1" ||
+		r2.DisplayName != "Model org/m1" {
+		t.Fatalf("caller mutation leaked into cache: %+v", r2)
+	}
+
+	// The structural clone must agree with the package's JSON-round-trip
+	// clone (the existing oracle) on the same JSON-shaped data.
+	oracle := cloneModelRegistryEntry(&r2.ModelRegistryEntry)
+	if fmt.Sprint(oracle.RuntimeParameters) != fmt.Sprint(r2.RuntimeParameters) ||
+		fmt.Sprint(oracle.Metadata) != fmt.Sprint(r2.Metadata) {
+		t.Fatalf("structural clone diverges from JSON clone:\n%v\n%v", oracle.RuntimeParameters, r2.RuntimeParameters)
+	}
+}
+
+func TestCachedStoreTransientErrorsNotCached(t *testing.T) {
+	for _, transient := range []error{
+		errors.New("dial tcp: connection refused"),
+		fmt.Errorf("store: user not found: %w", context.DeadlineExceeded), // Postgres wording for a timeout
+	} {
+		cached, counting, _ := newCachedMemoryStore(t)
+		seedUser(t, cached, "acct-1")
+		seedActiveModel(t, cached, "org/m1", "v1")
+		counting.failWith = transient
+
+		for i := 0; i < 3; i++ {
+			if _, err := cached.GetUserByAccountID("acct-1"); !errors.Is(err, transient) {
+				t.Fatalf("user get %d: err=%v", i, err)
+			}
+			if _, err := cached.GetModelRegistryRecord("org/m1"); !errors.Is(err, transient) {
+				t.Fatalf("model get %d: err=%v", i, err)
+			}
+		}
+		if n := counting.count("GetUserByAccountID"); n != 3 {
+			t.Fatalf("transient user error was cached: inner calls %d, want 3", n)
+		}
+		if n := counting.count("GetModelRegistryRecord"); n != 3 {
+			t.Fatalf("transient model error was cached: inner calls %d, want 3", n)
+		}
+		if st := cached.Stats(); st.Users.Entries != 0 || st.Models.Entries != 0 {
+			t.Fatalf("transient errors populated the cache: %+v", st)
+		}
+
+		// Recovery: once the inner store answers again the value is cached.
+		counting.failWith = nil
+		if u, err := cached.GetUserByAccountID("acct-1"); err != nil || u.AccountID != "acct-1" {
+			t.Fatalf("recovered get: %+v %v", u, err)
+		}
+	}
+}
+
+func TestCachedStoreColdLookupsPassThroughUncached(t *testing.T) {
+	cached, _, _ := newCachedMemoryStore(t)
+	seedUser(t, cached, "acct-1")
+	if err := cached.SetUserStripeAccount("acct-1", "acct_x", "ready", "US", "bank", "0001", false); err != nil {
+		t.Fatal(err)
+	}
+	if u, err := cached.GetUserByEmail("acct-1@example.test"); err != nil || u.AccountID != "acct-1" {
+		t.Fatalf("GetUserByEmail: %+v %v", u, err)
+	}
+	if u, err := cached.GetUserByStripeAccount("acct_x"); err != nil || u.AccountID != "acct-1" {
+		t.Fatalf("GetUserByStripeAccount: %+v %v", u, err)
+	}
+	if st := cached.Stats(); st.Users.Entries != 0 || st.Users.Hits+st.Users.Misses != 0 {
+		t.Fatalf("cold lookups touched the cache: %+v", st.Users)
+	}
+}
+
+func TestCacheConfigDefaults(t *testing.T) {
+	cfg := CacheConfig{}.withDefaults()
+	def := DefaultCacheConfig()
+	if cfg.UserTTL != def.UserTTL || cfg.ModelTTL != def.ModelTTL || cfg.NegativeTTL != def.NegativeTTL ||
+		cfg.MaxUsers != def.MaxUsers || cfg.MaxModels != def.MaxModels || cfg.Now == nil {
+		t.Fatalf("defaults not applied: %+v", cfg)
+	}
+	if def.ModelTTL >= def.UserTTL || def.NegativeTTL > def.ModelTTL {
+		t.Fatalf("expected negative <= model < user TTL ordering, got %+v", def)
+	}
+	// Zero-config wrapping must produce a working cache.
+	c := NewCached(NewMemory(Config{}), CacheConfig{})
+	seedUser(t, c, "acct-1")
+	if _, err := c.GetUserByAccountID("acct-1"); err != nil {
+		t.Fatal(err)
+	}
+	if c.Stats().Users.Entries != 1 {
+		t.Fatal("zero-config cache did not store")
+	}
+}
+
+// --- Profiler methods (#809) ---
+
+// TestCachedStoreForwardsProfilerMethods pins that the decorator forwards the
+// six profiler methods the Store interface gained in #809 (request profiles,
+// fleet snapshots, telemetry pruning) to the wrapped store: CachedStore embeds
+// Store and overrides none of them, so a write through the wrapper lands in
+// the inner store and reads back through the wrapper.
+func TestCachedStoreForwardsProfilerMethods(t *testing.T) {
+	inner := NewMemory(Config{})
+	cached := NewCached(inner, DefaultCacheConfig())
+	var _ Store = cached // the wrapper satisfies the full interface, #809's methods included
+
+	old := time.Now().Add(-2 * time.Hour)
+	recent := time.Now()
+	if err := cached.RecordRequestProfiles([]*RequestProfileRecord{
+		{RequestID: "req-old", Attempt: 0, CreatedAt: old},
+		{RequestID: "req-new", Attempt: 0, CreatedAt: recent},
+	}); err != nil {
+		t.Fatalf("RecordRequestProfiles through the wrapper: %v", err)
+	}
+	if got := cached.RequestProfilesSince(time.Time{}); len(got) != 2 {
+		t.Fatalf("RequestProfilesSince(zero) = %d rows, want 2", len(got))
+	}
+	if got := cached.RequestProfilesSinceFiltered(recent.Add(-time.Minute), RequestProfileFilter{}); len(got) != 1 || got[0].RequestID != "req-new" {
+		t.Fatalf("RequestProfilesSinceFiltered(recent) = %+v, want only req-new", got)
+	}
+	if err := cached.RecordFleetSnapshots([]FleetSnapshotRow{
+		{SampledAt: old, ProviderID: "p-old", Model: "m"},
+		{SampledAt: recent, ProviderID: "p-new", Model: "m"},
+	}); err != nil {
+		t.Fatalf("RecordFleetSnapshots through the wrapper: %v", err)
+	}
+	if got := cached.FleetSnapshotsSince(time.Time{}); len(got) != 2 {
+		t.Fatalf("FleetSnapshotsSince(zero) = %d rows, want 2", len(got))
+	}
+	// The rows live in the inner store; the wrapper keeps nothing of its own.
+	if got := inner.RequestProfilesSince(time.Time{}); len(got) != 2 {
+		t.Fatalf("inner RequestProfilesSince = %d rows, want 2", len(got))
+	}
+	if got := inner.FleetSnapshotsSince(time.Time{}); len(got) != 2 {
+		t.Fatalf("inner FleetSnapshotsSince = %d rows, want 2", len(got))
+	}
+
+	cutoff := recent.Add(-time.Hour)
+	deleted, err := cached.PruneTelemetry(context.Background(), cutoff, cutoff, 100)
+	if err != nil || deleted != 2 {
+		t.Fatalf("PruneTelemetry through the wrapper = (%d, %v), want (2, nil)", deleted, err)
+	}
+	if got := cached.RequestProfilesSince(time.Time{}); len(got) != 1 || got[0].RequestID != "req-new" {
+		t.Fatalf("after prune RequestProfilesSince = %+v, want only req-new", got)
+	}
+	if got := cached.FleetSnapshotsSince(time.Time{}); len(got) != 1 || got[0].ProviderID != "p-new" {
+		t.Fatalf("after prune FleetSnapshotsSince = %+v, want only p-new", got)
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -236,6 +236,15 @@ type InferenceRouteOutcome struct {
 	InvalidTTFT bool `json:"-"`
 }
 
+// InferenceRouteOutcomeUpdate is one outcome update addressed to a route row,
+// used by the batched UpdateInferenceRouteOutcomes path. It carries exactly the
+// arguments of UpdateInferenceRouteOutcome; Outcome nil is skipped.
+type InferenceRouteOutcomeUpdate struct {
+	RequestID string
+	Attempt   int
+	Outcome   *InferenceRouteOutcome
+}
+
 // RejectionRecord captures a single rejected inbound inference request (4xx/5xx)
 // at any stage of the pipeline, with the request's parameters and a
 // counterfactual servability snapshot ("could the fleet have served it?"). It

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -177,9 +177,23 @@ type TelemetryStore interface {
 	// request attempt. Best-effort; failures must not block inference.
 	RecordInferenceRoute(record *InferenceRouteRecord) error
 
+	// RecordInferenceRoutes persists a batch of routing decision snapshots with
+	// exactly the per-row semantics of RecordInferenceRoute (upsert on
+	// request_id/attempt, zero CreatedAt/UpdatedAt defaulted to now), issued as
+	// one multi-row statement per chunk instead of one round trip per record.
+	// Records are applied in slice order; a duplicate (request_id, attempt) key
+	// within the slice starts a new statement so the later record refreshes the
+	// earlier one exactly as sequential calls would. Nil records are skipped.
+	RecordInferenceRoutes(records []*InferenceRouteRecord) error
+
 	// UpdateInferenceRouteOutcome updates the attempt with final outcome data
 	// (tokens, timing, error). Best-effort; failures must not block inference.
 	UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error
+
+	// UpdateInferenceRouteOutcomes applies a batch of outcome updates in slice
+	// order with exactly the per-row semantics of UpdateInferenceRouteOutcome,
+	// pipelined as one round trip. Updates with a nil Outcome are skipped.
+	UpdateInferenceRouteOutcomes(updates []InferenceRouteOutcomeUpdate) error
 
 	// InferenceRouteRecordsSince returns routing records created at or after the
 	// given time. Zero since returns all records.

--- a/coordinator/store/ledger_credit_test.go
+++ b/coordinator/store/ledger_credit_test.go
@@ -1,0 +1,359 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ledgerShape is the byte-identical part of a ledger row: what the collapse
+// must preserve exactly (ids and created_at are assigned by the database).
+type ledgerShape struct {
+	Type   LedgerEntryType
+	Amount int64
+	After  int64
+	Ref    string
+}
+
+// ledgerShapes returns an account's ledger rows oldest-first by id.
+func ledgerShapes(s Store, accountID string) []ledgerShape {
+	entries := s.LedgerHistory(accountID)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	out := make([]ledgerShape, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, ledgerShape{Type: e.Type, Amount: e.AmountMicroUSD, After: e.BalanceAfter, Ref: e.Reference})
+	}
+	return out
+}
+
+// legacyCredit replays the pre-collapse sequence verbatim — BEGIN, balance
+// upsert, SELECT balance, ledger INSERT, COMMIT (five round trips) — so the
+// single-statement path can be checked against the exact rows it used to
+// produce. withdrawable selects the CreditWithdrawable variant of the upsert.
+func legacyCredit(t *testing.T, pool *pgxpool.Pool, withdrawable bool, accountID string, amount int64, entryType LedgerEntryType, reference string) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("legacy begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	upsert := `INSERT INTO balances (account_id, balance_micro_usd, updated_at)
+		 VALUES ($1, $2, NOW())
+		 ON CONFLICT (account_id) DO UPDATE SET
+		   balance_micro_usd = balances.balance_micro_usd + $2,
+		   updated_at = NOW()`
+	if withdrawable {
+		upsert = `INSERT INTO balances (account_id, balance_micro_usd, withdrawable_micro_usd, updated_at)
+		 VALUES ($1, $2, $2, NOW())
+		 ON CONFLICT (account_id) DO UPDATE SET
+		   balance_micro_usd = balances.balance_micro_usd + $2,
+		   withdrawable_micro_usd = balances.withdrawable_micro_usd + $2,
+		   updated_at = NOW()`
+	}
+	if _, err := tx.Exec(ctx, upsert, accountID, amount); err != nil {
+		t.Fatalf("legacy upsert: %v", err)
+	}
+	var after int64
+	if err := tx.QueryRow(ctx, `SELECT balance_micro_usd FROM balances WHERE account_id = $1`, accountID).Scan(&after); err != nil {
+		t.Fatalf("legacy read balance: %v", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference, created_at)
+		 VALUES ($1, $2, $3, $4, $5, COALESCE($6, NOW()))`,
+		accountID, string(entryType), amount, after, reference, nullableCreatedAt(time.Time{}),
+	); err != nil {
+		t.Fatalf("legacy ledger insert: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("legacy commit: %v", err)
+	}
+}
+
+// TestPostgresCreditIsOneRoundTripAndByteIdentical is the measured effect and
+// the equivalence proof in one: the legacy sequence costs five statements per
+// credit and the collapsed Credit / CreditWithdrawable cost one, while the
+// balances, withdrawable subsets and every ledger row (type, amount,
+// balance_after, reference) come out identical — including the unknown
+// account (created), the zero amount (recorded) and the negative amount
+// (applied) cases.
+func TestPostgresCreditIsOneRoundTripAndByteIdentical(t *testing.T) {
+	counter := &statementCounter{}
+	s := tracedPostgresStore(t, counter)
+
+	type step struct {
+		amount int64
+		typ    LedgerEntryType
+		ref    string
+	}
+	steps := []step{
+		{100, LedgerRefund, "r1"},     // unknown account: row created
+		{50, LedgerPlatformFee, "r2"}, // existing account
+		{0, LedgerRefund, "r3"},       // zero: still recorded
+		{-30, LedgerRefund, "r4"},     // negative: applied, recorded
+	}
+	wantRows := []ledgerShape{
+		{LedgerRefund, 100, 100, "r1"},
+		{LedgerPlatformFee, 50, 150, "r2"},
+		{LedgerRefund, 0, 150, "r3"},
+		{LedgerRefund, -30, 120, "r4"},
+	}
+
+	for _, withdrawable := range []bool{false, true} {
+		t.Run(fmt.Sprintf("withdrawable=%v", withdrawable), func(t *testing.T) {
+			legacyAcct := uniqueID("legacy")
+			cteAcct := uniqueID("cte")
+
+			counter.reset()
+			for _, st := range steps {
+				legacyCredit(t, s.pool, withdrawable, legacyAcct, st.amount, st.typ, st.ref)
+			}
+			if q, _, _ := counter.snapshot(); q != 5*len(steps) {
+				t.Fatalf("legacy path: %d statements for %d credits, want %d", q, len(steps), 5*len(steps))
+			}
+
+			counter.reset()
+			for _, st := range steps {
+				var err error
+				if withdrawable {
+					err = s.CreditWithdrawable(cteAcct, st.amount, st.typ, st.ref)
+				} else {
+					err = s.Credit(cteAcct, st.amount, st.typ, st.ref)
+				}
+				if err != nil {
+					t.Fatalf("credit %+v: %v", st, err)
+				}
+			}
+			if q, b, _ := counter.snapshot(); q != len(steps) || b != 0 {
+				t.Fatalf("collapsed path: %d statements / %d batches for %d credits, want %d / 0", q, b, len(steps), len(steps))
+			}
+
+			lb, lw := s.GetBalanceWithWithdrawable(legacyAcct)
+			cb, cw := s.GetBalanceWithWithdrawable(cteAcct)
+			if lb != cb || lw != cw {
+				t.Fatalf("balances differ: legacy=(%d,%d) cte=(%d,%d)", lb, lw, cb, cw)
+			}
+			wantW := int64(0)
+			if withdrawable {
+				wantW = 120
+			}
+			if cb != 120 || cw != wantW {
+				t.Fatalf("balance/withdrawable = (%d,%d), want (120,%d)", cb, cw, wantW)
+			}
+			legacyRows, cteRows := ledgerShapes(s, legacyAcct), ledgerShapes(s, cteAcct)
+			if !reflect.DeepEqual(legacyRows, wantRows) {
+				t.Fatalf("legacy rows = %+v, want %+v", legacyRows, wantRows)
+			}
+			if !reflect.DeepEqual(cteRows, wantRows) {
+				t.Fatalf("collapsed rows = %+v, want %+v (legacy produced %+v)", cteRows, wantRows, legacyRows)
+			}
+		})
+	}
+}
+
+// TestPostgresTransactionalCreditCallersUseOneStatement covers the callers
+// that keep their own transaction around the credit: the credit inside it is
+// now one statement, so CreditProviderWallet is BEGIN + credit + payout row +
+// COMMIT and CreditWithdrawableOnce is BEGIN + advisory lock + existence
+// check + credit + COMMIT (the duplicate skips the credit).
+func TestPostgresTransactionalCreditCallersUseOneStatement(t *testing.T) {
+	counter := &statementCounter{}
+	s := tracedPostgresStore(t, counter)
+
+	wallet := uniqueID("wallet")
+	fixedAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	counter.reset()
+	if err := s.CreditProviderWallet(&ProviderPayout{ProviderAddress: wallet, AmountMicroUSD: 700, Model: "m", JobID: uniqueID("job"), Timestamp: fixedAt}); err != nil {
+		t.Fatalf("CreditProviderWallet: %v", err)
+	}
+	if q, _, _ := counter.snapshot(); q != 4 {
+		t.Fatalf("CreditProviderWallet: %d statements, want 4 (BEGIN, credit, payout, COMMIT)", q)
+	}
+	// The caller's timestamp must reach the ledger row ($5 binding), not NOW().
+	if entries := s.LedgerHistory(wallet); len(entries) != 1 || !entries[0].CreatedAt.Equal(fixedAt) {
+		t.Fatalf("wallet ledger created_at = %v, want %v", entries, fixedAt)
+	}
+	if b, w := s.GetBalanceWithWithdrawable(wallet); b != 700 || w != 700 {
+		t.Fatalf("wallet balance/withdrawable = (%d,%d), want (700,700)", b, w)
+	}
+	if rows := ledgerShapes(s, wallet); len(rows) != 1 || rows[0].Type != LedgerPayout || rows[0].Amount != 700 || rows[0].After != 700 {
+		t.Fatalf("wallet ledger = %+v", rows)
+	}
+
+	acct, ref := uniqueID("once"), uniqueID("ref")
+	counter.reset()
+	applied, err := s.CreditWithdrawableOnce(acct, 300, LedgerRefund, ref)
+	if err != nil || !applied {
+		t.Fatalf("CreditWithdrawableOnce first: applied=%v err=%v", applied, err)
+	}
+	if q, _, _ := counter.snapshot(); q != 5 {
+		t.Fatalf("CreditWithdrawableOnce: %d statements, want 5 (BEGIN, lock, exists, credit, COMMIT)", q)
+	}
+	counter.reset()
+	applied, err = s.CreditWithdrawableOnce(acct, 300, LedgerRefund, ref)
+	if err != nil || applied {
+		t.Fatalf("CreditWithdrawableOnce duplicate: applied=%v err=%v", applied, err)
+	}
+	if q, _, _ := counter.snapshot(); q != 4 {
+		t.Fatalf("CreditWithdrawableOnce duplicate: %d statements, want 4 (no credit)", q)
+	}
+	if b, w := s.GetBalanceWithWithdrawable(acct); b != 300 || w != 300 {
+		t.Fatalf("once balance/withdrawable = (%d,%d), want (300,300)", b, w)
+	}
+	if rows := ledgerShapes(s, acct); len(rows) != 1 {
+		t.Fatalf("once ledger = %+v, want exactly one row", rows)
+	}
+}
+
+// TestCreditSemanticsAcrossBackends pins the observable contract on both
+// backends: unknown accounts are created, zero and negative amounts are
+// applied and recorded, Credit leaves the withdrawable subset alone while
+// CreditWithdrawable raises it, and Debit still refuses to overdraw.
+func TestCreditSemanticsAcrossBackends(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			acct := uniqueID("sem")
+			check := func(step string, wantBal, wantW int64, wantRows []ledgerShape) {
+				t.Helper()
+				b, w := s.GetBalanceWithWithdrawable(acct)
+				if b != wantBal || w != wantW {
+					t.Fatalf("%s: balance/withdrawable = (%d,%d), want (%d,%d)", step, b, w, wantBal, wantW)
+				}
+				if got := ledgerShapes(s, acct); !reflect.DeepEqual(got, wantRows) {
+					t.Fatalf("%s: ledger = %+v, want %+v", step, got, wantRows)
+				}
+			}
+
+			if err := s.Credit(acct, 250, LedgerRefund, "a"); err != nil {
+				t.Fatalf("credit unknown account: %v", err)
+			}
+			rows := []ledgerShape{{LedgerRefund, 250, 250, "a"}}
+			check("unknown account", 250, 0, rows)
+
+			if err := s.Credit(acct, 0, LedgerPlatformFee, "z"); err != nil {
+				t.Fatalf("zero credit: %v", err)
+			}
+			rows = append(rows, ledgerShape{LedgerPlatformFee, 0, 250, "z"})
+			check("zero amount", 250, 0, rows)
+
+			if err := s.Credit(acct, -100, LedgerRefund, "n"); err != nil {
+				t.Fatalf("negative credit: %v", err)
+			}
+			rows = append(rows, ledgerShape{LedgerRefund, -100, 150, "n"})
+			check("negative amount", 150, 0, rows)
+
+			if err := s.CreditWithdrawable(acct, 40, LedgerPayout, "w"); err != nil {
+				t.Fatalf("credit withdrawable: %v", err)
+			}
+			rows = append(rows, ledgerShape{LedgerPayout, 40, 190, "w"})
+			check("withdrawable", 190, 40, rows)
+
+			// A plain Credit on an account whose withdrawable balance is NONZERO
+			// must leave it exactly as is (the upsert omits the column).
+			if err := s.Credit(acct, 10, LedgerRefund, "k"); err != nil {
+				t.Fatalf("credit with nonzero withdrawable: %v", err)
+			}
+			rows = append(rows, ledgerShape{LedgerRefund, 10, 200, "k"})
+			check("credit keeps nonzero withdrawable", 200, 40, rows)
+			for _, e := range s.LedgerHistory(acct) {
+				if e.CreatedAt.IsZero() || time.Since(e.CreatedAt) > time.Minute {
+					t.Fatalf("ledger row %q created_at=%v, want a fresh database timestamp", e.Reference, e.CreatedAt)
+				}
+			}
+
+			if err := s.Debit(acct, 1000, LedgerCharge, "d"); !errors.Is(err, ErrInsufficientBalance) {
+				t.Fatalf("overdraw: err=%v, want ErrInsufficientBalance", err)
+			}
+			check("overdraw refused", 200, 40, rows)
+		})
+	}
+}
+
+// TestConcurrentCreditDebitLedgerConsistency runs 32 goroutines mixing Credit
+// and Debit on one account and checks that the final balance equals the seed
+// plus every credit minus every successful debit, that the ledger sums to it,
+// and that each row's balance_after equals the running sum in id order — the
+// chain that a lost update or a mis-read balance_after would break.
+func TestConcurrentCreditDebitLedgerConsistency(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			acct := uniqueID("conc")
+			const seed = int64(1_000_000)
+			if err := s.Credit(acct, seed, LedgerRefund, "seed"); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			const workers, opsPerWorker = 32, 8
+			var wg sync.WaitGroup
+			var credited, debited, credits, debits, failures, insufficient atomic.Int64
+			for w := 0; w < workers; w++ {
+				wg.Add(1)
+				go func(w int) {
+					defer wg.Done()
+					for i := 0; i < opsPerWorker; i++ {
+						n := int64((w*opsPerWorker+i)%7+1) * 100
+						if (w+i)%2 == 0 {
+							if err := s.Credit(acct, n, LedgerRefund, fmt.Sprintf("c-%d-%d", w, i)); err != nil {
+								failures.Add(1)
+								continue
+							}
+							credited.Add(n)
+							credits.Add(1)
+							continue
+						}
+						err := s.Debit(acct, n, LedgerCharge, fmt.Sprintf("d-%d-%d", w, i))
+						switch {
+						case err == nil:
+							debited.Add(n)
+							debits.Add(1)
+						case errors.Is(err, ErrInsufficientBalance):
+							insufficient.Add(1)
+						default:
+							failures.Add(1)
+						}
+					}
+				}(w)
+			}
+			wg.Wait()
+			if failures.Load() != 0 {
+				t.Fatalf("%d credit/debit calls failed", failures.Load())
+			}
+			// The seed exceeds every possible debit (max 700 × 128), so a Debit
+			// that reports insufficient balance is a broken debit, not a
+			// legitimate refusal — the totals below must not be allowed to pass
+			// on credits alone.
+			if insufficient.Load() != 0 || debits.Load() != workers*opsPerWorker/2 {
+				t.Fatalf("debits succeeded=%d insufficient=%d, want %d and 0", debits.Load(), insufficient.Load(), workers*opsPerWorker/2)
+			}
+
+			want := seed + credited.Load() - debited.Load()
+			if got := s.GetBalance(acct); got != want {
+				t.Fatalf("balance = %d, want %d", got, want)
+			}
+			entries := s.LedgerHistory(acct)
+			if int64(len(entries)) != 1+credits.Load()+debits.Load() {
+				t.Fatalf("ledger rows = %d, want %d", len(entries), 1+credits.Load()+debits.Load())
+			}
+			sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+			running := int64(0)
+			for _, e := range entries {
+				running += e.AmountMicroUSD
+				if e.BalanceAfter != running {
+					t.Fatalf("ledger id %d: balance_after=%d, running sum=%d (lost update or stale balance_after)", e.ID, e.BalanceAfter, running)
+				}
+			}
+			if running != want {
+				t.Fatalf("ledger sum = %d, want %d", running, want)
+			}
+		})
+	}
+}

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -923,89 +923,6 @@ func (s *MemoryStore) RecordUsageFullWithPublicModel(providerID, consumerKey, ke
 	}
 }
 
-// RecordInferenceRoute writes the routing decision snapshot for a request
-// attempt. Best-effort; failures are discarded.
-func (s *MemoryStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
-	if record == nil {
-		return nil
-	}
-
-	now := time.Now()
-	rec := *record
-	if rec.CreatedAt.IsZero() {
-		rec.CreatedAt = now
-	}
-	if rec.UpdatedAt.IsZero() {
-		rec.UpdatedAt = now
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	key := record.RequestID + "/" + strconv.Itoa(record.Attempt)
-	if idx, ok := s.inferenceRouteIndex[key]; ok {
-		rec.CreatedAt = s.inferenceRoutes[idx].CreatedAt
-		if rec.UpdatedAt.IsZero() {
-			rec.UpdatedAt = now
-		}
-		s.inferenceRoutes[idx] = rec
-		return nil
-	}
-	s.inferenceRoutes = append(s.inferenceRoutes, rec)
-	s.inferenceRouteIndex[key] = len(s.inferenceRoutes) - 1
-	return nil
-}
-
-// UpdateInferenceRouteOutcome updates the attempt with final outcome data.
-// Best-effort; failures are discarded.
-func (s *MemoryStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
-	if outcome == nil {
-		return nil
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	key := requestID + "/" + strconv.Itoa(attempt)
-	idx, ok := s.inferenceRouteIndex[key]
-	if !ok {
-		return nil
-	}
-
-	merged := s.inferenceRouteOutcomes[key]
-	mergeInferenceRouteOutcome(&merged, outcome)
-	s.inferenceRouteOutcomes[key] = merged
-	s.inferenceRoutes[idx].UpdatedAt = time.Now()
-	return nil
-}
-
-// InferenceRouteRecordsSince returns routing records created at or after the
-// given time. Zero since returns all records.
-func (s *MemoryStore) InferenceRouteRecordsSince(since time.Time) []InferenceRouteRecord {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	out := make([]InferenceRouteRecord, 0, len(s.inferenceRoutes))
-	for i := len(s.inferenceRoutes) - 1; i >= 0; i-- {
-		r := s.inferenceRoutes[i]
-		if !since.IsZero() && r.CreatedAt.Before(since) {
-			continue
-		}
-		key := r.RequestID + "/" + strconv.Itoa(r.Attempt)
-		if outcome, ok := s.inferenceRouteOutcomes[key]; ok {
-			applyInferenceRouteOutcomeToRecord(&r, outcome)
-		}
-		out = append(out, r)
-		if len(out) >= maxTelemetryReadRows {
-			break
-		}
-	}
-	if out == nil {
-		return []InferenceRouteRecord{}
-	}
-	return out
-}
-
 // RecordRejection writes a rejected-request record with its counterfactual
 // servability snapshot. Best-effort; failures are discarded.
 func (s *MemoryStore) RecordRejection(record *RejectionRecord) error {
@@ -1947,7 +1864,7 @@ func (s *MemoryStore) GetModelRegistryRecord(modelID string) (*ModelRegistryReco
 
 	rec := s.modelRegistryRecordLocked(modelID)
 	if rec == nil {
-		return nil, fmt.Errorf("model %q not found", modelID)
+		return nil, fmt.Errorf("model %q %w", modelID, ErrNotFound)
 	}
 	return rec, nil
 }
@@ -2209,7 +2126,7 @@ func (s *MemoryStore) GetUserByPrivyID(privyUserID string) (*User, error) {
 
 	u, ok := s.usersByPrivyID[privyUserID]
 	if !ok {
-		return nil, fmt.Errorf("user with Privy ID %q not found", privyUserID)
+		return nil, fmt.Errorf("user with Privy ID %q %w", privyUserID, ErrNotFound)
 	}
 	copy := *u
 	return &copy, nil
@@ -2222,7 +2139,7 @@ func (s *MemoryStore) GetUserByAccountID(accountID string) (*User, error) {
 
 	u, ok := s.usersByAccountID[accountID]
 	if !ok {
-		return nil, fmt.Errorf("user with account ID %q not found", accountID)
+		return nil, fmt.Errorf("user with account ID %q %w", accountID, ErrNotFound)
 	}
 	copy := *u
 	return &copy, nil

--- a/coordinator/store/memory_route_telemetry.go
+++ b/coordinator/store/memory_route_telemetry.go
@@ -1,0 +1,142 @@
+package store
+
+// Routing-telemetry paths for MemoryStore. The batch methods are the
+// single-row methods applied in order under ONE lock acquisition, so both
+// backends expose identical per-row semantics — including per-record
+// "now" for zero timestamps, exactly as sequential single-row calls would.
+
+import "time"
+
+// RecordInferenceRoute writes or refreshes the routing decision snapshot for a
+// request attempt. A refresh keeps the original CreatedAt and, like the
+// postgres upsert's COALESCE, keeps an existing error_reason when the fresh
+// record carries none.
+func (s *MemoryStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
+	if record == nil {
+		return nil
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.recordInferenceRouteLocked(record, now)
+	return nil
+}
+
+// RecordInferenceRoutes applies records in order under one lock; nil records
+// are skipped. A later duplicate (request_id, attempt) refreshes the earlier
+// one exactly as sequential RecordInferenceRoute calls would.
+func (s *MemoryStore) RecordInferenceRoutes(records []*InferenceRouteRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, record := range records {
+		if record != nil {
+			s.recordInferenceRouteLocked(record, time.Now())
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) recordInferenceRouteLocked(record *InferenceRouteRecord, now time.Time) {
+	rec := *record
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = now
+	}
+	if rec.UpdatedAt.IsZero() {
+		rec.UpdatedAt = now
+	}
+
+	key := inferenceRouteKey(record.RequestID, record.Attempt)
+	if idx, ok := s.inferenceRouteIndex[key]; ok {
+		existing := s.inferenceRoutes[idx]
+		rec.CreatedAt = existing.CreatedAt
+		if rec.ErrorReason == "" {
+			rec.ErrorReason = existing.ErrorReason
+		}
+		s.inferenceRoutes[idx] = rec
+		return
+	}
+	s.inferenceRoutes = append(s.inferenceRoutes, rec)
+	s.inferenceRouteIndex[key] = len(s.inferenceRoutes) - 1
+}
+
+// UpdateInferenceRouteOutcome merges outcome onto the attempt's row (zero
+// fields are "not present"). An update for an unknown row is a silent no-op,
+// matching the postgres UPDATE that affects zero rows.
+func (s *MemoryStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
+	if outcome == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.updateInferenceRouteOutcomeLocked(requestID, attempt, outcome)
+	return nil
+}
+
+// UpdateInferenceRouteOutcomes applies updates in order under one lock;
+// updates with a nil Outcome are skipped.
+func (s *MemoryStore) UpdateInferenceRouteOutcomes(updates []InferenceRouteOutcomeUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range updates {
+		u := &updates[i]
+		if u.Outcome != nil {
+			s.updateInferenceRouteOutcomeLocked(u.RequestID, u.Attempt, u.Outcome)
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) updateInferenceRouteOutcomeLocked(requestID string, attempt int, outcome *InferenceRouteOutcome) {
+	key := inferenceRouteKey(requestID, attempt)
+	idx, ok := s.inferenceRouteIndex[key]
+	if !ok {
+		return
+	}
+
+	merged := s.inferenceRouteOutcomes[key]
+	mergeInferenceRouteOutcome(&merged, outcome)
+	s.inferenceRouteOutcomes[key] = merged
+	s.inferenceRoutes[idx].UpdatedAt = time.Now()
+}
+
+// InferenceRouteRecordsSince returns route rows created at or after since
+// (zero = all), newest first, capped at maxTelemetryReadRows, with each row's
+// merged outcome applied.
+func (s *MemoryStore) InferenceRouteRecordsSince(since time.Time) []InferenceRouteRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]InferenceRouteRecord, 0, len(s.inferenceRoutes))
+	for i := len(s.inferenceRoutes) - 1; i >= 0; i-- {
+		r := s.inferenceRoutes[i]
+		if !since.IsZero() && r.CreatedAt.Before(since) {
+			continue
+		}
+		key := inferenceRouteKey(r.RequestID, r.Attempt)
+		if outcome, ok := s.inferenceRouteOutcomes[key]; ok {
+			applyInferenceRouteOutcomeToRecord(&r, outcome)
+		}
+		out = append(out, r)
+		if len(out) >= maxTelemetryReadRows {
+			break
+		}
+	}
+	if out == nil {
+		return []InferenceRouteRecord{}
+	}
+	return out
+}

--- a/coordinator/store/not_found_sentinel_test.go
+++ b/coordinator/store/not_found_sentinel_test.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// The user and model-registry getters must tag a true miss with ErrNotFound
+// (so errors.Is works for the read-through cache and any other caller that
+// distinguishes a miss from a transient failure) WITHOUT changing the rendered
+// message: api.isModelRegistryNotFound and friends still string-match on
+// "not found". The expected strings are the exact pre-sentinel messages of
+// each backend. Runs against the memory store always and Postgres when
+// DATABASE_URL is set.
+func TestNotFoundGettersWrapSentinelAndKeepMessage(t *testing.T) {
+	const (
+		missingAccount = "acct-does-not-exist"
+		missingPrivy   = "did:privy:does-not-exist"
+		missingModel   = "mlx-community/does-not-exist"
+	)
+	exact := map[string]map[string]string{
+		"memory": {
+			"GetUserByAccountID":     `user with account ID "` + missingAccount + `" not found`,
+			"GetUserByPrivyID":       `user with Privy ID "` + missingPrivy + `" not found`,
+			"GetModelRegistryRecord": `model "` + missingModel + `" not found`,
+			"GetModelManifest":       `model "` + missingModel + `" not found`,
+		},
+		"postgres": {
+			"GetUserByAccountID":     "store: user not found: no rows in result set",
+			"GetUserByPrivyID":       "store: user not found: no rows in result set",
+			"GetModelRegistryRecord": `model "` + missingModel + `" not found`,
+			"GetModelManifest":       `model "` + missingModel + `" not found`,
+		},
+	}
+	for name, st := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			calls := map[string]func() error{
+				"GetUserByAccountID": func() error {
+					_, err := st.GetUserByAccountID(missingAccount)
+					return err
+				},
+				"GetUserByPrivyID": func() error {
+					_, err := st.GetUserByPrivyID(missingPrivy)
+					return err
+				},
+				"GetModelRegistryRecord": func() error {
+					_, err := st.GetModelRegistryRecord(missingModel)
+					return err
+				},
+				"GetModelManifest": func() error {
+					_, err := st.GetModelManifest(missingModel)
+					return err
+				},
+			}
+			for method, call := range calls {
+				want, known := exact[name][method]
+				if !known {
+					t.Fatalf("no exact message recorded for %s/%s", name, method)
+				}
+				err := call()
+				if err == nil {
+					t.Fatalf("%s: expected an error for a missing row", method)
+				}
+				if !errors.Is(err, ErrNotFound) {
+					t.Errorf("%s: errors.Is(err, ErrNotFound) = false; err = %v", method, err)
+				}
+				if got := err.Error(); got != want {
+					t.Errorf("%s: message changed:\n got %q\nwant %q", method, got, want)
+				}
+			}
+		})
+	}
+}
+
+// The Postgres user getters must NOT tag transient scan failures (anything
+// other than pgx.ErrNoRows) with ErrNotFound -- a negative cache keyed on the
+// sentinel would otherwise pin a DB blip as "no such user".
+func TestWrapUserScanErrorOnlyTagsTrueMiss(t *testing.T) {
+	transient := errors.New("connection reset")
+	err := wrapUserScanError(transient)
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("transient error must not carry ErrNotFound: %v", err)
+	}
+	if !errors.Is(err, transient) {
+		t.Fatalf("transient error must still be wrapped: %v", err)
+	}
+	if got, want := err.Error(), "store: user not found: connection reset"; got != want {
+		t.Fatalf("transient message changed: got %q want %q", got, want)
+	}
+
+	miss := wrapUserScanError(pgx.ErrNoRows)
+	if !errors.Is(miss, ErrNotFound) || !errors.Is(miss, pgx.ErrNoRows) {
+		t.Fatalf("true miss must carry both sentinels: %v", miss)
+	}
+	if got, want := miss.Error(), "store: user not found: no rows in result set"; got != want {
+		t.Fatalf("miss message changed: got %q want %q", got, want)
+	}
+}

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -1791,8 +1791,6 @@ func (s *PostgresStore) RecordUsageFullWithPublicModel(providerID, consumerKey, 
 	)
 }
 
-const inferenceRouteErrorReasonUpsertAssignment = "error_reason = COALESCE(NULLIF(EXCLUDED.error_reason, ''), inference_routes.error_reason)"
-
 const inferenceRouteSelectColumns = `
 			id,
 			request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
@@ -1812,184 +1810,6 @@ const inferenceRouteSelectColumns = `
 			provider_region, consumer_region,
 			parse_ms, reserve_ms, route_ms, encrypt_ms, queue_wait_ms, dispatch_ms, actual_decode_tps,
 			admitted_but_failed, used_backup, backup_won, error_reason`
-
-// RecordInferenceRoute writes the routing decision snapshot for a request
-// attempt. Callers keep this best-effort by logging returned errors off the
-// request path rather than blocking inference.
-func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
-	if record == nil {
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	now := time.Now().UTC()
-	createdAt := record.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = now
-	}
-	updatedAt := record.UpdatedAt
-	if updatedAt.IsZero() {
-		updatedAt = now
-	}
-
-	_, err := s.pool.Exec(ctx,
-		`INSERT INTO inference_routes (
-			request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
-			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms, ttft_ms, best_ttft_ms,
-			effective_queue, candidate_count, capacity_rejections, model_too_large_rejections, vision_rejections, ttft_rejections,
-			effective_tps, static_tps, provider_status, provider_trust_level, provider_version,
-			hardware_chip, hardware_chip_family, hardware_tier, memory_gb, gpu_cores, cpu_cores,
-			system_memory_pressure, system_cpu_usage, system_thermal_state,
-			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
-			slot_state, backend_running, backend_waiting,
-			active_token_budget_used, active_token_budget_max, queued_token_budget,
-			estimated_prompt_tokens, requested_max_tokens,
-			requires_vision, has_tools, self_route_only, prefer_owner,
-			created_at, updated_at,
-			provider_region, consumer_region, error_reason
-		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8,
-			$9, $10, $11, $12, $13, $14, $15, $16, $17,
-			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28,
-			$29, $30, $31, $32, $33, $34,
-			$35, $36, $37,
-			$38, $39, $40,
-			$41, $42, $43,
-			$44, $45, $46,
-			$47, $48,
-			$49, $50, $51, $52,
-			$53, $54,
-			$55, $56, $57
-		) ON CONFLICT (request_id, attempt) DO UPDATE SET
-			provider_id = EXCLUDED.provider_id,
-			model = EXCLUDED.model,
-			public_model = EXCLUDED.public_model,
-			consumer_key_hash = EXCLUDED.consumer_key_hash,
-			key_id = EXCLUDED.key_id,
-			outcome = EXCLUDED.outcome,
-			cost_ms = EXCLUDED.cost_ms,
-			state_ms = EXCLUDED.state_ms,
-			queue_ms = EXCLUDED.queue_ms,
-			pending_ms = EXCLUDED.pending_ms,
-			backlog_ms = EXCLUDED.backlog_ms,
-			this_req_ms = EXCLUDED.this_req_ms,
-			health_ms = EXCLUDED.health_ms,
-			ttft_ms = EXCLUDED.ttft_ms,
-			best_ttft_ms = EXCLUDED.best_ttft_ms,
-			effective_queue = EXCLUDED.effective_queue,
-			candidate_count = EXCLUDED.candidate_count,
-			capacity_rejections = EXCLUDED.capacity_rejections,
-			model_too_large_rejections = EXCLUDED.model_too_large_rejections,
-			vision_rejections = EXCLUDED.vision_rejections,
-			ttft_rejections = EXCLUDED.ttft_rejections,
-			effective_tps = EXCLUDED.effective_tps,
-			static_tps = EXCLUDED.static_tps,
-			provider_status = EXCLUDED.provider_status,
-			provider_trust_level = EXCLUDED.provider_trust_level,
-			provider_version = EXCLUDED.provider_version,
-			hardware_chip = EXCLUDED.hardware_chip,
-			hardware_chip_family = EXCLUDED.hardware_chip_family,
-			hardware_tier = EXCLUDED.hardware_tier,
-			memory_gb = EXCLUDED.memory_gb,
-			gpu_cores = EXCLUDED.gpu_cores,
-			cpu_cores = EXCLUDED.cpu_cores,
-			system_memory_pressure = EXCLUDED.system_memory_pressure,
-			system_cpu_usage = EXCLUDED.system_cpu_usage,
-			system_thermal_state = EXCLUDED.system_thermal_state,
-			gpu_memory_active_gb = EXCLUDED.gpu_memory_active_gb,
-			gpu_memory_peak_gb = EXCLUDED.gpu_memory_peak_gb,
-			gpu_memory_cache_gb = EXCLUDED.gpu_memory_cache_gb,
-			slot_state = EXCLUDED.slot_state,
-			backend_running = EXCLUDED.backend_running,
-			backend_waiting = EXCLUDED.backend_waiting,
-			active_token_budget_used = EXCLUDED.active_token_budget_used,
-			active_token_budget_max = EXCLUDED.active_token_budget_max,
-			queued_token_budget = EXCLUDED.queued_token_budget,
-			estimated_prompt_tokens = EXCLUDED.estimated_prompt_tokens,
-			requested_max_tokens = EXCLUDED.requested_max_tokens,
-			requires_vision = EXCLUDED.requires_vision,
-			has_tools = EXCLUDED.has_tools,
-			self_route_only = EXCLUDED.self_route_only,
-			prefer_owner = EXCLUDED.prefer_owner,
-			provider_region = EXCLUDED.provider_region,
-			consumer_region = EXCLUDED.consumer_region,
-			`+inferenceRouteErrorReasonUpsertAssignment+`,
-			updated_at = EXCLUDED.updated_at`,
-		record.RequestID, record.Attempt, record.ProviderID, record.Model, record.PublicModel, record.ConsumerKeyHash, record.KeyID, record.Outcome,
-		record.CostMs, record.StateMs, record.QueueMs, record.PendingMs, record.BacklogMs, record.ThisReqMs, record.HealthMs, record.TTFTMs, record.BestTTFTMs,
-		record.EffectiveQueue, record.CandidateCount, record.CapacityRejections, record.ModelTooLargeRejections, record.VisionRejections, record.TTFTRejections,
-		record.EffectiveTPS, record.StaticTPS, record.ProviderStatus, record.ProviderTrustLevel, record.ProviderVersion,
-		record.HardwareChip, record.HardwareChipFamily, record.HardwareTier, record.MemoryGB, record.GPUCores, record.CPUCores,
-		record.SystemMemoryPressure, record.SystemCPUUsage, record.SystemThermalState,
-		record.GPUMemoryActiveGB, record.GPUMemoryPeakGB, record.GPUMemoryCacheGB,
-		record.SlotState, record.BackendRunning, record.BackendWaiting,
-		record.ActiveTokenBudgetUsed, record.ActiveTokenBudgetMax, record.QueuedTokenBudget,
-		record.EstimatedPromptTokens, record.RequestedMaxTokens,
-		record.RequiresVision, record.HasTools, record.SelfRouteOnly, record.PreferOwner,
-		createdAt, updatedAt,
-		record.ProviderRegion, record.ConsumerRegion, record.ErrorReason,
-	)
-	if err != nil {
-		return fmt.Errorf("store: record inference route: %w", err)
-	}
-	return nil
-}
-
-// UpdateInferenceRouteOutcome updates the attempt with final outcome data
-// (tokens, timing, error). Callers keep this best-effort by logging returned
-// errors off the request path rather than blocking inference.
-func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
-	if outcome == nil {
-		return nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	_, err := s.pool.Exec(ctx,
-		`UPDATE inference_routes SET
-			final_status = COALESCE(NULLIF($3, ''), final_status),
-			error_code = CASE WHEN $4 <> 0 THEN $4 ELSE error_code END,
-			error_class = COALESCE(NULLIF($5, ''), error_class),
-			error_reason = COALESCE(NULLIF($6, ''), error_reason),
-			prompt_tokens = CASE WHEN $7 <> 0 THEN $7 ELSE prompt_tokens END,
-			-- $24 (CompletionTokensSet) force-writes the count even when 0 so a
-			-- terminal cancel/error/timeout row persists 0 instead of NULL; the
-			-- OR $8 <> 0 keeps the legacy non-zero write path (mirrors the memory
-			-- store's mergeInferenceRouteOutcome exactly).
-			completion_tokens = CASE WHEN $24 OR $8 <> 0 THEN $8 ELSE completion_tokens END,
-			reasoning_tokens = CASE WHEN $9 <> 0 THEN $9 ELSE reasoning_tokens END,
-			cost_micro_usd = CASE WHEN $10 <> 0 THEN $10 ELSE cost_micro_usd END,
-			actual_ttft_ms = CASE WHEN $11 <> 0 THEN $11 ELSE actual_ttft_ms END,
-			dispatch_to_first_chunk_ms = CASE WHEN $12 <> 0 THEN $12 ELSE dispatch_to_first_chunk_ms END,
-			total_duration_ms = CASE WHEN $13 <> 0 THEN $13 ELSE total_duration_ms END,
-			parse_ms = CASE WHEN $14 <> 0 THEN $14 ELSE parse_ms END,
-			reserve_ms = CASE WHEN $15 <> 0 THEN $15 ELSE reserve_ms END,
-			route_ms = CASE WHEN $16 <> 0 THEN $16 ELSE route_ms END,
-			encrypt_ms = CASE WHEN $17 <> 0 THEN $17 ELSE encrypt_ms END,
-			queue_wait_ms = CASE WHEN $18 <> 0 THEN $18 ELSE queue_wait_ms END,
-			dispatch_ms = CASE WHEN $19 <> 0 THEN $19 ELSE dispatch_ms END,
-			actual_decode_tps = CASE WHEN $20 <> 0 THEN $20 ELSE actual_decode_tps END,
-			admitted_but_failed = COALESCE(admitted_but_failed, FALSE) OR $21,
-			used_backup = COALESCE(used_backup, FALSE) OR $22,
-			backup_won = COALESCE(backup_won, FALSE) OR $23,
-			updated_at = NOW()
-		 WHERE request_id = $1 AND attempt = $2`,
-		requestID, attempt,
-		outcome.FinalStatus, outcome.ErrorCode, outcome.ErrorClass, outcome.ErrorReason, outcome.PromptTokens, outcome.CompletionTokens, outcome.ReasoningTokens,
-		outcome.CostMicroUSD, outcome.ActualTTFTMs, outcome.DispatchToFirstChunkMs, outcome.TotalDurationMs,
-		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
-		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
-		outcome.CompletionTokensSet,
-	)
-	if err != nil {
-		return fmt.Errorf("store: update inference route outcome: %w", err)
-	}
-	return nil
-}
 
 // InferenceRouteRecordsSince returns routing records created at or after the
 // given time. Zero since returns all records.
@@ -2565,70 +2385,74 @@ func nullableCreatedAt(ts time.Time) any {
 	return ts
 }
 
-func creditTx(ctx context.Context, tx pgx.Tx, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string, createdAt time.Time) error {
-	_, err := tx.Exec(ctx,
-		`INSERT INTO balances (account_id, balance_micro_usd, updated_at)
-		 VALUES ($1, $2, NOW())
-		 ON CONFLICT (account_id) DO UPDATE SET
-		   balance_micro_usd = balances.balance_micro_usd + $2,
-		   updated_at = NOW()`,
-		accountID, amountMicroUSD,
-	)
-	if err != nil {
+// pgQuerier is the subset of *pgxpool.Pool and pgx.Tx the single-statement
+// ledger helpers need, so one helper serves both a standalone call (pool: one
+// round trip in an implicit transaction) and a caller's open transaction.
+type pgQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// creditBalanceSQL credits an account and records its ledger row in ONE
+// data-modifying CTE — one round trip instead of BEGIN + upsert + SELECT +
+// INSERT + COMMIT. The upsert's RETURNING is the post-credit balance, so
+// balance_after is exactly the value the old in-transaction SELECT read; the
+// ledger INSERT runs exactly once, to completion, under the row lock the
+// upsert took, so concurrent credits/debits on the account still serialize
+// on that one lock and no update is lost. Unknown accounts are created and
+// zero or negative amounts are applied and recorded, exactly as before.
+const creditBalanceSQL = `
+		WITH credit AS (
+			INSERT INTO balances (account_id, balance_micro_usd, updated_at)
+			VALUES ($1, $2, NOW())
+			ON CONFLICT (account_id) DO UPDATE SET
+			  balance_micro_usd = balances.balance_micro_usd + $2,
+			  updated_at = NOW()
+			RETURNING balance_micro_usd
+		), ledger AS (
+			INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference, created_at)
+			SELECT $1, $3, $2, balance_micro_usd, $4, COALESCE($5::timestamptz, NOW())
+			FROM credit
+		)
+		SELECT balance_micro_usd FROM credit`
+
+// creditWithdrawableBalanceSQL is creditBalanceSQL that also raises the
+// withdrawable subset by the same amount.
+const creditWithdrawableBalanceSQL = `
+		WITH credit AS (
+			INSERT INTO balances (account_id, balance_micro_usd, withdrawable_micro_usd, updated_at)
+			VALUES ($1, $2, $2, NOW())
+			ON CONFLICT (account_id) DO UPDATE SET
+			  balance_micro_usd = balances.balance_micro_usd + $2,
+			  withdrawable_micro_usd = balances.withdrawable_micro_usd + $2,
+			  updated_at = NOW()
+			RETURNING balance_micro_usd
+		), ledger AS (
+			INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference, created_at)
+			SELECT $1, $3, $2, balance_micro_usd, $4, COALESCE($5::timestamptz, NOW())
+			FROM credit
+		)
+		SELECT balance_micro_usd FROM credit`
+
+// creditBalance applies creditBalanceSQL through q (the pool for a standalone
+// credit, or the caller's transaction). A zero createdAt records NOW().
+func creditBalance(ctx context.Context, q pgQuerier, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string, createdAt time.Time) error {
+	var balanceAfter int64
+	if err := q.QueryRow(ctx, creditBalanceSQL,
+		accountID, amountMicroUSD, string(entryType), reference, nullableCreatedAt(createdAt),
+	).Scan(&balanceAfter); err != nil {
 		return fmt.Errorf("store: credit balance: %w", err)
 	}
-
-	var balanceAfter int64
-	err = tx.QueryRow(ctx,
-		`SELECT balance_micro_usd FROM balances WHERE account_id = $1`, accountID,
-	).Scan(&balanceAfter)
-	if err != nil {
-		return fmt.Errorf("store: read balance: %w", err)
-	}
-
-	_, err = tx.Exec(ctx,
-		`INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference, created_at)
-		 VALUES ($1, $2, $3, $4, $5, COALESCE($6, NOW()))`,
-		accountID, string(entryType), amountMicroUSD, balanceAfter, reference, nullableCreatedAt(createdAt),
-	)
-	if err != nil {
-		return fmt.Errorf("store: insert ledger entry: %w", err)
-	}
-
 	return nil
 }
 
-func creditWithdrawableTx(ctx context.Context, tx pgx.Tx, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string, createdAt time.Time) error {
-	_, err := tx.Exec(ctx,
-		`INSERT INTO balances (account_id, balance_micro_usd, withdrawable_micro_usd, updated_at)
-		 VALUES ($1, $2, $2, NOW())
-		 ON CONFLICT (account_id) DO UPDATE SET
-		   balance_micro_usd = balances.balance_micro_usd + $2,
-		   withdrawable_micro_usd = balances.withdrawable_micro_usd + $2,
-		   updated_at = NOW()`,
-		accountID, amountMicroUSD,
-	)
-	if err != nil {
+// creditWithdrawableBalance applies creditWithdrawableBalanceSQL through q.
+func creditWithdrawableBalance(ctx context.Context, q pgQuerier, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string, createdAt time.Time) error {
+	var balanceAfter int64
+	if err := q.QueryRow(ctx, creditWithdrawableBalanceSQL,
+		accountID, amountMicroUSD, string(entryType), reference, nullableCreatedAt(createdAt),
+	).Scan(&balanceAfter); err != nil {
 		return fmt.Errorf("store: credit withdrawable balance: %w", err)
 	}
-
-	var balanceAfter int64
-	err = tx.QueryRow(ctx,
-		`SELECT balance_micro_usd FROM balances WHERE account_id = $1`, accountID,
-	).Scan(&balanceAfter)
-	if err != nil {
-		return fmt.Errorf("store: read balance: %w", err)
-	}
-
-	_, err = tx.Exec(ctx,
-		`INSERT INTO ledger_entries (account_id, entry_type, amount_micro_usd, balance_after, reference, created_at)
-		 VALUES ($1, $2, $3, $4, $5, COALESCE($6, NOW()))`,
-		accountID, string(entryType), amountMicroUSD, balanceAfter, reference, nullableCreatedAt(createdAt),
-	)
-	if err != nil {
-		return fmt.Errorf("store: insert ledger entry: %w", err)
-	}
-
 	return nil
 }
 
@@ -2637,17 +2461,9 @@ func (s *PostgresStore) Credit(accountID string, amountMicroUSD int64, entryType
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("store: begin tx: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
-	if err := creditTx(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
-		return err
-	}
-
-	return tx.Commit(ctx)
+	// One statement, one round trip: the balance upsert and its ledger row
+	// still commit together or not at all (creditBalanceSQL).
+	return creditBalance(ctx, s.pool, accountID, amountMicroUSD, entryType, reference, time.Time{})
 }
 
 // GetWithdrawableBalance returns the withdrawable balance in micro-USD.
@@ -2686,17 +2502,8 @@ func (s *PostgresStore) CreditWithdrawable(accountID string, amountMicroUSD int6
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("store: begin tx: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
-	if err := creditWithdrawableTx(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
-		return err
-	}
-
-	return tx.Commit(ctx)
+	// One statement, one round trip (creditWithdrawableBalanceSQL).
+	return creditWithdrawableBalance(ctx, s.pool, accountID, amountMicroUSD, entryType, reference, time.Time{})
 }
 
 // CreditWithdrawableOnce credits only if no ledger entry with the same
@@ -2730,7 +2537,7 @@ func (s *PostgresStore) CreditWithdrawableOnce(accountID string, amountMicroUSD 
 	if exists {
 		return false, tx.Commit(ctx)
 	}
-	if err := creditWithdrawableTx(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
+	if err := creditWithdrawableBalance(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
 		return false, err
 	}
 	return true, tx.Commit(ctx)
@@ -3246,6 +3053,19 @@ func scanUser(row interface {
 	return &u, nil
 }
 
+// wrapUserScanError preserves the historical "store: user not found: ..."
+// message for every scan failure, and additionally tags a true miss
+// (pgx.ErrNoRows) with ErrNotFound so callers -- including the read-through
+// cache -- can distinguish "no such user" from a transient DB error with
+// errors.Is. ErrNotFound.Error() is exactly "not found", so the rendered
+// string is byte-for-byte unchanged.
+func wrapUserScanError(err error) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("store: user %w: %w", ErrNotFound, err)
+	}
+	return fmt.Errorf("store: user not found: %w", err)
+}
+
 // GetUserByPrivyID returns the user for a Privy DID.
 func (s *PostgresStore) GetUserByPrivyID(privyUserID string) (*User, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -3256,7 +3076,7 @@ func (s *PostgresStore) GetUserByPrivyID(privyUserID string) (*User, error) {
 	)
 	u, err := scanUser(row)
 	if err != nil {
-		return nil, fmt.Errorf("store: user not found: %w", err)
+		return nil, wrapUserScanError(err)
 	}
 	return u, nil
 }
@@ -3271,7 +3091,7 @@ func (s *PostgresStore) GetUserByAccountID(accountID string) (*User, error) {
 	)
 	u, err := scanUser(row)
 	if err != nil {
-		return nil, fmt.Errorf("store: user not found: %w", err)
+		return nil, wrapUserScanError(err)
 	}
 	return u, nil
 }
@@ -4410,7 +4230,7 @@ func (s *PostgresStore) CreditProviderWallet(payout *ProviderPayout) error {
 	}
 	defer tx.Rollback(ctx)
 
-	if err := creditWithdrawableTx(ctx, tx, payout.ProviderAddress, payout.AmountMicroUSD, LedgerPayout, payout.JobID, payout.Timestamp); err != nil {
+	if err := creditWithdrawableBalance(ctx, tx, payout.ProviderAddress, payout.AmountMicroUSD, LedgerPayout, payout.JobID, payout.Timestamp); err != nil {
 		return err
 	}
 

--- a/coordinator/store/postgres_model_registry.go
+++ b/coordinator/store/postgres_model_registry.go
@@ -213,7 +213,9 @@ func (s *PostgresStore) GetModelRegistryRecord(modelID string) (*ModelRegistryRe
 	rec, err := scanModelRegistryRecord(s.pool.QueryRow(ctx, activeModelRegistryQuery+` AND mr.id = $1`, modelID))
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return nil, fmt.Errorf("model %q not found", modelID)
+			// ErrNotFound renders as "not found", so the message is unchanged;
+			// the sentinel lets errors.Is callers recognize a true miss.
+			return nil, fmt.Errorf("model %q %w", modelID, ErrNotFound)
 		}
 		return nil, fmt.Errorf("store: get model registry record: %w", err)
 	}

--- a/coordinator/store/postgres_route_telemetry.go
+++ b/coordinator/store/postgres_route_telemetry.go
@@ -1,0 +1,318 @@
+package store
+
+// Routing-telemetry WRITE paths for PostgresStore: the per-attempt
+// inference_routes snapshot upsert (single row and multi-row) and the outcome
+// update (single statement and pipelined batch).
+//
+// The single-row methods are the n=1 case of the batch methods, so the column
+// list, the ON CONFLICT assignment block, and the bind-argument order live in
+// exactly one place and cannot drift between the two paths. The reader
+// (InferenceRouteRecordsSince) stays in postgres.go.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const inferenceRouteErrorReasonUpsertAssignment = "error_reason = COALESCE(NULLIF(EXCLUDED.error_reason, ''), inference_routes.error_reason)"
+
+// inferenceRouteInsertColumns is the ordered insert column list.
+// inferenceRouteInsertArgs MUST append values in exactly this order.
+const inferenceRouteInsertColumns = `request_id, attempt, provider_id, model, public_model, consumer_key_hash, key_id, outcome,
+			cost_ms, state_ms, queue_ms, pending_ms, backlog_ms, this_req_ms, health_ms, ttft_ms, best_ttft_ms,
+			effective_queue, candidate_count, capacity_rejections, model_too_large_rejections, vision_rejections, ttft_rejections,
+			effective_tps, static_tps, provider_status, provider_trust_level, provider_version,
+			hardware_chip, hardware_chip_family, hardware_tier, memory_gb, gpu_cores, cpu_cores,
+			system_memory_pressure, system_cpu_usage, system_thermal_state,
+			gpu_memory_active_gb, gpu_memory_peak_gb, gpu_memory_cache_gb,
+			slot_state, backend_running, backend_waiting,
+			active_token_budget_used, active_token_budget_max, queued_token_budget,
+			estimated_prompt_tokens, requested_max_tokens,
+			requires_vision, has_tools, self_route_only, prefer_owner,
+			created_at, updated_at,
+			provider_region, consumer_region, error_reason`
+
+// inferenceRouteInsertParamCount is the number of bind parameters per row —
+// the length of inferenceRouteInsertColumns.
+const inferenceRouteInsertParamCount = 57
+
+// maxInferenceRouteInsertRows caps the rows in one multi-row INSERT so the
+// statement stays far below PostgreSQL's 65535 bind-parameter ceiling
+// (57 x 512 = 29184). Larger batches are written as several statements.
+const maxInferenceRouteInsertRows = 512
+
+// inferenceRouteUpsertAssignments is the ON CONFLICT (request_id, attempt) DO
+// UPDATE block. It refreshes the routing snapshot columns only: the outcome
+// columns written by UpdateInferenceRouteOutcome are deliberately untouched
+// (error_reason keeps the existing value unless the record carries one), and
+// created_at keeps the first insert's timestamp.
+const inferenceRouteUpsertAssignments = `provider_id = EXCLUDED.provider_id,
+			model = EXCLUDED.model,
+			public_model = EXCLUDED.public_model,
+			consumer_key_hash = EXCLUDED.consumer_key_hash,
+			key_id = EXCLUDED.key_id,
+			outcome = EXCLUDED.outcome,
+			cost_ms = EXCLUDED.cost_ms,
+			state_ms = EXCLUDED.state_ms,
+			queue_ms = EXCLUDED.queue_ms,
+			pending_ms = EXCLUDED.pending_ms,
+			backlog_ms = EXCLUDED.backlog_ms,
+			this_req_ms = EXCLUDED.this_req_ms,
+			health_ms = EXCLUDED.health_ms,
+			ttft_ms = EXCLUDED.ttft_ms,
+			best_ttft_ms = EXCLUDED.best_ttft_ms,
+			effective_queue = EXCLUDED.effective_queue,
+			candidate_count = EXCLUDED.candidate_count,
+			capacity_rejections = EXCLUDED.capacity_rejections,
+			model_too_large_rejections = EXCLUDED.model_too_large_rejections,
+			vision_rejections = EXCLUDED.vision_rejections,
+			ttft_rejections = EXCLUDED.ttft_rejections,
+			effective_tps = EXCLUDED.effective_tps,
+			static_tps = EXCLUDED.static_tps,
+			provider_status = EXCLUDED.provider_status,
+			provider_trust_level = EXCLUDED.provider_trust_level,
+			provider_version = EXCLUDED.provider_version,
+			hardware_chip = EXCLUDED.hardware_chip,
+			hardware_chip_family = EXCLUDED.hardware_chip_family,
+			hardware_tier = EXCLUDED.hardware_tier,
+			memory_gb = EXCLUDED.memory_gb,
+			gpu_cores = EXCLUDED.gpu_cores,
+			cpu_cores = EXCLUDED.cpu_cores,
+			system_memory_pressure = EXCLUDED.system_memory_pressure,
+			system_cpu_usage = EXCLUDED.system_cpu_usage,
+			system_thermal_state = EXCLUDED.system_thermal_state,
+			gpu_memory_active_gb = EXCLUDED.gpu_memory_active_gb,
+			gpu_memory_peak_gb = EXCLUDED.gpu_memory_peak_gb,
+			gpu_memory_cache_gb = EXCLUDED.gpu_memory_cache_gb,
+			slot_state = EXCLUDED.slot_state,
+			backend_running = EXCLUDED.backend_running,
+			backend_waiting = EXCLUDED.backend_waiting,
+			active_token_budget_used = EXCLUDED.active_token_budget_used,
+			active_token_budget_max = EXCLUDED.active_token_budget_max,
+			queued_token_budget = EXCLUDED.queued_token_budget,
+			estimated_prompt_tokens = EXCLUDED.estimated_prompt_tokens,
+			requested_max_tokens = EXCLUDED.requested_max_tokens,
+			requires_vision = EXCLUDED.requires_vision,
+			has_tools = EXCLUDED.has_tools,
+			self_route_only = EXCLUDED.self_route_only,
+			prefer_owner = EXCLUDED.prefer_owner,
+			provider_region = EXCLUDED.provider_region,
+			consumer_region = EXCLUDED.consumer_region,
+			` + inferenceRouteErrorReasonUpsertAssignment + `,
+			updated_at = EXCLUDED.updated_at`
+
+// inferenceRouteOutcomeUpdateSQL merges one outcome onto its route row with
+// "zero means not present" semantics (mirrors mergeInferenceRouteOutcome).
+// $24 (CompletionTokensSet) force-writes completion_tokens even when 0 so a
+// terminal cancel/error/timeout row persists 0 instead of NULL.
+const inferenceRouteOutcomeUpdateSQL = `UPDATE inference_routes SET
+			final_status = COALESCE(NULLIF($3, ''), final_status),
+			error_code = CASE WHEN $4 <> 0 THEN $4 ELSE error_code END,
+			error_class = COALESCE(NULLIF($5, ''), error_class),
+			error_reason = COALESCE(NULLIF($6, ''), error_reason),
+			prompt_tokens = CASE WHEN $7 <> 0 THEN $7 ELSE prompt_tokens END,
+			completion_tokens = CASE WHEN $24 OR $8 <> 0 THEN $8 ELSE completion_tokens END,
+			reasoning_tokens = CASE WHEN $9 <> 0 THEN $9 ELSE reasoning_tokens END,
+			cost_micro_usd = CASE WHEN $10 <> 0 THEN $10 ELSE cost_micro_usd END,
+			actual_ttft_ms = CASE WHEN $11 <> 0 THEN $11 ELSE actual_ttft_ms END,
+			dispatch_to_first_chunk_ms = CASE WHEN $12 <> 0 THEN $12 ELSE dispatch_to_first_chunk_ms END,
+			total_duration_ms = CASE WHEN $13 <> 0 THEN $13 ELSE total_duration_ms END,
+			parse_ms = CASE WHEN $14 <> 0 THEN $14 ELSE parse_ms END,
+			reserve_ms = CASE WHEN $15 <> 0 THEN $15 ELSE reserve_ms END,
+			route_ms = CASE WHEN $16 <> 0 THEN $16 ELSE route_ms END,
+			encrypt_ms = CASE WHEN $17 <> 0 THEN $17 ELSE encrypt_ms END,
+			queue_wait_ms = CASE WHEN $18 <> 0 THEN $18 ELSE queue_wait_ms END,
+			dispatch_ms = CASE WHEN $19 <> 0 THEN $19 ELSE dispatch_ms END,
+			actual_decode_tps = CASE WHEN $20 <> 0 THEN $20 ELSE actual_decode_tps END,
+			admitted_but_failed = COALESCE(admitted_but_failed, FALSE) OR $21,
+			used_backup = COALESCE(used_backup, FALSE) OR $22,
+			backup_won = COALESCE(backup_won, FALSE) OR $23,
+			updated_at = NOW()
+		 WHERE request_id = $1 AND attempt = $2`
+
+// Per-statement deadlines. A batch statement carries up to
+// maxInferenceRouteInsertRows rows (or a whole pipelined group of updates),
+// so it gets a longer budget than the single-row write.
+const (
+	inferenceRouteWriteTimeout      = 5 * time.Second
+	inferenceRouteBatchWriteTimeout = 10 * time.Second
+)
+
+// inferenceRouteInsertSQL builds the multi-row upsert for rows records:
+// INSERT ... VALUES ($1..$57), ($58..$114), ... ON CONFLICT ... DO UPDATE.
+// rows == 1 is byte-for-byte the historical single-row statement shape.
+func inferenceRouteInsertSQL(rows int) string {
+	var b strings.Builder
+	b.Grow(len(inferenceRouteInsertColumns) + len(inferenceRouteUpsertAssignments) + rows*inferenceRouteInsertParamCount*6 + 128)
+	b.WriteString("INSERT INTO inference_routes (\n\t\t\t")
+	b.WriteString(inferenceRouteInsertColumns)
+	b.WriteString("\n\t\t) VALUES ")
+	param := 1
+	for r := 0; r < rows; r++ {
+		if r > 0 {
+			b.WriteString(",\n\t\t")
+		}
+		b.WriteByte('(')
+		for c := 0; c < inferenceRouteInsertParamCount; c++ {
+			if c > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteByte('$')
+			b.WriteString(strconv.Itoa(param))
+			param++
+		}
+		b.WriteByte(')')
+	}
+	b.WriteString(" ON CONFLICT (request_id, attempt) DO UPDATE SET\n\t\t\t")
+	b.WriteString(inferenceRouteUpsertAssignments)
+	return b.String()
+}
+
+// inferenceRouteInsertArgs appends record's bind values to dst in
+// inferenceRouteInsertColumns order. Zero CreatedAt/UpdatedAt default to now.
+func inferenceRouteInsertArgs(dst []any, record *InferenceRouteRecord, now time.Time) []any {
+	createdAt := record.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	updatedAt := record.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = now
+	}
+	return append(dst,
+		record.RequestID, record.Attempt, record.ProviderID, record.Model, record.PublicModel, record.ConsumerKeyHash, record.KeyID, record.Outcome,
+		record.CostMs, record.StateMs, record.QueueMs, record.PendingMs, record.BacklogMs, record.ThisReqMs, record.HealthMs, record.TTFTMs, record.BestTTFTMs,
+		record.EffectiveQueue, record.CandidateCount, record.CapacityRejections, record.ModelTooLargeRejections, record.VisionRejections, record.TTFTRejections,
+		record.EffectiveTPS, record.StaticTPS, record.ProviderStatus, record.ProviderTrustLevel, record.ProviderVersion,
+		record.HardwareChip, record.HardwareChipFamily, record.HardwareTier, record.MemoryGB, record.GPUCores, record.CPUCores,
+		record.SystemMemoryPressure, record.SystemCPUUsage, record.SystemThermalState,
+		record.GPUMemoryActiveGB, record.GPUMemoryPeakGB, record.GPUMemoryCacheGB,
+		record.SlotState, record.BackendRunning, record.BackendWaiting,
+		record.ActiveTokenBudgetUsed, record.ActiveTokenBudgetMax, record.QueuedTokenBudget,
+		record.EstimatedPromptTokens, record.RequestedMaxTokens,
+		record.RequiresVision, record.HasTools, record.SelfRouteOnly, record.PreferOwner,
+		createdAt, updatedAt,
+		record.ProviderRegion, record.ConsumerRegion, record.ErrorReason,
+	)
+}
+
+// inferenceRouteOutcomeUpdateArgs returns the bind values for
+// inferenceRouteOutcomeUpdateSQL.
+func inferenceRouteOutcomeUpdateArgs(requestID string, attempt int, outcome *InferenceRouteOutcome) []any {
+	return []any{
+		requestID, attempt,
+		outcome.FinalStatus, outcome.ErrorCode, outcome.ErrorClass, outcome.ErrorReason, outcome.PromptTokens, outcome.CompletionTokens, outcome.ReasoningTokens,
+		outcome.CostMicroUSD, outcome.ActualTTFTMs, outcome.DispatchToFirstChunkMs, outcome.TotalDurationMs,
+		outcome.ParseMs, outcome.ReserveMs, outcome.RouteMs, outcome.EncryptMs, outcome.QueueWaitMs, outcome.DispatchMs, outcome.ActualDecodeTPS,
+		outcome.AdmittedButFailed, outcome.UsedBackup, outcome.BackupWon,
+		outcome.CompletionTokensSet,
+	}
+}
+
+// RecordInferenceRoute writes the routing decision snapshot for a request
+// attempt. Callers keep this best-effort by logging returned errors off the
+// request path rather than blocking inference.
+func (s *PostgresStore) RecordInferenceRoute(record *InferenceRouteRecord) error {
+	if record == nil {
+		return nil
+	}
+	if err := s.execInferenceRouteInsert([]*InferenceRouteRecord{record}, inferenceRouteWriteTimeout); err != nil {
+		return fmt.Errorf("store: record inference route: %w", err)
+	}
+	return nil
+}
+
+// RecordInferenceRoutes writes many routing decision snapshots as one
+// multi-row upsert per chunk (see splitInferenceRouteBatches for the chunking
+// rules). Each chunk is a single statement and therefore atomic; a failure
+// stops at the failing chunk and is returned. Re-running the same records is
+// safe: the upsert is idempotent.
+func (s *PostgresStore) RecordInferenceRoutes(records []*InferenceRouteRecord) error {
+	for _, chunk := range splitInferenceRouteBatches(records, maxInferenceRouteInsertRows) {
+		if err := s.execInferenceRouteInsert(chunk, inferenceRouteBatchWriteTimeout); err != nil {
+			return fmt.Errorf("store: record inference routes (%d rows): %w", len(chunk), err)
+		}
+	}
+	return nil
+}
+
+// execInferenceRouteInsert issues one multi-row upsert for rows. The caller
+// guarantees rows is non-empty and free of duplicate (request_id, attempt)
+// keys. A zero CreatedAt/UpdatedAt is defaulted per record from its own
+// time.Now(), exactly as sequential single-row calls would stamp it (the
+// memory store does the same), so batch and single paths agree.
+func (s *PostgresStore) execInferenceRouteInsert(rows []*InferenceRouteRecord, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	args := make([]any, 0, len(rows)*inferenceRouteInsertParamCount)
+	for _, r := range rows {
+		args = inferenceRouteInsertArgs(args, r, time.Now().UTC())
+	}
+	_, err := s.pool.Exec(ctx, inferenceRouteInsertSQL(len(rows)), args...)
+	return err
+}
+
+// UpdateInferenceRouteOutcome updates the attempt with final outcome data
+// (tokens, timing, error). Callers keep this best-effort by logging returned
+// errors off the request path rather than blocking inference.
+func (s *PostgresStore) UpdateInferenceRouteOutcome(requestID string, attempt int, outcome *InferenceRouteOutcome) error {
+	if outcome == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), inferenceRouteWriteTimeout)
+	defer cancel()
+
+	_, err := s.pool.Exec(ctx, inferenceRouteOutcomeUpdateSQL, inferenceRouteOutcomeUpdateArgs(requestID, attempt, outcome)...)
+	if err != nil {
+		return fmt.Errorf("store: update inference route outcome: %w", err)
+	}
+	return nil
+}
+
+// UpdateInferenceRouteOutcomes pipelines the outcome updates as one pgx batch:
+// every statement is the same UPDATE UpdateInferenceRouteOutcome issues, they
+// execute on the server in slice order, and the whole group costs one network
+// round trip instead of one per update.
+//
+// pgx runs a batch in an implicit transaction, so a statement that errors
+// aborts the statements after it and rolls the group back; the first error is
+// returned. Re-running the same updates afterwards is safe: every assignment
+// is "set when non-zero / OR into", so re-applying a value is a no-op.
+func (s *PostgresStore) UpdateInferenceRouteOutcomes(updates []InferenceRouteOutcomeUpdate) error {
+	batch := &pgx.Batch{}
+	for i := range updates {
+		u := &updates[i]
+		if u.Outcome == nil {
+			continue
+		}
+		batch.Queue(inferenceRouteOutcomeUpdateSQL, inferenceRouteOutcomeUpdateArgs(u.RequestID, u.Attempt, u.Outcome)...)
+	}
+	if batch.Len() == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), inferenceRouteBatchWriteTimeout)
+	defer cancel()
+
+	results := s.pool.SendBatch(ctx, batch)
+	var firstErr error
+	for i := 0; i < batch.Len(); i++ {
+		if _, err := results.Exec(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := results.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if firstErr != nil {
+		return fmt.Errorf("store: update inference route outcomes (%d rows): %w", batch.Len(), firstErr)
+	}
+	return nil
+}

--- a/coordinator/store/route_telemetry.go
+++ b/coordinator/store/route_telemetry.go
@@ -1,5 +1,50 @@
 package store
 
+import "strconv"
+
+// inferenceRouteKey is the (request_id, attempt) identity of a route row, the
+// same key the memory index and the postgres UNIQUE(request_id, attempt)
+// constraint use.
+func inferenceRouteKey(requestID string, attempt int) string {
+	return requestID + "/" + strconv.Itoa(attempt)
+}
+
+// splitInferenceRouteBatches partitions records, preserving order, into
+// slices that are safe to write as ONE multi-row upsert each:
+//
+//   - a slice never contains the same (request_id, attempt) twice, because a
+//     single INSERT ... ON CONFLICT DO UPDATE cannot affect one row a second
+//     time — the duplicate starts the next slice, so the later record refreshes
+//     the earlier one exactly as sequential single-row calls would;
+//   - a slice holds at most maxRows records (bind-parameter budget).
+//
+// Nil records are dropped. maxRows <= 0 means unbounded.
+func splitInferenceRouteBatches(records []*InferenceRouteRecord, maxRows int) [][]*InferenceRouteRecord {
+	var out [][]*InferenceRouteRecord
+	var cur []*InferenceRouteRecord
+	seen := map[string]struct{}{}
+	flush := func() {
+		if len(cur) > 0 {
+			out = append(out, cur)
+			cur = nil
+			seen = map[string]struct{}{}
+		}
+	}
+	for _, r := range records {
+		if r == nil {
+			continue
+		}
+		key := inferenceRouteKey(r.RequestID, r.Attempt)
+		if _, dup := seen[key]; dup || (maxRows > 0 && len(cur) >= maxRows) {
+			flush()
+		}
+		seen[key] = struct{}{}
+		cur = append(cur, r)
+	}
+	flush()
+	return out
+}
+
 // mergeInferenceRouteOutcome applies non-zero outcome fields onto dst. Outcome
 // updates are emitted from different goroutines (commit, response relay,
 // provider terminal), so treating zero values as "not present" prevents a
@@ -87,7 +132,12 @@ func applyInferenceRouteOutcomeToRecord(rec *InferenceRouteRecord, outcome Infer
 	rec.FinalStatus = outcome.FinalStatus
 	rec.ErrorCode = outcome.ErrorCode
 	rec.ErrorClass = outcome.ErrorClass
-	rec.ErrorReason = outcome.ErrorReason
+	// Outcome updates only ever set error_reason when they carry one (the
+	// postgres UPDATE is COALESCE(NULLIF($6, ''), error_reason)); a reason the
+	// route record itself was written with must survive reason-less updates.
+	if outcome.ErrorReason != "" {
+		rec.ErrorReason = outcome.ErrorReason
+	}
 	rec.PromptTokens = outcome.PromptTokens
 	rec.CompletionTokens = outcome.CompletionTokens
 	rec.ReasoningTokens = outcome.ReasoningTokens

--- a/coordinator/store/route_telemetry_batch_test.go
+++ b/coordinator/store/route_telemetry_batch_test.go
@@ -1,0 +1,418 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// --- pure helpers ---
+
+func TestSplitInferenceRouteBatches(t *testing.T) {
+	rec := func(id string, attempt int) *InferenceRouteRecord {
+		return &InferenceRouteRecord{RequestID: id, Attempt: attempt}
+	}
+
+	t.Run("empty and nil-only input yields no batches", func(t *testing.T) {
+		if got := splitInferenceRouteBatches(nil, 10); len(got) != 0 {
+			t.Fatalf("nil input: got %d batches", len(got))
+		}
+		if got := splitInferenceRouteBatches([]*InferenceRouteRecord{nil, nil}, 10); len(got) != 0 {
+			t.Fatalf("nil-only input: got %d batches", len(got))
+		}
+	})
+
+	t.Run("duplicate key starts a new batch, order preserved", func(t *testing.T) {
+		in := []*InferenceRouteRecord{rec("a", 1), rec("b", 1), nil, rec("a", 1), rec("c", 1), rec("a", 2)}
+		got := splitInferenceRouteBatches(in, 0)
+		if len(got) != 2 {
+			t.Fatalf("batches = %d, want 2: %+v", len(got), got)
+		}
+		if len(got[0]) != 2 || got[0][0].RequestID != "a" || got[0][1].RequestID != "b" {
+			t.Fatalf("batch 0 = %+v", got[0])
+		}
+		// (a,2) is a different key from (a,1) and stays in the second batch.
+		if len(got[1]) != 3 || got[1][0].RequestID != "a" || got[1][1].RequestID != "c" || got[1][2].Attempt != 2 {
+			t.Fatalf("batch 1 = %+v", got[1])
+		}
+	})
+
+	t.Run("maxRows chunks without reordering", func(t *testing.T) {
+		var in []*InferenceRouteRecord
+		for i := 0; i < 7; i++ {
+			in = append(in, rec(fmt.Sprintf("r%d", i), 1))
+		}
+		got := splitInferenceRouteBatches(in, 3)
+		if len(got) != 3 || len(got[0]) != 3 || len(got[1]) != 3 || len(got[2]) != 1 {
+			t.Fatalf("chunk sizes wrong: %d batches", len(got))
+		}
+		if got[2][0].RequestID != "r6" {
+			t.Fatalf("last chunk = %+v", got[2])
+		}
+	})
+}
+
+func TestInferenceRouteInsertSQLShape(t *testing.T) {
+	// The column list and the per-row parameter count must agree, or the
+	// multi-row VALUES tuples would be misaligned with the columns.
+	if n := len(strings.Split(inferenceRouteInsertColumns, ",")); n != inferenceRouteInsertParamCount {
+		t.Fatalf("column list has %d entries, inferenceRouteInsertParamCount = %d", n, inferenceRouteInsertParamCount)
+	}
+
+	one := inferenceRouteInsertSQL(1)
+	if !strings.Contains(one, "$57)") || strings.Contains(one, "$58") {
+		t.Fatalf("single-row statement must end its tuple at $57: %s", one)
+	}
+	if !strings.Contains(one, "ON CONFLICT (request_id, attempt) DO UPDATE SET") {
+		t.Fatalf("single-row statement lost the upsert clause")
+	}
+	if !strings.Contains(one, inferenceRouteErrorReasonUpsertAssignment) {
+		t.Fatalf("upsert must keep the qualified error_reason assignment")
+	}
+
+	three := inferenceRouteInsertSQL(3)
+	if strings.Count(three, "VALUES (") != 1 || strings.Count(three, "($") != 3 {
+		t.Fatalf("three-row statement must have exactly three tuples: %s", three)
+	}
+	if !strings.Contains(three, "$171)") || strings.Contains(three, "$172") {
+		t.Fatalf("three-row statement must end at $171: %s", three)
+	}
+	if got := len(inferenceRouteInsertArgs(nil, &InferenceRouteRecord{}, time.Now())); got != inferenceRouteInsertParamCount {
+		t.Fatalf("inferenceRouteInsertArgs produced %d args, want %d", got, inferenceRouteInsertParamCount)
+	}
+	if got := len(inferenceRouteOutcomeUpdateArgs("r", 1, &InferenceRouteOutcome{})); got != 24 {
+		t.Fatalf("inferenceRouteOutcomeUpdateArgs produced %d args, want 24 ($1..$24)", got)
+	}
+}
+
+// --- both backends ---
+
+func TestInferenceRouteBatch(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) { testInferenceRouteBatch(t, s) })
+	}
+}
+
+func testInferenceRouteBatch(t *testing.T, s Store) {
+	t.Helper()
+
+	if err := s.RecordInferenceRoutes(nil); err != nil {
+		t.Fatalf("RecordInferenceRoutes(nil): %v", err)
+	}
+	if err := s.RecordInferenceRoutes([]*InferenceRouteRecord{nil}); err != nil {
+		t.Fatalf("RecordInferenceRoutes([nil]): %v", err)
+	}
+	if err := s.UpdateInferenceRouteOutcomes(nil); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcomes(nil): %v", err)
+	}
+
+	prefix := uniqueID("batch")
+	id := func(i int) string { return fmt.Sprintf("%s-%d", prefix, i) }
+	firstCreated := time.Now().Add(-time.Hour).UTC().Truncate(time.Microsecond)
+
+	// One batch: four distinct keys, one re-record of key 1 (queued -> selected,
+	// the live dispatch.go pattern) and a nil entry. The re-record must land
+	// AFTER the first write (later record wins the snapshot) and must keep the
+	// original created_at, exactly like sequential single-row upserts.
+	records := []*InferenceRouteRecord{
+		{RequestID: id(1), Attempt: 1, ProviderID: "", Outcome: "queued", Model: "m", CreatedAt: firstCreated, UpdatedAt: firstCreated},
+		{RequestID: id(2), Attempt: 1, ProviderID: "p2", Outcome: "selected", Model: "m", CandidateCount: 2},
+		nil,
+		{RequestID: id(3), Attempt: 1, ProviderID: "p3", Outcome: "selected", Model: "m", ProviderRegion: "us-east"},
+		{RequestID: id(1), Attempt: 1, ProviderID: "p1", Outcome: "selected", Model: "m", CandidateCount: 5},
+		{RequestID: id(1), Attempt: 2, ProviderID: "p1b", Outcome: "selected", Model: "m"},
+	}
+	if err := s.RecordInferenceRoutes(records); err != nil {
+		t.Fatalf("RecordInferenceRoutes: %v", err)
+	}
+
+	// One pipelined update batch, in order: a commit-style latency update, a
+	// terminal on the same key (must merge on top, not replace), a terminal for
+	// another key, a nil outcome (skipped), and an unknown key (no-op).
+	updates := []InferenceRouteOutcomeUpdate{
+		{RequestID: id(1), Attempt: 1, Outcome: &InferenceRouteOutcome{ActualTTFTMs: 42, UsedBackup: true}},
+		{RequestID: id(1), Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "error", ErrorCode: 502, ErrorClass: "provider_error", CompletionTokensSet: true}},
+		{RequestID: id(1), Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "partial_success"}},
+		{RequestID: id(2), Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "success", PromptTokens: 10, CompletionTokens: 20, CostMicroUSD: 7, CompletionTokensSet: true}},
+		{RequestID: id(3), Attempt: 1, Outcome: nil},
+		{RequestID: id(3) + "-missing", Attempt: 9, Outcome: &InferenceRouteOutcome{FinalStatus: "success"}},
+	}
+	if err := s.UpdateInferenceRouteOutcomes(updates); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcomes: %v", err)
+	}
+
+	byKey := map[string]InferenceRouteRecord{}
+	for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+		if strings.HasPrefix(r.RequestID, prefix) {
+			byKey[inferenceRouteKey(r.RequestID, r.Attempt)] = r
+		}
+	}
+	if len(byKey) != 4 {
+		t.Fatalf("rows = %d, want 4 (nil skipped, duplicate merged): %v", len(byKey), byKey)
+	}
+
+	r1 := byKey[inferenceRouteKey(id(1), 1)]
+	if r1.ProviderID != "p1" || r1.Outcome != "selected" || r1.CandidateCount != 5 {
+		t.Fatalf("re-recorded row must carry the LATER snapshot: %+v", r1)
+	}
+	if !r1.CreatedAt.Equal(firstCreated) {
+		t.Fatalf("re-record must keep the first created_at: got %v want %v", r1.CreatedAt, firstCreated)
+	}
+	// Ordered merge: latency from update 1, error from update 2, final status
+	// overridden by update 3 while error_code/class (zero in update 3) survive.
+	if r1.FinalStatus != "partial_success" || r1.ErrorCode != 502 || r1.ErrorClass != "provider_error" || r1.ActualTTFTMs != 42 || !r1.UsedBackup {
+		t.Fatalf("ordered outcome merge wrong: %+v", r1)
+	}
+	if r1.CompletionTokens != 0 {
+		t.Fatalf("terminal error must persist completion_tokens 0: %+v", r1)
+	}
+
+	r2 := byKey[inferenceRouteKey(id(2), 1)]
+	if r2.FinalStatus != "success" || r2.PromptTokens != 10 || r2.CompletionTokens != 20 || r2.CostMicroUSD != 7 || r2.CandidateCount != 2 {
+		t.Fatalf("row 2 outcome/snapshot wrong: %+v", r2)
+	}
+	r3 := byKey[inferenceRouteKey(id(3), 1)]
+	if r3.FinalStatus != "" || r3.ProviderRegion != "us-east" {
+		t.Fatalf("row 3 must be untouched by the nil update: %+v", r3)
+	}
+	if r12 := byKey[inferenceRouteKey(id(1), 2)]; r12.ProviderID != "p1b" {
+		t.Fatalf("attempt 2 must be its own row: %+v", r12)
+	}
+
+	// A single-row write after a batch behaves identically (same code path).
+	if err := s.RecordInferenceRoute(&InferenceRouteRecord{RequestID: id(3), Attempt: 1, ProviderID: "p3-refresh", Outcome: "selected", Model: "m"}); err != nil {
+		t.Fatalf("RecordInferenceRoute: %v", err)
+	}
+	if err := s.UpdateInferenceRouteOutcome(id(3), 1, &InferenceRouteOutcome{FinalStatus: "cancelled", CompletionTokensSet: true}); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcome: %v", err)
+	}
+	for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+		if r.RequestID == id(3) && r.Attempt == 1 {
+			if r.ProviderID != "p3-refresh" || r.FinalStatus != "cancelled" || r.ProviderRegion != "" {
+				t.Fatalf("single-row refresh + update after batch wrong: %+v", r)
+			}
+		}
+	}
+}
+
+// TestInferenceRouteBatchChunking writes more rows than fit in one statement
+// so the chunk boundary is exercised on both backends, with a duplicate key
+// straddling the boundary.
+func TestInferenceRouteBatchChunking(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			prefix := uniqueID("chunk")
+			n := maxInferenceRouteInsertRows + 40
+			records := make([]*InferenceRouteRecord, 0, n+1)
+			for i := 0; i < n; i++ {
+				records = append(records, &InferenceRouteRecord{RequestID: fmt.Sprintf("%s-%d", prefix, i), Attempt: 1, Outcome: "selected", ProviderID: "p"})
+			}
+			// Re-record row 0 at the very end: lands in the last chunk and must
+			// win over the first chunk's write.
+			records = append(records, &InferenceRouteRecord{RequestID: fmt.Sprintf("%s-%d", prefix, 0), Attempt: 1, Outcome: "selected", ProviderID: "p-last"})
+			if err := s.RecordInferenceRoutes(records); err != nil {
+				t.Fatalf("RecordInferenceRoutes(%d): %v", len(records), err)
+			}
+			updates := make([]InferenceRouteOutcomeUpdate, 0, n)
+			for i := 0; i < n; i++ {
+				updates = append(updates, InferenceRouteOutcomeUpdate{RequestID: fmt.Sprintf("%s-%d", prefix, i), Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: i + 1}})
+			}
+			if err := s.UpdateInferenceRouteOutcomes(updates); err != nil {
+				t.Fatalf("UpdateInferenceRouteOutcomes(%d): %v", len(updates), err)
+			}
+			got := 0
+			for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+				if !strings.HasPrefix(r.RequestID, prefix) {
+					continue
+				}
+				got++
+				if r.FinalStatus != "success" || r.CompletionTokens == 0 {
+					t.Fatalf("row %s missing its outcome: %+v", r.RequestID, r)
+				}
+				if r.RequestID == fmt.Sprintf("%s-%d", prefix, 0) && r.ProviderID != "p-last" {
+					t.Fatalf("re-record across chunks must win: %+v", r)
+				}
+			}
+			if got != n {
+				t.Fatalf("rows = %d, want %d", got, n)
+			}
+		})
+	}
+}
+
+// --- postgres statement accounting ---
+
+// statementCounter is a pgx tracer that counts round trips: one TraceQueryStart
+// per Exec/Query statement and one TraceBatchStart per SendBatch pipeline.
+type statementCounter struct {
+	mu           sync.Mutex
+	queries      int
+	batches      int
+	batchQueries int
+}
+
+func (c *statementCounter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.queries, c.batches, c.batchQueries = 0, 0, 0
+}
+
+func (c *statementCounter) snapshot() (queries, batches, batchQueries int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.queries, c.batches, c.batchQueries
+}
+
+func (c *statementCounter) TraceQueryStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceQueryStartData) context.Context {
+	c.mu.Lock()
+	c.queries++
+	c.mu.Unlock()
+	return ctx
+}
+
+func (c *statementCounter) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func (c *statementCounter) TraceBatchStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceBatchStartData) context.Context {
+	c.mu.Lock()
+	c.batches++
+	c.mu.Unlock()
+	return ctx
+}
+
+func (c *statementCounter) TraceBatchQuery(_ context.Context, _ *pgx.Conn, _ pgx.TraceBatchQueryData) {
+	c.mu.Lock()
+	c.batchQueries++
+	c.mu.Unlock()
+}
+
+func (c *statementCounter) TraceBatchEnd(context.Context, *pgx.Conn, pgx.TraceBatchEndData) {}
+
+// tracedPostgresStore returns a PostgresStore whose pool reports every
+// statement to counter. The schema is migrated (and truncated) by the regular
+// harness first, so this store only issues the writes under test.
+func tracedPostgresStore(t *testing.T, counter *statementCounter) *PostgresStore {
+	t.Helper()
+	testPostgresStore(t)
+
+	cfg, err := pgxpool.ParseConfig(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	cfg.ConnConfig.Tracer = counter
+	cfg.MaxConns = 4
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		t.Fatalf("NewWithConfig: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return &PostgresStore{pool: pool, priceCache: make(map[string]cachedPrice)}
+}
+
+// TestPostgresInferenceRouteBatchStatementCount is the measured effect of the
+// batch paths: N single-row writes cost N statements; the same N rows through
+// the batch methods cost ONE multi-row INSERT and ONE pipelined batch.
+func TestPostgresInferenceRouteBatchStatementCount(t *testing.T) {
+	counter := &statementCounter{}
+	s := tracedPostgresStore(t, counter)
+	const n = 50
+	prefix := uniqueID("count")
+	rec := func(tag string, i int) *InferenceRouteRecord {
+		return &InferenceRouteRecord{RequestID: fmt.Sprintf("%s-%s-%d", prefix, tag, i), Attempt: 1, ProviderID: "p", Outcome: "selected", Model: "m"}
+	}
+	upd := func(tag string, i int) InferenceRouteOutcomeUpdate {
+		return InferenceRouteOutcomeUpdate{RequestID: fmt.Sprintf("%s-%s-%d", prefix, tag, i), Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "success", CompletionTokens: 3, CompletionTokensSet: true}}
+	}
+
+	// Before: one statement per record / per update.
+	counter.reset()
+	for i := 0; i < n; i++ {
+		if err := s.RecordInferenceRoute(rec("single", i)); err != nil {
+			t.Fatalf("RecordInferenceRoute: %v", err)
+		}
+	}
+	for i := 0; i < n; i++ {
+		if err := s.UpdateInferenceRouteOutcome(fmt.Sprintf("%s-single-%d", prefix, i), 1, upd("single", i).Outcome); err != nil {
+			t.Fatalf("UpdateInferenceRouteOutcome: %v", err)
+		}
+	}
+	if q, b, _ := counter.snapshot(); q != 2*n || b != 0 {
+		t.Fatalf("single-row path: queries=%d batches=%d, want %d/0", q, b, 2*n)
+	}
+
+	// After: one multi-row INSERT for all records, one pipeline for all updates.
+	records := make([]*InferenceRouteRecord, 0, n)
+	updates := make([]InferenceRouteOutcomeUpdate, 0, n)
+	for i := 0; i < n; i++ {
+		records = append(records, rec("batch", i))
+		updates = append(updates, upd("batch", i))
+	}
+	counter.reset()
+	if err := s.RecordInferenceRoutes(records); err != nil {
+		t.Fatalf("RecordInferenceRoutes: %v", err)
+	}
+	if q, b, _ := counter.snapshot(); q != 1 || b != 0 {
+		t.Fatalf("batch insert: queries=%d batches=%d, want 1/0", q, b)
+	}
+	counter.reset()
+	if err := s.UpdateInferenceRouteOutcomes(updates); err != nil {
+		t.Fatalf("UpdateInferenceRouteOutcomes: %v", err)
+	}
+	if q, b, bq := counter.snapshot(); q != 0 || b != 1 || bq != n {
+		t.Fatalf("batch update: queries=%d batches=%d batchQueries=%d, want 0/1/%d", q, b, bq, n)
+	}
+
+	// Both populations read back identically.
+	single, batch := 0, 0
+	for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+		if !strings.HasPrefix(r.RequestID, prefix) || r.FinalStatus != "success" || r.CompletionTokens != 3 {
+			continue
+		}
+		if strings.Contains(r.RequestID, "-single-") {
+			single++
+		} else {
+			batch++
+		}
+	}
+	if single != n || batch != n {
+		t.Fatalf("rows with outcome: single=%d batch=%d, want %d/%d", single, batch, n, n)
+	}
+}
+
+// TestPostgresInferenceRouteBatchDuplicateKeysSplit proves the store splits a
+// batch at a repeated (request_id, attempt) instead of tripping PostgreSQL's
+// "ON CONFLICT DO UPDATE command cannot affect row a second time".
+func TestPostgresInferenceRouteBatchDuplicateKeysSplit(t *testing.T) {
+	counter := &statementCounter{}
+	s := tracedPostgresStore(t, counter)
+	id := uniqueID("dup")
+	counter.reset()
+	err := s.RecordInferenceRoutes([]*InferenceRouteRecord{
+		{RequestID: id, Attempt: 1, Outcome: "queued"},
+		{RequestID: id, Attempt: 1, Outcome: "selected", ProviderID: "p"},
+		{RequestID: id, Attempt: 1, Outcome: "selected", ProviderID: "p-final"},
+	})
+	if err != nil {
+		t.Fatalf("RecordInferenceRoutes with duplicates: %v", err)
+	}
+	if q, _, _ := counter.snapshot(); q != 3 {
+		t.Fatalf("three same-key records need three statements, got %d", q)
+	}
+	for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+		if r.RequestID == id {
+			if r.ProviderID != "p-final" || r.Outcome != "selected" {
+				t.Fatalf("last record must win: %+v", r)
+			}
+			return
+		}
+	}
+	t.Fatal("row not found")
+}

--- a/coordinator/store/route_telemetry_parity_test.go
+++ b/coordinator/store/route_telemetry_parity_test.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestInferenceRouteErrorReasonSurvivesReasonlessWrites pins backend parity
+// for error_reason: a reason written with the route record must survive both
+// a reason-less refresh (the postgres upsert keeps the existing column when
+// EXCLUDED.error_reason is empty) and a reason-less outcome update (the UPDATE
+// keeps the existing column when the bound reason is empty), through the
+// single-row and batch paths alike, and a later explicit reason replaces it.
+func TestInferenceRouteErrorReasonSurvivesReasonlessWrites(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			id := uniqueID("reason")
+			read := func() InferenceRouteRecord {
+				t.Helper()
+				for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+					if r.RequestID == id && r.Attempt == 1 {
+						return r
+					}
+				}
+				t.Fatal("row not found")
+				return InferenceRouteRecord{}
+			}
+
+			if err := s.RecordInferenceRoute(&InferenceRouteRecord{RequestID: id, Attempt: 1, Outcome: "selected", ProviderID: "p1", ErrorReason: "jinja_template"}); err != nil {
+				t.Fatalf("RecordInferenceRoute: %v", err)
+			}
+			if err := s.RecordInferenceRoute(&InferenceRouteRecord{RequestID: id, Attempt: 1, Outcome: "selected", ProviderID: "p2"}); err != nil {
+				t.Fatalf("refresh: %v", err)
+			}
+			if r := read(); r.ErrorReason != "jinja_template" || r.ProviderID != "p2" {
+				t.Fatalf("reason-less single refresh must keep the reason and take the snapshot: %+v", r)
+			}
+
+			if err := s.UpdateInferenceRouteOutcome(id, 1, &InferenceRouteOutcome{FinalStatus: "error", ErrorClass: "client_error", ErrorCode: 500, CompletionTokensSet: true}); err != nil {
+				t.Fatalf("reason-less update: %v", err)
+			}
+			if r := read(); r.ErrorReason != "jinja_template" || r.FinalStatus != "error" || r.ErrorClass != "client_error" {
+				t.Fatalf("reason-less update must keep the reason and apply the rest: %+v", r)
+			}
+
+			if err := s.UpdateInferenceRouteOutcomes([]InferenceRouteOutcomeUpdate{{RequestID: id, Attempt: 1, Outcome: &InferenceRouteOutcome{ErrorReason: "provider_error"}}}); err != nil {
+				t.Fatalf("explicit reason update: %v", err)
+			}
+			if r := read(); r.ErrorReason != "provider_error" {
+				t.Fatalf("explicit reason must replace: %+v", r)
+			}
+
+			if err := s.RecordInferenceRoutes([]*InferenceRouteRecord{{RequestID: id, Attempt: 1, Outcome: "selected", ProviderID: "p3"}}); err != nil {
+				t.Fatalf("batch refresh: %v", err)
+			}
+			if r := read(); r.ErrorReason != "provider_error" || r.ProviderID != "p3" || r.FinalStatus != "error" {
+				t.Fatalf("reason-less batch refresh must keep reason and outcome: %+v", r)
+			}
+		})
+	}
+}
+
+// TestInferenceRouteBatchStampsEachRecord checks that zero timestamps in a
+// batch are defaulted per record from the write clock (never left zero, never
+// earlier than the call, and non-decreasing in slice order), on both backends.
+func TestInferenceRouteBatchStampsEachRecord(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			prefix := uniqueID("stamp")
+			before := time.Now().Add(-time.Millisecond)
+			records := []*InferenceRouteRecord{
+				{RequestID: prefix + "-a", Attempt: 1, Outcome: "selected"},
+				{RequestID: prefix + "-b", Attempt: 1, Outcome: "selected"},
+				{RequestID: prefix + "-c", Attempt: 1, Outcome: "selected", CreatedAt: before.Add(-time.Hour), UpdatedAt: before.Add(-time.Hour)},
+			}
+			if err := s.RecordInferenceRoutes(records); err != nil {
+				t.Fatalf("RecordInferenceRoutes: %v", err)
+			}
+			after := time.Now().Add(time.Millisecond)
+			got := map[string]InferenceRouteRecord{}
+			for _, r := range s.InferenceRouteRecordsSince(time.Time{}) {
+				if r.RequestID == prefix+"-a" || r.RequestID == prefix+"-b" || r.RequestID == prefix+"-c" {
+					got[r.RequestID] = r
+				}
+			}
+			a, b, c := got[prefix+"-a"], got[prefix+"-b"], got[prefix+"-c"]
+			for _, r := range []InferenceRouteRecord{a, b} {
+				if r.CreatedAt.Before(before) || r.CreatedAt.After(after) || r.UpdatedAt.Before(before) || r.UpdatedAt.After(after) {
+					t.Fatalf("defaulted timestamps outside the write window: %+v (window %v..%v)", r, before, after)
+				}
+			}
+			if b.CreatedAt.Before(a.CreatedAt) {
+				t.Fatalf("per-record stamps must be non-decreasing in slice order: a=%v b=%v", a.CreatedAt, b.CreatedAt)
+			}
+			if !c.CreatedAt.Equal(before.Add(-time.Hour).UTC().Truncate(time.Microsecond)) && !c.CreatedAt.Equal(before.Add(-time.Hour)) {
+				t.Fatalf("explicit CreatedAt must be kept: %v", c.CreatedAt)
+			}
+		})
+	}
+}

--- a/coordinator/store/write_errors.go
+++ b/coordinator/store/write_errors.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// IsTransientWriteError reports whether a store write failed for a reason
+// that is NOT about the rows being written: the statement deadline expired,
+// the connection or pool is gone, or the server refused for resource,
+// shutdown, or concurrency reasons. Callers that batch best-effort writes use
+// it to choose between replaying the rows one by one (a row fault —
+// constraint, type, or syntax error — worth isolating so one poison row does
+// not discard its neighbours) and dropping the whole group (the store is
+// unavailable, so N replays would just be N more timeouts).
+func IsTransientWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		// SQLSTATE classes: 08 connection exception, 40 transaction rollback
+		// (deadlock / serialization), 53 insufficient resources, 57 operator
+		// intervention (admin shutdown, cannot connect now). Every other class
+		// — 22 data, 23 integrity, 42 syntax/access, ... — describes the rows.
+		if len(pgErr.Code) >= 2 {
+			switch pgErr.Code[:2] {
+			case "08", "40", "53", "57":
+				return true
+			}
+		}
+		return false
+	}
+	var connErr *pgconn.ConnectError
+	if errors.As(err, &connErr) {
+		return true
+	}
+	if pgconn.Timeout(err) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	// pgxpool surfaces puddle.ErrClosedPool ("closed pool") once the pool is
+	// closed; the sentinel lives in an indirect dependency, so match its text.
+	return strings.Contains(err.Error(), "closed pool")
+}

--- a/coordinator/store/write_errors_test.go
+++ b/coordinator/store/write_errors_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsTransientWriteError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain row fault", errors.New("injected poison row"), false},
+		{"deadline (wrapped)", fmt.Errorf("store: record inference routes: %w", context.DeadlineExceeded), true},
+		{"canceled", context.Canceled, true},
+		{"eof", fmt.Errorf("conn: %w", io.EOF), true},
+		{"unexpected eof", io.ErrUnexpectedEOF, true},
+		{"unique violation 23505", &pgconn.PgError{Code: "23505"}, false},
+		{"numeric overflow 22003", fmt.Errorf("w: %w", &pgconn.PgError{Code: "22003"}), false},
+		{"syntax 42601", &pgconn.PgError{Code: "42601"}, false},
+		{"connection failure 08006", &pgconn.PgError{Code: "08006"}, true},
+		{"deadlock 40P01", &pgconn.PgError{Code: "40P01"}, true},
+		{"too many connections 53300", &pgconn.PgError{Code: "53300"}, true},
+		{"admin shutdown 57P01", fmt.Errorf("w: %w", &pgconn.PgError{Code: "57P01"}), true},
+		{"connect error", fmt.Errorf("w: %w", &pgconn.ConnectError{}), true},
+		{"net timeout", &net.DNSError{Err: "timeout", IsTimeout: true}, true},
+		{"closed pool text", errors.New("store: record inference routes (3 rows): closed pool"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTransientWriteError(tc.err); got != tc.want {
+				t.Fatalf("IsTransientWriteError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPostgresRouteWritesAfterPoolCloseAreTransient pins the shutdown case the
+// sink relies on: once the pool is closed every route write fails with an
+// error the classifier calls transient, so the sink drops the group instead
+// of replaying N rows that would each fail the same way.
+func TestPostgresRouteWritesAfterPoolCloseAreTransient(t *testing.T) {
+	s := tracedPostgresStore(t, &statementCounter{})
+	s.pool.Close()
+
+	id := uniqueID("closed")
+	records := []*InferenceRouteRecord{
+		{RequestID: id + "-1", Attempt: 1, Outcome: "selected"},
+		{RequestID: id + "-2", Attempt: 1, Outcome: "selected"},
+	}
+	if err := s.RecordInferenceRoutes(records); err == nil || !IsTransientWriteError(err) {
+		t.Fatalf("batch insert on closed pool: err=%v, want transient", err)
+	}
+	if err := s.RecordInferenceRoute(records[0]); err == nil || !IsTransientWriteError(err) {
+		t.Fatalf("single insert on closed pool: err=%v, want transient", err)
+	}
+	updates := []InferenceRouteOutcomeUpdate{
+		{RequestID: id + "-1", Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "success"}},
+		{RequestID: id + "-2", Attempt: 1, Outcome: &InferenceRouteOutcome{FinalStatus: "success"}},
+	}
+	if err := s.UpdateInferenceRouteOutcomes(updates); err == nil || !IsTransientWriteError(err) {
+		t.Fatalf("batch update on closed pool: err=%v, want transient", err)
+	}
+	if err := s.UpdateInferenceRouteOutcome(id+"-1", 1, updates[0].Outcome); err == nil || !IsTransientWriteError(err) {
+		t.Fatalf("single update on closed pool: err=%v, want transient", err)
+	}
+}

--- a/docs/operations/coordinator-deploy.md
+++ b/docs/operations/coordinator-deploy.md
@@ -1,6 +1,6 @@
 # Deploy the coordinator (production)
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-04 · commit `bda995368`
 
 Runbook for swapping the production coordinator container on the GCE VM
 `darkbloom-coordinator` to a Cloud-Build image of a reviewed `master` commit,
@@ -358,6 +358,7 @@ reference copy; editing it changes nothing on the host.
 | `refresh-env: missing required key` | a `required-env-keys.txt` key is absent on this host | add the value by hand (secrets are never fetched by the script), re-run `--check` |
 | New flag "not working" | value read once at start; or a kill switch left from an incident (`EIGENINFERENCE_HEALTH_EJECTION=off`, `EIGENINFERENCE_QUEUE_BEFORE_SHED=false`) | `grep` the env file; recreate the container |
 | Release registration `503 not_configured` | `EIGENINFERENCE_R2_CDN_URL` unset | set it, recreate the container |
+| A manual SQL edit to `users` (role, platform fee, Stripe fields) or the model-registry tables "did not apply" | those lookups are served from an in-process read-through cache (`store.NewCached`: users 30 s, model records 10 s, misses 5 s); only writes made through the coordinator invalidate at once | wait out the TTL, or make the change through the admin API (`PUT /v1/admin/users/role`, `POST /v1/admin/models/...`) |
 
 ## Related
 

--- a/docs/reports/2026-09-02-coordinator-performance-pr-body.md
+++ b/docs/reports/2026-09-02-coordinator-performance-pr-body.md
@@ -1,0 +1,95 @@
+# PR body draft — coordinator performance program (2026-09-02)
+
+> Last updated: 2026-09-02 · commit `fa6abe3da`
+
+_(Draft for the PR description. Numbers in the tables are filled from
+`docs/reports/2026-09-02-coordinator-performance-program.md`.)_
+
+## Summary
+
+First-principles performance pass over every coordinator operation on the
+inference path and at fleet scale. The 2026-09-01 collapse showed the
+per-request cost is dominated by full-fleet walks; this PR removes the walks'
+per-provider costs and prunes them to the providers that advertise the model,
+removes the per-request database round trips, parses the request body once,
+batches route telemetry, coalesces streamed chunks per flush, and caches the
+public read endpoints. Every change is measured by a committed benchmark
+(`registry/fleet_scale_bench_test.go`, 1,260 providers) and an end-to-end
+harness (`api/perf_e2e_test.go`, real HTTP + WebSocket providers).
+
+## Before / After — behavior
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[request] --> B1["auth: API-key cache hit + users SELECT"]
+    B1 --> C1["parse body once, re-marshal 6–9×"]
+    C1 --> D1["model_registry SELECT ×2, called 3–4×"]
+    D1 --> E1["PredictServable: walk 1,260 providers"]
+    E1 --> F1["QuickCapacityCheck: walk 1,260"]
+    F1 --> G1["ReserveProviderEx: walk 1,260 (time.Now + sort + concat per provider)"]
+    G1 --> H1["INSERT inference_routes per attempt"]
+    H1 --> I1["stream: write+flush per token"]
+    I1 --> J1["settle: users SELECT + 3 txns"]
+  end
+  subgraph After
+    A2[request] --> B2["auth: API-key + user cache hits"]
+    B2 --> C2["parse once, mutate map, marshal once"]
+    C2 --> D2["model record: cache hit"]
+    D2 --> E2["PredictServable: walk advertisers only"]
+    E2 --> F2["preflight: advertisers only, 1 alloc"]
+    F2 --> G2["reserve: advertisers only, 21 allocs, clock hoisted"]
+    G2 --> H2["route rows batched: 1 multi-row INSERT / 100 ms"]
+    H2 --> I2["stream: queued chunks coalesced per flush"]
+    I2 --> J2["settle: user cache hit"]
+  end
+```
+
+## Before / After — code
+
+```mermaid
+flowchart LR
+  subgraph Before
+    R1[Registry.scanCandidatesLocked] --> P1["for p in r.providers (all)"]
+    P1 --> S1["snapshotProviderLockedEx (time.Now, Median sort, string keys, struct copies)"]
+    ST1[store.PostgresStore] --> Q1["GetUserByAccountID / GetModelRegistryRecord: SQL per call"]
+    T1[telemetrySink] --> U1["RecordInferenceRoute per record"]
+    V1[handleStreamingResponse] --> W1["Fprintf + Flush per chunk"]
+  end
+  subgraph After
+    R2[Registry.scanCandidatesLocked] --> P2["providersForModelLocked (index)"]
+    P2 --> S2["snapshot in place, TPS cache, struct keys, one clock"]
+    ST2["store.CachedStore (NewCached)"] --> Q2["TTL + invalidation on mutators; store.As for optional capabilities"]
+    T2["telemetrySink (typed, coalescing)"] --> U2["RecordInferenceRoutes / UpdateInferenceRouteOutcomes"]
+    V2[handleStreamingResponse] --> W2["drain queued chunks → one buffered write → one Flush"]
+  end
+```
+
+## Measurements
+
+| Path (1,260-provider fixture) | Before | After |
+|---|---|---|
+| Reservation scan | 323 µs, 824 allocs | 68–73 µs, 21 allocs |
+| Capacity preflight | 151 µs, 672 allocs | 47 µs, 1 alloc |
+| Servability prediction | 188 µs, 672 allocs | 43 µs, 1 alloc |
+| `/v1/models` aggregate | 191 µs, 1,281 allocs | 138 µs, 19 allocs |
+| Heartbeat with a queued unservable model | 88 µs | 4 µs |
+
+| End to end (same machine state) | Before | After |
+|---|---|---|
+| 1,000 providers, 16 KB bodies | 448 req/s, TTFB p50 44 ms | 954 req/s, TTFB p50 20 ms |
+| 100 providers, 60 KB bodies | 395 req/s, TTFB p95 127 ms | 1,377 req/s, TTFB p95 11 ms |
+
+Per request in production, additionally: 4–5 database round trips become
+cache hits (user + model record), the completion settlement loses three
+round trips (`Credit` as one statement), and route telemetry batches to one
+multi-row insert per 100 ms. Full detail: `docs/reports/2026-09-02-coordinator-performance-program.md`.
+
+## Notes for reviewers
+
+- No overlap with PR #799's hunks (`consumer.go` 93–115 / 587–640 / 871–1130 /
+  1426–1450, `dispatch.go` 184 / 1213 / 1652 / 1720, `inference_admission.go`
+  219–340, `server.go` 27 / 492 / 793 / 1294, `main.go` 591–700 / 1048+).
+- Single-process assumption for the store cache is documented in
+  `store/cached.go`; manual SQL edits take up to the TTL to become visible
+  (runbook row added).

--- a/docs/reports/2026-09-02-coordinator-performance-program.md
+++ b/docs/reports/2026-09-02-coordinator-performance-program.md
@@ -1,0 +1,325 @@
+# Coordinator performance program — 2026-09-02
+
+> Last updated: 2026-09-02 · commit `5508b4f84`
+
+Status: complete, awaiting review/push (branch `worktree-bridge-cse_01TuyfD42fkRyG4ZqSTmeN4U`, based on master `a1f51ea4c`).
+
+This report is the first-principles pass over every coordinator operation with a
+measurable cost: the inference hot path (auth → parse → admit → route → dispatch →
+stream → settle), the fleet-scale paths (heartbeats, eviction, aggregates), and
+the store layer. Each finding names the mechanism, the measured cost, and the
+change made. Numbers are from `coordinator/registry/fleet_scale_bench_test.go`
+(1,260 providers, 15 models, live heartbeats, in-flight pending requests) on an
+Apple M4 Max unless stated otherwise.
+
+## 1. Why now
+
+The 2026-09-01 congestion collapse (PR #799) showed the coordinator's per-request
+CPU cost is dominated by full-fleet walks: every request scans all ~1,260
+providers at least twice (capacity preflight + reservation scan), and the failure
+path re-scans up to 64 times. PR #799 bounds the retry ladder and adds a scan
+semaphore; this program attacks the cost of each scan and of everything else on
+the request path.
+
+## 2. Baseline (before)
+
+| Benchmark | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| FleetReserveProviderEx (scan + commit + release) | 403,844 | 186,309 | 824 |
+| FleetReserveProviderExParallel (GOMAXPROCS=16) | 355,349 | 231,610 | 1,027 |
+| FleetQuickCapacityCheck (preflight) | 151,308 | 80,976 | 672 |
+| FleetHeartbeat (ingest) | 529 | 449 | 6 |
+| FleetListModels (`/v1/models` aggregate) | 180,489 | 249,272 | 1,281 |
+
+CPU profile of the reservation scan (top of `pprof -top`):
+
+| Share | Where | Mechanism |
+|---:|---|---|
+| 35% | `runtime.walltime` | `time.Now()` per provider — `snapshotProviderLockedEx` calls it before any gate, so all 1,260 providers pay it even though ~90% do not advertise the model |
+| 8.5% | `runtime.duffcopy` | `routingSnapshot` (large struct) copied by value through snapshot → candidate → discount |
+| 3% | `healthEjectionEnabled` | `os.Getenv` + `ToLower`/`TrimSpace` per provider per scan |
+| 3.5% | `prefixCacheV2CapabilitiesForModel` | second full fleet walk per request, `p.mu` on every provider, run even with cache routing off |
+| ~2% | `slices.pdqsort` | `TPSRegistry.Median` copies + sorts up to 50 samples per provider |
+| ~2% | `runtime.concatstrings` | `providerID + ":" + model` map keys for every cooldown/breaker/clamp gate |
+| ~4% (alloc) | `versionSegments` / `strings.Split` | semver re-parsed per provider per scan |
+
+Allocation profile: `buildCandidateWithReason` 44% (one heap candidate with an
+embedded snapshot copy per eligible provider), `TPSRegistry.Median` 23%,
+`providerPooledTokenBudgetWithLayout` 11% (a map per provider per snapshot).
+
+End-to-end (`EIGENINFERENCE_PERF_E2E=1 go test ./api/ -run TestPerfE2E`; real HTTP,
+in-process WebSocket fake providers answering instantly, memory store, 16 KB
+bodies, 40 streamed chunks):
+
+| Fleet | Concurrency | Throughput | TTFB p50 / p95 | Total p50 / p95 |
+|---|---:|---:|---|---|
+| 100 providers | 16 | 1,523 req/s | 6.8 ms / 9.7 ms | 10.2 ms / 14.0 ms |
+| 1,000 providers | 32 | 524 req/s | 42.3 ms / 54.7 ms | 62.1 ms / 83.0 ms |
+
+Ten times the fleet costs six times the first-byte latency with providers that
+respond instantly: the per-request fleet walk is the coordinator's dominant
+cost at production scale.
+
+## 3. Hot-path inventory (per chat completion, success path)
+
+| Stage | Cost mechanism | Finding |
+|---|---|---|
+| `requireAuth` | API key cached (60s) but `GetUserByAccountID` is a Postgres round trip on every request | uncached |
+| `parseInferencePrelude` + `handleChatCompletions` | body parsed once, then re-marshalled/re-parsed 6–9× (tool-constraint validation re-parses the original body; alias/reasoning/defaults/max_tokens each re-marshal; `providerBodyForModel` recomputed for the same model) | CPU + allocs proportional to body size, up to MBs with inline media |
+| `GetModelRegistryRecord` | two queries per call, called 3–4× per request | uncached |
+| `reserveInferenceBalance` | one round trip | necessary |
+| `runInferenceAdmission` | `QuickCapacityCheck` full fleet walk | see §2 |
+| `ReserveProviderEx` | full fleet walk + global write-lock commit | see §2 |
+| `recordRoutingDecisionFor` | one INSERT per attempt through a 1-worker, 4096-deep sink | write amplification, drops under a slow DB |
+| streaming relay | one `Fprintf` + `Flush` (syscall) per token; seven `strings.Contains` per chunk | per-token syscalls |
+| `handleCompleteAt` | `GetUserByAccountID` again, three separate credit transactions, usage insert | 4–6 round trips per completion |
+
+Fleet-scale: `Registry.Heartbeat` is cheap (0.5 µs); the API-side heartbeat
+branch adds capacity deep-copies and telemetry; `ListModels` re-aggregates the
+fleet on every `/v1/models`; `/v1/stats` is cached, other public endpoints are
+not.
+
+## 4. Changes
+
+_(per worker, in merge order)_
+
+### 4.1 Store read-through cache (`store/cached.go`, `store/cached_domain.go`, `store/cached_clone.go`)
+
+`store.NewCached` wraps both backends at construction in `cmd/coordinator/main.go`.
+It overrides only the hot-path lookups and the mutators that can change them:
+
+| Cached lookup | TTL | Invalidated by |
+|---|---|---|
+| `GetUserByAccountID`, `GetUserByPrivyID` | 30 s | `CreateUser`, `SetUserRole`, `SetUserPlatformFeePercent`, `SetUserStripeAccount` (whole user domain) |
+| `GetModelRegistryRecord`, `GetModelManifest` | 10 s | every model-registry writer (whole model domain) |
+| "not found" results | 5 s | same |
+
+Reads return deep copies, a generation counter drops loads that raced a
+write, domains are bounded (10k users, 1k models) with random eviction, and
+transient DB errors are never cached. Effect: the per-request `requireAuth`
+user lookup and the 3–4 registry-record lookups (two queries each) become
+in-memory hits after the first request per key/model. Single-process
+assumption documented in the file header; TTLs bound staleness from
+out-of-band SQL edits.
+
+Decorating the store hides backend-only capabilities that callers discover by
+type assertion (`codeAttestPushBudgetStore`, `verificationDuePageStore`), which
+would have silently downgraded APNs push-budget durability and verification-job
+pagination. `store.As[T]` walks `Unwrap()` through decorators and the four
+assertion sites use it; tests pin that both capabilities survive the wrap.
+Cache counters are emitted as `store.cache.*` gauges per domain.
+
+
+### 4.2 Routing scan (`registry/`)
+
+Ten commits, all inside `registry/`, each measured on the fleet benchmark:
+
+| Step | Mechanism | Reserve ns/op (min) |
+|---|---|---:|
+| baseline | | 372k |
+| clock hoist | one `time.Now()` per walk (scan, preflight, `PredictServable`, commit) | 262k |
+| TPS caches | `Median`/`SoloMedian`/`SoloMedianAllChips` maintained on `Record` (≤50 samples), O(1) zero-alloc reads | 221k |
+| kill switch + hint skip | health-ejection env read once at init (test hook); cache-capability walk skipped when hints are impossible (tracker nil / mode off / no plan) | 202k |
+| version memo + struct keys | semver segments memoized (bounded 256, reset-on-full); `{providerID, model}` keys for dispatch-load cooldowns and pending loads | 176k |
+| in-place snapshots | snapshot filled in place, `buildCandidateInto`, chunked `candidateArena`, pointer-passing (no `duffcopy`) | 135k |
+| per-model index | `providersForModelLocked`: advertised model → providers, maintained at every `p.Models` mutation and removal site; used by the reservation scan, preflight, `PredictServable`, cache-capability lookup, and the alias probes (2–8 walks per aliased request) | 103k |
+| calibrator bound | TTFT calibrator no longer re-sweeps its pending map on every reservation at capacity | 68k |
+
+Eligibility gates are unchanged; the index only prunes providers that cannot
+advertise the model. Review follow-ups landed with it: the health-ejection
+test hook moved out of the production file; the calibrator prefers expired
+entries at capacity (bounded probe plus a 5 s capacity sweep); a fault-state
+fixture pins index equivalence with breaker-open, health-ejected and
+capacity-cooled providers; the TPS median cache is safe for a zero-value
+registry; the version memo skips oversized keys and the accepted provider
+version is capped at 64 bytes at registration (provider-controlled input must
+not be retained unbounded). Tests pin index == brute-force walk after every mutation
+type and identical routing results with/without the index on the 1,260-provider
+fixture for plain/tools/vision/TTFT-ceiling shapes.
+
+### 4.3 Route telemetry batching (`api/telemetry_sink*.go`, `store/*route_telemetry*.go`)
+
+The routing-telemetry sink now queues typed operations (route record, outcome
+update, closure) and one worker gathers up to 256 ops or 100 ms, writing the
+group's records with one multi-row `INSERT … ON CONFLICT`
+(`RecordInferenceRoutes`) and each run of outcome updates with one pgx batch
+pipeline (`UpdateInferenceRouteOutcomes`). A tracer-backed Postgres test shows
+50 records + 50 updates go from 100 statements to 1 statement + 1 pipeline.
+Per-key insert → update order is preserved by opening a new group whenever a
+record's key already appears in the current group; the non-blocking
+drop-and-count contract, single worker (now enforced), panic isolation per
+row, transient-error classification (`store.IsTransientWriteError`: no
+per-row replay on deadline/connection errors), post-close rejection, and a
+bounded 2 s flush in `Server.Close` before the pool closes are all covered by
+tests on both backends.
+
+Settlement consolidation (one transaction for the consumer refund, provider
+earning and platform fee) was evaluated and **not shipped**: the three writes
+fail independently today, `CreditProviderAccount` is idempotent on job id
+while `Credit` is not, and a single transaction over three balance rows adds a
+deadlock cycle between concurrent settlements. Instead, `Credit` and
+`CreditWithdrawable` were collapsed from five round trips (BEGIN, upsert,
+SELECT, INSERT, COMMIT) to one data-modifying CTE statement, the shape `Debit`
+already used; the transactional callers (`CreditWithdrawableOnce`,
+`CreditProviderWallet`) reuse the same statement inside their transactions. A
+tracer-backed test replays the legacy five-statement sequence against the new
+path and asserts byte-identical ledger rows and balances for unknown, existing,
+zero and negative amounts; a 32-goroutine mixed Credit/Debit test asserts the
+ledger running sums.
+
+### 4.4 Streaming relay and public read endpoints (`api/stream_coalesce.go`, `api/chat_stream_relay.go`, `api/sse_normalize_gate.go`, `api/models_cache.go`)
+
+All three relays (chat, Responses, generic completions/messages) now drain the
+chunks already queued in `ChunkCh` after each receive (bounded by the channel
+capacity, never waiting), apply the identical per-chunk transforms and holds
+in order, and flush once. Goldens pinned against the pre-change byte stream:
+
+| Relay | flushes/op (200-chunk burst) | bytes/op |
+|---|---:|---:|
+| chat | 203 → 9 | identical |
+| responses | 208 → 9 | identical |
+| completions | 202 → 8 | identical |
+| messages | 205 → 9 | identical |
+
+The relay also fixed two latent ordering bugs the reviewers surfaced: queued
+chunks now always precede a concurrently-ready in-band error, and the
+Responses/generic close paths report a buffered provider error instead of
+"provider ended without completion".
+
+`normalizeSSEChunk` decides with one pass instead of nine `strings.Contains`
+scans: content delta 915 → 191 ns, usage chunk 1.1 µs → 155 ns, byte-identical
+output over a 36-case differential corpus.
+
+Public read endpoints newly served from the TTL read cache: `/v1/models` and
+`/v1/models/{id}` (2 s, shared entry memo keyed by include_builds; self-route
+views stay live), `/v1/models/openrouter` (5 s), `/v1/providers/attestation`
+(2 s). Admin alias/registry mutations invalidate the catalog-derived entries
+through `SyncModelCatalog`/`SyncModelAliases`, so the TTLs only bound
+out-of-band edits.
+
+### 4.5 Fleet-scale aggregate and periodic paths (`registry/registry.go` ListModels/evictStale, `registry/provider_snapshot.go`)
+
+| Path | Before | After |
+|---|---:|---:|
+| `ListModels` (`/v1/models` aggregate) | 182 µs, 1,281 allocs | 115 µs, 19 allocs |
+| `PublicProviderModels` (`/v1/stats`, `/v1/providers/attestation`) | 181 µs, 1,266 allocs | 144 µs, 7 allocs |
+| `evictStale` (every 30 s) | full fleet walk under the registry **write** lock (~85 µs, stalls routing readers) | walk under the read lock; write lock only to install a changed strike map |
+
+New benchmarks cover every aggregate and periodic walk (`fleet_scale_aggregate_bench_test.go`,
+`provider_heartbeat_bench_test.go`). Findings left for follow-up: the
+model-swap planner runs a fleet walk on every heartbeat while the queue is
+non-empty (~350 µs per heartbeat from a provider advertising a queued model,
+~9% of a core at 250 heartbeats/s per queued model). Fixed in the registry
+follow-up (`registry/model_swap_coalesce.go`): heartbeats now admit at most
+one swap plan per 250 ms fleet-wide (the api cold-dispatch kick still plans
+immediately), the planner's two walks iterate the per-model index, and the
+per-heartbeat drain is unchanged — a direct plan with a queued unservable
+model went from 82 µs to 0.2 µs and the full heartbeat ingest in that state
+from 88 µs to 4 µs. Three read-only getters that took the write lock
+(`CodeAttestationEnforced` in the 15 s gauge loop) now take the read lock;
+`recordMLXCacheTelemetry` emits nine `provider_id`-tagged gauges per heartbeat
+(~11k Datadog series per flush — an observability cardinality decision, not
+changed here); throttled provider persistence is ~126 DB writes/s fleet-wide
+(a product freshness choice, not changed).
+
+### 4.6 Request body pipeline (`api/inference_preprocess.go`, `api/provider_body_*.go`, `api/toolschema_parsed.go`, `api/json_encoded_len.go`)
+
+The chat handler now parses the body once, mutates the map (alias, stop
+normalization, runtime defaults, max_tokens bound, reasoning policy, metadata
+strip) behind a dirty flag, and serializes once at the first byte consumer.
+Tool-schema normalization and tool-constraint validation run on the parsed
+map (the legacy `"tools"` byte gate is preserved so escaped keys still pass
+verbatim); the five message-tree walks are fused into one; billing bytes are
+counted with a JSON-encoded-length routine instead of a full marshal; the
+per-model provider body is memoized per request; and the legacy cache-bust
+size/seal is computed by arithmetic splice on already-canonical bodies.
+
+Full-body operations per request (chat, alias + runtime defaults, no
+`max_tokens`): parses 5 → 1, marshals 10 → 1. With tools on the Responses
+surface: parses 11 → 4, marshals up to 16 → 3.
+
+| Body | Helper-level ns/op | HTTP end-to-end ns/op | allocs (HTTP) |
+|---|---:|---:|---:|
+| 2 KB chat | 99,418 → 22,360 | 492,662 → 445,907 | 1,290 → 801 |
+| 60 KB history | 2,744,618 → 542,521 | 4,306,086 → 1,724,408 | 3,482 → 1,412 |
+| 60 KB history + tools | 3,454,648 → 652,058 | 4,825,177 → 1,857,896 | 7,047 → 2,189 |
+| 3 MB inline image | 147,274,823 → 19,902,326 | 193,711,639 → 53,986,076 | 1,854 → 972 |
+
+Provider-visible bytes are pinned by identity tests against independent
+oracles for every rewrite (verbatim passthrough, alias, stop, max_tokens,
+runtime defaults, reasoning on/off, stripped fields, tool normalization,
+Responses lowering, protocol-0 seal, alias-capacity fallback on both
+surfaces, media inlining), plus property tests for the encoded-length and
+splice routines against the decode → re-encode reference.
+
+## 5. After
+
+Registry benchmarks (1,260 providers; baseline and after measured back to back
+in the same machine state, load average ~13):
+
+| Benchmark | Before ns/op | After ns/op | allocs/op before → after |
+|---|---:|---:|---|
+| FleetReserveProviderEx | 322,881 | 67,933–73,309 | 824 → 21 |
+| FleetReserveProviderExParallel | 355,349 (quiet baseline) | 84,749–87,103 | 1,027 → 20 |
+| FleetQuickCapacityCheck | 151,054 | 47,347–47,922 | 672 → 1 |
+| FleetPredictServable (new) | 187,760 (worker A/B) | 43,302–43,530 | 672 → 1 |
+| FleetListModels | 191,167 | 138,012–139,786 | 1,281 → 19 |
+| FleetHeartbeat | 529 | 641–662 | 6 → 6 (TPS caches now maintained on write) |
+| FleetTickTriggerModelSwapsUnservableQueued | 82,390 | 216 | 3 → 3 |
+| FleetTickHeartbeatQueuedColdAdvertised | 87,884 | 4,047 | 12 → 9 |
+
+End-to-end (real HTTP, in-process WebSocket fake providers, memory store;
+baseline and after measured back to back, same machine state):
+
+| Scenario | Before | After |
+|---|---|---|
+| 100 providers, 16 KB, 16 concurrent | 1,435 req/s, TTFB p50 7.3 ms / p95 10.1 ms | 1,871 req/s, TTFB p50 4.3 ms / p95 7.5 ms |
+| 1,000 providers, 16 KB, 32 concurrent | 448 req/s, TTFB p50 44.3 ms / p95 64.5 ms | 954 req/s, TTFB p50 20.4 ms / p95 29.1 ms |
+| 100 providers, 60 KB, 16 concurrent | 395 req/s, TTFB p50 16.1 ms / p95 126.6 ms | 1,377 req/s, TTFB p50 7.6 ms / p95 10.8 ms |
+| 1,000 providers, 60 KB, 32 concurrent | 410 req/s, TTFB p50 56.9 ms / p95 86.5 ms | 717 req/s, TTFB p50 28.5 ms / p95 46.5 ms |
+
+The memory store hides the database wins: in production each request also
+loses one `users` round trip and three to four two-query `model_registry`
+round trips (now cache hits), each completion loses three round trips in the
+`Credit` collapse, and route telemetry goes from one statement per attempt to
+one multi-row insert per 100 ms.
+
+Request preprocessing alone (helper-level benchmark, `-benchtime 2s`): 2 KB
+body 99 µs → 22 µs; 60 KB history 2.74 ms → 0.54 ms; 3 MB inline image
+147 ms → 20 ms.
+
+## 6. Not done / recommendations
+
+- **Settlement consolidation** (one transaction for refund + provider earning +
+  platform fee) was evaluated and not shipped — see §4.3. The `Credit`
+  round-trip collapse captures most of the DB win without changing failure
+  semantics.
+- **`/v1/pricing`** is still uncached (handler lives in `billing_handlers.go`);
+  wrap it in the read cache with a 2 s TTL like the other public endpoints.
+- **Datadog cardinality**: `recordMLXCacheTelemetry` emits nine gauges tagged
+  by `provider_id` on every heartbeat (~11k series per flush at fleet scale).
+  Aggregating by chip family, or sampling, is an observability decision worth
+  making before the fleet grows further.
+- **Provider persistence**: throttled `UpsertProvider`/`TouchProviderSession`/
+  `UpsertReputation` writes are ~126 statements/s fleet-wide at 30 s freshness.
+  Batching them (multi-row upserts on a 5 s cadence) would cut DB write load
+  without changing the freshness contract.
+- **Container GC settings**: the container runs with no `GOMEMLIMIT`/`GOGC`
+  (deploy/gcp/vm-startup.sh); a soft memory limit tuned to the VM would let
+  the GC run less often under the allocation rates measured here. Deploy-side
+  change, human-only.
+- **pprof listener**: PR #799 adds `EIGENINFERENCE_PPROF_ADDR`; not
+  duplicated here. The generic completions/messages handlers still call
+  `resolveRequestedModel` (inside #799's hunks) and can be folded onto the
+  parse-once path after #799 merges.
+- **Review coverage**: every worker slice had both a Codex and an independent
+  Claude review; the merged branch had both as well. The Codex leg for the
+  final registry batch (planner coalescing, memo bounds, walk clock) was
+  launched but its result never came back through the wrapper; that batch
+  carries the independent Claude review (PASS) only.
+- **Not exercised here**: the system-level `e2e/` integration suite (needs a
+  Swift provider binary and a downloaded model) and a real Datadog agent.
+- **Swap-planner coalescing window**: a request enqueued right after a plan
+  waits up to 250 ms for the next heartbeat-triggered plan (the api
+  cold-dispatch kick still plans immediately); on a fleet with no heartbeats at
+  all no plan runs, which only matters for single-provider dev setups.

--- a/docs/reports/2026-09-03-perf-pr-a-body.md
+++ b/docs/reports/2026-09-03-perf-pr-a-body.md
@@ -1,0 +1,175 @@
+# PR body — coordinator performance program, PR A: `store/` + `api/` (2026-09-03)
+
+> Last updated: 2026-09-04 · commit `bda995368`
+
+_Branch `perf/coordinator-store-api-2026-09-03`. Merge after
+`perf/coordinator-tier1-2026-09-03`; before `perf/coordinator-registry-scan-2026-09-03`._
+
+The measurements retain their original 2026-09-03 context. Shutdown and relay
+instrumentation notes were corrected during review on 2026-09-04 against
+`bda995368`.
+
+## Summary
+
+Lands the store and API half of the 2026-09-02 coordinator performance program
+(`docs/reports/2026-09-02-coordinator-performance-program.md`, §4.1, §4.3,
+§4.4, §4.6) on current master. The registry half (§4.2 routing scan, §4.5
+aggregate paths, fleet-scale bench) is PR B; `coordinator/registry/` in this
+branch is byte-identical to master.
+
+Per inference request this PR removes the per-request database round trips
+(user + model record become read-through cache hits), parses the request body
+once instead of 5–11 times, batches route telemetry into one multi-row insert
+per 100 ms, collapses `Credit`/`CreditWithdrawable` from five statements to one,
+coalesces already-queued streamed chunks into one write + one flush, decides
+SSE normalization in one pass, and serves the public read endpoints from a TTL
+cache. Provider-visible bytes and the client byte stream are pinned by identity
+and golden tests against the pre-change output.
+
+## Before / After — behaviour
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A1[request] --> B1["requireAuth: API-key cache hit + users SELECT"]
+    B1 --> C1["parse body ×5–11, marshal ×10–16"]
+    C1 --> D1["model_registry SELECT ×2, called 3–4×"]
+    D1 --> E1["dispatch (registry, unchanged here)"]
+    E1 --> F1["INSERT inference_routes per attempt (goroutine each)"]
+    F1 --> G1["relay: Fprintf + Flush per chunk"]
+    G1 --> H1["settle: Credit = BEGIN, upsert, SELECT, INSERT, COMMIT"]
+    I1["/v1/models, /openrouter, /providers/attestation: full walk per call"]
+  end
+  subgraph After
+    A2[request] --> B2["requireAuth: API-key + user cache hits (30 s TTL)"]
+    B2 --> C2["parse once, mutate map behind a dirty flag, marshal once"]
+    C2 --> D2["model record: cache hit (10 s TTL, invalidated by every writer)"]
+    D2 --> E2["dispatch (registry, unchanged here)"]
+    E2 --> F2["route rows queued → one multi-row INSERT / 256 ops or 100 ms"]
+    F2 --> G2["relay: drain queued chunks → one write → one Flush"]
+    G2 --> H2["settle: Credit = one data-modifying CTE"]
+    I2["/v1/models 2 s, /openrouter 5 s, /providers/attestation 2 s read cache; admin mutations invalidate"]
+  end
+```
+
+## Before / After — code
+
+```mermaid
+flowchart LR
+  subgraph Before
+    ST1["store.PostgresStore / MemoryStore"] --> Q1["GetUserByAccountID, GetModelRegistryRecord: SQL per call"]
+    ST1 --> CR1["Credit: 5 round trips"]
+    T1["telemetrySink (untyped, 1 op per write)"] --> U1["RecordInferenceRoute per record"]
+    V1["handleStreamingResponseWithFirstChunkAndError: inline per-chunk pipeline"] --> W1["Fprintf + Flush per chunk; rs.wrote per write"]
+    P1["preprocessInferenceRequest: unmarshal/marshal per step"] --> X1["normalizeToolSchemas, validateToolConstraints on bytes"]
+    N1["normalizeSSEChunk: 9× strings.Contains"]
+  end
+  subgraph After
+    ST2["store.CachedStore (NewCached, wraps both backends)"] --> Q2["TTL + generation-checked domains; store.As[T] for backend-only capabilities"]
+    ST2 --> CR2["Credit / CreditWithdrawable: one CTE (postgres.go)"]
+    T2["telemetrySink (typed ops, coalescing worker)"] --> U2["RecordInferenceRoutes + UpdateInferenceRouteOutcomes (pgx batch)"]
+    V2["chatStreamRelay.handleChunk + finishStream + drainQueuedChunks"] --> W2["flush writes batch → relayStamps.wroteFrames records frames, bytes and error"]
+    P2["preprocessInferenceRequest: parsed map + dirty flag"] --> X2["toolschema_parsed, request_introspection fused walk, json_encoded_len, provider_body_memo/splice/seal"]
+    N2["sse_normalize_gate: one pass"]
+  end
+```
+
+## What is in this PR
+
+| Slice | Files | Effect |
+|---|---|---|
+| §4.1 store read-through cache | `store/cached*.go`, `store/as.go`, `cmd/coordinator/main.go` | user (30 s) / model record + manifest (10 s) / not-found (5 s) cached; invalidated by every mutator; deep copies; generation counter; bounded domains; `store.As[T]` keeps `codeAttestPushBudgetStore` and `verificationDuePageStore` reachable through the decorator; `store.cache.*` gauges |
+| §4.3 route-telemetry batching | `api/telemetry_sink*.go`, `api/route_telemetry_submit.go`, `store/*route_telemetry*.go`, `store/write_errors.go` | one worker, ≤256 ops / 100 ms groups, one multi-row `INSERT … ON CONFLICT` + one pgx pipeline per group, per-key order preserved, transient-error classification, post-close rejection, bounded 2 s flush in `Server.Close` |
+| §4.3 Credit collapse | `store/postgres.go`, `store/ledger_credit_test.go` | `Credit`/`CreditWithdrawable` 5 → 1 round trip; tracer test asserts byte-identical ledger rows and balances vs the legacy sequence |
+| §4.4 streaming relay | `api/chat_stream_relay.go`, `api/stream_coalesce.go`, `api/consumer.go`, `api/generic_endpoint_stream.go`, `api/responses_stream.go` | chat/Responses/generic relays drain already-queued chunks per wake-up (never waiting), identical transforms in order, one flush; goldens: 200-chunk burst 203 → 9 flushes, bytes identical; queued chunks always precede an in-band error |
+| §4.4 SSE gate + read cache | `api/sse_normalize_gate.go`, `api/models_cache.go`, `api/models_endpoints.go`, `api/openrouter_endpoint.go`, `api/server.go` | `normalizeSSEChunk` 915 → 191 ns; `/v1/models`, `/v1/models/{id}` (2 s), `/v1/models/openrouter` (5 s), `/v1/providers/attestation` (2 s) cached; `SyncModelCatalog`/`SyncModelAliases` invalidate |
+| §4.6 body pipeline | `api/inference_preprocess.go`, `api/provider_body_{memo,seal,splice}.go`, `api/toolschema_parsed.go`, `api/request_introspection.go`, `api/json_encoded_len.go`, `api/tool_constraints.go`, `api/reasoning_request_policy.go` | parses 5 → 1, marshals 10 → 1 (chat); 11 → 4 / 16 → 3 with tools on Responses; identity tests against independent oracles for every rewrite |
+| harness | `api/perf_e2e_test.go` | gated (`EIGENINFERENCE_PERF_E2E=1`): real HTTP + in-process WebSocket providers, memory store; knobs `PERF_E2E_{PROVIDERS,REQUESTS,CONCURRENCY,BODY_KB,CHUNKS}` |
+| docs | `docs/operations/coordinator-deploy.md`, `AGENTS.md`, `docs/reports/2026-09-02-*` | runbook row for cache staleness after manual SQL edits; AGENTS invariant for the store cache; the program report and its PR-body draft |
+
+## Merge resolution against master (#799, #809, #816)
+
+Source: perf branch `worktree-bridge-cse_01TuyfD42fkRyG4ZqSTmeN4U` (75 commits,
+tip `5508b4f84`, based on `a1f51ea4c`), merged onto `ac60c5ada` with
+`coordinator/registry/` reset to master and the 26 registry files the branch
+added removed. Conflicts and the semantic hazards from
+`docs/reports/2026-09-03-coordinator-perf-proposal/05-port-feasibility.md`:
+
+| Where | Master side | Resolution |
+|---|---|---|
+| `api/consumer.go` (3 hunks), `api/generic_endpoint_stream.go` (1 hunk) | #809 `rs.wrote(n, werr)` after every client write, `rs.done()` after the terminal `[DONE]`, `profileClientGone(pr, phaseAfterCommit)` on every `Context().Done()` arm; #799 `writeChatStreamProviderError` + in-band `ErrorCh` select | perf's `chatStreamRelay` + `finishStream()` structure kept. `chatStreamRelay.flush` writes the batch and calls `relayStamps.wroteFrames` with its frame count, accepted bytes, and write error, so `chunks_out` keeps meaning SSE frames delivered (not flushes), `bytes_out` counts only accepted bytes, and a failed/short write sets `client_write_err`. `rs.done()` runs once after the terminal flush on the non-Responses success path (as on master). `profileClientGone` is on every relay `Context().Done()` arm including the generic relay's `finishStream`. #799's error writer, in-band select, `maxFirstChunkTimeoutRetries`, `errRoutingScanSaturated`, `errClientGoneBeforeScan` and the `dispatchOneProvider`/`dispatchWithReserver` arities are master's. `TestStreamRelay_ChatBurstByteIdentical` now also reads back the persisted request profile: `chunks_out` = 53 frames (a flush-count implementation would read ~9), `bytes_out` = the golden's length, `done_flushed_us` stamped, `client_write_err` false. |
+| H7 — six #809 `store.Store` methods | `RecordRequestProfiles`, `RequestProfilesSince[Filtered]`, `RecordFleetSnapshots`, `FleetSnapshotsSince`, `PruneTelemetry` | `CachedStore` embeds `Store` and overrides none of them; `TestCachedStoreForwardsProfilerMethods` writes through the wrapper and reads back from the inner store. `profiler_sink.go` is its own goroutine, so the route sink's post-close rejection cannot drop profile writes. |
+| H9 — independent sink shutdown | #809 `profileSink` | `Server.Close` waits up to 2 s for `routeTelemetry.closeAndWait`, then signals `profiler.close()`. The route sink gets a bounded drain-and-wait; the profile sink is best-effort, with no queue drain or worker wait guaranteed. Although `main.go` defers pool closure until after `Server.Close`, queued profile records can still be discarded or outlive that closure. |
+| H10 — `api/profiler_sink.go` calls `isPowerOfTen` | perf's sink rewrite deleted it (kept `crossesPowerOfTen(before, after)`) | one call site switched to `crossesPowerOfTen(n-1, n)`: identical throttle (fires at 1, 10, 100, …), no duplicated helper. The walk now stops at 10^18 (`p > 0` guard) instead of overflowing near `math.MaxInt64`; cases added to `TestCrossesPowerOfTen`. |
+| H11 — `store/memory.go` `strconv` | #809 kept one `strconv.Itoa` use; perf dropped the import | import restored. |
+| `api/server.go`, `cmd/coordinator/main.go` | #816 rewrote the runtime manifest loading in both | auto-merged; perf's hunks (bounded sink flush in `Close`, catalog-cache invalidation, `emitStoreCacheGauges`, `store.NewCached` wiring) do not overlap. |
+| `AGENTS.md` | — | the perf branch's "per-model provider index" invariant (a `registry/model_index.go` contract) is dropped here; it returns with PR B. |
+
+Profiler semantics note (for the system-profiler docs): the held finish/usage
+frames now count in `chunks_out` and `bytes_out` (master's #809 wrote them
+without an `rs.wrote`, stamping only the extras and `[DONE]` frames — an
+undercount this fixes). For the chat relay, `first_flush_us` /
+`max_chunk_gap_us` are stamped per actual flush. Responses, completions, and
+messages emitters call `relayStamps.wrote` for each event write while using
+`deferredFlusher`; their timestamps precede the outer relay's coalesced flush
+and describe event-write timing, not wire-flush timing. See
+`relayStamps.flushedFrames` in `coordinator/api/profiler_dispatch.go`.
+
+## Measurements
+
+The program report's numbers (registry benchmarks, helper-level body
+benchmarks, e2e at load ≈ 13) are in
+`docs/reports/2026-09-02-coordinator-performance-program.md` §5. The e2e
+harness was re-run on the merged tree against master on the same machine,
+interleaved master → PR A per round, **at load average 265–340 on 16 cores**
+(other sessions' builds and benchmarks were running); absolute numbers are
+therefore ~10× below the report's and only the paired comparison is meaningful.
+Memory store, 100 providers, 400 requests, 16 concurrent, 40 chunks:
+
+| Body | Rounds | master `ac60c5ada` | PR A | Δ throughput |
+|---|---|---|---|---|
+| 16 KB | 2 | 167.2 / 157.6 req/s (median 162.4); TTFB p50 33.9 / 38.8 ms, p95 168.9 / 196.7 ms | 195.9 / 201.4 req/s (median 198.7); TTFB p50 36.8 / 33.5 ms, p95 111.1 / 152.0 ms | **+22 %** (both rounds ahead); p95 TTFB −28 % |
+| 60 KB | 5 | 117.2 / 105.6 / 50.0 / 98.9 / 103.6 req/s (median 103.6); TTFB p95 median 238 ms | 127.5 / 75.7 / 133.9 / 111.1 / 138.4 req/s (median 127.5); TTFB p95 median 216 ms | **+23 %** median (ahead in 4 of 5) |
+
+With master's registry the reserve/preflight scans are unchanged, and the
+memory store hides the database wins, so this is the relay + body-pipeline
+share of the program. The database share is measured directly: tracer-backed
+tests pin 50 route records + 50 outcome updates at 1 statement + 1 pipeline
+(was 100 statements), `Credit` at one statement (was five), and the
+`requireAuth` user lookup plus the 3–4 registry-record lookups per request at
+zero statements after the first hit. Re-measure on a quiet box before quoting
+absolute numbers (feasibility plan step 3).
+
+## Gates run
+
+`gofmt -l` clean; `go build ./...`, `go vet ./...` clean; `golangci-lint
+v2.1.6 run ./...` 0 issues. `go test ./store/` against a fresh Postgres 16
+(`DATABASE_URL` set, 0 skips, 74 s), `./api/` (131 s), `./cmd/...`,
+`./protocol/` all pass. Named suites run verbosely: `TestStreamRelay_*`
+(7 goldens + client-disconnect + buffered-error), `TestTelemetrySink*` (16),
+`TestServerRouteTelemetry*`, `TestServerCloseFlushesRouteTelemetryBeforeReturning`,
+`TestProviderBodyByteIdentity*` (4), `TestSSENormalizeGateMatchesLegacy`,
+`TestStoreCacheInvalidatesThroughAdminModelAction`, `TestRelayStamps*`,
+`TestChatStreamRelayFlushReportsFramesAndBytes`, `TestCachedStore*` (incl.
+`OverPostgres` and `ForwardsProfilerMethods`), `TestInferenceRoute*`,
+`TestPostgresCredit*`, `TestCreditSemanticsAcrossBackends`,
+`TestConcurrentCreditDebitLedgerConsistency`, `TestPerfE2E_ChatCompletions`.
+
+Independent review (general-purpose agent, read-only) returned PASS on all
+four criteria — #799/#809 relay semantics, decorator forwarding, registry
+byte-identical, test adequacy — with one should-fix (the profile-row
+assertion above) and two nits (the overflow guard; the `flushedFrames`
+comment now says the emitter relays stamp per event write, ahead of their
+deferred Flush), all applied. staticcheck items it listed in auto-merged perf
+files (`S1017` ×2, `ST1008`, `ST1018`, `SA4006`) are pre-existing on the source
+branch and out of scope here.
+
+## Notes for reviewers
+
+- The store cache assumes a single coordinator process (documented in
+  `store/cached.go`); manual SQL edits take up to the TTL to become visible
+  (runbook row in `docs/operations/coordinator-deploy.md`).
+- `api/` compiles against master's registry API unchanged; nothing in this PR
+  depends on the PR B registry changes.
+- Known flakes not touched here: `promptcontract` supervisor tests under load;
+  `TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix`.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-04 · commit `bda995368`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -54,6 +54,14 @@ Plans and decision memos live in [`../design/`](../design/README.md).
 |---|---|---|
 | 2026-07-04 | [provider-trust-reliability](2026-07-04-provider-trust-reliability.md) | Why ~11% of the fleet stalled at `self_signed`, and the per-connection MDM fix |
 | 2026-07-17 | [eigencloud-to-gcp-migration](2026-07-17-eigencloud-to-gcp-migration.md) | Record of the prod move from EigenCloud to a GCP Confidential VM (complete) |
+
+## Coordinator performance program (2026-09)
+
+| Date | Report | One line |
+|---|---|---|
+| 2026-09-02 | [coordinator-performance-program](2026-09-02-coordinator-performance-program.md) | First-principles pass over every coordinator operation with a measurable cost: fleet-scale benchmarks, store cache, route batching, relay coalescing, parse-once bodies |
+| 2026-09-02 | [coordinator-performance-pr-body](2026-09-02-coordinator-performance-pr-body.md) | Original PR body of the 75-commit program branch, kept as the record |
+| 2026-09-03 | [perf-pr-a-body](2026-09-03-perf-pr-a-body.md) | Landing the store/api half of the program on master (read-through cache, batched route sink, parse-once bodies, relay coalescing) |
 
 ## Raw benchmark outputs
 


### PR DESCRIPTION
Repeated lookups, per-event SQL writes, repeated body parsing, and tiny stream writes add avoidable coordinator CPU and database work. This PR caches repeated user/model reads, batches route telemetry, makes ledger Credit one statement, and coalesces relay output within a byte cap.

- `store.NewCached` wraps the store with bounded read-through caches and mutation invalidation. Store-specific behavior remains available through typed unwrapping.
- Model entry/list/OpenRouter caches use generation-checked publication so a read started before invalidation cannot restore stale data.
- Route telemetry batches writes and has bounded shutdown draining. Profile telemetry remains best-effort; the documentation distinguishes its shutdown behavior and emitter timestamps from actual chat wire flushes.
- Request introspection and provider body construction reuse parsed data. Relay coalescing accounts for encoded bytes and flushes on the configured size/time boundaries.
- The CachedStore scheduler fixture uses deterministic dispatcher control.

## Before
```mermaid
flowchart LR
  R[Request] --> L[Repeated Store lookups and SQL round trips]
  R --> P[Repeated body parsing and encoding]
  R --> T[One route event per database write]
  P --> S[Small stream writes]
  L --> O[Higher CPU and per-request database work]
  T --> O
  S --> O
```

## After
```mermaid
flowchart LR
  R[Request] --> C[NewCached and generation-checked model caches]
  R --> P[Parsed request and reusable provider body]
  R --> T[Batched route telemetry sink]
  P --> S[Byte-capped relay coalescing]
  C --> O[Fewer repeated reads and writes]
  T --> O
  S --> O
  I[Store mutation or model sync] --> G[Invalidate and advance generation]
  G --> C
```

Validation: full coordinator tests, targeted API/store race tests, isolated PostgreSQL store tests under `-race`, build, vet, lint, and documentation checks passed. Reported SQL reductions depend on cache hits; final production latency gains have not been measured.

Merge order: #821 → #820 → #819 → #823 → #822. Each PR targets its immediate parent; retarget to master as its parent lands.

The maintainer has deferred the known Threat Model Review credential failure. The benchmark environment remains subject to its existing manual approval gate.
