### PR TITLE
test(coordinator): stabilize scheduler, attestation and persistence fixtures

### DIFF
--- a/coordinator/api/mdm_scheduler_test.go
+++ b/coordinator/api/mdm_scheduler_test.go
@@ -118,6 +118,29 @@ func waitSchedulerCondition(t *testing.T, condition func() bool, message string)
 	}
 }
 
+// withoutLiveDispatcher consumes the scheduler's start Once so Submit's Start
+// becomes a no-op and no dispatcher or worker goroutine ever runs. Tests that
+// drive loadDueRows by hand are then the only actor over sch.jobs and
+// dueScanOffset: nothing concurrently pages the same due rows, claims the
+// reseeded job (rewriting job.record) or completes and drops it. Close stays
+// safe because the WaitGroup is never armed.
+func withoutLiveDispatcher(sch *mdmVerificationScheduler) {
+	sch.start.Do(func() {})
+}
+
+// schedulerJobDue reports whether the scheduler currently holds the job and
+// its recorded due time, both read under sch.mu so a test never races the
+// dispatcher's claimAndDispatch, which rewrites job.record.
+func schedulerJobDue(sch *mdmVerificationScheduler, sePubKey string, kind store.VerificationTaskKind) (bool, time.Time) {
+	sch.mu.Lock()
+	defer sch.mu.Unlock()
+	job := sch.jobs[verificationSchedulerKey(sePubKey, kind)]
+	if job == nil {
+		return false, time.Time{}
+	}
+	return true, job.record.NextAttemptAt
+}
+
 func TestMDMSchedulerGlobalConcurrencyCap(t *testing.T) {
 	var active atomic.Int32
 	var maximum atomic.Int32
@@ -969,6 +992,7 @@ func TestMDMSchedulerQueueRejectedChallengeSettlesDurablyAndReseeds(t *testing.T
 	}, mdmSchedulerDeps{now: nowFn, jitter: func(time.Duration, time.Duration) time.Duration {
 		return 3 * time.Minute
 	}})
+	withoutLiveDispatcher(sch)
 	evicted := schedulerTestProvider(t, srv, "evicted-refresh", "se-evicted-refresh")
 	sch.Submit(context.Background(), evicted.ID, evicted, store.VerificationPriorityRefresh)
 	urgent := schedulerTestProvider(t, srv, "urgent-first", "se-urgent-first")
@@ -991,18 +1015,9 @@ func TestMDMSchedulerQueueRejectedChallengeSettlesDurablyAndReseeds(t *testing.T
 	sch.Unbind("se-urgent-first", urgentGeneration)
 	clock.Store(wantDue.UnixNano())
 	sch.loadDueRows()
-	sch.mu.Lock()
-	job := sch.jobs[verificationSchedulerKey(
-		"se-evicted-refresh", store.VerificationTaskSecurityInfo,
-	)]
-	var reseeded *store.VerificationJob
-	if job != nil {
-		record := job.record
-		reseeded = &record
-	}
-	sch.mu.Unlock()
-	if reseeded == nil || !reseeded.NextAttemptAt.Equal(wantDue) {
-		t.Fatalf("durable queue-pressure job was not reseeded at preserved due time: %+v", reseeded)
+	found, reseededDue := schedulerJobDue(sch, "se-evicted-refresh", store.VerificationTaskSecurityInfo)
+	if !found || !reseededDue.Equal(wantDue) {
+		t.Fatalf("durable queue-pressure job was not reseeded at preserved due time: found=%v due=%s", found, reseededDue)
 	}
 }
 
@@ -1021,6 +1036,7 @@ func TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix(t *tes
 			return time.Hour
 		},
 	})
+	withoutLiveDispatcher(sch)
 	for i := range 5 {
 		_, err := st.UpsertVerificationJob(context.Background(), store.VerificationJob{
 			SEPubKey:      fmt.Sprintf("a-disconnected-%02d", i),
@@ -1055,21 +1071,12 @@ func TestMDMSchedulerDuePagingCannotStarveLiveRowBehindDisconnectedPrefix(t *tes
 	for range 4 {
 		sch.loadDueRows()
 	}
-	sch.mu.Lock()
-	job := sch.jobs[verificationSchedulerKey(
-		"z-se-paging-live", store.VerificationTaskSecurityInfo,
-	)]
-	var reseeded *store.VerificationJob
-	if job != nil {
-		record := job.record
-		reseeded = &record
-	}
-	sch.mu.Unlock()
-	if reseeded == nil {
+	found, reseededDue := schedulerJobDue(sch, "z-se-paging-live", store.VerificationTaskSecurityInfo)
+	if !found {
 		t.Fatal("live queue-rejected row remained hidden behind disconnected due-row prefix")
 	}
-	if !reseeded.NextAttemptAt.Equal(due) {
-		t.Fatalf("paged reseed due = %s, want %s", reseeded.NextAttemptAt, due)
+	if !reseededDue.Equal(due) {
+		t.Fatalf("paged reseed due = %s, want %s", reseededDue, due)
 	}
 }
 

--- a/coordinator/api/provider_registration_test.go
+++ b/coordinator/api/provider_registration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
@@ -182,102 +183,109 @@ func TestProviderRegistrationBindsProtectedRuntimeClaims(t *testing.T) {
 
 func TestProviderRegistrationAttestationFreshnessVersionGate(t *testing.T) {
 	cases := []struct {
-		name      string
-		version   string
-		timestamp time.Time
-		accepted  bool
+		name            string
+		version         string
+		timestampOffset time.Duration
+		accepted        bool
 	}{
 		{
-			name:      "missing version retains legacy reconnect semantics",
-			timestamp: time.Now().Add(-10 * time.Minute),
-			accepted:  true,
+			name:            "missing version retains legacy reconnect semantics",
+			timestampOffset: -10 * time.Minute,
+			accepted:        true,
 		},
 		{
-			name:      "last legacy release accepts reconnect replay",
-			version:   "0.8.14",
-			timestamp: time.Now().Add(-10 * time.Minute),
-			accepted:  true,
+			name:            "last legacy release accepts reconnect replay",
+			version:         "0.8.14",
+			timestampOffset: -10 * time.Minute,
+			accepted:        true,
 		},
 		{
-			name:      "capability release rejects stale replay",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(-10 * time.Minute),
+			name:            "capability release rejects stale replay",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: -10 * time.Minute,
 		},
 		{
-			name:      "newer release rejects stale replay",
-			version:   "0.8.16",
-			timestamp: time.Now().Add(-10 * time.Minute),
+			name:            "newer release rejects stale replay",
+			version:         "0.8.16",
+			timestampOffset: -10 * time.Minute,
 		},
 		{
-			name:      "capability release accepts future skew just under boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew - time.Second),
-			accepted:  true,
+			name:            "capability release accepts future skew just under boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew - time.Second,
+			accepted:        true,
 		},
 		{
-			name:      "capability release accepts future skew at boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew),
-			accepted:  true,
+			name:            "capability release accepts future skew at boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew,
+			accepted:        true,
 		},
 		{
-			name:      "capability release rejects future skew over boundary",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now().Add(RegistrationAttestationMaxFutureSkew + time.Second),
+			name:            "capability release rejects future skew just over boundary",
+			version:         minProviderVersionForReconnectAttestation,
+			timestampOffset: RegistrationAttestationMaxFutureSkew + time.Second,
 		},
 		{
-			name:      "capability release accepts fresh reconnect",
-			version:   minProviderVersionForReconnectAttestation,
-			timestamp: time.Now(),
-			accepted:  true,
+			name:     "capability release accepts fresh reconnect",
+			version:  minProviderVersionForReconnectAttestation,
+			accepted: true,
 		},
 	}
 
 	for index, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			reg := registry.New(logger)
-			srv := NewServer(
-				reg,
-				store.NewMemory(store.Config{AdminKey: "test-key"}),
-				ServerConfig{},
-				logger,
-			)
-			publicKey := testPublicKeyB64()
-			regMsg := &protocol.RegisterMessage{
-				Type:      protocol.TypeRegister,
-				Version:   tc.version,
-				PublicKey: publicKey,
-				Attestation: buildTestAttestationJSONWithFields(
-					t, publicKey, "", "", tc.timestamp, nil),
-			}
-			provider := reg.Register(fmt.Sprintf("reconnect-%d", index), nil, regMsg)
-			srv.verifyProviderAttestation(provider.ID, provider, regMsg)
+			synctest.Test(t, func(t *testing.T) {
+				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+				reg := registry.New(logger)
+				srv := NewServer(
+					reg,
+					store.NewMemory(store.Config{AdminKey: "test-key"}),
+					ServerConfig{},
+					logger,
+				)
+				defer srv.Close()
+				publicKey := testPublicKeyB64()
+				// The bubble freezes time at a whole-second instant while this
+				// synchronous verification runs, so the signed fixture keeps exact
+				// below/at/one-second-over boundary coverage without aging between
+				// construction and CheckTimestamp. Production clocks are untouched.
+				timestamp := time.Now().Add(tc.timestampOffset)
+				regMsg := &protocol.RegisterMessage{
+					Type:      protocol.TypeRegister,
+					Version:   tc.version,
+					PublicKey: publicKey,
+					Attestation: buildTestAttestationJSONWithFields(
+						t, publicKey, "", "", timestamp, nil),
+				}
+				provider := reg.Register(fmt.Sprintf("reconnect-%d", index), nil, regMsg)
+				srv.verifyProviderAttestation(provider.ID, provider, regMsg)
 
-			provider.Mu().Lock()
-			defer provider.Mu().Unlock()
-			if tc.accepted {
-				if provider.Status == registry.StatusUntrusted ||
+				provider.Mu().Lock()
+				defer provider.Mu().Unlock()
+				if tc.accepted {
+					if provider.Status == registry.StatusUntrusted ||
+						provider.AttestationResult == nil ||
+						!provider.AttestationResult.Valid {
+						t.Fatalf("freshness-compatible registration rejected: status=%s result=%+v",
+							provider.Status, provider.AttestationResult)
+					}
+					if provider.LastChallengeVerified.IsZero() {
+						t.Fatal("accepted registration did not initialize periodic challenge freshness")
+					}
+					return
+				}
+				if provider.Status != registry.StatusUntrusted ||
 					provider.AttestationResult == nil ||
-					!provider.AttestationResult.Valid {
-					t.Fatalf("freshness-compatible registration rejected: status=%s result=%+v",
+					provider.AttestationResult.Error != "attestation timestamp outside freshness window" {
+					t.Fatalf("replayed attestation state = status=%s result=%+v",
 						provider.Status, provider.AttestationResult)
 				}
-				if provider.LastChallengeVerified.IsZero() {
-					t.Fatal("accepted registration did not initialize periodic challenge freshness")
+				if len(provider.RuntimeCapabilities) != 0 {
+					t.Fatalf("replayed attestation retained capabilities: %v",
+						provider.RuntimeCapabilities)
 				}
-				return
-			}
-			if provider.Status != registry.StatusUntrusted ||
-				provider.AttestationResult == nil ||
-				provider.AttestationResult.Error != "attestation timestamp outside freshness window" {
-				t.Fatalf("replayed attestation state = status=%s result=%+v",
-					provider.Status, provider.AttestationResult)
-			}
-			if len(provider.RuntimeCapabilities) != 0 {
-				t.Fatalf("replayed attestation retained capabilities: %v",
-					provider.RuntimeCapabilities)
-			}
+			})
 		})
 	}
 }

--- a/coordinator/registry/reputation_persist_throttle_test.go
+++ b/coordinator/registry/reputation_persist_throttle_test.go
@@ -20,8 +20,11 @@ type reputationUpsertCounter struct {
 }
 
 func (c *reputationUpsertCounter) UpsertReputation(ctx context.Context, providerID string, rep store.ReputationRecord) error {
+	err := c.MemoryStore.UpsertReputation(ctx, providerID, rep)
+	// Waiters inspect the persisted row after observing this count, so publish
+	// completion only after the wrapped write has made that row visible.
 	c.upserts.Add(1)
-	return c.MemoryStore.UpsertReputation(ctx, providerID, rep)
+	return err
 }
 
 func waitForUpserts(t *testing.T, st *reputationUpsertCounter, want int64) {


### PR DESCRIPTION
The coordinator tests could race the live MDM dispatcher, the wall clock at an attestation boundary, or an asynchronous reputation write. This test-only prerequisite makes those observations deterministic; production scheduling, freshness tolerances, and persistence behavior are unchanged.

- Disable the live dispatcher only in the two scheduler fixtures and read job state under the scheduler mutex.
- Use `testing/synctest` to preserve exact below/at/one-second-over freshness coverage without wall-clock drift.
- Signal a counted reputation upsert after the wrapped store write completes, so assertions observe persisted data.

## Before
```mermaid
flowchart LR
  T[Test] --> D[Live claimAndDispatch mutates job]
  T --> C[Wall clock advances during signature check]
  T --> W[Upsert counter advances before MemoryStore write]
  D --> F[Intermittent assertion failure]
  C --> F
  W --> F
```

## After
```mermaid
flowchart LR
  T[Test] --> D[withoutLiveDispatcher and schedulerJobDue]
  T --> C[synctest freezes verification time]
  T --> W[MemoryStore write completes before counter signal]
  D --> P[Deterministic assertions]
  C --> P
  W --> P
```

Validation: scheduler and exact-clock cases passed 100 repetitions under `-race`; the reputation completion-order fixture passed 30 repetitions. The complete coordinator race suite also passed in the integrated stack.

Merge order: #821 → #820 → #819 → #823 → #822. Each PR targets its immediate parent; retarget to master as its parent lands.

The maintainer has deferred the known Threat Model Review credential failure. The benchmark environment remains subject to its existing manual approval gate.
