### PR TITLE
perf(registry): use per-identity fault gates and shared reservation commits (Tier 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — coordinator performance Tiers 2 and 3
+
+- Cache repeated user and model lookups, batch route telemetry writes, and credit balances in one database statement. Invalidate model caches without allowing older in-flight reads to republish stale entries.
+- Coalesce streaming output within a byte cap and parse request bodies once.
+- Reduce routing scan work with per-model provider indexes, maintained medians, reusable snapshots, bounded version memoization, and coalesced swap and queue-drain planning.
+- Commit reservations under the registry read lock and the selected provider's lock. Keep fault tracking on per-identity gates, with validated rebind and sweep handling; retain `EIGENINFERENCE_RESERVE_COMMIT_MODE=global` as the reservation rollback switch.
+- Preserve newer rejection state when capacity-accept bookkeeping arrives late.
+- Make scheduler, attestation timestamp, and reputation persistence test fixtures deterministic.
+
 ## Unreleased — provider lifecycle and bounded coordinator work
 
 - Fragment large provider WebSocket messages, bound queue-drain work, and keep control traffic responsive.

--- a/coordinator/api/dispatch_nonfault_breaker_test.go
+++ b/coordinator/api/dispatch_nonfault_breaker_test.go
@@ -41,6 +41,7 @@ func newBreakerExemptionHarness(t *testing.T, name string) (*Server, *registry.R
 	provider.Mu().Lock()
 	provider.AccountID = "acct-" + name
 	provider.Mu().Unlock()
+	provider.RebindStableFaultKey()
 	pr := &registry.PendingRequest{
 		RequestID: "req-" + name,
 		Model:     "test-model",

--- a/coordinator/api/gate_wait_metric_test.go
+++ b/coordinator/api/gate_wait_metric_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// awaitMetric polls the collector until a packet for metric arrives or the
+// timeout lapses (the DogStatsD client may buffer briefly). Matched as a
+// substring: the client prefixes every name with the configured namespace.
+func awaitMetric(t *testing.T, c *udpCollector, metric string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, p := range c.drain() {
+			if strings.Contains(p, metric+":") {
+				return p
+			}
+		}
+	}
+	t.Fatalf("no %s packet within %v", metric, timeout)
+	return ""
+}
+
+// TestRegistryGateWaitHistogramTaggedBySite: NewServer wires the registry's
+// gate-wait observer to the registry.gate.wait_ms histogram, tagged with the
+// recorder site, so the per-identity locks that replaced the request-path
+// registry write lock stay observable.
+func TestRegistryGateWaitHistogramTaggedBySite(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "test-key"}), ServerConfig{}, logger)
+	defer srv.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "gate-wait-metric-model"
+	p := makeRoutableProvider(t, reg, "gate-wait-metric-provider", model)
+
+	// Block the recorder behind its identity's held gate so the wait is
+	// measurable (well above the 1 ms reporting threshold).
+	release := reg.HoldGateForTest(p.ID)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		release()
+	}()
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+
+	packet := awaitMetric(t, collector, "registry.gate.wait_ms", 5*time.Second)
+	if !strings.Contains(packet, "site:breaker") {
+		t.Fatalf("gate-wait histogram missing the site tag: %s", packet)
+	}
+	if !strings.Contains(packet, "|h|") {
+		t.Fatalf("gate-wait metric is not a histogram: %s", packet)
+	}
+}

--- a/coordinator/api/lock_wait_metrics_test.go
+++ b/coordinator/api/lock_wait_metrics_test.go
@@ -33,6 +33,7 @@ func waitForMetric(t *testing.T, collector *udpCollector, substr string) string 
 // lock-wait observer to the registry.mu.write_wait_ms histogram, tagged with
 // the call site.
 func TestRegistryLockWaitHistogramTaggedBySite(t *testing.T) {
+	t.Setenv("EIGENINFERENCE_RESERVE_COMMIT_MODE", "global")
 	collector := newUDPCollector(t)
 	defer collector.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -46,16 +47,15 @@ func TestRegistryLockWaitHistogramTaggedBySite(t *testing.T) {
 	const model = "lock-wait-metric-model"
 	p := makeRoutableProvider(t, reg, "lock-wait-metric-provider", model)
 
-	// Block the recorder behind a held write lock so the wait is measurable.
-	release := reg.HoldWriteLockForTest()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		release()
-	}()
-	reg.ClearDispatchLoadCooldown(p.ID, model)
+	// The global compatibility commit still emits the write-lock metric.
+	reserved, _, _ := reg.ReserveProviderWithPlan(model, &registry.PendingRequest{RequestID: "global-metric", Model: model, EstimatedPromptTokens: 1})
+	if reserved == nil {
+		t.Fatal("global reservation failed")
+	}
+	defer p.RemovePending("global-metric")
 
 	packet := waitForMetric(t, collector, "registry.mu.write_wait_ms")
-	if !strings.Contains(packet, "site:dispatch_load_cooldown") {
+	if !strings.Contains(packet, "site:commit") {
 		t.Fatalf("lock-wait histogram missing the site tag: %s", packet)
 	}
 	if !strings.Contains(packet, "|h|") {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -870,6 +870,12 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		s.trustReplayInFlight = make(map[string]struct{})
 	}
 	reg.SetRuntimeCapabilitiesPromotedHook(s.handleRuntimeCapabilitiesPromoted)
+	// The per-identity gate locks that replaced the request-path registry
+	// write lock (registry/gate_state.go) report any acquisition wait above
+	// 1 ms here, tagged by recorder site, so the new locks stay observable.
+	reg.SetGateWaitObserver(func(site string, wait time.Duration) {
+		s.ddHistogram("registry.gate.wait_ms", float64(wait.Microseconds())/1000, []string{"site:" + site})
+	})
 	s.profiler = newProfilerFromEnv(s)
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -2,9 +2,11 @@ package registry
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
@@ -554,5 +556,79 @@ func TestMergeProviderModelsRejectsNonCatalogBuild(t *testing.T) {
 	makeProviderRoutable(registerProviderWithModel(devReg, "p1", aliasFP8))
 	if m, _ := devReg.MergeProviderModels("p1", []protocol.ModelInfo{{ID: "anything/goes"}}); len(m) != 1 {
 		t.Fatalf("nil catalog should keep permissive merge, got %v", m)
+	}
+}
+
+// The alias resolver decides Desired vs Previous from providerCanRouteBuildLocked,
+// whose dispatch-load cooldown read is the session's cached gate. A session
+// rebinding away from an identity it SHARES with a sibling moves its cooldown
+// to the new gate and resets the shared source, so a read that loaded the
+// source just before the move would say "not cooled" and resolve the alias to
+// a Desired build whose only provider is cooled; dispatch then observes the
+// real cooldown and queues or rejects instead of taking the routable Previous
+// build. The read runs under p.mu and the bind holds p.mu, so the resolver
+// sees one consistent gate: while the Desired-only session flaps between the
+// shared identity and its own serial carrying a cooldown that travels with it,
+// every resolution must pick Previous.
+func TestResolveModelReadsTheSessionsCurrentGateAcrossRebinds(t *testing.T) {
+	reg := New(testLogger())
+	desired := makeSchedulerProvider(t, reg, "alias-desired", aliasQAT, 100)
+	// The sibling keeps the shared gate live (so a rebind resets it instead of
+	// orphaning it) and serves neither build, so its clean gate cannot make
+	// Desired routable.
+	sibling := makeSchedulerProvider(t, reg, "alias-sibling", "other-model", 100)
+	previous := makeSchedulerProvider(t, reg, "alias-previous", aliasFP8, 100)
+	shared := &attestation.VerificationResult{Valid: true, PublicKey: "PK-ALIAS"}
+	enriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-ALIAS", SerialNumber: "SER-ALIAS"}
+	desired.SetAttestationResult(shared)
+	sibling.SetAttestationResult(shared)
+	previous.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-PREVIOUS"})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+	})
+	if build, _, _ := reg.ResolveModel("gemma-4-26b"); build != aliasQAT {
+		t.Fatalf("precondition: with a clean Desired provider the alias must resolve to it, got %q", build)
+	}
+	// The Desired provider's pair is cooled for longer than the test runs; the
+	// cooldown follows the session through every rebind (mergeLocked keeps the
+	// later expiry both ways).
+	withGateForSession(reg, desired.ID, func(g *gateState) {
+		g.dispatchLoadCooldowns[aliasQAT] = time.Now().Add(time.Hour)
+	})
+	if build, _, _ := reg.ResolveModel("gemma-4-26b"); build != aliasFP8 {
+		t.Fatalf("precondition: with Desired cooled the alias must fall back to Previous, got %q", build)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var wrong []string
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if build, _, ok := reg.ResolveModel("gemma-4-26b"); !ok || build != aliasFP8 {
+				wrong = append(wrong, build)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 3000; i++ {
+			desired.SetAttestationResult(enriched)
+			desired.SetAttestationResult(shared)
+		}
+		close(stop)
+	}()
+	wg.Wait()
+	if len(wrong) > 0 {
+		t.Fatalf("%d resolutions picked %q while its only provider was cooled (first: %q)", len(wrong), aliasQAT, wrong[0])
+	}
+	if !reg.dispatchLoadCooled(desired.ID, aliasQAT, time.Now()) || sibling.gate.Load() != desired.gate.Load() {
+		t.Fatal("postcondition: the cooldown must still follow the Desired session, back on the shared gate")
 	}
 }

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -59,12 +59,12 @@ import (
 // telemetry keep the existing protections (pair cooldown at threshold 5,
 // node-level streaks) and are never clamped, so a single 503 cannot gate them.
 //
-// Keyed by the STABLE fault identity (faultKeyLocked: serial → SE-key →
+// Lives on the STABLE fault identity's gate (gate_state.go: serial → SE-key →
 // account → session fallback) like every sibling breaker, so a reconnect
-// cannot shed the clamp; migrated on identity rebind (migrateFaultStateLocked)
-// and deliberately NOT cleared by Disconnect. Map is bounded by the same
-// opportunistic >1024 sweep as the sibling cooldown maps. All state is guarded
-// by r.mu; the routing-path reads happen under r.mu held in either mode.
+// cannot shed the clamp; migrated on identity rebind (mergeLocked) and
+// deliberately NOT cleared by Disconnect. TTL-expired entries are dropped by
+// the periodic gate sweep. All state is guarded by gate.mu; the routing-path
+// read is one lock-free flag load for the common no-clamp case.
 const (
 	// envBudgetClamp is the kill switch. Default ON; set to false/0 to restore
 	// pre-clamp behavior (stale-heartbeat admission).
@@ -109,9 +109,9 @@ func loadBudgetClampConfig() budgetClampConfig {
 }
 
 // budgetClampEntry is one pair's active (or released/expired-awaiting-sweep)
-// clamp. Written ONLY under the r.mu write lock (armed/re-armed in
-// RecordCapacityReject, accept flag in RecordCapacityAccept); routing paths
-// read it under r.mu in either mode.
+// clamp. Written and read ONLY under the identity's gate.mu (armed/re-armed
+// in RecordCapacityReject, accept flag in RecordCapacityAccept, routing reads
+// in budgetClampActive).
 type budgetClampEntry struct {
 	// clampedAt is when the capacity-503 landed — the freshness reference for
 	// release condition (a) and the TTL anchor.
@@ -137,21 +137,11 @@ type budgetClampEntry struct {
 // currently reports a token budget; it is STICKY across re-arms of a LIVE
 // clamp (a re-reject during a reconnect's budgetless window must not downgrade
 // the identity's demonstrated budget reporting) but is NOT inherited from a
-// TTL-expired entry — see the in-body comment. Caller holds the r.mu write
-// lock (called from RecordCapacityReject).
-func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported bool, now time.Time) {
-	if !r.budgetClampCfg.Enabled {
+// TTL-expired entry — see the in-body comment. Caller holds g.mu (called from
+// recordCapacityReject).
+func (g *gateState) recordBudgetClampLocked(cfg budgetClampConfig, model string, budgetReported bool, now time.Time) {
+	if !cfg.Enabled {
 		return
-	}
-	// Opportunistic sweep (mirrors the sibling cooldown maps): session-keyed
-	// entries for churned identities are never re-keyed, so bound the map by
-	// dropping TTL-expired clamps once it grows.
-	if len(r.budgetClamps) > 1024 {
-		for k, e := range r.budgetClamps {
-			if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
-				delete(r.budgetClamps, k)
-			}
-		}
 	}
 	// Sticky-or the demonstrated budget reporting from the PREVIOUS entry —
 	// but only while that entry is still inside its TTL. The sticky-or exists
@@ -161,21 +151,20 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported
 	// would let a later benign budgetless reject (cold "not loaded" miss,
 	// pre-heartbeat window) re-arm as stale-budget dishonesty and gate the pair
 	// for another TTL — exactly what the budgetless-armed exemption forbids.
-	if prev, ok := r.budgetClamps[key]; ok && now.Before(prev.clampedAt.Add(r.budgetClampCfg.TTL)) {
+	if prev, ok := g.budgetClamps[model]; ok && now.Before(prev.clampedAt.Add(cfg.TTL)) {
 		budgetReported = budgetReported || prev.budgetReported
 	}
-	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
+	g.budgetClamps[model] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
 }
 
-// providerReportsTokenBudgetLocked reports whether the provider's CURRENT
-// backend snapshot carries a token budget for the model (the arming-time input
-// to budgetClampEntry.budgetReported). A missing provider (the reject often
-// races the disconnect that caused it) or a missing/budgetless slot reads
-// false — the sticky-or in recordBudgetClampLocked keeps an identity's
-// demonstrated reporting from being downgraded by such a race. Caller holds
-// r.mu (either mode); takes p.mu internally (r.mu → p.mu lock order).
-func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) bool {
-	p := r.providers[providerID]
+// providerReportsTokenBudget reports whether the provider's CURRENT backend
+// snapshot carries a token budget for the model (the arming-time input to
+// budgetClampEntry.budgetReported). A missing provider (the reject often races
+// the disconnect that caused it) or a missing/budgetless slot reads false —
+// the sticky-or in recordBudgetClampLocked keeps an identity's demonstrated
+// reporting from being downgraded by such a race. Takes p.mu; the caller must
+// not hold a gate.mu (lock order p.mu → gate.mu).
+func providerReportsTokenBudget(p *Provider, modelID string) bool {
 	if p == nil {
 		return false
 	}
@@ -192,20 +181,9 @@ func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) 
 	return false
 }
 
-// noteBudgetClampAcceptLocked records release condition (b): the pair accepted
-// work after the clamp. The entry is kept (not deleted) — release also needs a
-// strictly-fresher heartbeat with meaningful headroom, which the routing-path
-// read evaluates against the provider's live budget fields. Caller holds the
-// r.mu write lock (called from RecordCapacityAccept).
-func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
-	if e, ok := r.budgetClamps[key]; ok {
-		e.acceptedSince = true
-	}
-}
-
-// budgetClampActiveLocked reports whether admission must treat the pair's slot
-// as FULL right now. READ-ONLY (no lazy delete) — routing paths call it under
-// r.mu held in either mode, mirroring capacityCooldownActiveLocked.
+// budgetClampActive reports whether admission must treat the pair's slot as
+// FULL right now. READ-ONLY (no lazy delete): lock-free "no clamp on any
+// model" fast path, otherwise one short gate.mu section. nil-safe.
 //
 // heartbeatAt is when the provider's CURRENT BackendCapacity was delivered
 // (p.LastHeartbeat — Heartbeat overwrites BackendCapacity and stamps
@@ -227,15 +205,17 @@ func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
 // not even once a later heartbeat starts reporting a budget, since no dispatch
 // could get through the clamp to produce the accept proof (the reject was
 // never a stale-budget lie to begin with).
-func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
-	if !r.budgetClampCfg.Enabled {
+func (g *gateState) budgetClampActive(cfg budgetClampConfig, model string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	if !cfg.Enabled || !g.hasPairState(gateFlagBudgetClamp) {
 		return false
 	}
-	e, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+	g = g.lockResolved()
+	defer g.mu.Unlock()
+	e, ok := g.budgetClamps[model]
 	if !ok {
 		return false
 	}
-	if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+	if !now.Before(e.clampedAt.Add(cfg.TTL)) {
 		return false // TTL lapsed: fail open (a re-reject re-arms)
 	}
 	if !e.budgetReported {
@@ -266,14 +246,31 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	return !released
 }
 
-// providerBudgetSnapshotLocked reads the pair's live budget snapshot — the
-// heartbeat freshness anchor, the raw headroom (max - used - queued,
-// unclamped), and whether the current capacity report carries a budget for the
-// model at all. A missing provider or a missing/budgetless slot reads
-// zero/false. Caller holds r.mu (either mode); takes p.mu internally
-// (r.mu → p.mu lock order).
-func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
-	p := r.providers[providerID]
+// budgetClamped resolves the session's gate; the scan uses the cached p.gate
+// through budgetClampedFor.
+func (r *Registry) budgetClamped(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	return r.lookupGateForSession(providerID).budgetClampActive(r.budgetClampCfg, modelID, heartbeatAt, rawBudgetRemaining, budgetReported, now)
+}
+
+// budgetClampedFor is budgetClampActive on the connected provider's cached
+// gate, confirmed against p.gate (gateView) — the routing snapshot's admission
+// input (snapshotProviderIntoPLockedEx and the preflight), read under p.mu.
+func (r *Registry) budgetClampedFor(p *Provider, model string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	view := r.gateViewOf(p)
+	for {
+		clamped := view.g.budgetClampActive(r.budgetClampCfg, model, heartbeatAt, rawBudgetRemaining, budgetReported, now)
+		if !view.moved() {
+			return clamped
+		}
+	}
+}
+
+// providerBudgetSnapshot reads the pair's live budget snapshot — the heartbeat
+// freshness anchor, the raw headroom (max - used - queued, unclamped), and
+// whether the current capacity report carries a budget for the model at all.
+// A missing provider or a missing/budgetless slot reads zero/false. Takes
+// p.mu; the caller must not hold a gate.mu (lock order p.mu → gate.mu).
+func providerBudgetSnapshot(p *Provider, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
 	if p == nil {
 		return time.Time{}, 0, false
 	}
@@ -295,41 +292,28 @@ func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (hea
 // dropInactiveBudgetClampLocked deletes the pair's clamp entry when it can no
 // longer gate admission, so the entry's lifecycle matches its effect:
 //   - armed budgetless (entry.budgetReported == false: the exemption means it
-//     NEVER gates, so keeping it only costs the accept fast path);
+//     NEVER gates, so keeping it only costs a lock section per scan);
 //   - TTL lapsed (fail-open — a re-reject re-arms fresh anyway);
 //   - fully released (accept proof AND a strictly-fresher heartbeat with
-//     meaningful headroom, evaluated against the provider's live snapshot).
+//     meaningful headroom, evaluated against the supplied live snapshot).
 //
-// Deleting on release matters twice over: a lingering released entry (a) keeps
-// pulling every subsequent RecordCapacityAccept for the pair onto the r.mu
-// write lock (the fast-path gate keys on map presence), and (b) revives as a
-// block on the identity's next reconnect — the budgetless pre-heartbeat hold
-// branch treats an unreleased-looking entry as an active clamp, re-blocking a
-// pair that already proved recovery. A deleted entry re-arms from scratch on
-// the next reject, with budgetReported re-read at arm time. Called from the
-// accept path (RecordCapacityAcceptOutcome); the heartbeat release sweep uses
-// the snapshot variant below. Caller holds the r.mu WRITE lock.
-func (r *Registry) dropInactiveBudgetClampLocked(providerID, modelID string, now time.Time) {
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	r.dropInactiveBudgetClampSnapshotLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, now)
-}
-
-// dropInactiveBudgetClampSnapshotLocked is dropInactiveBudgetClampLocked with
-// the budget snapshot supplied by the caller instead of re-read from
-// r.providers. The heartbeat release sweep passes the just-delivered
-// heartbeat's OWN stamped time and slot values, so the release proof cannot be
-// voided by a disconnect racing in between the heartbeat stamping the provider
-// and the sweep running — a re-read would find no provider, skip the delete,
-// and let the released entry re-block the identity's next reconnect. Caller
-// holds the r.mu WRITE lock.
-func (r *Registry) dropInactiveBudgetClampSnapshotLocked(providerID, modelID string, heartbeatAt time.Time, rawRemaining int64, budgetReported bool, now time.Time) {
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	e, ok := r.budgetClamps[key]
+// Deleting on release matters: a lingering released entry revives as a block
+// on the identity's next reconnect — the budgetless pre-heartbeat hold branch
+// treats an unreleased-looking entry as an active clamp, re-blocking a pair
+// that already proved recovery. A deleted entry re-arms from scratch on the
+// next reject, with budgetReported re-read at arm time. The snapshot is
+// supplied by the caller (read under p.mu before the gate was taken): the
+// heartbeat release sweep passes the just-delivered heartbeat's OWN stamped
+// time and slot values, so the release proof cannot be voided by a disconnect
+// racing in between the heartbeat stamping the provider and the sweep running.
+// Caller holds g.mu.
+func (g *gateState) dropInactiveBudgetClampLocked(cfg budgetClampConfig, model string, heartbeatAt time.Time, rawRemaining int64, budgetReported bool, now time.Time) {
+	e, ok := g.budgetClamps[model]
 	if !ok {
 		return
 	}
-	if !e.budgetReported || !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
-		delete(r.budgetClamps, key)
+	if !e.budgetReported || !now.Before(e.clampedAt.Add(cfg.TTL)) {
+		delete(g.budgetClamps, model)
 		return
 	}
 	if !e.acceptedSince {
@@ -338,58 +322,54 @@ func (r *Registry) dropInactiveBudgetClampSnapshotLocked(providerID, modelID str
 	if budgetReported &&
 		heartbeatAt.After(e.clampedAt) &&
 		rawRemaining >= budgetClampReleaseMinHeadroomTokens {
-		delete(r.budgetClamps, key)
+		delete(g.budgetClamps, model)
 	}
 }
 
 // releaseBudgetClampsOnHeartbeat drops any clamp entries for the provider's
 // heartbeat-reported models that the just-stamped capacity snapshot proves
 // inactive (released / TTL-expired / budgetless-armed). Called from Heartbeat
-// AFTER BackendCapacity and LastHeartbeat are written, so the
-// accept-then-heartbeat release order cleans up even when the pair gets no
-// further traffic — otherwise the released entry would linger and re-block the
-// identity's next reconnect before its first heartbeat.
+// AFTER BackendCapacity and LastHeartbeat are written (and after p.mu is
+// released), so the accept-then-heartbeat release order cleans up even when
+// the pair gets no further traffic — otherwise the released entry would linger
+// and re-block the identity's next reconnect before its first heartbeat.
 //
 // heartbeatAt and capacity are the heartbeat's OWN stamped time and (clamped)
-// report, evaluated directly rather than re-read from r.providers, so a
+// report, evaluated directly rather than re-read from the provider, so a
 // disconnect racing in after the heartbeat cannot void this heartbeat's
-// release proof. The common case (no clamp state for the provider) is a
-// read-locked probe with one map lookup per reported slot; the write lock is
-// taken only when an entry actually exists.
+// release proof. The common case (no clamp state for the identity) is one
+// lock-free flag load; the gate is locked only when an entry exists.
 func (r *Registry) releaseBudgetClampsOnHeartbeat(providerID string, heartbeatAt time.Time, capacity *protocol.BackendCapacity) {
 	if !r.budgetClampCfg.Enabled || capacity == nil || len(capacity.Slots) == 0 {
 		return
 	}
-	r.mu.RLock()
-	faultKey := r.faultKeyLocked(providerID)
-	var found []protocol.BackendSlotCapacity
-	for _, slot := range capacity.Slots {
-		if _, ok := r.budgetClamps[capacityRejectKey{ProviderID: faultKey, ModelID: slot.Model}]; ok {
-			found = append(found, slot)
-		}
-	}
-	r.mu.RUnlock()
-	if len(found) == 0 {
+	ref, has := r.refHasPairState(r.lookupSessionGateRef(providerID), gateFlagBudgetClamp)
+	if !has {
 		return
 	}
-	r.mu.Lock()
-	now := time.Now()
-	for _, slot := range found {
-		rawRemaining := slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
-		r.dropInactiveBudgetClampSnapshotLocked(providerID, slot.Model, heartbeatAt, rawRemaining, slot.ActiveTokenBudgetMax > 0, now)
+	hold := r.lockGate(ref, "clamp_heartbeat")
+	defer hold.unlock()
+	g := hold.g
+	if g == nil {
+		return
 	}
-	r.mu.Unlock()
+
+	now := time.Now()
+	for _, slot := range capacity.Slots {
+		rawRemaining := slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
+		g.dropInactiveBudgetClampLocked(r.budgetClampCfg, slot.Model, heartbeatAt, rawRemaining, slot.ActiveTokenBudgetMax > 0, now)
+	}
+	g.publishLocked()
 }
 
 // BudgetClampActive reports whether the (provider, model) pair's token budget
 // is currently clamped for admission. Exposed for tests and observability; the
-// routing hot path uses budgetClampActiveLocked under the already-held r.mu.
+// routing hot path reads the cached p.gate directly.
 func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.providers[providerID] == nil {
+	p := r.sessionProvider(providerID)
+	if p == nil {
 		return false
 	}
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
+	heartbeatAt, rawRemaining, budgetReported := providerBudgetSnapshot(p, modelID)
+	return r.budgetClamped(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
 }

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -71,12 +71,23 @@ func reserveOnce(r *Registry, model, requestID string) (*Provider, RoutingDecisi
 // ageBudgetClamp rewinds the pair's clamp time by d (simulating TTL passage
 // without sleeping), keyed by the pair's CURRENT fault key.
 func ageBudgetClamp(r *Registry, providerID, model string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
-	if e, ok := r.budgetClamps[key]; ok {
-		e.clampedAt = e.clampedAt.Add(-d)
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.budgetClamps[model]; ok {
+			e.clampedAt = e.clampedAt.Add(-d)
+		}
+	})
+}
+
+// clampEntryUnderKey reports whether the identity filed under key holds a
+// clamp entry for model (the old budgetClamps[key] presence check).
+func clampEntryUnderKey(r *Registry, key, model string) bool {
+	found := false
+	readGateForKey(r, key, func(g *gateState) {
+		if g != nil {
+			_, found = g.budgetClamps[model]
+		}
+	})
+	return found
 }
 
 // One capacity-503 must IMMEDIATELY stop admission for a request that fit
@@ -337,15 +348,26 @@ func TestBudgetClampAndRateStateMigrateOnFirstBind(t *testing.T) {
 	// Attestation binds session → serial; state must migrate.
 	setAttestationAndBind(t, r, p, "SER-MIG-CLAMP")
 
-	r.mu.RLock()
-	sessKey := capacityRejectKey{ProviderID: "migrate-sess", ModelID: model}
-	serialKey := capacityRejectKey{ProviderID: "serial:SER-MIG-CLAMP", ModelID: model}
-	_, sessClamp := r.budgetClamps[sessKey]
-	_, serialClamp := r.budgetClamps[serialKey]
-	sessRejects := len(r.capacityRateRejects[sessKey])
-	serialRejects := len(r.capacityRateRejects[serialKey])
-	serialAccepts := len(r.capacityRateAccepts[serialKey])
-	r.mu.RUnlock()
+	// The session-keyed gate is gone after the bind (its state moved); read
+	// the raw index so a forwarded pointer cannot mask leftover residue.
+	var sessClamp bool
+	var sessRejects int
+	if g := rawGateForKey(r, "migrate-sess"); g != nil {
+		g.mu.Lock()
+		_, sessClamp = g.budgetClamps[model]
+		sessRejects = len(g.capacityRateRejects[model])
+		g.mu.Unlock()
+	}
+	var serialClamp bool
+	var serialRejects, serialAccepts int
+	readGateForKey(r, "serial:SER-MIG-CLAMP", func(g *gateState) {
+		if g == nil {
+			return
+		}
+		_, serialClamp = g.budgetClamps[model]
+		serialRejects = len(g.capacityRateRejects[model])
+		serialAccepts = len(g.capacityRateAccepts[model])
+	})
 
 	if sessClamp || sessRejects > 0 {
 		t.Fatal("session-keyed gray-box state orphaned after the identity bind")
@@ -437,10 +459,7 @@ func TestBudgetClampReleasedEntryDoesNotReviveOnReconnect(t *testing.T) {
 		if r.BudgetClampActive(p1.ID, model) {
 			t.Fatal("setup: clamp must have released")
 		}
-		r.mu.RLock()
-		_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
-		r.mu.RUnlock()
-		if lingering {
+		if clampEntryUnderKey(r, "serial:"+serial, model) {
 			t.Fatal("released clamp entry must be deleted, not linger in budgetClamps")
 		}
 
@@ -513,10 +532,7 @@ func TestBudgetClampHeartbeatReleaseSurvivesDisconnectRace(t *testing.T) {
 	r.Disconnect("rel-race-1")
 	r.releaseBudgetClampsOnHeartbeat("rel-race-1", heartbeatAt, capacity)
 
-	r.mu.RLock()
-	_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
-	r.mu.RUnlock()
-	if lingering {
+	if clampEntryUnderKey(r, "serial:"+serial, model) {
 		t.Fatal("release proof voided by the disconnect race — the sweep must evaluate the heartbeat's own snapshot")
 	}
 
@@ -540,10 +556,7 @@ func TestBudgetClampInactiveEntriesAreDeleted(t *testing.T) {
 	const model = "gemma-4-26b-qat-4bit"
 
 	clampEntryExists := func(r *Registry, providerID string) bool {
-		r.mu.RLock()
-		defer r.mu.RUnlock()
-		_, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}]
-		return ok
+		return clampEntryUnderKey(r, r.faultKeyForSession(providerID), model)
 	}
 
 	t.Run("TTL-expired entry dropped on the next accept", func(t *testing.T) {
@@ -648,10 +661,7 @@ func TestBudgetClampLifecycleMissWithStaleBudgetSnapshotDoesNotClamp(t *testing.
 	if r.BudgetClampActive(p.ID, model) {
 		t.Fatal("a lifecycle cold-404 must not arm a gating clamp from the stale budget snapshot")
 	}
-	r.mu.RLock()
-	_, armed := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(p.ID), ModelID: model}]
-	r.mu.RUnlock()
-	if armed {
+	if clampEntryUnderKey(r, r.faultKeyForSession(p.ID), model) {
 		t.Fatal("a lifecycle cold-404 must not touch the clamp map at all")
 	}
 	if sel, _ := reserveOnce(r, model, "rewarm"); sel == nil {

--- a/coordinator/registry/cache_routing_hints.go
+++ b/coordinator/registry/cache_routing_hints.go
@@ -100,6 +100,16 @@ func (hint cacheRoutingHint) currentForProvider(provider *Provider, model string
 	}
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
+	return hint.currentForProviderLocked(provider, model)
+}
+
+// currentForProviderLocked is currentForProvider for a caller that already
+// holds provider.mu (the reservation commit evaluates the discount inside its
+// p.mu section).
+func (hint cacheRoutingHint) currentForProviderLocked(provider *Provider, model string) bool {
+	if provider == nil || hint.Provider != provider {
+		return false
+	}
 	capability, ok := provider.PrefixCacheV2Models[model]
 	return ok &&
 		provider.PrefixCacheProtocol >= 2 &&

--- a/coordinator/registry/capacity_accept_ordering_test.go
+++ b/coordinator/registry/capacity_accept_ordering_test.go
@@ -7,28 +7,29 @@ import (
 )
 
 // capacityStrikesOf returns the pair's recorded reject strikes (chronological).
-func capacityStrikesOf(r *Registry, providerID, modelID string) []time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	strikes := r.capacityRejectStrikes[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	return append([]time.Time(nil), strikes...)
+func capacityStrikesOf(r *Registry, providerID, modelID string) (out []time.Time) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			out = append([]time.Time(nil), g.capacityRejectStrikes[modelID]...)
+		}
+	})
+	return
 }
 
 // TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation: the
 // commit-time accept is observed at the first content chunk but applied when
-// its goroutine finally holds the registry write lock (~190 ms behind queued
-// writers in production). A capacity reject for the same pair recorded in that
+// its goroutine finally holds the identity gate lock. A capacity reject for the same pair recorded in that
 // gap happened AFTER the accept and must survive it; a strike recorded before
-// the observation is still cleared. The test holds the write lock, starts the
+// the observation is still cleared. The test holds the gate lock, starts the
 // accept, records one older and one newer strike while the accept is blocked,
 // then releases the lock.
 func TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation(t *testing.T) {
 	r := New(nil)
 	const provider, model = "prov-late-accept", "gemma-4-26b-8bit"
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
+	g := r.gateForSession(provider).g
 
 	observedAt := time.Now()
-	r.mu.Lock()
+	g.mu.Lock()
 	applied := make(chan struct{})
 	go func() {
 		defer close(applied)
@@ -39,8 +40,9 @@ func TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation(t *testing
 	older := observedAt.Add(-time.Second)
 	time.Sleep(2 * time.Millisecond)
 	newer := time.Now()
-	r.capacityRejectStrikes[key] = []time.Time{older, newer}
-	r.mu.Unlock()
+	g.capacityRejectStrikes[model] = []time.Time{older, newer}
+	g.publishLocked()
+	g.mu.Unlock()
 	<-applied
 
 	got := capacityStrikesOf(r, provider, model)
@@ -113,10 +115,13 @@ func TestCapacityAcceptObservedBeforeClampDoesNotProveRelease(t *testing.T) {
 
 // capacityTripsOf returns the pair's cooldown trip count (0 = never tripped or
 // accept-cleared).
-func capacityTripsOf(r *Registry, providerID, modelID string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+func capacityTripsOf(r *Registry, providerID, modelID string) (out int) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			out = g.capacityCooldownTrips[modelID]
+		}
+	})
+	return
 }
 
 // TestCapacityAcceptAppliedLateKeepsCooldownArmedByNewerStrikes: while the
@@ -234,25 +239,26 @@ func TestCapacityAcceptRebuildsNewCooldownWithFreshBackoff(t *testing.T) {
 		t.Run(fmt.Sprintf("old_active_%v", active), func(t *testing.T) {
 			r := New(nil)
 			const provider, model = "old-backoff", "model"
-			key := capacityRejectKey{ProviderID: provider, ModelID: model}
+			g := r.gateForSession(provider).g
 			observed := time.Now().Add(-time.Second)
 			oldExpiry := time.Now().Add(-time.Second)
 			if active {
 				oldExpiry = time.Now().Add(5 * time.Minute)
 			}
-			r.mu.Lock()
-			r.capacityCooldownTrips[key] = 4
-			r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: oldExpiry}
-			r.mu.Unlock()
+			g.mu.Lock()
+			g.capacityCooldownTrips[model] = 4
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: oldExpiry}
+			g.publishLocked()
+			g.mu.Unlock()
 			for range r.capacityCooldownCfg.Threshold {
 				r.RecordCapacityReject(provider, model)
 			}
 			strikes := capacityStrikesOf(r, provider, model)
 			wantExpiry := strikes[r.capacityCooldownCfg.Threshold-1].Add(r.capacityCooldownCfg.BaseTTL)
 			r.RecordCapacityAcceptObserved(provider, model, observed, true)
-			r.mu.RLock()
-			got, trips := *r.capacityCooldowns[key], r.capacityCooldownTrips[key]
-			r.mu.RUnlock()
+			g.mu.Lock()
+			got, trips := *g.capacityCooldowns[model], g.capacityCooldownTrips[model]
+			g.mu.Unlock()
 			if trips != 1 || !got.expiry.Equal(wantExpiry) {
 				t.Fatalf("rebuilt cooldown: trips=%d expiry=%v, want 1/%v", trips, got.expiry, wantExpiry)
 			}
@@ -262,18 +268,19 @@ func TestCapacityAcceptRebuildsNewCooldownWithFreshBackoff(t *testing.T) {
 
 func TestCapacityAcceptRebuildPreservesNewProbe(t *testing.T) {
 	r := New(nil)
-	key := capacityRejectKey{ProviderID: "probe", ModelID: "model"}
+	const provider, model = "probe", "model"
+	g := r.gateForSession(provider).g
 	now := time.Now()
 	r.capacityCooldownCfg = capacityCooldownConfig{Threshold: 2, Window: time.Minute, BaseTTL: time.Second, MaxTTL: time.Minute}
-	r.capacityRejectStrikes[key] = []time.Time{now.Add(-4 * time.Second), now.Add(-3 * time.Second)}
+	g.capacityRejectStrikes[model] = []time.Time{now.Add(-4 * time.Second), now.Add(-3 * time.Second)}
 	probeAt := now.Add(-time.Second)
-	r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: now.Add(-2 * time.Second), probeAt: probeAt}
-	r.capacityCooldownTrips[key] = 4
-	r.RecordCapacityAcceptObserved(key.ProviderID, key.ModelID, now.Add(-5*time.Second), false)
-	if entry := r.capacityCooldowns[key]; entry == nil || !entry.probeAt.Equal(probeAt) {
+	g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: now.Add(-2 * time.Second), probeAt: probeAt}
+	g.capacityCooldownTrips[model] = 4
+	r.RecordCapacityAcceptObserved(provider, model, now.Add(-5*time.Second), false)
+	if entry := g.capacityCooldowns[model]; entry == nil || !entry.probeAt.Equal(probeAt) {
 		t.Fatalf("lost current probe: %+v", entry)
 	}
-	if !r.CapacityCooldownActive(key.ProviderID, key.ModelID) {
+	if !r.CapacityCooldownActive(provider, model) {
 		t.Fatal("rebuild allowed a second probe while the first is pending")
 	}
 }

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -35,10 +35,10 @@ import (
 //
 // RE-PROBE + BACKOFF — TRUE HALF-OPEN. A trip quarantines the pair for
 // BaseTTL (default 120s). After expiry EXACTLY ONE request passes as the
-// probe: the routing gate opens only while no probe claim is fresh, and
-// ReserveProviderEx claims the probe (claimCapacityProbeLocked, under the
-// r.mu write lock held for the whole reservation, so concurrent reservations
-// serialize) the moment it reserves the pair — every other request keeps
+// probe: the routing gate opens only while no probe claim is fresh, and the
+// reservation commit claims the probe (tryClaimCapacityProbe — check and claim
+// in one gate.mu section, so concurrent reservations for the identity
+// serialize there) the moment it reserves the pair — every other request keeps
 // seeing the cooldown until the probe's outcome lands. Accept → all state
 // cleared, the pair is fully re-admitted (a genuinely-full box that recovered
 // gets traffic back). Reject → immediate re-arm with an exponentially doubled
@@ -54,12 +54,11 @@ import (
 // truthful outcome is the queue/429 path, not a guaranteed-reject dispatch.
 // TTLs stagger, so re-probes trickle back on their own.
 //
-// State is keyed by the provider's STABLE fault identity (faultKeyLocked:
+// State lives on the provider's STABLE fault identity gate (gate_state.go:
 // serial → SE-key → account → session fallback), so a reconnect cannot reset
 // a black hole's streak, cooldown, or backoff trip count — the same
-// reconnect-proofing as error_cooldown.go and provider_breaker.go. Maps are
-// bounded by the same opportunistic >1024 sweep. r.mu discipline and the
-// transition-bool return also mirror error_cooldown.go.
+// reconnect-proofing as error_cooldown.go and provider_breaker.go. Guarded by
+// gate.mu; the transition-bool return mirrors error_cooldown.go.
 
 // Env tunables — read ONCE at Registry construction (coordinator restart
 // applies changes). All values have safe defaults; setting the threshold to 0
@@ -91,9 +90,8 @@ const (
 const capacityProbeOutcomeWindow = 30 * time.Second
 
 // capacityCooldownEntry is one pair's active (or expired-awaiting-probe)
-// cooldown. Fields are written ONLY under the r.mu write lock (arm/re-arm in
-// RecordCapacityReject, probe claim in claimCapacityProbeLocked); the routing
-// gate reads them under either lock mode.
+// cooldown. Fields are written and read ONLY under the identity's gate.mu
+// (arm/re-arm in RecordCapacityReject, probe claim in tryClaimCapacityProbe).
 type capacityCooldownEntry struct {
 	// expiry is when the quarantine TTL lapses and the pair becomes eligible
 	// for a single half-open probe.
@@ -138,13 +136,6 @@ func loadCapacityCooldownConfig() capacityCooldownConfig {
 		cfg.MaxTTL = cfg.BaseTTL
 	}
 	return cfg
-}
-
-// capacityRejectKey identifies a capacity-cooldown bucket. A struct key (vs a
-// delimiter-joined string) cannot alias across ids containing the delimiter.
-type capacityRejectKey struct {
-	ProviderID string
-	ModelID    string
 }
 
 // RecordCapacityReject records one capacity-class rejection (token budget /
@@ -241,13 +232,24 @@ func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped
 // armClamp gates the budget clamp (false only for request-deterministic
 // rejects, which indict the request rather than the provider). The cooldown
 // strike is fed on all paths.
+//
+// The pair's budget snapshot (does the provider currently report a token
+// budget for the model?) is read under p.mu BEFORE the gate is taken — the
+// lock order is p.mu → gate.mu, never the reverse. Only gate.mu is then held;
+// never r.mu.
 func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, armClamp bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
-	hold := r.lockWrite("capacity_reject")
+	budgetReported := false
+	if armClamp {
+		budgetReported = providerReportsTokenBudget(r.sessionProvider(providerID), modelID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "capacity_reject")
 	defer hold.unlock()
+	g := hold.g
 	now := time.Now()
+	defer g.updatedLocked(now)
 
 	// Gray-box trackers ride the SAME classified entry point but have their own
 	// kill switches, independent of the cooldown threshold: the budget clamp
@@ -260,12 +262,11 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 	// never reset off. The clamp is armed only when the reject indicts the
 	// PROVIDER (armClamp=false for request-deterministic rejects — an oversized
 	// prompt says nothing about the pair's budget honesty).
-	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	if armClamp {
-		r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
+		g.recordBudgetClampLocked(r.budgetClampCfg, modelID, budgetReported, now)
 	}
 	if deratePair {
-		r.recordCapacityRateRejectLocked(clampKey, now)
+		g.recordCapacityRateRejectLocked(r.capacityRateCfg, modelID, now)
 	}
 
 	cfg := r.capacityCooldownCfg
@@ -273,36 +274,8 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 		return false // disabled via EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD=0
 	}
 
-	// Opportunistic sweep (mirrors error_cooldown.go): session provider ids are
-	// per-connection UUIDs that never get re-keyed — bound the maps by dropping
-	// expired/idle entries once they grow.
-	if len(r.capacityCooldowns) > 1024 {
-		for key, e := range r.capacityCooldowns {
-			// Half-open entries live PAST their expiry by design: the fresh
-			// probe claim (probeAt) is the only thing keeping the gate closed
-			// while the single probe's outcome is pending. Sweeping such an
-			// entry would reopen the gate mid-probe and leak a thundering herd
-			// through the post-expiry window — keep entries whose claim is
-			// still fresh; they self-resolve within capacityProbeOutcomeWindow.
-			if !now.Before(e.expiry) &&
-				(e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))) {
-				delete(r.capacityCooldowns, key)
-				delete(r.capacityCooldownTrips, key)
-			}
-		}
-	}
-	if len(r.capacityRejectStrikes) > 1024 {
-		for key, strikes := range r.capacityRejectStrikes {
-			if len(strikes) == 0 || !strikes[len(strikes)-1].Add(cfg.Window).After(now) {
-				delete(r.capacityRejectStrikes, key)
-			}
-		}
-	}
-
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-
 	// Slide the window: keep only strikes still inside it, then add this one.
-	strikes := r.capacityRejectStrikes[key]
+	strikes := g.capacityRejectStrikes[modelID]
 	kept := strikes[:0]
 	for _, ts := range strikes {
 		if now.Sub(ts) < cfg.Window {
@@ -310,14 +283,14 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 		}
 	}
 	kept = append(kept, now)
-	r.capacityRejectStrikes[key] = kept
+	g.capacityRejectStrikes[modelID] = kept
 
 	// Active cooldown: record only — never extend or re-arm (see doc above).
-	if e, ok := r.capacityCooldowns[key]; ok && now.Before(e.expiry) {
+	if e, ok := g.capacityCooldowns[modelID]; ok && now.Before(e.expiry) {
 		return false
 	}
 
-	trips := r.capacityCooldownTrips[key]
+	trips := g.capacityCooldownTrips[modelID]
 	// A fresh pair (trips == 0) needs the full threshold inside the window. A
 	// half-open pair (trips > 0: tripped before, no accept since, cooldown
 	// expired → this reject IS the failed re-probe) re-arms immediately.
@@ -326,28 +299,85 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 	}
 
 	// Arm/re-arm: fresh entry with an unclaimed probe slot for the NEXT expiry.
-	r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: now.Add(capacityCooldownBackoff(cfg, trips))}
-	r.capacityCooldownTrips[key] = trips + 1
+	g.capacityCooldowns[modelID] = &capacityCooldownEntry{expiry: now.Add(capacityCooldownBackoff(cfg, trips))}
+	g.capacityCooldownTrips[modelID] = trips + 1
 	return true
 }
 
-// claimCapacityProbeLocked claims the single half-open probe for an EXPIRED
-// cooldown entry, called by ReserveProviderEx at reservation commit — the
-// moment a request is actually bound to the pair. Caller MUST hold the r.mu
-// WRITE lock (ReserveProviderEx does, for the whole selection+reservation), so
-// concurrent reservations serialize: the first to reserve the pair claims the
-// probe, and the gate (capacityCooldownActiveLocked) closes for everyone else
-// until the probe's outcome lands or the claim goes stale. A no-op for pairs
-// with no cooldown entry (the overwhelmingly common case — one map lookup) or
-// one still inside its TTL (unreachable via routing, but harmless).
-func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time.Time) {
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
-	if !ok || now.Before(e.expiry) {
-		return
+// tryClaimCapacityProbe claims the single half-open probe for an EXPIRED
+// cooldown entry, called by the reservation commit (under p.mu, in both
+// commit modes) at the moment a request is actually bound to the pair. The
+// check and the claim are ONE gate.mu section, so concurrent commits for the
+// same identity serialize here even though the commit itself no longer holds
+// the registry write lock: the first to reserve the pair claims the probe and
+// every later one sees the fresh claim.
+//
+// Returns false when the pair's gate is CLOSED right now — inside its TTL, or
+// expired with another request's probe claim still fresh — so the caller
+// rejects the reservation instead of leaking a second probe through the
+// post-expiry window. Returns true (a no-op) for a pair with no cooldown entry
+// — the overwhelmingly common case, one lock-free flag load — and true after
+// claiming an unclaimed or stale slot. nil-safe (a bare Provider has no gate).
+//
+// The claim is a mutation, so it goes through lockGate like the recorders: a
+// rebind that lands between loading p.gate and taking the lock moves the
+// cooldown entry to the session's new gate, and a claim made on the old
+// (emptied) gate would find no entry and admit — a leaked probe through a
+// cooled pair. lockGate sees p.gate moved and re-resolves. Lock order: the
+// caller holds p.mu; gatesMu (on a re-resolve) and gate.mu nest under it.
+func (r *Registry) tryClaimCapacityProbe(p *Provider, model string, now time.Time) bool {
+	return r.claimCapacityProbeRef(r.probeGateRef(p), model, now)
+}
+
+// probeGateRef resolves the gate the commit's probe claim targets: the
+// connected Provider's cached p.gate (no lock), remembering p so lockGate can
+// tell when the session rebound between this load and the lock. A Provider
+// that was never registered (bare test objects) falls back to the session
+// lookup; nil resolves to no gate.
+func (r *Registry) probeGateRef(p *Provider) gateRef {
+	if p == nil {
+		return gateRef{}
+	}
+	if g := p.gate.Load(); g != nil {
+		return gateRef{g: g.resolve(), p: p, session: p.ID}
+	}
+	return r.lookupSessionGateRef(p.ID)
+}
+
+// claimCapacityProbeRef is tryClaimCapacityProbe on an already-resolved ref
+// (split out so a test can interpose a rebind between resolution and claim).
+func (r *Registry) claimCapacityProbeRef(ref gateRef, model string, now time.Time) bool {
+	ref, has := r.refHasPairState(ref, gateFlagCapacityCooldown)
+	if !has {
+		return true
+	}
+	hold := r.lockGate(ref, "capacity_probe")
+	if hold.g == nil {
+		return true
+	}
+	// Release directly, not via hold.unlock(): the caller holds p.mu (and
+	// r.mu in global commit mode), and the observer's DogStatsD emit must
+	// never run inside those sections. The probe's gate wait is therefore not
+	// reported; the recorders' waits on the same gates are.
+	defer hold.g.mu.Unlock()
+	return hold.g.tryClaimCapacityProbeLocked(model, now)
+}
+
+// tryClaimCapacityProbeLocked is the check-and-claim itself. Caller holds
+// g.mu (lockGate has validated the gate is the session's current one).
+func (g *gateState) tryClaimCapacityProbeLocked(model string, now time.Time) bool {
+	e, ok := g.capacityCooldowns[model]
+	if !ok {
+		return true
+	}
+	if now.Before(e.expiry) {
+		return false
 	}
 	if e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow)) {
 		e.probeAt = now
+		return true
 	}
+	return false
 }
 
 // RecordCapacityAccept records that the (provider, model) pair ACCEPTED work —
@@ -372,9 +402,9 @@ func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time
 // first content says nothing about fault behavior, and wiping the exponential
 // backoff on any served chunk would let a flapping node reset it forever;
 // RecordProviderServeOutcome(ok=true) at clean completion is the fault-recovery
-// signal. An ACTIVE ejection window (healthEjectionUntil still in the future)
-// is also left untouched: ejection doesn't cancel in-flight work, so content
-// can flow from an ejected node, and lifting the quarantine early on it would
+// signal. An ACTIVE ejection window (ejectionUntil still in the future) is
+// also left untouched: ejection doesn't cancel in-flight work, so content can
+// flow from an ejected node, and lifting the quarantine early on it would
 // defeat the cooldown — recovery goes through the half-open success probe.
 // It returns whether a capacity-503 RATE outcome was recorded for this accept
 // (see RecordCapacityAcceptOutcome) so commit-time callers can stamp the request
@@ -396,134 +426,128 @@ func (r *Registry) RecordCapacityAccept(providerID, modelID string) (rateOutcome
 // that never commit content without double-counting streamed requests. The
 // cooldown/streak/clamp accept semantics below are identical for both values
 // (belt-and-braces accepts stay harmless there).
+//
+// This takes ONLY the identity's gate.mu
+// — never r.mu. The one provider read it may need (the live budget snapshot
+// that decides whether an accept RELEASES a clamp) happens under p.mu before
+// the gate is taken, and only when the gate's flag word says a clamp exists.
 func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	return r.RecordCapacityAcceptObserved(providerID, modelID, time.Now(), countRateOutcome)
 }
 
-// RecordCapacityAcceptObserved is RecordCapacityAcceptOutcome for an accept
-// that was OBSERVED at observedAt but is being applied now — the commit-time
-// accept runs off the dispatch goroutine so the first client byte never waits
-// for the registry write lock, and even a synchronous caller waits behind
-// every queued writer (~190 ms at the production median) before its accept
-// lands. In that gap a capacity reject for the SAME pair can be recorded. It
-// happened AFTER the accept, so it is not "a reject with no accept after it"
-// erased by the accept; it is the first strike of a possible new streak and
-// must survive. Concretely:
-//
-//   - reject STRIKES stamped after observedAt are kept (their timestamps are
-//     the existing per-strike window stamps); older ones are cleared;
-//   - the budget clamp's accept proof (release condition b) is granted only
-//     when the clamp was armed at or before observedAt — a clamp re-armed by
-//     a later reject keeps waiting for an accept that follows it;
-//   - cooldown history is rebuilt from the surviving strikes with fresh
-//     backoff: an observed accept resets every earlier trip. Retaining the
-//     previous trip count would incorrectly lengthen a newly justified trip;
-//   - the node-level capacity streak is always cleared: it is a bare count
-//     that cannot be split by time; keeping it would over-count toward
-//     ejection of a node that has just served content, and completion
-//     (RecordProviderServeOutcome ok=true) clears it anyway;
-//   - the capacity-503 RATE outcome is stamped with the apply time: the rate
-//     window is order-independent by design and its histories must stay
-//     chronological.
-//
-// A zero or future observedAt means "observed now".
+// RecordCapacityAcceptObserved applies a first-content accept at its original
+// observation time. A delayed recorder retains newer strikes, rebuilds their
+// cooldown with fresh backoff, and proves clamp release only if observed after
+// the clamp was armed. The rate window records apply time to stay ordered.
+// All fault-state mutations remain under gate.mu, never the global registry
+// lock. A zero or future observation is treated as now.
 func (r *Registry) RecordCapacityAcceptObserved(providerID, modelID string, observedAt time.Time, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
-	// The rate config is immutable after Registry construction. An enabled
-	// offered outcome is the common path and already requires the write lock, so
-	// skip a redundant read-lock probe. Completion calls that already counted
-	// their rate outcome retain the old healthy fast path: use the read lock to
-	// avoid write acquisition when there is no cooldown/clamp state to clear.
-	shouldRecordRate := countRateOutcome && r.capacityRateCfg.PenaltyMs > 0
-	if !shouldRecordRate {
-		r.mu.RLock()
-		key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-		_, hasStrikes := r.capacityRejectStrikes[key]
-		_, hasCooldown := r.capacityCooldowns[key]
-		_, hasTrips := r.capacityCooldownTrips[key]
-		_, hasClamp := r.budgetClamps[key]
-		_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
-		capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
-		r.mu.RUnlock()
-		if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasNodeStreak && !capacityTripped {
+	// An identity with no gate has nothing to clear; create one only when
+	// there is a rate outcome to record, so a straggling accept for a dead
+	// session does not file a gate under its id.
+	ref := r.lookupSessionGateRef(providerID)
+	if ref.g == nil {
+		if !countRateOutcome || r.capacityRateCfg.PenaltyMs <= 0 {
 			return false
 		}
+		ref = r.gateForSession(providerID)
 	}
-	hold := r.lockWrite("capacity_accept")
+	var heartbeatAt time.Time
+	var rawRemaining int64
+	var budgetReported bool
+	ref, hasClamp := r.refHasPairState(ref, gateFlagBudgetClamp)
+	if hasClamp {
+		heartbeatAt, rawRemaining, budgetReported = providerBudgetSnapshot(r.sessionProvider(providerID), modelID)
+	}
+	hold := r.lockGate(ref, "capacity_accept")
+	defer hold.unlock()
+	g := hold.g
+	if g == nil {
+		return false
+	}
+
 	now := time.Now()
 	if observedAt.IsZero() || observedAt.After(now) {
 		observedAt = now
 	}
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	// Clear the strikes this accept answers — those recorded up to the instant
-	// it was observed. Strikes are chronological, so the survivors are a suffix.
-	if strikes := r.capacityRejectStrikes[key]; len(strikes) > 0 {
+	if strikes := g.capacityRejectStrikes[modelID]; len(strikes) > 0 {
 		kept := strikes[:0]
-		for _, ts := range strikes {
-			if ts.After(observedAt) {
-				kept = append(kept, ts)
+		for _, stamp := range strikes {
+			if stamp.After(observedAt) {
+				kept = append(kept, stamp)
 			}
 		}
 		if len(kept) == 0 {
-			delete(r.capacityRejectStrikes, key)
+			delete(g.capacityRejectStrikes, modelID)
 		} else {
-			r.capacityRejectStrikes[key] = kept
+			g.capacityRejectStrikes[modelID] = kept
 		}
 	}
-	r.rebuildCapacityCooldownLocked(key)
+	g.rebuildCapacityCooldownLocked(r.capacityCooldownCfg, modelID)
 	// Gray-box trackers: the accept is PROOF for the clamp's release condition
 	// (b) — never an instant release, which still needs a strictly-fresher
 	// heartbeat with meaningful headroom — and ONE served outcome for the rate
 	// window (which deliberately has NO reset semantics: the accept/reject mix
 	// IS the signal). Then drop the entry if it is now inactive (this accept
 	// completed the release proof, the TTL lapsed, or it was armed budgetless):
-	// a lingering inactive entry would keep every later accept for the pair off
-	// the read-lock fast path above and would re-block the identity's next
-	// budgetless reconnect window.
-	if e, hasClamp := r.budgetClamps[key]; hasClamp {
-		// An accept observed BEFORE the clamp armed is not proof the clamp
-		// has released; only a clamp armed at or before the observation is.
+	// a lingering inactive entry would keep re-blocking the identity's next
+	// budgetless reconnect window. The snapshot was read before the gate was
+	// taken (lock order p.mu → gate.mu), so two benign races exist: a clamp
+	// armed in between sees a zero snapshot and keeps holding, and a heartbeat
+	// delivered in between already ran its own release pass before
+	// acceptedSince was set, so the release lands on the NEXT heartbeat or
+	// accept. Neither can release early.
+	if e, hasClamp := g.budgetClamps[modelID]; hasClamp {
 		if !e.clampedAt.After(observedAt) {
-			r.noteBudgetClampAcceptLocked(key)
+			e.acceptedSince = true
 		}
-		r.dropInactiveBudgetClampLocked(providerID, modelID, now)
+		g.dropInactiveBudgetClampLocked(r.budgetClampCfg, modelID, heartbeatAt, rawRemaining, budgetReported, now)
 	}
 	if countRateOutcome {
-		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)
+		rateOutcomeRecorded = g.recordCapacityRateAcceptLocked(r.capacityRateCfg, modelID, now)
 	}
-	delete(r.healthEjectionCapacityStreaks, key.ProviderID)
-	if r.healthEjectionLastTripCapacity[key.ProviderID] {
-		delete(r.healthEjectionTrips, key.ProviderID)
-		delete(r.healthEjectionLastTripCapacity, key.ProviderID)
+	g.ejectionCapacityStreak = capacityStreak{}
+	if g.ejectionLastTripCapacity {
+		g.ejectionTrips = 0
+		g.ejectionLastTripCapacity = false
 	}
-	hold.unlock()
+	g.updatedLocked(now)
 	return rateOutcomeRecorded
 }
 
 // CapacityCooldownActive reports whether the (provider, model) pair is
 // currently quarantined by the capacity-reject cooldown. Exposed for tests and
-// observability; the routing hot path uses capacityCooldownActiveLocked under
-// the already-held r.mu.
+// observability.
 func (r *Registry) CapacityCooldownActive(providerID, modelID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownActiveLocked(providerID, modelID, time.Now())
+	return r.capacityCooled(providerID, modelID, time.Now())
 }
 
-// capacityCooldownActiveLocked reports whether routing should skip the pair.
-// READ-ONLY (no lazy delete, no claim) — some callers hold only r.mu.RLock.
-// Caller holds r.mu in either mode (mirrors inferenceErrorCooldownActiveLocked).
+// capacityCooled resolves the session's gate; the scan uses the cached p.gate
+// directly.
+func (r *Registry) capacityCooled(providerID, modelID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).capacityCooled(modelID, now)
+}
+
+// capacityCooled reports whether routing should skip the pair. READ-ONLY (no
+// lazy delete, no claim): lock-free "no cooldown entry on any model" fast
+// path, otherwise one short gate.mu section. nil-safe.
 //
 // Half-open semantics: inside the TTL the gate is closed. Once now reaches the
 // expiry it opens ONLY while no probe claim is fresh — the first reservation
-// through claims the probe (claimCapacityProbeLocked, write lock), which
-// closes the gate again for everyone else until the probe's outcome lands
-// (accept deletes the entry; reject re-arms it) or the claim goes stale after
+// through claims the probe (tryClaimCapacityProbe, at commit), which closes
+// the gate again for everyone else until the probe's outcome lands (accept
+// deletes the entry; reject re-arms it) or the claim goes stale after
 // capacityProbeOutcomeWindow (a lost probe must not wedge the pair).
-func (r *Registry) capacityCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+func (g *gateState) capacityCooled(modelID string, now time.Time) bool {
+	if !g.hasPairState(gateFlagCapacityCooldown) {
+		return false
+	}
+	g = g.lockResolved()
+	defer g.mu.Unlock()
+	e, ok := g.capacityCooldowns[modelID]
 	if !ok {
 		return false
 	}
@@ -552,12 +576,11 @@ func capacityCooldownBackoff(cfg capacityCooldownConfig, trips int) time.Duratio
 
 // rebuildCapacityCooldownLocked applies the post-accept strike history from a
 // fresh breaker. The caller has removed every strike answered by the accept.
-func (r *Registry) rebuildCapacityCooldownLocked(key capacityRejectKey) {
-	previous := r.capacityCooldowns[key]
-	delete(r.capacityCooldowns, key)
-	delete(r.capacityCooldownTrips, key)
-	cfg := r.capacityCooldownCfg
-	strikes := r.capacityRejectStrikes[key]
+func (g *gateState) rebuildCapacityCooldownLocked(cfg capacityCooldownConfig, modelID string) {
+	previous := g.capacityCooldowns[modelID]
+	delete(g.capacityCooldowns, modelID)
+	delete(g.capacityCooldownTrips, modelID)
+	strikes := g.capacityRejectStrikes[modelID]
 	if cfg.Threshold <= 0 || len(strikes) < cfg.Threshold {
 		return
 	}
@@ -574,6 +597,6 @@ func (r *Registry) rebuildCapacityCooldownLocked(key capacityRejectKey) {
 	if previous != nil && !previous.probeAt.IsZero() && !previous.probeAt.Before(expiry) {
 		entry.probeAt = previous.probeAt
 	}
-	r.capacityCooldowns[key] = entry
-	r.capacityCooldownTrips[key] = trips
+	g.capacityCooldowns[modelID] = entry
+	g.capacityCooldownTrips[modelID] = trips
 }

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -11,69 +11,84 @@ import (
 // error_cooldown_test.go and provider_breaker_test.go) ---
 
 func capacityCooldownActiveAt(r *Registry, providerID, modelID string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownActiveLocked(providerID, modelID, now)
+	return r.capacityCooled(providerID, modelID, now)
 }
 
-func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (time.Time, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	if !ok {
-		return time.Time{}, false
+func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (expiry time.Time, ok bool) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		if e, has := g.capacityCooldowns[modelID]; has {
+			expiry, ok = e.expiry, true
+		}
+	})
+	return expiry, ok
+}
+
+// claimCapacityProbe claims the pair's half-open probe as the reservation
+// commit would (check-and-claim under gate.mu); returns whether the claim
+// went through (false = the gate was closed to this request).
+func claimCapacityProbe(r *Registry, providerID, modelID string) bool {
+	if p := r.sessionProvider(providerID); p != nil {
+		return r.tryClaimCapacityProbe(p, modelID, time.Now())
 	}
-	return e.expiry, true
-}
-
-// claimCapacityProbe claims the pair's half-open probe as ReserveProviderEx
-// would at reservation commit (under the r.mu write lock).
-func claimCapacityProbe(r *Registry, providerID, modelID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.claimCapacityProbeLocked(providerID, modelID, time.Now())
+	return r.claimCapacityProbeRef(r.gateForSession(providerID), modelID, time.Now())
 }
 
 // ageCapacityProbeClaim rewinds the pair's probe claim by d, simulating a
 // probe whose outcome never landed (stale claim) without sleeping.
 func ageCapacityProbeClaim(r *Registry, providerID, modelID string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok && !e.probeAt.IsZero() {
-		e.probeAt = e.probeAt.Add(-d)
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.capacityCooldowns[modelID]; ok && !e.probeAt.IsZero() {
+			e.probeAt = e.probeAt.Add(-d)
+		}
+	})
 }
 
-func capacityCooldownTripsOf(r *Registry, providerID, modelID string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+func capacityCooldownTripsOf(r *Registry, providerID, modelID string) (trips int) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			trips = g.capacityCooldownTrips[modelID]
+		}
+	})
+	return trips
 }
 
 // expireCapacityCooldown rewinds the pair's cooldown expiry into the past
 // (and clears any probe claim), simulating the TTL elapsing (active ->
 // half-open, probe unclaimed) without sleeping.
 func expireCapacityCooldown(r *Registry, providerID, modelID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok {
-		e.expiry = time.Now().Add(-time.Second)
-		e.probeAt = time.Time{}
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.capacityCooldowns[modelID]; ok {
+			e.expiry = time.Now().Add(-time.Second)
+			e.probeAt = time.Time{}
+		}
+	})
 }
 
 // ageCapacityStrikes rewinds every recorded reject strike for the pair by d,
 // simulating the passage of time without sleeping.
 func ageCapacityStrikes(r *Registry, providerID, modelID string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: providerID, ModelID: modelID}
-	strikes := r.capacityRejectStrikes[key]
-	aged := make([]time.Time, len(strikes))
-	for i, ts := range strikes {
-		aged[i] = ts.Add(-d)
-	}
-	r.capacityRejectStrikes[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		strikes := g.capacityRejectStrikes[modelID]
+		aged := make([]time.Time, len(strikes))
+		for i, ts := range strikes {
+			aged[i] = ts.Add(-d)
+		}
+		g.capacityRejectStrikes[modelID] = aged
+	})
+}
+
+// capacityCooldownEntryOf returns the pair's cooldown entry pointer (nil when
+// none), for tests that inspect the probe claim directly.
+func capacityCooldownEntryOf(r *Registry, providerID, modelID string) (entry *capacityCooldownEntry) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			entry = g.capacityCooldowns[modelID]
+		}
+	})
+	return entry
 }
 
 // Regression for the 2026-07 black-hole incident: 7 providers capacity-rejected
@@ -450,43 +465,43 @@ func TestCapacityCooldownHalfOpenExactlyOneProbe(t *testing.T) {
 	}
 }
 
-// Map-bound sweep: expired cooldowns and idle strike lists are dropped once the
-// maps grow past the bound, so per-session UUID keys cannot leak forever.
+// Gate sweep: identities whose only capacity state is an expired cooldown and
+// aged-out strikes are idle, so once no live session references them and the
+// idle grace has passed the periodic sweep drops their gates — per-session
+// UUID keys cannot leak forever.
 func TestCapacityCooldownMapsBounded(t *testing.T) {
 	r := New(nil)
 	const model = "gemma-4-26b-8bit"
 	cfg := r.capacityCooldownCfg
 
-	// Seed >1024 expired cooldowns and stale strike lists directly.
-	r.mu.Lock()
+	// Seed >1024 dead identities with expired cooldowns and stale strikes.
 	past := time.Now().Add(-time.Hour)
 	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("dead-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: past}
-		r.capacityCooldownTrips[key] = 1
-		r.capacityRejectStrikes[key] = []time.Time{past.Add(-cfg.Window)}
+		withGateForKey(r, fmt.Sprintf("dead-%d", i), func(g *gateState) {
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: past}
+			g.capacityCooldownTrips[model] = 1
+			g.capacityRejectStrikes[model] = []time.Time{past.Add(-cfg.Window)}
+			g.touched = past
+		})
 	}
-	r.mu.Unlock()
-
-	r.RecordCapacityReject("prov-live", model)
-
-	r.mu.RLock()
-	cooldowns, strikes := len(r.capacityCooldowns), len(r.capacityRejectStrikes)
-	r.mu.RUnlock()
-	if cooldowns > 8 {
-		t.Fatalf("expired cooldowns not swept: %d entries remain", cooldowns)
+	if n := r.gateCount(); n < 1100 {
+		t.Fatalf("setup produced too few gates: %d", n)
 	}
-	if strikes > 8 {
-		t.Fatalf("stale strike lists not swept: %d entries remain", strikes)
+
+	r.sweepGates(time.Now())
+
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("idle identities not swept: %d gates remain", n)
 	}
 }
 
-// Regression (PR #510 Codex P2): the >1024 bound sweep must NOT delete a
-// half-open entry whose probe claim is still fresh. In that state expiry is
-// deliberately in the past and probeAt is the only thing holding the gate
-// closed while the single probe's outcome pends — sweeping it (triggered by a
-// reject on ANY other pair) reopened the gate to a thundering herd mid-probe
-// and dropped the pair's exponential-backoff state.
+// Regression (PR #510 Codex P2): the sweep must NOT delete a half-open entry
+// whose probe claim is still fresh. In that state expiry is deliberately in the
+// past and probeAt is the only thing holding the gate closed while the single
+// probe's outcome pends — sweeping it reopened the gate to a thundering herd
+// mid-probe and dropped the pair's exponential-backoff state. With per-identity
+// gates the same rule holds twice over: a gate with a live session is never
+// dropped, and a fresh claim keeps even a disconnected identity's gate non-idle.
 func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 	r := New(nil)
 	const provider, model = "prov-probed", "gemma-4-26b-8bit"
@@ -497,37 +512,41 @@ func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 		r.RecordCapacityReject(provider, model)
 	}
 	expireCapacityCooldown(r, provider, model)
-	claimCapacityProbe(r, provider, model)
+	if !claimCapacityProbe(r, provider, model) {
+		t.Fatal("setup: the first post-expiry claim must succeed")
+	}
 	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
 		t.Fatal("setup: pending probe should hold the gate closed")
 	}
+	// Age every other tracker the rejects armed (strikes, the gray-box clamp
+	// and rate window) out of their windows and backdate the identity's last
+	// activity, so the fresh probe claim is the ONLY thing keeping the gate.
+	ageCapacityStrikes(r, provider, model, cfg.Window+time.Second)
+	ageBudgetClamp(r, provider, model, r.budgetClampCfg.TTL+time.Second)
+	ageCapacityRateRejects(r, provider, model, capacityRateWindow+time.Second)
+	withGateForSession(r, provider, func(g *gateState) { g.touched = time.Now().Add(-time.Hour) })
 
-	// Grow the map past the sweep bound with long-expired junk entries.
-	r.mu.Lock()
+	// Grow the index past the high-water mark with long-idle junk identities.
 	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
-		r.capacityCooldownTrips[key] = 1
+		withGateForKey(r, fmt.Sprintf("junk-%d", i), func(g *gateState) {
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
+			g.capacityCooldownTrips[model] = 1
+			g.touched = time.Now().Add(-time.Hour)
+		})
 	}
-	r.mu.Unlock()
 
-	// A reject on an unrelated pair triggers the opportunistic sweep.
-	r.RecordCapacityReject("prov-other", model)
+	r.sweepGates(time.Now())
 
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
-	r.mu.RLock()
-	_, probedAlive := r.capacityCooldowns[key]
-	trips := r.capacityCooldownTrips[key]
-	size := len(r.capacityCooldowns)
-	r.mu.RUnlock()
-	if !probedAlive {
+	entry := capacityCooldownEntryOf(r, provider, model)
+	trips := capacityCooldownTripsOf(r, provider, model)
+	if entry == nil {
 		t.Fatal("sweep deleted the half-open entry with a fresh probe claim")
 	}
 	if trips == 0 {
 		t.Fatal("sweep dropped the pair's backoff state mid-probe")
 	}
-	if size > 8 {
-		t.Fatalf("junk entries not bounded by the sweep: %d remain", size)
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("junk identities not bounded by the sweep: %d remain", n)
 	}
 	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
 		t.Fatal("gate reopened to the herd mid-probe after the sweep")
@@ -536,18 +555,10 @@ func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 	// A STALE claim (outcome never landed) must still be sweepable — the
 	// liveness bound, not the claim itself, decides retention.
 	ageCapacityProbeClaim(r, provider, model, capacityProbeOutcomeWindow+time.Second)
-	r.mu.Lock()
-	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk2-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
-	}
-	r.mu.Unlock()
-	r.RecordCapacityReject("prov-other-2", model)
-	r.mu.RLock()
-	_, staleAlive := r.capacityCooldowns[key]
-	r.mu.RUnlock()
-	if staleAlive {
-		t.Fatal("sweep retained an entry whose probe claim went stale")
+	withGateForSession(r, provider, func(g *gateState) { g.touched = time.Now().Add(-time.Hour) })
+	r.sweepGates(time.Now())
+	if rawGateForKey(r, provider) != nil {
+		t.Fatal("sweep retained an identity whose probe claim went stale")
 	}
 }
 

--- a/coordinator/registry/capacity_rate.go
+++ b/coordinator/registry/capacity_rate.go
@@ -44,10 +44,11 @@ import (
 // Rejects are recorded once per failed dispatch attempt by
 // RecordCapacityReject.
 //
-// Keyed by the STABLE fault identity like every sibling tracker: reconnects
-// cannot reset the window, entries migrate on identity rebind
-// (migrateFaultStateLocked), Disconnect does NOT clear them, and the maps are
-// bounded by the same opportunistic >1024 sweep. Guarded by r.mu.
+// Keyed by the STABLE fault identity like every sibling tracker: the windows
+// live on the identity's gate (gate_state.go), so reconnects cannot reset
+// them, they migrate on identity rebind (mergeLocked), Disconnect does NOT
+// clear them, and the periodic gate sweep drops fully aged windows. Guarded by
+// gate.mu.
 const (
 	// envCapacityRatePenaltyMs scales the penalty (and is the kill switch: 0
 	// or negative disables the tracker entirely — no recording, no penalty).
@@ -83,28 +84,23 @@ func loadCapacityRateConfig() capacityRateConfig {
 }
 
 // recordCapacityRateRejectLocked appends one capacity-503 outcome for the pair
-// and prunes the window. Caller holds the r.mu write lock (called from
-// RecordCapacityReject).
-func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now time.Time) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// and prunes the window. Caller holds g.mu (called from recordCapacityReject).
+func (g *gateState) recordCapacityRateRejectLocked(cfg capacityRateConfig, model string, now time.Time) {
+	if cfg.PenaltyMs <= 0 {
 		return
 	}
-	_, existed := r.capacityRateRejects[key]
-	r.capacityRateRejects[key] = appendWindowedOutcome(r.capacityRateRejects[key], now)
-	if !existed {
-		sweepCapacityRateMapLocked(r.capacityRateRejects, now)
-	}
+	g.capacityRateRejects[model] = appendWindowedOutcome(g.capacityRateRejects[model], now)
 
 	// A pair may have gone quiet long enough for its accept-only history to
 	// expire before this first/new reject. Prune it now so repeated routing reads
 	// do not keep scanning stale timestamps and the first rate uses only the same
 	// five-minute window as the reject side.
-	if accepts, ok := r.capacityRateAccepts[key]; ok {
+	if accepts, ok := g.capacityRateAccepts[model]; ok {
 		accepts = pruneWindowedOutcomes(accepts, now)
 		if len(accepts) == 0 {
-			delete(r.capacityRateAccepts, key)
+			delete(g.capacityRateAccepts, model)
 		} else {
-			r.capacityRateAccepts[key] = accepts
+			g.capacityRateAccepts[model] = accepts
 		}
 	}
 }
@@ -116,16 +112,12 @@ func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now tim
 // The rate/penalty read paths still return zero while no reject is in-window, so
 // this healthy history is observationally dormant. Returns whether the accept
 // was stored so the api layer can stamp the request (MarkRateOutcomeCounted)
-// and prevent completion from double-counting it. Caller holds r.mu for write.
-func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) (recorded bool) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// and prevent completion from double-counting it. Caller holds g.mu.
+func (g *gateState) recordCapacityRateAcceptLocked(cfg capacityRateConfig, model string, now time.Time) (recorded bool) {
+	if cfg.PenaltyMs <= 0 {
 		return false
 	}
-	_, existed := r.capacityRateAccepts[key]
-	r.capacityRateAccepts[key] = appendWindowedOutcome(r.capacityRateAccepts[key], now)
-	if !existed {
-		sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
-	}
+	g.capacityRateAccepts[model] = appendWindowedOutcome(g.capacityRateAccepts[model], now)
 	return true
 }
 
@@ -154,24 +146,8 @@ func appendWindowedOutcome(outcomes []time.Time, now time.Time) []time.Time {
 	return append(pruneWindowedOutcomes(outcomes, now), now)
 }
 
-// sweepCapacityRateMapLocked bounds a rate map by dropping pairs whose newest
-// outcome has aged out of the window, once the map grows (mirrors the sibling
-// cooldown sweeps — churned session-keyed identities are never re-keyed).
-// Histories must remain chronological because this deliberately uses the tail
-// for an O(1) newest check while holding the registry lock.
-func sweepCapacityRateMapLocked(m map[capacityRejectKey][]time.Time, now time.Time) {
-	if len(m) <= 1024 {
-		return
-	}
-	for key, outcomes := range m {
-		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
-			delete(m, key)
-		}
-	}
-}
-
 // countInWindow counts timestamps still inside the window without mutating the
-// chronological slice, so read paths stay safe under r.mu.RLock.
+// chronological slice, so read paths stay safe under a shared lock.
 func countInWindow(outcomes []time.Time, now time.Time) int {
 	cutoff := now.Add(-capacityRateWindow)
 	first := sort.Search(len(outcomes), func(i int) bool {
@@ -180,42 +156,74 @@ func countInWindow(outcomes []time.Time, now time.Time) int {
 	return len(outcomes) - first
 }
 
-// capacityRatePenaltyLocked returns the cost penalty (ms) and the measured
+// capacityRatePenalty returns the cost penalty (ms) and the measured
 // capacity-reject rate for the pair. Penalty is nonzero only when the window
 // holds at least capacityRateMinSample outcomes AND the rate exceeds
 // capacityRateThreshold; the rate is returned whenever computable so callers
-// can expose it for observability. READ-ONLY — callers hold r.mu in either
-// mode (buildCandidateWithReason runs under the selection locks).
-func (r *Registry) capacityRatePenaltyLocked(providerID, modelID string, now time.Time) (penaltyMs, rate float64) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// can expose it for observability.
+//
+// Hot-path fast exit without the lock: the gate publishes its newest rate
+// reject as an atomic, so a healthy pair — no capacity-503 inside the window
+// on ANY model — pays nothing (buildCandidateInto runs this once per
+// candidate per scan). Only a pair with an in-window reject takes the short
+// gate.mu section. nil-safe.
+func (g *gateState) capacityRatePenalty(cfg capacityRateConfig, model string, now time.Time) (penaltyMs, rate float64) {
+	if cfg.PenaltyMs <= 0 || g == nil {
 		return 0, 0
 	}
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	rejects := countInWindow(r.capacityRateRejects[key], now)
-	if rejects == 0 {
-		return 0, 0 // hot-path fast exit: healthy pairs pay nothing
+	newest := g.newestRateRejectNS.Load()
+	if newest == 0 || now.UnixNano()-newest >= int64(capacityRateWindow) {
+		return 0, 0
 	}
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
+	g = g.lockResolved()
+	rejects := countInWindow(g.capacityRateRejects[model], now)
+	accepts := countInWindow(g.capacityRateAccepts[model], now)
+	g.mu.Unlock()
+	if rejects == 0 {
+		return 0, 0
+	}
 	total := rejects + accepts
 	rate = float64(rejects) / float64(total)
 	if total < capacityRateMinSample || rate <= capacityRateThreshold {
 		return 0, rate
 	}
-	return rate * r.capacityRateCfg.PenaltyMs, rate
+	return rate * cfg.PenaltyMs, rate
+}
+
+// capacityRatePenalty resolves the session's gate; the scan uses the cached
+// p.gate through capacityRatePenaltyFor.
+func (r *Registry) capacityRatePenalty(providerID, modelID string, now time.Time) (penaltyMs, rate float64) {
+	return r.lookupGateForSession(providerID).capacityRatePenalty(r.capacityRateCfg, modelID, now)
+}
+
+// capacityRatePenaltyFor is capacityRatePenalty on the connected provider's
+// cached gate, confirmed against p.gate (gateView): the candidate's cost
+// input (buildCandidateInto).
+func (r *Registry) capacityRatePenaltyFor(p *Provider, model string, now time.Time) (penaltyMs, rate float64) {
+	view := r.gateViewOf(p)
+	for {
+		penaltyMs, rate = view.g.capacityRatePenalty(r.capacityRateCfg, model, now)
+		if !view.moved() {
+			return penaltyMs, rate
+		}
+	}
 }
 
 // CapacityRejectRate exposes the pair's windowed capacity-reject rate and
 // sample count for tests and observability.
 func (r *Registry) CapacityRejectRate(providerID, modelID string) (rate float64, samples int) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	g := r.lookupGateForSession(providerID)
+	if g == nil {
+		return 0, 0
+	}
 	now := time.Now()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	rejects := countInWindow(r.capacityRateRejects[key], now)
+	g = g.lockResolved()
+	rejects := countInWindow(g.capacityRateRejects[modelID], now)
+	accepts := countInWindow(g.capacityRateAccepts[modelID], now)
+	g.mu.Unlock()
 	if rejects == 0 {
 		return 0, 0
 	}
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
 	total := rejects + accepts
 	if total == 0 {
 		return 0, 0

--- a/coordinator/registry/capacity_rate_followup_test.go
+++ b/coordinator/registry/capacity_rate_followup_test.go
@@ -49,18 +49,18 @@ func TestCapacityRateFirstRejectPrunesExpiredAccepts(t *testing.T) {
 	r := New(testLogger())
 	const provider, model = "prov-accept-window", "gemma-4-26b-qat-4bit"
 	now := time.Now()
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
 
-	r.mu.Lock()
-	r.capacityRateAccepts[key] = []time.Time{
-		now.Add(-capacityRateWindow - time.Nanosecond),
-		now.Add(-capacityRateWindow),
-		now.Add(-capacityRateWindow + time.Nanosecond),
-	}
-	r.recordCapacityRateRejectLocked(key, now)
-	rejects := countInWindow(r.capacityRateRejects[key], now)
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
-	r.mu.Unlock()
+	var rejects, accepts int
+	withGateForSession(r, provider, func(g *gateState) {
+		g.capacityRateAccepts[model] = []time.Time{
+			now.Add(-capacityRateWindow - time.Nanosecond),
+			now.Add(-capacityRateWindow),
+			now.Add(-capacityRateWindow + time.Nanosecond),
+		}
+		g.recordCapacityRateRejectLocked(r.capacityRateCfg, model, now)
+		rejects = countInWindow(g.capacityRateRejects[model], now)
+		accepts = countInWindow(g.capacityRateAccepts[model], now)
+	})
 
 	if rejects != 1 || accepts != 1 {
 		t.Fatalf("windowed outcomes = rejects %d accepts %d, want 1/1", rejects, accepts)
@@ -142,9 +142,9 @@ func TestCapacityRateIsIndependentOfOutcomeOrder(t *testing.T) {
 
 // Identity enrichment can merge a stale source history into a destination
 // that already has fresh state from a previous connection. Every timestamp
-// history must remain oldest-to-newest because the bounded-map sweeps use the
-// tail as the newest outcome. This exercises the real sekey -> serial rebind
-// and the >1024 cleanup consequence for both rate maps.
+// history must remain oldest-to-newest because the gate sweep uses the tail as
+// the newest outcome. This exercises the real sekey -> serial rebind and the
+// sweep's consequence for both rate windows.
 func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 	r := New(testLogger())
 	const (
@@ -165,26 +165,27 @@ func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 	now := time.Now()
 	expired := now.Add(-capacityRateWindow - time.Minute)
 	fresh := now.Add(-time.Minute)
-	oldRateKey := capacityRejectKey{ProviderID: oldID, ModelID: model}
-	newRateKey := capacityRejectKey{ProviderID: newID, ModelID: model}
-	oldInferenceKey := inferenceErrorKey{ProviderID: oldID, ModelID: model, Shape: "base"}
-	newInferenceKey := inferenceErrorKey{ProviderID: newID, ModelID: model, Shape: "base"}
+	shapeKey := modelShapeKey{Model: model, Shape: "base"}
 
-	r.mu.Lock()
-	r.inferenceErrorStrikes[oldInferenceKey] = []time.Time{expired}
-	r.inferenceErrorStrikes[newInferenceKey] = []time.Time{fresh}
-	r.capacityRejectStrikes[oldRateKey] = []time.Time{expired}
-	r.capacityRejectStrikes[newRateKey] = []time.Time{fresh}
-	r.capacityRateRejects[oldRateKey] = []time.Time{expired}
-	r.capacityRateRejects[newRateKey] = []time.Time{fresh}
-	r.capacityRateAccepts[oldRateKey] = []time.Time{expired}
-	r.capacityRateAccepts[newRateKey] = []time.Time{fresh}
+	withGateForKey(r, oldID, func(g *gateState) {
+		g.inferenceErrorStrikes[shapeKey] = []time.Time{expired}
+		g.capacityRejectStrikes[model] = []time.Time{expired}
+		g.capacityRateRejects[model] = []time.Time{expired}
+		g.capacityRateAccepts[model] = []time.Time{expired}
+	})
+	withGateForKey(r, newID, func(g *gateState) {
+		g.inferenceErrorStrikes[shapeKey] = []time.Time{fresh}
+		g.capacityRejectStrikes[model] = []time.Time{fresh}
+		g.capacityRateRejects[model] = []time.Time{fresh}
+		g.capacityRateAccepts[model] = []time.Time{fresh}
+	})
 	for i := 0; i < 1024; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("expired-rate-%d", i), ModelID: model}
-		r.capacityRateRejects[key] = []time.Time{expired}
-		r.capacityRateAccepts[key] = []time.Time{expired}
+		withGateForKey(r, fmt.Sprintf("expired-rate-%d", i), func(g *gateState) {
+			g.capacityRateRejects[model] = []time.Time{expired}
+			g.capacityRateAccepts[model] = []time.Time{expired}
+			g.touched = now.Add(-gateIdleGrace - time.Minute)
+		})
 	}
-	r.mu.Unlock()
 
 	p.SetAttestationResult(&attestation.VerificationResult{
 		Valid: true, PublicKey: publicKey, SerialNumber: serial,
@@ -193,20 +194,36 @@ func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 		t.Fatalf("enriched fault key = %q, want %q", got, newID)
 	}
 
-	r.mu.Lock()
-	mergedInference := append([]time.Time(nil), r.inferenceErrorStrikes[newInferenceKey]...)
-	mergedCapacity := append([]time.Time(nil), r.capacityRejectStrikes[newRateKey]...)
-	mergedRejects := append([]time.Time(nil), r.capacityRateRejects[newRateKey]...)
-	mergedAccepts := append([]time.Time(nil), r.capacityRateAccepts[newRateKey]...)
-	_, oldInferenceRemains := r.inferenceErrorStrikes[oldInferenceKey]
-	_, oldCapacityRemains := r.capacityRejectStrikes[oldRateKey]
-	_, oldRejectsRemain := r.capacityRateRejects[oldRateKey]
-	_, oldAcceptsRemain := r.capacityRateAccepts[oldRateKey]
-	sweepCapacityRateMapLocked(r.capacityRateRejects, now)
-	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
-	freshRejects := countInWindow(r.capacityRateRejects[newRateKey], now)
-	freshAccepts := countInWindow(r.capacityRateAccepts[newRateKey], now)
-	r.mu.Unlock()
+	var mergedInference, mergedCapacity, mergedRejects, mergedAccepts []time.Time
+	readGateForKey(r, newID, func(g *gateState) {
+		mergedInference = append([]time.Time(nil), g.inferenceErrorStrikes[shapeKey]...)
+		mergedCapacity = append([]time.Time(nil), g.capacityRejectStrikes[model]...)
+		mergedRejects = append([]time.Time(nil), g.capacityRateRejects[model]...)
+		mergedAccepts = append([]time.Time(nil), g.capacityRateAccepts[model]...)
+	})
+	// The source identity's gate is orphaned and gone from the index after
+	// the migration; any residue would be filed under its raw key.
+	var oldInferenceRemains, oldCapacityRemains, oldRejectsRemain, oldAcceptsRemain bool
+	if g := rawGateForKey(r, oldID); g != nil {
+		g.mu.Lock()
+		_, oldInferenceRemains = g.inferenceErrorStrikes[shapeKey]
+		_, oldCapacityRemains = g.capacityRejectStrikes[model]
+		_, oldRejectsRemain = g.capacityRateRejects[model]
+		_, oldAcceptsRemain = g.capacityRateAccepts[model]
+		g.mu.Unlock()
+	}
+	r.sweepGates(now)
+	var freshRejects, freshAccepts int
+	readGateForKey(r, newID, func(g *gateState) {
+		if g == nil {
+			t.Fatal("the live identity's gate must survive the sweep")
+		}
+		freshRejects = countInWindow(g.capacityRateRejects[model], now)
+		freshAccepts = countInWindow(g.capacityRateAccepts[model], now)
+	})
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("expired identities not swept: %d gates remain", n)
+	}
 
 	for name, history := range map[string][]time.Time{
 		"inference strikes": mergedInference,

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -16,9 +16,19 @@ import (
 // capacityRatePenaltyOf reads the pair's penalty and rate under the lock, as
 // buildCandidateWithReason does.
 func capacityRatePenaltyOf(r *Registry, providerID, model string) (penaltyMs, rate float64) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityRatePenaltyLocked(providerID, model, time.Now())
+	return r.capacityRatePenalty(providerID, model, time.Now())
+}
+
+// rateHistoryOf returns copies of the pair's windowed reject/accept histories.
+func rateHistoryOf(r *Registry, providerID, model string) (rejects, accepts []time.Time) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		rejects = append([]time.Time(nil), g.capacityRateRejects[model]...)
+		accepts = append([]time.Time(nil), g.capacityRateAccepts[model]...)
+	})
+	return rejects, accepts
 }
 
 // seedRateOutcomes drives the real entry points in reject-first order. Other
@@ -34,15 +44,14 @@ func seedRateOutcomes(r *Registry, providerID, model string, rejects, accepts in
 
 // ageCapacityRateRejects rewinds the pair's reject outcomes by d.
 func ageCapacityRateRejects(r *Registry, providerID, model string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
-	outcomes := r.capacityRateRejects[key]
-	aged := make([]time.Time, len(outcomes))
-	for i, ts := range outcomes {
-		aged[i] = ts.Add(-d)
-	}
-	r.capacityRateRejects[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		outcomes := g.capacityRateRejects[model]
+		aged := make([]time.Time, len(outcomes))
+		for i, ts := range outcomes {
+			aged[i] = ts.Add(-d)
+		}
+		g.capacityRateRejects[model] = aged
+	})
 }
 
 // Below the minimum sample no penalty may apply, no matter how bad the rate —
@@ -135,10 +144,8 @@ func TestCapacityRateDecays(t *testing.T) {
 	// observationally inert; accept history must not be deleted just because the
 	// last reject expired.
 	r.RecordCapacityAcceptOutcome(provider, model, true)
-	r.mu.RLock()
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
-	accepts := countInWindow(r.capacityRateAccepts[key], time.Now())
-	r.mu.RUnlock()
+	_, acceptHistory := rateHistoryOf(r, provider, model)
+	accepts := countInWindow(acceptHistory, time.Now())
 	if accepts != 7 {
 		t.Fatalf("recent accept history = %d, want 7 after the new accept", accepts)
 	}
@@ -161,9 +168,12 @@ func TestCapacityRateAcceptsDoNotResetRejects(t *testing.T) {
 	}
 	// The cooldown strike streak WAS cleared by those accepts (its designed
 	// discriminator) — proving the two trackers are decoupled.
-	r.mu.RLock()
-	strikes := len(r.capacityRejectStrikes[capacityRejectKey{ProviderID: provider, ModelID: model}])
-	r.mu.RUnlock()
+	strikes := -1
+	readGateForSession(r, provider, func(g *gateState) {
+		if g != nil {
+			strikes = len(g.capacityRejectStrikes[model])
+		}
+	})
 	if strikes != 0 {
 		t.Fatalf("cooldown strikes = %d after accepts, want 0 (accept-reset is the cooldown's contract)", strikes)
 	}

--- a/coordinator/registry/dispatch_load_cooldown_test.go
+++ b/coordinator/registry/dispatch_load_cooldown_test.go
@@ -6,9 +6,7 @@ import (
 )
 
 func cooldownActive(r *Registry, providerID, modelID string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.dispatchLoadCooldownActiveLocked(providerID, modelID, now)
+	return r.dispatchLoadCooled(providerID, modelID, now)
 }
 
 // Regression for the prod fleet outage: providers wedged on "insufficient
@@ -102,27 +100,24 @@ func TestDispatchLoadCooldownSurvivesRegister(t *testing.T) {
 
 func TestDispatchLoadCooldownSweepBoundsMap(t *testing.T) {
 	r := New(testLogger())
-	// Insert >1024 entries, then force them all past expiry by recording a
-	// fresh failure after the TTL — the opportunistic sweep must drop them.
+	// >1024 identity-less sessions record a load failure and vanish. Once the
+	// cooldowns expire and the idle grace passes, the gate sweep must drop
+	// every one of their gates; a connected provider's gate always survives.
 	for i := 0; i < 1100; i++ {
 		r.RecordDispatchLoadFailure("dead-provider-"+string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune('0'+(i/10)%10))+string(rune('0'+(i/100)%10)), "m")
 	}
-	r.mu.Lock()
-	for k := range r.dispatchLoadCooldowns {
-		r.dispatchLoadCooldowns[k] = time.Now().Add(-time.Second)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
-	size := len(r.dispatchLoadCooldowns)
-	r.mu.Unlock()
-	if size < 1000 {
-		t.Fatalf("setup produced too few distinct entries: %d", size)
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordDispatchLoadFailure(live.ID, "m")
+
+	r.sweepGates(time.Now().Add(gateIdleGrace + dispatchLoadCooldownTTL + time.Second))
+
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
 	}
-
-	r.RecordDispatchLoadFailure("live", "m")
-
-	r.mu.Lock()
-	after := len(r.dispatchLoadCooldowns)
-	r.mu.Unlock()
-	if after != 1 {
-		t.Fatalf("sweep should leave only the live entry, got %d", after)
+	if rawGateForKey(r, live.ID) == nil {
+		t.Fatal("the connected provider's gate must never be swept")
 	}
 }

--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -349,12 +349,14 @@ func (r *Registry) ReserveProviderWithPlan(model string, pr *PendingRequest, exc
 //     valve still protects the all-providers-broken case).
 //
 // Ledger note (why plan reservations cannot double-spend a heartbeat budget):
-// the r.mu WRITE lock is held for the whole loop, exactly like
-// ReserveProviderEx, so reservations serialize fleet-wide; and each entry is
-// re-snapshotted here, so freeMemoryAdmits charges every pending request
-// admitted since the plan was built (fillSnapshotPendingAndPool →
-// coordinatorExtra / pooledBudgetAdmits). See the ledger rationale on
-// reserveProvider's pending-debit path in scheduler.go.
+// each entry is re-snapshotted, re-costed, admit-checked and debited inside
+// ONE p.mu section (exactly like commitProviderReservation), so
+// freeMemoryAdmits charges every pending request admitted since the plan was
+// built (fillSnapshotPendingAndPool → coordinatorExtra / pooledBudgetAdmits)
+// and no concurrent commit can slip between the check and the debit. r.mu is
+// held for reading across the loop (identity checks against r.providers stay
+// valid); the global commit mode takes it for writing instead. See the ledger
+// rationale on reserveProvider's pending-debit path in scheduler.go.
 //
 // Version-diverse retry (SOFT — parity with scanCandidatesLocked's
 // post-candidate AvoidVersion narrowing): when pr.Traits.AvoidVersion is set,
@@ -396,8 +398,9 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	enforceTTFT := pr.MaxTTFTMs > 0 && !pr.RequiresVision
 
 	var skips []PlanSkip
-	hold := r.lockWrite("commit_plan")
-	defer hold.unlock()
+	lock := r.commitLock("commit_plan")
+	lock.lock()
+	defer lock.unlock()
 
 	// tryReserve runs the full CURRENT gate chain against one identity-checked
 	// entry and, on success, commits the reservation. Failure appends the
@@ -422,36 +425,43 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 			return nil, RoutingDecision{}, false
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, false, now)
-		if !ok {
+
+		// Snapshot, cost, admit and reservation under ONE p.mu hold — the same
+		// commit sequence as commitProviderReservation, so nothing can change
+		// the provider between the admit re-check and the debit.
+		p.mu.Lock()
+		var snap routingSnapshot
+		if ok, _ := r.snapshotProviderIntoPLockedEx(&snap, p, model, pr.Traits, relaxTrust, false, now); !ok {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
 		candidate, _, ok := r.buildCandidateWithReason(snap, pr, now)
 		if !ok {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
 		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
-
-		// Final admit + reservation under p.mu — the same commit sequence as
-		// reserveProvider (snapshotProviderIntoLockedEx released p.mu, so the admit
-		// re-check closes the snapshot→reserve gap, including the vision gate).
-		p.mu.Lock()
 		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false, now) ||
 			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
+		// Half-open capacity probe: check-and-claim under gate.mu, identical to
+		// the primary reservation path (p.mu → gate.mu).
+		if !r.tryClaimCapacityProbe(p, model, now) {
+			p.mu.Unlock()
+			skip(PlanSkipGateRejected)
+			return nil, RoutingDecision{}, false
+		}
 		pr.ProviderID = p.ID
 		p.addPendingLocked(pr)
-		// Half-open capacity probe claim: identical to the primary reservation
-		// path (the r.mu write lock held across this loop serializes claims).
-		r.claimCapacityProbeLocked(p.ID, model, now)
 		if p.Status != StatusUntrusted && p.Status != StatusOffline {
 			p.Status = StatusServing
 		}
@@ -522,7 +532,7 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	}
 	// Pass 2: no diverse entry was admissible — fall back to the avoided
 	// version rather than failing closed. The pass-1 identity checks remain
-	// valid: r.providers cannot change while the r.mu write lock is held.
+	// valid: r.providers cannot change while r.mu is held in either mode.
 	for _, entry := range deferred {
 		if p, decision, ok := tryReserve(entry); ok {
 			return p, decision, skips

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -134,10 +134,16 @@ func TestReserveProviderWithPlanPrimarySelectionUnchanged(t *testing.T) {
 	if pA == nil || pB == nil || pA.ID != pB.ID {
 		t.Fatalf("winners differ: ReserveProviderEx=%v ReserveProviderWithPlan=%v", pA, pB)
 	}
-	// The profiler's wall-clock stamps (lock wait, scan, admit, heartbeat age)
-	// legitimately differ between two reservations; everything else must match.
+	// The profiler's wall-clock stamps (lock wait, scan, admit, heartbeat age
+	// — on the decision AND inside the candidate summaries) legitimately differ
+	// between two reservations built a few hundred microseconds apart;
+	// everything else must match.
 	for _, d := range []*RoutingDecision{&decA, &decB} {
 		d.LockWaitUS, d.ScanUS, d.AdmitUS, d.SnapshotAgeMs = 0, 0, 0, 0
+		for i := range d.Top {
+			d.Top[i].HBAgeMs = 0
+		}
+		d.RunnerUp.HBAgeMs, d.BestIdle.HBAgeMs = 0, 0
 	}
 	if decA != decB {
 		t.Fatalf("decisions differ:\n ex:   %+v\n plan: %+v", decA, decB)

--- a/coordinator/registry/error_cooldown.go
+++ b/coordinator/registry/error_cooldown.go
@@ -12,10 +12,10 @@ import "time"
 // provider-side (5xx) errors so routing falls to other providers — and, paired
 // with version-diverse retry, to other binary versions.
 //
-// SHAPE-KEYED. The breaker is keyed by (provider, model, shape) rather than a
-// "providerID:modelID" string — where "provider" is the STABLE fault key
-// (faultKeyLocked: serial/SE-key when bound, session id otherwise), so strikes
-// and cooldowns survive reconnect churn. Shape ("tools" / "base", from
+// SHAPE-KEYED. The breaker is keyed by (provider, model, shape) — the
+// provider's gate is its STABLE fault key (faultKeyForSession: serial/SE-key
+// when bound, session id otherwise), so strikes and cooldowns survive
+// reconnect churn, and inside the gate a modelShapeKey names the bucket. Shape ("tools" / "base", from
 // RequestTraits.CooldownShape) closes the root bug behind the prod incident: a
 // deterministic tool/template failure that fails EVERY tool request can be
 // interleaved with clean non-tool text successes for the same pair. With a
@@ -24,11 +24,11 @@ import "time"
 // was never quarantined for tools. Per-shape buckets make tool failures
 // accumulate in the "tools" bucket independent of "base" successes, and a
 // success clears ONLY its own shape bucket. The struct key also closes the
-// threat-model colon-collision note (a provider/model id containing ':' could
-// alias a different pair under the old concat key).
+// threat-model colon-collision note (a model id containing ':' could alias a
+// different pair under the old concat key).
 //
-// Modeled on dispatchLoadCooldowns (registry.go): same r.mu discipline, same
-// opportunistic map bounding, window-rebuild-on-write. Only sickness-shaped
+// Modeled on the dispatch-load cooldown (registry.go): per-identity gate
+// state (gate_state.go), window-rebuild-on-write. Only sickness-shaped
 // status codes (500/502/504) count toward quarantine: 4xx are client-shape
 // failures (bad request, context too long) and 503 is the provider's
 // capacity/lifecycle signal (token budget, request rejected, update drain) —
@@ -47,19 +47,6 @@ const (
 	// own even without a served request.
 	inferenceErrorCooldownTTL = 5 * time.Minute
 )
-
-// inferenceErrorKey identifies a circuit-breaker bucket. ProviderID holds the
-// provider's STABLE fault key (faultKeyLocked: serial/SE-key when bound, the
-// session id otherwise) so buckets survive reconnect churn. Shape is the
-// request dimension from RequestTraits.CooldownShape ("tools" / "base"), so a
-// failure that only affects one shape quarantines only that shape. A struct
-// key (vs a delimiter-joined string) cannot alias across ids that contain the
-// delimiter.
-type inferenceErrorKey struct {
-	ProviderID string
-	ModelID    string
-	Shape      string
-}
 
 // RecordInferenceError records a provider-side inference failure for the
 // (provider, model, shape) triple. Only statusCodes that indicate provider
@@ -80,6 +67,9 @@ type inferenceErrorKey struct {
 // inferenceErrorCooldownTTL; further strikes while cooling extend the expiry.
 // Returns true ONLY on the transition into cool-down so callers can emit
 // metrics without double-counting (mirrors RecordDispatchLoadFailure).
+//
+// State lives on the identity's gate (gate_state.go), keyed inside it by
+// (model, shape); only gate.mu is taken, never r.mu.
 func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode int, shape string) (enteredCooldown bool) {
 	switch statusCode {
 	case 500, 502, 504:
@@ -88,39 +78,24 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 		return false
 	}
 
-	hold := r.lockWrite("inference_error")
+	var source disconnectSource
+	if statusCode == disconnectFlushStatusCode {
+		source = r.captureDisconnectSource(providerID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "inference_error")
 	defer hold.unlock()
-	// Recheck under the mutation lock: a version reset can race any API-side check.
-	if statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+	g := hold.g
+	if statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
 		return false
 	}
+
 	now := time.Now()
-	// Key by the stable fault key (serial/SE-key when bound, session id
-	// otherwise) so strikes and cooldowns survive reconnect churn.
-	providerID = r.faultKeyLocked(providerID)
+	defer g.updatedLocked(now)
 
-	// Opportunistic sweep, mirroring dispatchLoadCooldowns: churned identities
-	// are never re-keyed — bound both maps by dropping expired ones once they
-	// grow.
-	if len(r.inferenceErrorCooldowns) > 1024 {
-		for key, expiry := range r.inferenceErrorCooldowns {
-			if !now.Before(expiry) {
-				delete(r.inferenceErrorCooldowns, key)
-			}
-		}
-	}
-	if len(r.inferenceErrorStrikes) > 1024 {
-		for key, strikes := range r.inferenceErrorStrikes {
-			if len(strikes) == 0 || !strikes[len(strikes)-1].Add(inferenceErrorWindow).After(now) {
-				delete(r.inferenceErrorStrikes, key)
-			}
-		}
-	}
-
-	key := inferenceErrorKey{ProviderID: providerID, ModelID: modelID, Shape: shape}
+	key := modelShapeKey{Model: modelID, Shape: shape}
 
 	// Slide the window: keep only strikes still inside it, then add this one.
-	strikes := r.inferenceErrorStrikes[key]
+	strikes := g.inferenceErrorStrikes[key]
 	kept := strikes[:0]
 	for _, ts := range strikes {
 		if now.Sub(ts) < inferenceErrorWindow {
@@ -128,27 +103,21 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 		}
 	}
 	kept = append(kept, now)
-	r.inferenceErrorStrikes[key] = kept
-	// The disconnect-flush tags (version_reset.go) must stay a subset of the
-	// live strikes: slide their window with the strikes, or an identity that
-	// churns on the SAME version for weeks — the reset never fires for it —
-	// keeps every flushed request's timestamp forever.
-	r.pruneInferenceFlushStrikesLocked(key, now)
-	// Tag the disconnect-flush strike so a version-changed reconnect can
-	// remove exactly it (version_reset.go).
+	g.inferenceErrorStrikes[key] = kept
+	g.pruneInferenceFlushStrikesLocked(key, now)
 	if statusCode == disconnectFlushStatusCode {
-		r.noteInferenceFlushStrikeLocked(key, now)
+		g.noteInferenceFlushStrikeLocked(key, now)
 	}
 
 	if len(kept) < inferenceErrorThreshold {
 		return false
 	}
 
-	expiry, active := r.inferenceErrorCooldowns[key]
+	expiry, active := g.inferenceErrorCooldowns[key]
 	active = active && now.Before(expiry)
 	// Threshold met: (re-)arm the cool-down. Repeated failures extend an
 	// active cool-down, but only the transition reports true.
-	r.inferenceErrorCooldowns[key] = now.Add(inferenceErrorCooldownTTL)
+	g.inferenceErrorCooldowns[key] = now.Add(inferenceErrorCooldownTTL)
 	return !active
 }
 
@@ -160,28 +129,41 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 // deterministic tool failure interleaved with text traffic could never trip
 // the breaker (the original incident).
 func (r *Registry) RecordInferenceSuccess(providerID, modelID, shape string) {
-	hold := r.lockWrite("inference_success")
+	hold := r.lockGate(r.lookupSessionGateRef(providerID), "inference_success")
 	defer hold.unlock()
-	key := inferenceErrorKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID, Shape: shape}
-	delete(r.inferenceErrorStrikes, key)
-	delete(r.inferenceErrorCooldowns, key)
-	// The flush tags mark strikes that no longer exist.
-	delete(r.inferenceErrorFlushStrikes, key)
+	g := hold.g
+	if g == nil {
+		return
+	}
+
+	key := modelShapeKey{Model: modelID, Shape: shape}
+	delete(g.inferenceErrorStrikes, key)
+	delete(g.inferenceErrorCooldowns, key)
+	delete(g.inferenceErrorFlushStrikes, key)
+	g.updatedLocked(time.Now())
 }
 
 // InferenceErrorCooldownActive reports whether the (provider, model, shape)
 // triple is currently quarantined by the inference-error circuit breaker.
 func (r *Registry) InferenceErrorCooldownActive(providerID, modelID, shape string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.inferenceErrorCooldownActiveLocked(providerID, modelID, shape, time.Now())
+	return r.inferenceErrorCooled(providerID, modelID, shape, time.Now())
 }
 
-// inferenceErrorCooldownActiveLocked reports whether routing should skip the
-// triple. READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock.
-// Caller holds r.mu in either mode (mirrors dispatchLoadCooldownActiveLocked).
-func (r *Registry) inferenceErrorCooldownActiveLocked(providerID, modelID, shape string, now time.Time) bool {
-	key := inferenceErrorKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID, Shape: shape}
-	expiry, ok := r.inferenceErrorCooldowns[key]
+// inferenceErrorCooled reports whether routing should skip the triple.
+// Resolves the session's gate; the scan uses the cached p.gate directly.
+func (r *Registry) inferenceErrorCooled(providerID, modelID, shape string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).inferenceErrorCooled(modelID, shape, now)
+}
+
+// inferenceErrorCooled is the gate-level check: lock-free "no cooldown on any
+// shape" fast path, otherwise one short gate.mu section. READ-ONLY (no lazy
+// delete). nil-safe.
+func (g *gateState) inferenceErrorCooled(modelID, shape string, now time.Time) bool {
+	if !g.hasPairState(gateFlagErrorCooldown) {
+		return false
+	}
+	g = g.lockResolved()
+	expiry, ok := g.inferenceErrorCooldowns[modelShapeKey{Model: modelID, Shape: shape}]
+	g.mu.Unlock()
 	return ok && now.Before(expiry)
 }

--- a/coordinator/registry/error_cooldown_test.go
+++ b/coordinator/registry/error_cooldown_test.go
@@ -7,24 +7,22 @@ import (
 )
 
 func inferenceCooldownActiveAt(r *Registry, providerID, modelID, shape string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.inferenceErrorCooldownActiveLocked(providerID, modelID, shape, now)
+	return r.inferenceErrorCooled(providerID, modelID, shape, now)
 }
 
 // ageInferenceStrikes rewinds every recorded strike for the (provider, model,
 // shape) triple by d, simulating the passage of time without sleeping in the
 // test.
 func ageInferenceStrikes(r *Registry, providerID, modelID, shape string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := inferenceErrorKey{ProviderID: providerID, ModelID: modelID, Shape: shape}
-	strikes := r.inferenceErrorStrikes[key]
-	aged := make([]time.Time, len(strikes))
-	for i, ts := range strikes {
-		aged[i] = ts.Add(-d)
-	}
-	r.inferenceErrorStrikes[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		key := modelShapeKey{Model: modelID, Shape: shape}
+		strikes := g.inferenceErrorStrikes[key]
+		aged := make([]time.Time, len(strikes))
+		for i, ts := range strikes {
+			aged[i] = ts.Add(-d)
+		}
+		g.inferenceErrorStrikes[key] = aged
+	})
 }
 
 // Regression for the prod incident: a deterministic provider-side failure
@@ -269,41 +267,35 @@ func TestInferenceErrorShapeKeyedBucketsIndependent(t *testing.T) {
 
 func TestInferenceErrorMapsBounded(t *testing.T) {
 	r := New(testLogger())
-	// Trip the breaker for >1024 distinct dead pairs so both maps grow, then
-	// force everything past expiry — the opportunistic sweep must drop them.
+	// Trip the breaker for >1024 distinct dead identities, then let everything
+	// expire — the gate sweep must drop every idle gate, while a connected
+	// provider's gate keeps its (pruned) state.
 	for i := 0; i < 1100; i++ {
 		id := fmt.Sprintf("dead-provider-%d", i)
 		r.RecordInferenceError(id, "m", 500, "base")
 		r.RecordInferenceError(id, "m", 500, "base")
 	}
-	r.mu.Lock()
-	for k := range r.inferenceErrorCooldowns {
-		r.inferenceErrorCooldowns[k] = time.Now().Add(-time.Second)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
-	for k, strikes := range r.inferenceErrorStrikes {
-		aged := make([]time.Time, len(strikes))
-		for i, ts := range strikes {
-			aged[i] = ts.Add(-(inferenceErrorWindow + time.Second))
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordInferenceError(live.ID, "m", 500, "base")
+
+	future := time.Now().Add(gateIdleGrace + inferenceErrorCooldownTTL + time.Second)
+	r.sweepGates(future)
+
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
+	}
+	readGateForSession(r, live.ID, func(g *gateState) {
+		if g == nil {
+			t.Fatal("the connected provider's gate must never be swept")
 		}
-		r.inferenceErrorStrikes[k] = aged
-	}
-	cooldowns, strikes := len(r.inferenceErrorCooldowns), len(r.inferenceErrorStrikes)
-	r.mu.Unlock()
-	if cooldowns < 1000 || strikes < 1000 {
-		t.Fatalf("setup produced too few distinct entries: cooldowns=%d strikes=%d", cooldowns, strikes)
-	}
-
-	r.RecordInferenceError("live", "m", 500, "base")
-
-	r.mu.Lock()
-	cooldownsAfter, strikesAfter := len(r.inferenceErrorCooldowns), len(r.inferenceErrorStrikes)
-	r.mu.Unlock()
-	if cooldownsAfter != 0 {
-		t.Fatalf("cooldown sweep should drop every expired entry (live pair has no cooldown yet), got %d", cooldownsAfter)
-	}
-	if strikesAfter != 1 {
-		t.Fatalf("strike sweep should leave only the live entry, got %d", strikesAfter)
-	}
+		if len(g.inferenceErrorStrikes) != 0 || len(g.inferenceErrorCooldowns) != 0 {
+			t.Fatalf("expired strikes/cooldowns must be pruned from a live gate: strikes=%d cooldowns=%d",
+				len(g.inferenceErrorStrikes), len(g.inferenceErrorCooldowns))
+		}
+	})
 }
 
 // End-to-end through the production dispatch hot path (ReserveProviderEx): a

--- a/coordinator/registry/fleet_sample.go
+++ b/coordinator/registry/fleet_sample.go
@@ -230,8 +230,10 @@ func (r *Registry) appendProviderSample(rows []store.FleetSnapshotRow, p *Provid
 		// registry-side state is gone or belongs to a new session — drop it.
 		return rows[:start]
 	}
-	breakerOpen := r.providerBreakerOpenLocked(p.ID, now)
-	ejected := stableID != "" && r.healthEjectionOpenLocked(stableID, now)
+	gate := r.gateOf(p)
+	nowNS := now.UnixNano()
+	breakerOpen := gate.breakerOpenAt(nowNS)
+	ejected := r.ejectionOpenFor(gate, stableID, nowNS)
 	if scratch == nil {
 		row := &rows[start]
 		row.BreakerOpen = breakerOpen
@@ -254,10 +256,10 @@ func (r *Registry) appendProviderSample(rows []store.FleetSnapshotRow, p *Provid
 		row.BreakerOpen = breakerOpen
 		row.Ejected = ejected
 		row.EffectiveCap = r.effectiveMaxConcurrencyForModelResolvedLocked(p, raw)
-		row.CooldownActive = r.dispatchLoadCooldownActiveLocked(p.ID, raw, now) ||
-			r.inferenceErrorCooldownActiveLocked(p.ID, raw, shape, now) ||
-			r.capacityCooldownActiveLocked(p.ID, raw, now)
-		row.ClampActive = r.budgetClampActiveLocked(p.ID, raw, heartbeatAt, scratch[i].rawRemaining, scratch[i].budgetReported, now)
+		row.CooldownActive = gate.dispatchLoadCooled(raw, now) ||
+			gate.inferenceErrorCooled(raw, shape, now) ||
+			gate.capacityCooled(raw, now)
+		row.ClampActive = gate.budgetClampActive(r.budgetClampCfg, raw, heartbeatAt, scratch[i].rawRemaining, scratch[i].budgetReported, now)
 	}
 	p.mu.Unlock()
 	// Eligibility via the real routing gates (the snapshot helper takes p.mu
@@ -311,11 +313,13 @@ func (r *Registry) slotEligibilityReasonLocked(p *Provider, model string, probe 
 // a provider with no resident slot to evaluate a model against. Caller holds
 // r.mu (read) and p.mu.
 func (r *Registry) providerLevelGateReasonLocked(p *Provider, now time.Time) (bool, GateReason) {
-	if r.providerBreakerOpenLocked(p.ID, now) {
+	g := r.gateOf(p)
+	nowNS := now.UnixNano()
+	if g.breakerOpenAt(nowNS) {
 		return false, GateBreaker
 	}
 	if healthEjectionEnabled() {
-		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, now) {
+		if r.ejectionOpenFor(g, stableProviderIdentityLocked(p), nowNS) {
 			return false, GateEjection
 		}
 	}

--- a/coordinator/registry/gate_commit_mode.go
+++ b/coordinator/registry/gate_commit_mode.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// gate_commit_mode.go — the EIGENINFERENCE_RESERVE_COMMIT_MODE kill switch:
+// how the reservation commit holds the registry lock (shared RLock, or the
+// fleet-wide write lock it replaced). Design and file map: gate_state.go.
+
+// --- reservation commit lock mode ---
+
+// reserveCommitMode selects how commitProviderReservation and
+// ReserveNextFromPlan hold the registry lock while they debit a provider.
+type reserveCommitMode uint8
+
+const (
+	// reserveCommitShared (default) commits under r.mu.RLock + p.mu: the
+	// double-booking guard is the admit re-check under p.mu, the herd guard
+	// is the "winner unchanged since scan" compare under the same p.mu, and
+	// the probe claim is atomic under gate.mu. Commits no longer drain the
+	// fleet-scan reader batch.
+	reserveCommitShared reserveCommitMode = iota
+	// reserveCommitGlobal is the kill switch: commits take r.mu.Lock() and
+	// serialize fleet-wide exactly as before. The recorders stay on their
+	// per-identity gates in both modes — that half is safe on its own.
+	reserveCommitGlobal
+)
+
+// envReserveCommitMode selects the mode: "global" restores the fleet-wide
+// commit serialization; anything else (including unset) is "shared". Read
+// once at Registry construction.
+const envReserveCommitMode = "EIGENINFERENCE_RESERVE_COMMIT_MODE"
+
+func loadReserveCommitMode(logger *slog.Logger) reserveCommitMode {
+	raw := os.Getenv(envReserveCommitMode)
+	mode, known := parseReserveCommitMode(raw)
+	if !known && logger != nil {
+		// A kill switch that silently ignores a typo is not a kill switch.
+		logger.Warn("unknown reserve commit mode; using shared",
+			"env", envReserveCommitMode, "value", raw)
+	}
+	return mode
+}
+
+// parseReserveCommitMode maps the raw value to a mode; known reports whether
+// the value named one ("" and "shared" are shared, "global" is global).
+func parseReserveCommitMode(raw string) (mode reserveCommitMode, known bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "shared":
+		return reserveCommitShared, true
+	case "global":
+		return reserveCommitGlobal, true
+	default:
+		return reserveCommitShared, false
+	}
+}
+
+func (m reserveCommitMode) String() string {
+	if m == reserveCommitGlobal {
+		return "global"
+	}
+	return "shared"
+}
+
+// commitLock is the registry lock held across a reservation commit in the
+// configured mode. A value type so the commit path allocates nothing.
+type commitLock struct {
+	r      *Registry
+	global bool
+	site   string
+	write  writeHold
+}
+
+func (r *Registry) commitLock(site string) commitLock {
+	return commitLock{r: r, global: r.reserveCommitMode == reserveCommitGlobal, site: site}
+}
+
+func (l *commitLock) lock() {
+	if l.global {
+		l.write = l.r.lockWrite(l.site)
+	} else {
+		l.r.mu.RLock()
+	}
+}
+
+func (l *commitLock) unlock() {
+	if l.global {
+		l.write.unlock()
+	} else {
+		l.r.mu.RUnlock()
+	}
+}

--- a/coordinator/registry/gate_disconnected_binding.go
+++ b/coordinator/registry/gate_disconnected_binding.go
@@ -1,0 +1,47 @@
+package registry
+
+import "sync/atomic"
+
+// disconnectedGateBinding is a cache-owned identity redirect shared with
+// recorder refs. It retains only an immutable key, never a disconnected
+// Provider or its request/connection state. The cache's existing TTL bounds
+// its lifetime; refs may keep it alive only while an outcome is in flight.
+type disconnectedGateBinding struct {
+	key atomic.Pointer[string]
+}
+
+func newDisconnectedGateBinding(key string) *disconnectedGateBinding {
+	binding := &disconnectedGateBinding{}
+	binding.store(key)
+	return binding
+}
+
+func (binding *disconnectedGateBinding) store(key string) {
+	binding.key.Store(&key)
+}
+
+func (binding *disconnectedGateBinding) load() string {
+	if key := binding.key.Load(); key != nil {
+		return *key
+	}
+	return ""
+}
+
+// retargetDisconnectedGateBindingsLocked moves cached session identities with
+// their fault state. Caller holds gatesMu and the source gate's mu, so a
+// cached ref either records before the migration or detects the redirect
+// after acquiring the source gate. Keep the original disconnect time: it is
+// both the cache TTL anchor and the version-reset ordering signal.
+func (r *Registry) retargetDisconnectedGateBindingsLocked(oldKey, newKey string) {
+	for sessionID, cached := range r.disconnectedStableIDs {
+		if cached.id != oldKey {
+			continue
+		}
+		if cached.binding == nil {
+			cached.binding = newDisconnectedGateBinding(oldKey)
+		}
+		cached.binding.store(newKey)
+		cached.id = newKey
+		r.disconnectedStableIDs[sessionID] = cached
+	}
+}

--- a/coordinator/registry/gate_disconnected_binding_test.go
+++ b/coordinator/registry/gate_disconnected_binding_test.go
@@ -1,0 +1,87 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestDisconnectedGateRefFollowsSharedIdentityEnrichment(t *testing.T) {
+	for _, captureWhileLive := range []bool{false, true} {
+		name := "cached-ref"
+		if captureWhileLive {
+			name = "live-ref-then-disconnect"
+		}
+		t.Run(name, func(t *testing.T) {
+			reg := New(testLogger())
+			const model = "m"
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-CACHED-REF"}
+			bind := func(id string) *Provider {
+				p := makeSchedulerProvider(t, reg, id, model, 100)
+				p.SetAttestationResult(identity)
+				p.SetVersion("0.9.0")
+				return p
+			}
+			old := bind("cached-ref-old")
+			current := bind("cached-ref-current")
+			sibling := bind("cached-ref-sibling")
+			var ref gateRef
+			var source disconnectSource
+			if captureWhileLive {
+				ref = reg.gateForSession(old.ID)
+				source = reg.captureDisconnectSource(old.ID)
+			}
+			reg.DisconnectWithReason(old.ID, DisconnectReasonReadError)
+			if !captureWhileLive {
+				ref = reg.gateForSession(old.ID)
+				source = reg.captureDisconnectSource(old.ID)
+				if ref.disconnectedBinding == nil {
+					t.Fatal("cached resolution did not retain the small identity binding")
+				}
+			}
+			reg.gatesMu.RLock()
+			disconnectedAt := reg.disconnectedStableIDs[old.ID].at
+			reg.gatesMu.RUnlock()
+			shared := ref.g
+			current.SetVersion("0.9.1")
+			// A real post-reset pair state also exercises the lock-free false
+			// flag path after the shared source is emptied by migration.
+			withGateForSession(reg, current.ID, func(g *gateState) {
+				g.dispatchLoadCooldowns[model] = time.Now().Add(time.Minute)
+			})
+			current.SetAttestationResult(&attestation.VerificationResult{
+				Valid: true, PublicKey: identity.PublicKey, SerialNumber: versionResetSerial,
+			})
+			target := current.gate.Load()
+			if target == shared || sibling.gate.Load() != shared || shared.forwardTo.Load() != nil {
+				t.Fatal("precondition: a live sibling must retain the unforwarded source")
+			}
+			reg.gatesMu.RLock()
+			cached := reg.disconnectedStableIDs[old.ID]
+			reg.gatesMu.RUnlock()
+			if cached.id != versionResetStable || !cached.at.Equal(disconnectedAt) {
+				t.Fatalf("cached identity/time = %q/%v, want %q/%v", cached.id, cached.at, versionResetStable, disconnectedAt)
+			}
+
+			hold := reg.lockGate(ref, "breaker")
+			if hold.g != target {
+				hold.unlock()
+				t.Fatal("old-session recorder locked the emptied source instead of the enriched identity")
+			}
+			if !source.supersededBy(hold.g) {
+				hold.unlock()
+				t.Fatal("stale recorder missed the new binary's migrated reset marker")
+			}
+			hold.unlock()
+
+			resolved, has := reg.refHasPairState(ref, gateFlagDispatchLoad)
+			if !has || resolved.g != target || resolved.p != nil {
+				t.Fatal("stale false flag did not re-resolve through the redirected disconnect cache")
+			}
+			if !reg.IsSupersededDisconnectFlush(old.ID, disconnectFlushStatusCode) {
+				t.Fatal("fresh old-session lookup lost the version reset after enrichment")
+			}
+		})
+	}
+}

--- a/coordinator/registry/gate_index.go
+++ b/coordinator/registry/gate_index.go
@@ -1,0 +1,303 @@
+package registry
+
+import "time"
+
+// gate_index.go — the registry side of the per-identity gates: the r.gates /
+// r.sessions index under gatesMu, session → gate resolution (gateRef), the
+// scan's gateOf, and attach/detach at Register / Disconnect. Design, lock
+// order and file map: gate_state.go.
+
+// --- Registry side: the gate index ---
+
+// gatesInit lazily creates the gate index so bare &Registry{} test
+// constructions work without New(). Caller holds gatesMu for writing.
+func (r *Registry) gatesInitLocked() {
+	if r.gates == nil {
+		r.gates = make(map[string]*gateState)
+	}
+	if r.sessions == nil {
+		r.sessions = make(map[string]*Provider)
+	}
+	if r.disconnectedStableIDs == nil {
+		r.disconnectedStableIDs = make(map[string]disconnectedStableID)
+	}
+}
+
+// ensureGateLocked returns the gate for key, creating it on first use. Caller
+// holds gatesMu for writing. A creation past the high-water mark runs the
+// rate-limited inline sweep so the index stays bounded without the eviction
+// loop.
+func (r *Registry) ensureGateLocked(key string, now time.Time) *gateState {
+	r.gatesInitLocked()
+	if g, ok := r.gates[key]; ok {
+		return g
+	}
+	if len(r.gates) > gateSweepHighWater && now.Sub(r.gateSweepAt) > gateSweepMinInterval {
+		r.sweepGatesLocked(now)
+	}
+	g := newGateState(key)
+	g.touched = now // creation counts as activity: see gateState.touched
+	r.gates[key] = g
+	return g
+}
+
+// gateForKey returns the gate filed under an explicit fault key / stable
+// identity (RecordProviderServeOutcome is keyed by the caller's stable id),
+// creating it on first use. One gatesMu.RLock in the common case.
+func (r *Registry) gateForKey(key string) gateRef {
+	r.gatesMu.RLock()
+	g := r.gates[key]
+	r.gatesMu.RUnlock()
+	if g == nil {
+		r.gatesMu.Lock()
+		g = r.ensureGateLocked(key, time.Now())
+		r.gatesMu.Unlock()
+	}
+	return gateRef{g: g.resolve(), key: key, insert: true}
+}
+
+// lookupGateForKey is gateForKey without the insert: nil when the identity has
+// no state.
+func (r *Registry) lookupGateForKey(key string) *gateState {
+	r.gatesMu.RLock()
+	g := r.gates[key]
+	r.gatesMu.RUnlock()
+	return g.resolve()
+}
+
+// gateForSession resolves a live session id to its identity's gate, creating
+// the (session-keyed) gate when the identity has none. Precedence mirrors the
+// old faultKeyLocked: the bound identity of a live session → the identity
+// cached at Disconnect for the trailing ErrorCh flush → the session id itself.
+// Recorders call this; it never touches r.mu.
+func (r *Registry) gateForSession(sessionID string) gateRef {
+	return r.sessionGateRef(sessionID, true)
+}
+
+// lookupSessionGateRef is gateForSession without the insert: ref.g is nil when
+// the session's identity has no state. The recorders that only CLEAR state
+// (and so have nothing to do for an identity without a gate) resolve through
+// this, so a straggling clear for a dead session never files a gate under
+// its id — including when lockGate has to re-resolve.
+func (r *Registry) lookupSessionGateRef(sessionID string) gateRef {
+	return r.sessionGateRef(sessionID, false)
+}
+
+// lookupGateForSession is the plain-pointer form of lookupSessionGateRef for
+// readers (the scan's fallback for a bare provider, the *Active probes,
+// tests): nil when the session's identity has no state.
+func (r *Registry) lookupGateForSession(sessionID string) *gateState {
+	return r.sessionGateRef(sessionID, false).g
+}
+
+func (r *Registry) sessionGateRef(sessionID string, insert bool) gateRef {
+	r.gatesMu.RLock()
+	ref, _ := r.sessionGateRefLocked(sessionID, insert)
+	r.gatesMu.RUnlock()
+	if ref.g == nil && insert {
+		r.gatesMu.Lock()
+		// The session or cached identity may have changed since the miss.
+		// Resolve again before inserting so an enrichment cannot recreate
+		// state under the disconnected session's obsolete key.
+		var key string
+		ref, key = r.sessionGateRefLocked(sessionID, insert)
+		if ref.g == nil {
+			ref.g = r.ensureGateLocked(key, time.Now())
+		}
+		r.gatesMu.Unlock()
+	}
+	ref.g = ref.g.resolve()
+	return ref
+}
+
+// sessionGateRefLocked captures the cached binding in the same index read as
+// the gate. Caller holds gatesMu (either mode).
+func (r *Registry) sessionGateRefLocked(sessionID string, insert bool) (gateRef, string) {
+	g, key, via := r.resolveSessionGateLocked(sessionID)
+	ref := gateRef{g: g, p: via, session: sessionID, insert: insert}
+	if via == nil {
+		if cached, ok := r.disconnectedStableIDs[sessionID]; ok && cached.id == key {
+			ref.disconnectedBinding = cached.binding
+		}
+	}
+	return ref, key
+}
+
+// resolveSessionGateLocked returns the gate a session resolves to (nil when
+// its key has no gate yet), that key, and — when the gate came from a live
+// session's cached pointer — that session's Provider, so the caller can later
+// detect a rebind (gateRef.p). Caller holds gatesMu (either mode).
+func (r *Registry) resolveSessionGateLocked(sessionID string) (g *gateState, key string, via *Provider) {
+	if p := r.sessions[sessionID]; p != nil {
+		if g := p.gate.Load(); g != nil {
+			return g, g.key, p
+		}
+		return r.gates[sessionID], sessionID, nil
+	}
+	if c, ok := r.disconnectedStableIDs[sessionID]; ok && c.id != "" && time.Since(c.at) < disconnectedStableIDTTL {
+		return r.gates[c.id], c.id, nil
+	}
+	return r.gates[sessionID], sessionID, nil
+}
+
+// faultKeyForSession resolves a session provider id to the key its fault state
+// lives under: the bound stable identity (serial/SE-key/account), the identity
+// cached at Disconnect for the trailing ErrorCh flush, or — when no identity
+// was ever available — the session id itself. Takes gatesMu for reading.
+func (r *Registry) faultKeyForSession(sessionID string) string {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	_, key, _ := r.resolveSessionGateLocked(sessionID)
+	return key
+}
+
+// sessionProvider returns the live Provider for a session id without touching
+// r.mu (the recorders that need a budget snapshot read p.BackendCapacity
+// under p.mu). nil when the session is gone.
+func (r *Registry) sessionProvider(sessionID string) *Provider {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return r.sessions[sessionID]
+}
+
+// gateOf returns the gate the scan should consult for p: the pointer cached on
+// the connected Provider (no lock), falling back to a session lookup for a
+// Provider that was never registered (bare test objects). nil-safe result:
+// every gate read treats a nil gate as "no state".
+func (r *Registry) gateOf(p *Provider) *gateState {
+	if p == nil {
+		return nil
+	}
+	if g := p.gate.Load(); g != nil {
+		return g.resolve()
+	}
+	return r.lookupGateForSession(p.ID)
+}
+
+// gateView is the routing read path's handle on a session's gate for one
+// batch of reads: the gate gateOf loaded plus the Provider it was loaded
+// from, so the reads can be confirmed against the pointer afterwards. A value
+// type — the scan allocates nothing.
+//
+// A rebind runs under the session's p.mu (bindStableFaultKey's callers hold
+// it), so a read made under p.mu sees one p.gate for its whole section. Not
+// every dispatch-deciding read is made there — the candidate's capacity-rate
+// penalty (buildCandidateInto) is computed after the scan has released p.mu —
+// and the gate chain's p.mu is its caller's contract, not this file's, so the
+// reads are confirmed independently of that lock. Without it, a gate is read
+// lock-free (or under gate.mu for the per-model maps) holding nothing a rebind
+// respects, and a rebind that lands between the load and the reads can leave
+// the loaded gate saying nothing about the session:
+// migrateGateLocked moves the state to the session's new gate and, when the
+// source is SHARED with another live session, resets the source and
+// republishes it — zeros. A scan trusting that view would dispatch the
+// session past a breaker or cooldown that moved with it. So every batch of
+// reads is confirmed (moved): if p.gate still resolves to the gate that was
+// read, the verdict stands; otherwise the view is rebased on the new gate and
+// the reads run again. Sound without a lock because the migration repoints
+// p.gate BEFORE it resets and republishes the source (all under the source's
+// mu) and Go's atomics are sequentially consistent: a reader whose confirming
+// load still returns the source made its atomic reads before the zeroing
+// stores, and a reader that took the source's mu after the migration finds
+// the pointer moved. Both verdicts are confirmed — a reset source can already
+// carry the sibling session's fresh faults, which are not this session's.
+//
+// Which reads confirm: everything that feeds a dispatch decision — the
+// routing gate (gateStateReasonLocked: the scan, the commit's admit re-check
+// and the preflight), the snapshot's budget clamp (budgetClampedFor) and the
+// candidate's capacity-rate penalty (capacityRatePenaltyFor). Rejected-provider
+// classification (classifyRejectedProvider) also confirms its view because it
+// controls the fail-open rescan and capacity/no-provider response. Gate tallies,
+// fleet_sample rows and warm-pool planning read gateOf unconfirmed: a stale
+// sample there miscounts once and dispatches nothing.
+//
+// No retired check: the sweep drops only gates with no live session, and
+// every read site holds r.mu (Disconnect removes the session under
+// r.mu.Lock) or checks r.providers[p.ID] == p under it, so a live session's
+// gate is never retired underneath a read.
+type gateView struct {
+	p       *Provider
+	g       *gateState
+	rereads int
+}
+
+// gateViewOf loads the gate the routing reads for p consult (gateOf) into a
+// view to confirm them against. nil-safe: a nil or never-registered Provider
+// has no cached gate, and nothing can rebind it.
+func (r *Registry) gateViewOf(p *Provider) gateView {
+	return gateView{p: p, g: r.gateOf(p)}
+}
+
+// moved reports whether the session rebound since the view was loaded — its
+// cached gate no longer resolves to v.g — and, when it did, rebases the view
+// on the session's current gate so the caller re-reads. Bounded by
+// gateRelockMaxRetries like lockGate's re-resolve; at the bound the last
+// view's verdict stands (today's behaviour, no worse).
+func (v *gateView) moved() bool {
+	if v.p == nil || v.rereads >= gateRelockMaxRetries {
+		return false
+	}
+	cur := v.p.gate.Load()
+	if cur == nil {
+		return false // never registered: nothing rebinds a bare Provider
+	}
+	if cur = cur.resolve(); cur == v.g {
+		return false
+	}
+	v.g = cur
+	v.rereads++
+	return true
+}
+
+// attachSessionGate files a freshly registered session under its own id and
+// caches the gate on the Provider. Called by Register (under r.mu; the order
+// r.mu → gatesMu holds).
+func (r *Registry) attachSessionGate(p *Provider) {
+	now := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	g := r.ensureGateLocked(p.ID, now)
+	g.live++
+	p.gate.Store(g)
+	r.sessions[p.ID] = p
+}
+
+// detachSessionGate removes a disconnecting session from the index. stableID
+// is the identity derived at disconnect: when present it is cached so the
+// trailing pending-request flush still resolves the session (its state lives
+// on under the identity's gate — FAULT STATE IS NOT CLEARED ON DISCONNECT);
+// when absent the session-keyed gate is the only thing that ever referenced
+// this identity, so its residue is dropped for hygiene, exactly as the old
+// implementation dropped the session-keyed map entries. Called by Disconnect
+// (under r.mu and p.mu; the order r.mu → p.mu → gatesMu holds).
+func (r *Registry) detachSessionGate(p *Provider, stableID string) {
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	// Live references and later disconnect-cache lookups must date the same
+	// event identically when comparing it with a concurrent version reset.
+	disconnectedAt := time.Now()
+	p.gateDisconnectedAtNS.Store(disconnectedAt.UnixNano())
+	delete(r.sessions, p.ID)
+	g := p.gate.Load()
+	if g != nil {
+		g.live--
+		g.mu.Lock()
+		g.touched = disconnectedAt
+		g.mu.Unlock()
+	}
+	if stableID != "" {
+		r.rememberDisconnectedStableIDLocked(p.ID, stableID, disconnectedAt)
+		return
+	}
+	if g != nil && g.key == p.ID && g.live <= 0 && r.gates[p.ID] == g {
+		delete(r.gates, p.ID)
+	}
+}
+
+// gateCount reports the size of the gate index (tests / observability).
+func (r *Registry) gateCount() int {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return len(r.gates)
+}

--- a/coordinator/registry/gate_index_test.go
+++ b/coordinator/registry/gate_index_test.go
@@ -1,0 +1,186 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the gate index (gate_index.go): session → gate resolution through
+// the disconnect cache, nil-safety of the scan's gate reads, and the routing
+// read path confirming its view against p.gate across a shared-identity
+// rebind (gateView).
+
+// The trailing pending-request flush runs after Disconnect removed the session:
+// its faults must still resolve to the stable identity's gate through the
+// disconnect cache, exactly as the map-keyed faultKeyLocked fallback did.
+func TestDisconnectedTrailingFlushResolvesIdentityGate(t *testing.T) {
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-flush", "m", "SER-FLUSH", 100)
+	reg.Disconnect(p.ID)
+	if got := reg.faultKeyForSession(p.ID); got != "serial:SER-FLUSH" {
+		t.Fatalf("post-disconnect fault key = %q, want the cached identity", got)
+	}
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 502, "provider disconnected")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-FLUSH") || rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("trailing-flush faults must land on the identity's gate, not a session gate")
+	}
+	if !reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("the identity's breaker must be open via the disconnected session id")
+	}
+}
+
+// Gate reads on a Provider that was never registered (bare test objects) and
+// on a nil gate are "no state", never a panic.
+func TestGateReadsAreNilSafe(t *testing.T) {
+	reg := New(testLogger())
+	bare := &Provider{ID: "bare"}
+	g := reg.gateOf(bare)
+	now := time.Now()
+	if g != nil {
+		t.Fatalf("bare provider resolved to a gate: %+v", g)
+	}
+	if g.breakerOpenAt(now.UnixNano()) || g.ejectedAt(now.UnixNano()) || g.dispatchLoadCooled("m", now) ||
+		g.inferenceErrorCooled("m", "base", now) || g.capacityCooled("m", now) ||
+		g.budgetClampActive(reg.budgetClampCfg, "m", now, 0, false, now) {
+		t.Fatal("a nil gate must read as no state")
+	}
+	if pen, rate := g.capacityRatePenalty(reg.capacityRateCfg, "m", now); pen != 0 || rate != 0 {
+		t.Fatal("a nil gate must carry no rate penalty")
+	}
+	if !reg.tryClaimCapacityProbe(bare, "m", now) || !reg.tryClaimCapacityProbe(nil, "m", now) {
+		t.Fatal("a provider with no gate must admit the probe claim")
+	}
+	if reg.ejectionOpenFor(g, "serial:none", now.UnixNano()) {
+		t.Fatal("an unknown identity must not read as ejected")
+	}
+}
+
+// A routing scan that loaded a session's gate just before the session rebound
+// away from a SHARED identity must not trust what it reads there: the
+// migration moves the state to the session's new gate and resets the shared
+// source — now the sibling's alone — to zeros, so an unconfirmed read admits
+// the session past the breaker or cooldown that moved with it.
+// gateStateReasonLocked confirms the verdict against p.gate and re-reads from
+// the new gate. The sibling's view, loaded at the same moment, stays put and
+// reads its identity's (now empty) state: a rebind never makes the OTHER
+// session look faulty. Both read kinds are covered — the breaker (an atomic)
+// and the dispatch-load cooldown (a per-model map under gate.mu) — in both
+// commit modes: the scan's gate and the commit's admit re-check are the same
+// function, and the end-to-end reservation must never land on the rebound
+// session.
+func TestScanRevalidatesGateAcrossSharedRebind(t *testing.T) {
+	const model = "m"
+	cases := []struct {
+		name   string
+		fault  func(reg *Registry, sessionID string)
+		read   func(g *gateState, now time.Time) bool // the unconfirmed read the scan used to make
+		reason GateReason
+	}{
+		{
+			name: "breaker",
+			fault: func(reg *Registry, id string) {
+				for i := 0; i < providerBreakerConsecTrip; i++ {
+					reg.RecordProviderOutcome(id, false, 500, "internal error")
+				}
+			},
+			read:   func(g *gateState, now time.Time) bool { return g.breakerOpenAt(now.UnixNano()) },
+			reason: GateBreaker,
+		},
+		{
+			name:   "dispatch-load cooldown",
+			fault:  func(reg *Registry, id string) { reg.RecordDispatchLoadFailure(id, model) },
+			read:   func(g *gateState, now time.Time) bool { return g.dispatchLoadCooled(model, now) },
+			reason: GateDispatchLoadCooldown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+				reg := New(testLogger())
+				setReserveCommitModeForTest(reg, mode)
+				p1 := makeSchedulerProvider(t, reg, "sess-view-1", model, 100)
+				p2 := makeSchedulerProvider(t, reg, "sess-view-2", model, 100)
+				pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-VIEW"}
+				p1.SetAttestationResult(pk)
+				p2.SetAttestationResult(pk)
+				shared := reg.lookupGateForKey("sekey:PK-VIEW")
+				if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+					t.Fatal("both sessions must share the identity's gate")
+				}
+				tc.fault(reg, p1.ID)
+				now := time.Now()
+				// The scan's gate evaluation on an already-loaded view, under
+				// p.mu as the scan holds it.
+				verdict := func(view *gateView) (ok bool, reason GateReason) {
+					view.p.mu.Lock()
+					defer view.p.mu.Unlock()
+					return reg.gateStateReasonLocked(view, model, RequestTraits{}, now, false, false)
+				}
+				// Precondition: the identity's fault gates both sessions.
+				for _, p := range []*Provider{p1, p2} {
+					view := reg.gateViewOf(p)
+					if ok, reason := verdict(&view); ok || reason != tc.reason {
+						t.Fatalf("pre-rebind verdict for %s = (%v, %v), want gated by %v", p.ID, ok, reason, tc.reason)
+					}
+				}
+
+				// Two scans load the shared gate, one per session...
+				view1, view2 := reg.gateViewOf(p1), reg.gateViewOf(p2)
+				if view1.g != shared || view2.g != shared {
+					t.Fatalf("views = %+v / %+v, want the shared gate", view1, view2)
+				}
+				// ...and p1 enriches to a serial before either reads it.
+				p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-VIEW", SerialNumber: "SER-VIEW"})
+				target := p1.gate.Load()
+				if target == shared || target.key != "serial:SER-VIEW" || p2.gate.Load() != shared {
+					t.Fatalf("after the rebind p1 → %+v, p2 → %+v; want p1 on serial:SER-VIEW and p2 unmoved", target, p2.gate.Load())
+				}
+				// The race: the gate the scan holds now reads clean — the state
+				// moved with p1 and the shared source was reset for p2.
+				if tc.read(shared, now) || !tc.read(target, now) {
+					t.Fatalf("precondition: the %s must have moved from the shared gate to p1's new gate", tc.name)
+				}
+
+				// p1's scan must not admit p1: the view is confirmed against
+				// p.gate, found moved, and re-read from the new gate.
+				if ok, reason := verdict(&view1); ok || reason != tc.reason {
+					t.Fatalf("p1's stale view verdict = (%v, %v), want gated by %v", ok, reason, tc.reason)
+				}
+				if view1.g != target || view1.rereads != 1 {
+					t.Fatalf("p1's view after the verdict = %+v, want rebased on serial:SER-VIEW after one re-read", view1)
+				}
+				// p2's scan reads its own identity, which now has nothing: not
+				// gated, and the view did not move.
+				if ok, reason := verdict(&view2); !ok || reason != GateReasonCount {
+					t.Fatalf("p2's view verdict = (%v, %v), want not gated — a rebind must not make the other session look faulty", ok, reason)
+				}
+				if view2.g != shared || view2.rereads != 0 {
+					t.Fatalf("p2's view after the verdict = %+v, want the shared gate, unmoved", view2)
+				}
+
+				// End to end, in this commit mode: the reservation must never
+				// land on p1 (its fault lives on its new gate); p2's identity is
+				// clean and takes the request.
+				pr := &PendingRequest{
+					RequestID:             "view-" + mode.String() + "-" + tc.name,
+					Model:                 model,
+					EstimatedPromptTokens: 200,
+					RequestedMaxTokens:    128,
+					FirstContentBudgetMS:  10_000,
+					FirstContentDeadline:  time.Now().Add(10 * time.Second),
+				}
+				got, _ := reg.ReserveProviderEx(model, pr)
+				if got == p1 {
+					t.Fatal("the reservation landed on the rebound session past the fault that moved with it")
+				}
+				if got != p2 {
+					t.Fatalf("reservation = %v, want p2 (the sibling's identity carries no state after the move)", got)
+				}
+			})
+		})
+	}
+}

--- a/coordinator/registry/gate_lock.go
+++ b/coordinator/registry/gate_lock.go
@@ -1,0 +1,245 @@
+package registry
+
+import "time"
+
+// gate_lock.go — acquiring a gate for a recorder: gateRef (a resolution that
+// remembers how it was reached), lockGate (validate under gate.mu, re-resolve
+// on a moved or retired gate), the lock-free flag fast path (refHasPairState)
+// and the gate-wait observer. Design, lock order and file map: gate_state.go.
+
+// gateWaitReportThreshold is the gate.mu acquisition wait above which the
+// wait is reported to the gate-wait observer (registry.gate.wait_ms). Below it
+// the lock is doing what it should; above it something is holding a gate too
+// long or the convoy is re-forming on a new lock.
+const gateWaitReportThreshold = time.Millisecond
+
+// lockResolved locks the gate, following a migration that landed between the
+// caller's resolve and the lock. The caller unlocks the RETURNED gate.
+func (g *gateState) lockResolved() *gateState {
+	for {
+		g.mu.Lock()
+		next := g.forwardTo.Load()
+		if next == nil {
+			return g
+		}
+		g.mu.Unlock()
+		g = next
+	}
+}
+
+// gateRef is a recorder's resolution of a gate: the gate plus how it was
+// reached, so that lockGate can prove — under gate.mu — that the gate is
+// still the one the outcome belongs to, and re-resolve when it is not. A
+// value type: the recorder path allocates nothing.
+type gateRef struct {
+	g *gateState
+	// p is the live session whose cached p.gate produced g; nil when g was
+	// reached through the disconnect cache, the bare session id or an
+	// explicit fault key. After the lock,
+	// p.gate.Load() != g means the session rebound to another gate in
+	// between and the outcome belongs there.
+	p *Provider
+	// A disconnected identity can still be enriched by a live sibling. Its
+	// cache-owned redirect validates that move without retaining Provider or
+	// acquiring gatesMu while gate.mu is held.
+	disconnectedBinding *disconnectedGateBinding
+	// Exactly one of session / key names what to re-resolve.
+	session string
+	key     string
+	// insert says whether re-resolution may create the gate (gateForSession /
+	// gateForKey) or must find an existing one (lookupSessionGateRef: the
+	// "clear" recorders, which have nothing to clear on an identity without a
+	// gate and must not file one under a dead session id).
+	insert bool
+}
+
+// currentLocked reports whether g — locked by the caller — is still the gate
+// ref's outcome belongs to: not retired by the sweep, and, when the ref was
+// reached through a live session's cached pointer, still that session's gate.
+func (ref gateRef) currentLocked(g *gateState) bool {
+	if g.retired {
+		return false
+	}
+	return ref.bindingCurrent(g)
+}
+
+// bindingCurrent is safe for the lock-free pair-flag probe as well as the
+// locked validation. All identity redirects publish before resetting src.
+func (ref gateRef) bindingCurrent(g *gateState) bool {
+	if ref.p != nil {
+		// A ref captured while live must switch to the disconnect cache on
+		// drop; a later sibling enrichment redirects that cache, not this
+		// detached Provider's cached gate pointer.
+		return ref.p.gateDisconnectedAtNS.Load() == 0 && ref.p.gate.Load() == g
+	}
+	if ref.disconnectedBinding != nil {
+		return g != nil && ref.disconnectedBinding.load() == g.key
+	}
+	return true
+}
+
+// gateRelockMaxRetries bounds how many times lockGate re-resolves a gate that
+// went stale between the index lookup and the lock, and how many times a
+// routing read re-reads a gate the session moved away from (gateView.moved).
+// One retry is the expected maximum (a rebind or a sweep landed in the
+// window). A recorder that exhausts the optimistic retries stabilizes the
+// index while resolving and acquiring the gate; it never mutates a stale
+// gate merely to bound the number of retries.
+const gateRelockMaxRetries = 4
+
+// lockGate acquires gate.mu for a recorder at the named site. It follows any
+// migration forward (see lockResolved) and then validates, under the lock,
+// that the gate is still current for the ref (currentLocked); a stale gate is
+// released and the ref re-resolved through the index — gatesMu is never
+// taken while a gate.mu is held, so the lock order stands — and locked again.
+// The uncontended path is one TryLock — no clock reads; only a contended
+// acquisition is timed, and only a wait above gateWaitReportThreshold is
+// reported. The caller uses hold.g (the gate actually locked) and calls
+// hold.unlock. A vanished no-insert identity returns a nil gate; callers must
+// treat that hold as a no-op.
+func (r *Registry) lockGate(ref gateRef, site string) gateHold {
+	return r.lockGateWithRetries(ref, site, 0)
+}
+
+// lockGateWithRetries carries the optimistic retry count explicitly so the
+// exhaustion path can be exercised without scheduling several racing rebinds.
+func (r *Registry) lockGateWithRetries(ref gateRef, site string, retries int) gateHold {
+	var wait time.Duration
+	g := ref.g
+	for {
+		if retries >= gateRelockMaxRetries {
+			return r.lockGateWithIndex(ref, site, wait)
+		}
+		if g == nil {
+			return gateHold{r: r, site: site, wait: wait}
+		}
+		if !g.mu.TryLock() {
+			start := time.Now()
+			g.mu.Lock()
+			wait += time.Since(start)
+		}
+		if next := g.forwardTo.Load(); next != nil {
+			g.mu.Unlock()
+			g = next
+			retries++
+			continue
+		}
+		if ref.currentLocked(g) {
+			return gateHold{g: g, r: r, site: site, wait: wait}
+		}
+		// Never retain g after a failed validation: it may still belong to
+		// another live session even if this session's next lookup is empty.
+		g.mu.Unlock()
+		retries++
+		if retries >= gateRelockMaxRetries {
+			continue
+		}
+		ref = r.reresolveGate(ref)
+		g = ref.g
+	}
+}
+
+// lockGateWithIndex is the rare retry-exhaustion path. Holding gatesMu until
+// the current gate is locked prevents a rebind or sweep from invalidating the
+// resolution. The index lock is released before returning the gate, preserving
+// gatesMu -> gate.mu without taking r.mu or p.mu. The write lock permits an
+// inserting recorder to recreate an idle gate retired by a concurrent sweep.
+func (r *Registry) lockGateWithIndex(ref gateRef, site string, wait time.Duration) gateHold {
+	start := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	key := ref.key
+	var g *gateState
+	if key != "" {
+		g = r.gates[key]
+	} else {
+		g, key, _ = r.resolveSessionGateLocked(ref.session)
+	}
+	if g == nil && ref.insert {
+		g = r.ensureGateLocked(key, time.Now())
+	}
+	g = g.resolve()
+	if g == nil {
+		return gateHold{r: r, site: site, wait: wait + time.Since(start)}
+	}
+	g.mu.Lock()
+	return gateHold{g: g, r: r, site: site, wait: wait + time.Since(start)}
+}
+
+// reresolveGate resolves ref again through the index (takes gatesMu; the
+// caller holds no gate.mu).
+func (r *Registry) reresolveGate(ref gateRef) gateRef {
+	if ref.key != "" {
+		return r.gateForKey(ref.key)
+	}
+	return r.sessionGateRef(ref.session, ref.insert)
+}
+
+// refHasPairState is the lock-free "does this identity hold any of the
+// flagged per-model state" fast path for a ref about to be locked, made safe
+// against a rebind: an emptied source gate's flag says "nothing" precisely
+// because the state moved to the session's new gate, so a cleared flag counts
+// only while p.gate still points at ref.g; otherwise the ref is re-resolved
+// and the flag read again. Sound without a lock because the migration
+// repoints p.gate BEFORE it republishes the emptied source (migrateGateLocked)
+// — a reader that sees the cleared flag then sees the moved pointer. A set
+// flag needs no confirmation: the caller proceeds to lockGate, which
+// validates under the lock. Returns the ref to lock. A retired gate needs no
+// handling here: it was idle, so "nothing" is true for the identity.
+func (r *Registry) refHasPairState(ref gateRef, flag uint32) (gateRef, bool) {
+	for retries := 0; ; retries++ {
+		has := ref.g.hasPairState(flag)
+		if has || ref.bindingCurrent(ref.g) {
+			return ref, has
+		}
+		if retries >= gateRelockMaxRetries {
+			// A stale false flag cannot prove there is nothing to clear or
+			// claim. Force the caller through lockGate's validated acquisition.
+			return ref, true
+		}
+		ref = r.reresolveGate(ref)
+	}
+}
+
+// gateHold is an acquired gate.mu. unlock releases the gate and only then
+// reports a long acquisition wait to the observer, so the DogStatsD emit never
+// runs inside the critical section.
+type gateHold struct {
+	g    *gateState
+	r    *Registry
+	site string
+	wait time.Duration
+}
+
+func (h gateHold) unlock() {
+	if h.g != nil {
+		h.g.mu.Unlock()
+	}
+	if h.r != nil && h.wait > gateWaitReportThreshold {
+		if obs := h.r.gateWaitObserver.Load(); obs != nil {
+			(*obs)(h.site, h.wait)
+		}
+	}
+}
+
+// SetGateWaitObserver registers an optional observer for gate.mu acquisition
+// waits above gateWaitReportThreshold on the recorder sites. The api layer
+// turns it into the registry.gate.wait_ms histogram tagged by site, so the
+// per-identity locks that replaced the global write lock are observable. Set
+// once at startup; nil clears it. Thread-safe.
+func (r *Registry) SetGateWaitObserver(fn func(site string, wait time.Duration)) {
+	if fn == nil {
+		r.gateWaitObserver.Store(nil)
+		return
+	}
+	r.gateWaitObserver.Store(&fn)
+}
+
+// HoldGateForTest acquires the gate.mu of the provider's current gate and
+// returns the release function. Test-only (mirrors reservationAfterScan): it
+// lets a test prove a recorder blocks on the identity's gate, not on r.mu, and
+// that a long wait reaches the observer. Production code never calls it.
+func (r *Registry) HoldGateForTest(providerID string) (release func()) {
+	hold := r.lockGate(r.gateForSession(providerID), "test")
+	return hold.g.mu.Unlock
+}

--- a/coordinator/registry/gate_lock_fallback_test.go
+++ b/coordinator/registry/gate_lock_fallback_test.go
@@ -1,0 +1,110 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestVanishedClearRefLeavesLiveSiblingGateUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		retries int
+	}{{"optimistic", 0}, {"retry-exhaustion", gateRelockMaxRetries}} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			const model = "m"
+			p1 := makeSchedulerProvider(t, reg, "vanished-clear-1", model, 100)
+			p2 := makeSchedulerProvider(t, reg, "vanished-clear-2", model, 100)
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-VANISHED-CLEAR"}
+			p1.SetAttestationResult(identity)
+			p2.SetAttestationResult(identity)
+			reg.RecordDispatchLoadFailure(p1.ID, model)
+			ref, has := reg.refHasPairState(reg.lookupSessionGateRef(p1.ID), gateFlagDispatchLoad)
+			if !has || ref.g != p2.gate.Load() {
+				t.Fatal("precondition: clear must have observed the shared gate's state")
+			}
+			shared := ref.g
+
+			// Interpose after the clear's lookup. The shared gate remains live
+			// for p2, while p1's new anonymous session gate disappears entirely.
+			p1.SetAttestationResult(nil)
+			reg.Disconnect(p1.ID)
+			reg.RecordDispatchLoadFailure(p2.ID, model)
+			if reg.lookupSessionGateRef(p1.ID).g != nil {
+				t.Fatal("precondition: the cleared session must no longer resolve")
+			}
+
+			hold := reg.lockGateWithRetries(ref, "dispatch_load_clear", tc.retries)
+			if hold.g != nil {
+				hold.unlock()
+				t.Fatalf("vanished clear returned gate %q; it could erase a sibling's fresh fault", hold.g.key)
+			}
+			hold.unlock() // A missing identity's hold is safe to release.
+			if p2.gate.Load() != shared || !reg.dispatchLoadCooled(p2.ID, model, time.Now()) {
+				t.Fatal("vanished session's clear disturbed the live sibling's cooldown")
+			}
+			if rawGateForKey(reg, p1.ID) != nil {
+				t.Fatal("a no-insert clear recreated the vanished session gate")
+			}
+		})
+	}
+}
+
+func TestGateRetryExhaustionLocksCurrentSharedBinding(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "exhausted-bind-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "exhausted-bind-2", "m", 100)
+	identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-EXHAUSTED-BIND"}
+	p1.SetAttestationResult(identity)
+	p2.SetAttestationResult(identity)
+	ref := reg.gateForSession(p1.ID)
+	shared := ref.g
+	p1.SetAttestationResult(&attestation.VerificationResult{
+		Valid: true, PublicKey: identity.PublicKey, SerialNumber: "SER-EXHAUSTED-BIND",
+	})
+	target := p1.gate.Load()
+	if target == shared || p2.gate.Load() != shared {
+		t.Fatal("precondition: only the recording session must change gates")
+	}
+
+	// Enter with the optimistic budget consumed, the same state reached after
+	// repeated rebinds. Exhaustion must not waive currentLocked's invariant.
+	hold := reg.lockGateWithRetries(ref, "breaker", gateRelockMaxRetries)
+	if hold.g != target {
+		hold.unlock()
+		t.Fatal("retry exhaustion returned the live sibling's obsolete gate")
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if providerBreakerTripsOf(reg, p1.ID) != 1 || providerBreakerTripsOf(reg, p2.ID) != 0 {
+		t.Fatal("record after retry exhaustion landed on the wrong identity")
+	}
+}
+
+func TestGateRetryExhaustionRecreatesRetiredIdentity(t *testing.T) {
+	reg := New(testLogger())
+	const key = "serial:SER-EXHAUSTED-SWEEP"
+	ref := reg.gateForKey(key)
+	withGateForKey(reg, key, func(g *gateState) {
+		g.touched = time.Now().Add(-gateIdleGrace - time.Minute)
+	})
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, key) != nil {
+		t.Fatal("precondition: identity must have been swept")
+	}
+	hold := reg.lockGateWithRetries(ref, "health_ejection", gateRelockMaxRetries)
+	if hold.g == nil || hold.g == ref.g || hold.g.retired {
+		hold.unlock()
+		t.Fatal("retry exhaustion returned the retired identity gate")
+	}
+	current := hold.g
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if rawGateForKey(reg, key) != current {
+		t.Fatal("recorded gate is absent from the current index")
+	}
+}

--- a/coordinator/registry/gate_lock_test.go
+++ b/coordinator/registry/gate_lock_test.go
@@ -1,0 +1,427 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the recorders' validated gate lock (gate_lock.go): the probe
+// claim's per-identity exclusivity, the wait observer, recorders never
+// blocking behind r.mu, and lockGate / refHasPairState re-resolving a gate
+// that a shared-identity rebind or a sweep invalidated in the window between
+// the index lookup and the lock. The trackers' semantics are covered by
+// their own files; the commit lock mode lives in reserve_commit_test.go.
+
+// Two sessions of one identity racing for the single half-open probe: the
+// check-and-claim under gate.mu lets exactly one through, and the gate reads
+// closed for both afterwards.
+func TestTryClaimCapacityProbeIsExclusivePerIdentity(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := attestSchedulerProvider(t, reg, "sess-probe-1", model, "SER-PROBE", 100)
+	p2 := attestSchedulerProvider(t, reg, "sess-probe-2", model, "SER-PROBE", 100)
+	if reg.gateOf(p1) != reg.gateOf(p2) {
+		t.Fatal("sessions of one identity must share a gate")
+	}
+	for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+		reg.RecordCapacityReject(p1.ID, model)
+	}
+	if !reg.CapacityCooldownActive(p2.ID, model) {
+		t.Fatal("the cooldown must be visible through the sibling session")
+	}
+	expireCapacityCooldown(reg, p1.ID, model)
+	if reg.CapacityCooldownActive(p1.ID, model) {
+		t.Fatal("an expired, unclaimed cooldown must read open")
+	}
+
+	now := time.Now()
+	var claimed atomic.Int32
+	var wg sync.WaitGroup
+	for _, p := range []*Provider{p1, p2, p1, p2} {
+		wg.Add(1)
+		go func(p *Provider) {
+			defer wg.Done()
+			if reg.tryClaimCapacityProbe(p, model, now) {
+				claimed.Add(1)
+			}
+		}(p)
+	}
+	wg.Wait()
+	if claimed.Load() != 1 {
+		t.Fatalf("probe claims = %d, want exactly 1", claimed.Load())
+	}
+	if !reg.CapacityCooldownActive(p1.ID, model) || !reg.CapacityCooldownActive(p2.ID, model) {
+		t.Fatal("the claimed probe must close the gate for every session of the identity")
+	}
+	// No cooldown entry at all: the claim is a lock-free no-op that admits.
+	if !reg.tryClaimCapacityProbe(p1, "other-model", now) {
+		t.Fatal("a pair with no cooldown entry must always claim")
+	}
+}
+
+// A gate.mu wait above the threshold reaches the observer tagged by site — and
+// only then: uncontended recorders report nothing.
+func TestGateWaitObserverReportsLongWaits(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-wait", "m", 100)
+	type seen struct {
+		site string
+		wait time.Duration
+	}
+	var mu sync.Mutex
+	var got []seen
+	reg.SetGateWaitObserver(func(site string, wait time.Duration) {
+		mu.Lock()
+		got = append(got, seen{site, wait})
+		mu.Unlock()
+	})
+
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+	mu.Lock()
+	n := len(got)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("uncontended recorder reported a wait: %+v", got)
+	}
+
+	release := reg.HoldGateForTest(p.ID)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		release()
+	}()
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 || got[0].site != "breaker" || got[0].wait < 5*time.Millisecond {
+		t.Fatalf("observer calls = %+v, want one 'breaker' wait of >= 5ms", got)
+	}
+	reg.SetGateWaitObserver(nil)
+}
+
+// An accept on the first-byte path must not queue behind the registry write
+// lock: with r.mu held for writing by someone else, the recorders still run.
+func TestRecordersDoNotTakeTheRegistryWriteLock(t *testing.T) {
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-nolock", "m", "SER-NOLOCK", 100)
+	reg.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reg.RecordCapacityAccept(p.ID, "m")
+		reg.RecordInferenceSuccess(p.ID, "m", "base")
+		reg.RecordProviderOutcome(p.ID, true, 200, "")
+		reg.RecordProviderServeOutcome("serial:SER-NOLOCK", true, 200, "")
+		reg.ClearDispatchLoadCooldown(p.ID, "m")
+		reg.RecordDispatchLoadFailure(p.ID, "m")
+		reg.RecordInferenceError(p.ID, "m", 500, "base")
+		reg.RecordCapacityReject(p.ID, "m")
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		reg.mu.Unlock()
+		t.Fatal("a recorder blocked behind the registry write lock")
+	}
+	reg.mu.Unlock()
+}
+
+// A recorder that resolved a gate SHARED by two sessions just before one of
+// them rebinds (sekey: → serial: enrichment) must land its outcome on the
+// rebinding session's NEW gate — the shared gate stays in the index for the
+// other session, carries no forward, and was emptied by the migration, so
+// only the session's own repointed p.gate can tell the stale holder to move.
+// The other session's recorder, resolved at the same moment, stays put.
+func TestStaleRefFollowsSharedIdentityRebind(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "sess-rebind-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-rebind-2", "m", 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-REBIND"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	shared := reg.lookupGateForKey("sekey:PK-REBIND")
+	if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+		t.Fatal("both sessions must share the identity's gate")
+	}
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+
+	// Two recorders resolve the shared gate, one per session...
+	ref1 := reg.gateForSession(p1.ID)
+	ref2 := reg.gateForSession(p2.ID)
+	if ref1.g != shared || ref1.p != p1 || ref2.g != shared || ref2.p != p2 {
+		t.Fatalf("refs = %+v / %+v, want the shared gate via each session", ref1, ref2)
+	}
+	// ...and p1 enriches to a serial before either takes the lock.
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-REBIND", SerialNumber: "SER-REBIND"})
+	target := p1.gate.Load()
+	if target == shared || target.key != "serial:SER-REBIND" {
+		t.Fatalf("p1's gate after the rebind = %+v, want serial:SER-REBIND", target)
+	}
+	if shared.forwardTo.Load() != nil || rawGateForKey(reg, "sekey:PK-REBIND") != shared {
+		t.Fatal("precondition: the shared gate stays in the index, unforwarded, for p2")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-REBIND") || gateHasBreakerWindow(reg, "sekey:PK-REBIND") {
+		t.Fatal("precondition: the fault history moved to the enriched identity")
+	}
+
+	hold := reg.lockGate(ref1, "test")
+	if hold.g != target {
+		hold.unlock()
+		t.Fatalf("p1's recorder locked %q, want the session's new gate serial:SER-REBIND", hold.g.key)
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if got := providerBreakerTripsOf(reg, p1.ID); got != 1 {
+		t.Fatalf("p1's outcome did not land on its identity: trips=%d", got)
+	}
+	readGateForKey(reg, "sekey:PK-REBIND", func(g *gateState) {
+		if g == nil || g.breakerTrips != 0 || g.outcomes != nil {
+			t.Fatalf("p2's identity must be untouched by p1's stale recorder: %+v", g)
+		}
+	})
+
+	hold = reg.lockGate(ref2, "test")
+	if hold.g != shared {
+		hold.unlock()
+		t.Fatalf("p2's recorder locked %q, want its own (shared) gate", hold.g.key)
+	}
+	hold.g.healthWindowLocked().record(false, time.Now())
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if !gateHasBreakerWindow(reg, "sekey:PK-REBIND") || providerBreakerTripsOf(reg, p2.ID) != 0 {
+		t.Fatal("p2's outcome must land on p2's identity, and only there")
+	}
+}
+
+// A trailing-flush recorder that resolved a disconnected identity's gate just
+// before the sweep dropped it (idle, no live session, past the grace) must not
+// write into the retired gate — the fault would vanish before the identity's
+// next reconnect. lockGate sees retired, re-resolves, and the fault lands on
+// the gate a fresh lookup finds. Both resolution paths: by session id through
+// the disconnect cache (RecordProviderOutcome) and by stable id
+// (RecordProviderServeOutcome).
+func TestStaleRefSurvivesSweepOfDisconnectedGate(t *testing.T) {
+	const key = "serial:SER-SWEEP-RACE"
+	backdate := func(g *gateState) { g.touched = time.Now().Add(-gateIdleGrace - time.Minute) }
+	for _, tc := range []struct {
+		name    string
+		resolve func(reg *Registry, sessionID string) gateRef
+	}{
+		{"by session through the disconnect cache", func(reg *Registry, sessionID string) gateRef { return reg.gateForSession(sessionID) }},
+		{"by stable id", func(reg *Registry, _ string) gateRef { return reg.gateForKey(key) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p := attestSchedulerProvider(t, reg, "sess-sweep-race", "m", "SER-SWEEP-RACE", 100)
+			reg.Disconnect(p.ID)
+			// Nothing was ever recorded on the identity, so its gate is idle;
+			// backdate its creation past the grace so a PRESENT-time sweep
+			// drops it (a future-time sweep would also expire the disconnect
+			// cache the trailing flush resolves through).
+			withGateForKey(reg, key, backdate)
+
+			ref := tc.resolve(reg, p.ID)
+			stale := ref.g
+			if stale == nil || stale.key != key || ref.p != nil {
+				t.Fatalf("pre-sweep ref = %+v, want the disconnected identity's gate with no live session", ref)
+			}
+			reg.sweepGates(time.Now())
+			if rawGateForKey(reg, key) != nil {
+				t.Fatal("precondition: the sweep must drop the idle disconnected gate")
+			}
+
+			hold := reg.lockGate(ref, "test")
+			if hold.g == stale {
+				hold.unlock()
+				t.Fatal("lockGate handed out the gate the sweep retired")
+			}
+			if hold.g.key != key || rawGateForKey(reg, key) != hold.g {
+				hold.unlock()
+				t.Fatalf("re-resolved to %q (in index: %v), want a fresh %s gate", hold.g.key, rawGateForKey(reg, key) == hold.g, key)
+			}
+			now := time.Now()
+			hold.g.healthWindowLocked().record(false, now)
+			hold.g.updatedLocked(now)
+			hold.unlock()
+
+			stale.mu.Lock()
+			retired := stale.retired
+			stale.mu.Unlock()
+			if !retired {
+				t.Fatal("the swept gate must be marked retired under its lock")
+			}
+			if !gateHasBreakerWindow(reg, key) {
+				t.Fatal("the trailing fault must be on the gate a fresh lookup finds")
+			}
+			// The rest of the flush lands on the same gate and trips the
+			// identity's breaker — the reconnecting-zombie signal survives.
+			for i := 1; i < providerBreakerConsecTrip; i++ {
+				reg.RecordProviderOutcome(p.ID, false, 502, "provider disconnected")
+			}
+			if !reg.ProviderBreakerOpen(p.ID) {
+				t.Fatal("the identity's breaker must be open through the disconnected session id")
+			}
+		})
+	}
+}
+
+// A CLEAR recorder (no-insert resolution) whose gate was swept in the window
+// has nothing left to clear: it returns a nil hold rather than retaining the
+// old gate or filing a gate under an identity nothing references.
+func TestClearRefNeverFilesAGateForASweptIdentity(t *testing.T) {
+	const key = "serial:SER-CLEAR-RACE"
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-clear-race", "m", "SER-CLEAR-RACE", 100)
+	reg.Disconnect(p.ID)
+	withGateForKey(reg, key, func(g *gateState) { g.touched = time.Now().Add(-gateIdleGrace - time.Minute) })
+
+	ref := reg.lookupSessionGateRef(p.ID)
+	stale := ref.g
+	if stale == nil || stale.key != key || ref.insert {
+		t.Fatalf("pre-sweep lookup ref = %+v, want a no-insert ref to the identity's gate", ref)
+	}
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, key) != nil {
+		t.Fatal("precondition: the sweep must drop the idle disconnected gate")
+	}
+	hold := reg.lockGate(ref, "test")
+	if hold.g != nil {
+		hold.unlock()
+		t.Fatalf("a clear re-resolved to %q; it must return a no-op hold", hold.g.key)
+	}
+	hold.unlock()
+	if rawGateForKey(reg, key) != nil || rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("a clear must not file a gate for a swept identity or a dead session")
+	}
+	// Through the real recorder, on the dead session: still nothing filed.
+	reg.ClearDispatchLoadCooldown(p.ID, "m")
+	reg.RecordInferenceSuccess(p.ID, "m", "base")
+	if reg.gateCount() != 0 {
+		t.Fatalf("gate index after a straggling clear = %d, want 0", reg.gateCount())
+	}
+}
+
+// A reservation commit that resolved the probe's gate just before its session
+// rebound away from a SHARED identity must claim the probe on the session's
+// NEW gate — where the cooldown entry migrated — and leave the other
+// identity's (reset) state untouched. A claim on the old gate would find no
+// entry and admit: a leaked probe through a cooled pair. The claim is the
+// same in both commit modes (the mode only chooses the r.mu lock kind).
+func TestProbeClaimFollowsSharedIdentityRebind(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "m"
+		p1 := makeSchedulerProvider(t, reg, "sess-probe-rebind-1", model, 100)
+		p2 := makeSchedulerProvider(t, reg, "sess-probe-rebind-2", model, 100)
+		pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-PROBE-REBIND"}
+		p1.SetAttestationResult(pk)
+		p2.SetAttestationResult(pk)
+		shared := reg.lookupGateForKey("sekey:PK-PROBE-REBIND")
+		if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+			t.Fatal("both sessions must share the identity's gate")
+		}
+		for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+			reg.RecordCapacityReject(p1.ID, model)
+		}
+		expireCapacityCooldown(reg, p1.ID, model)
+		if reg.CapacityCooldownActive(p1.ID, model) {
+			t.Fatal("precondition: an expired, unclaimed cooldown must read open")
+		}
+
+		// The commit resolves the probe's gate (under p.mu)...
+		ref := reg.probeGateRef(p1)
+		if ref.g != shared || ref.p != p1 {
+			t.Fatalf("probe ref = %+v, want the shared gate via p1", ref)
+		}
+		// ...and p1 enriches to a serial before the claim takes the lock.
+		p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-PROBE-REBIND", SerialNumber: "SER-PROBE-REBIND"})
+		target := p1.gate.Load()
+		if target == shared || target.key != "serial:SER-PROBE-REBIND" {
+			t.Fatalf("p1's gate after the rebind = %+v, want serial:SER-PROBE-REBIND", target)
+		}
+		if !target.hasPairState(gateFlagCapacityCooldown) || shared.hasPairState(gateFlagCapacityCooldown) {
+			t.Fatal("precondition: the cooldown entry moved with the session")
+		}
+
+		now := time.Now()
+		if !reg.claimCapacityProbeRef(ref, model, now) {
+			t.Fatal("the expired, unclaimed probe must be claimable")
+		}
+		readGateForKey(reg, "serial:SER-PROBE-REBIND", func(g *gateState) {
+			if g == nil {
+				t.Fatal("the enriched identity's gate must exist")
+			}
+			if e := g.capacityCooldowns[model]; e == nil || !e.probeAt.Equal(now) {
+				t.Fatalf("the claim must land on the session's new gate: entry=%+v", e)
+			}
+		})
+		readGateForKey(reg, "sekey:PK-PROBE-REBIND", func(g *gateState) {
+			if g == nil {
+				t.Fatal("the shared gate must stay in the index for p2")
+			}
+			if len(g.capacityCooldowns) != 0 {
+				t.Fatalf("the other identity's state must be untouched by the stale claim: %+v", g.capacityCooldowns)
+			}
+		})
+		if !reg.CapacityCooldownActive(p1.ID, model) {
+			t.Fatal("the claimed probe must close the gate for p1's identity")
+		}
+		if reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("p2's identity carries no cooldown after the migration")
+		}
+		// A second commit through the live path sees the fresh claim: exactly
+		// one probe gets through.
+		if reg.tryClaimCapacityProbe(p1, model, now) {
+			t.Fatal("a second claim must see the fresh claim and reject")
+		}
+	})
+}
+
+// The lock-free "no per-model state" fast path the clear recorders and the
+// probe claim take before locking must not trust the flag of a gate the
+// session has moved away from: after a shared-identity rebind the emptied
+// source says "nothing" precisely because the state migrated. refHasPairState
+// re-resolves to the session's new gate; a genuinely empty current gate is
+// reported as such without a re-resolve.
+func TestRefHasPairStateFollowsSharedIdentityRebind(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := makeSchedulerProvider(t, reg, "sess-flag-rebind-1", model, 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-flag-rebind-2", model, 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-FLAG-REBIND"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	shared := reg.lookupGateForKey("sekey:PK-FLAG-REBIND")
+	reg.RecordDispatchLoadFailure(p1.ID, model)
+
+	ref := reg.lookupSessionGateRef(p1.ID) // ClearDispatchLoadCooldown's resolution
+	if ref.g != shared || ref.p != p1 || !shared.hasPairState(gateFlagDispatchLoad) {
+		t.Fatalf("pre-rebind ref = %+v, want the shared gate (with dispatch-load state) via p1", ref)
+	}
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-FLAG-REBIND", SerialNumber: "SER-FLAG-REBIND"})
+	target := p1.gate.Load()
+	if target == shared || shared.hasPairState(gateFlagDispatchLoad) || !target.hasPairState(gateFlagDispatchLoad) {
+		t.Fatal("precondition: the dispatch-load cooldown moved with the session and the shared gate reads empty")
+	}
+
+	got, has := reg.refHasPairState(ref, gateFlagDispatchLoad)
+	if !has || got.g != target || got.p != p1 {
+		t.Fatalf("refHasPairState = (%+v, %v), want the session's new gate with state", got, has)
+	}
+	// Through the real recorder: the completion-time clear lands on the new
+	// identity, so the pair is routable again.
+	reg.ClearDispatchLoadCooldown(p1.ID, model)
+	if reg.dispatchLoadCooled(p1.ID, model, time.Now()) {
+		t.Fatal("the clear must land on the session's new gate")
+	}
+	// A genuinely empty current gate: reported empty, ref unchanged.
+	got, has = reg.refHasPairState(reg.lookupSessionGateRef(p2.ID), gateFlagDispatchLoad)
+	if has || got.g != shared {
+		t.Fatalf("refHasPairState on p2's empty gate = (%+v, %v), want (shared, false)", got, has)
+	}
+}

--- a/coordinator/registry/gate_migrate.go
+++ b/coordinator/registry/gate_migrate.go
@@ -1,0 +1,295 @@
+package registry
+
+import "time"
+
+// gate_migrate.go — identity binds and the migration of accumulated fault
+// state between gates: the forward a migrated-away gate leaves behind
+// (resolve), the merge and reset policy, bindStableFaultKey and
+// migrateGateLocked. Design, lock order and file map: gate_state.go.
+//
+// Rebind semantics. Fault state is keyed by IDENTITY, and a rebind MOVES the
+// identity's accumulated state to the refined identity (session id → sekey:
+// on the first bind, sekey: → serial: on MDA enrichment); the source identity
+// is left with nothing — exactly what the map-keyed implementation did
+// (migrateFaultStateLocked deleted the old key's entries). When the source
+// gate is SHARED with another live session (the same machine connected twice:
+// one SE key, two sessions), that session's identity starts from nothing too:
+// the state was the machine's and now lives under the machine's better key,
+// where the sibling lands at its own enrichment. It is deliberately not
+// copied — mergeLocked does not deduplicate histories, so a copy would
+// double-count every fault (strike lists, health rings, consecutive-fault
+// streaks) the moment the sibling enriches to the same serial. The shared
+// source's reset is published (its atomics zeroed) so the sibling's readers
+// see the move at once. A bind runs under the rebinding session's p.mu, so
+// the routing sections that hold p.mu (the scan's gate chain, the reservation
+// commit through its debit, the alias resolver) never observe the move
+// mid-section; the routing readers also confirm their view against p.gate
+// (gateView) so a read made without p.mu cannot mistake the emptied source
+// for the session's state, and the recorders re-validate under gate.mu
+// (lockGate) for the same reason.
+
+// resolve follows forwardTo to the gate that currently holds this identity's
+// state. Lock-free; one atomic load in the common (not migrated) case.
+// nil-safe.
+func (g *gateState) resolve() *gateState {
+	for g != nil {
+		next := g.forwardTo.Load()
+		if next == nil {
+			return g
+		}
+		g = next
+	}
+	return nil
+}
+
+// mergeLocked folds src's state into g for an identity rebind whose new key
+// ALREADY has history (e.g. this session's sekey:-keyed faults migrating onto
+// a serial: gate populated by a previous connection). Merge policy: expiries
+// and streak recency take the max, trip counts take the max, timestamp
+// histories merge chronologically, health rings merge in timestamp order
+// bounded by the ring size (providerHealthWindow.merge) so an in-progress
+// consecutive-fault streak survives the rebind, and a clamp entry with the
+// later clamp time wins whole. Caller holds BOTH g.mu and src.mu (only the
+// identity bind, under gatesMu.Lock, ever does).
+func (g *gateState) mergeLocked(src *gateState) {
+	if g.identityVersion == "" {
+		g.identityVersion = src.identityVersion
+	}
+	if src.versionResetAt.After(g.versionResetAt) {
+		g.versionResetAt = src.versionResetAt
+	}
+	if len(src.inferenceErrorFlushStrikes) > 0 && g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
+	}
+	for key, stamps := range src.inferenceErrorFlushStrikes {
+		g.inferenceErrorFlushStrikes[key] = mergeChronologicalTimestamps(g.inferenceErrorFlushStrikes[key], stamps)
+	}
+	for model, expiry := range src.dispatchLoadCooldowns {
+		if cur, ok := g.dispatchLoadCooldowns[model]; !ok || expiry.After(cur) {
+			g.dispatchLoadCooldowns[model] = expiry
+		}
+	}
+	for k, strikes := range src.inferenceErrorStrikes {
+		g.inferenceErrorStrikes[k] = mergeChronologicalTimestamps(g.inferenceErrorStrikes[k], strikes)
+	}
+	for k, expiry := range src.inferenceErrorCooldowns {
+		if cur, ok := g.inferenceErrorCooldowns[k]; !ok || expiry.After(cur) {
+			g.inferenceErrorCooldowns[k] = expiry
+		}
+	}
+
+	if src.outcomes != nil {
+		if g.outcomes != nil {
+			g.outcomes.merge(src.outcomes)
+		} else {
+			g.outcomes = src.outcomes
+		}
+	}
+	if src.breakerUntil.After(g.breakerUntil) {
+		g.breakerUntil = src.breakerUntil
+	}
+	if src.breakerTrips > g.breakerTrips {
+		g.breakerTrips = src.breakerTrips
+	}
+
+	for model, strikes := range src.capacityRejectStrikes {
+		g.capacityRejectStrikes[model] = mergeChronologicalTimestamps(g.capacityRejectStrikes[model], strikes)
+	}
+	for model, entry := range src.capacityCooldowns {
+		if cur, ok := g.capacityCooldowns[model]; !ok || entry.expiry.After(cur.expiry) {
+			g.capacityCooldowns[model] = entry
+		}
+	}
+	for model, trips := range src.capacityCooldownTrips {
+		if cur, ok := g.capacityCooldownTrips[model]; !ok || trips > cur {
+			g.capacityCooldownTrips[model] = trips
+		}
+	}
+	for model, entry := range src.budgetClamps {
+		if cur, ok := g.budgetClamps[model]; !ok || entry.clampedAt.After(cur.clampedAt) {
+			g.budgetClamps[model] = entry
+		}
+	}
+	for model, outcomes := range src.capacityRateRejects {
+		g.capacityRateRejects[model] = mergeChronologicalTimestamps(g.capacityRateRejects[model], outcomes)
+	}
+	for model, outcomes := range src.capacityRateAccepts {
+		g.capacityRateAccepts[model] = mergeChronologicalTimestamps(g.capacityRateAccepts[model], outcomes)
+	}
+
+	if src.ejection != nil {
+		if g.ejection != nil {
+			g.ejection.merge(src.ejection)
+		} else {
+			g.ejection = src.ejection
+		}
+	}
+	if src.ejectionUntil.After(g.ejectionUntil) {
+		g.ejectionUntil = src.ejectionUntil
+	}
+	// The last-trip marker travels with the trip count it describes: the
+	// destination's own marker wins when it has trips of its own.
+	if g.ejectionTrips == 0 {
+		g.ejectionLastTripCapacity = src.ejectionLastTripCapacity
+	}
+	if src.ejectionTrips > g.ejectionTrips {
+		g.ejectionTrips = src.ejectionTrips
+	}
+	if src.ejectionCapacityStreak.n > g.ejectionCapacityStreak.n {
+		g.ejectionCapacityStreak = src.ejectionCapacityStreak
+	}
+	if src.touched.After(g.touched) {
+		g.touched = src.touched
+	}
+}
+
+// resetLocked drops every tracker (the key, live count and forwardTo stay).
+// After a migration the source key starts from nothing, as the old map-keyed
+// implementation left it. Caller holds g.mu.
+func (g *gateState) resetLocked() {
+	g.identityVersion = ""
+	g.versionResetAt = time.Time{}
+	clear(g.inferenceErrorFlushStrikes)
+	g.outcomes, g.breakerUntil, g.breakerTrips = nil, time.Time{}, 0
+	g.ejection, g.ejectionUntil, g.ejectionTrips = nil, time.Time{}, 0
+	g.ejectionCapacityStreak, g.ejectionLastTripCapacity = capacityStreak{}, false
+	g.inferenceErrorStrikes = make(map[modelShapeKey][]time.Time)
+	g.inferenceErrorCooldowns = make(map[modelShapeKey]time.Time)
+	g.dispatchLoadCooldowns = make(map[string]time.Time)
+	g.capacityRejectStrikes = make(map[string][]time.Time)
+	g.capacityCooldowns = make(map[string]*capacityCooldownEntry)
+	g.capacityCooldownTrips = make(map[string]int)
+	g.budgetClamps = make(map[string]*budgetClampEntry)
+	g.capacityRateRejects = make(map[string][]time.Time)
+	g.capacityRateAccepts = make(map[string][]time.Time)
+}
+
+// bindStableFaultKey binds a live session to its stable identity so every
+// fault tracker keys by identity and survives reconnects. Called by
+// SetAttestationResult on every (re-)attestation — i.e. BEFORE the session is
+// routable for public traffic — which is what re-attaches a reconnecting
+// machine's accumulated fault state to its fresh session id. An empty stableID
+// (attestation cleared / never valid) unbinds, falling back to session keying;
+// the identity's state stays on its own gate (an unbind never migrates).
+//
+// Only LIVE sessions bind: a re-attestation racing Disconnect must not
+// re-insert an entry Disconnect already removed. Liveness is the sessions
+// index under gatesMu, so this never takes r.mu.
+//
+// Caller holds p.mu (SetAttestationResult, RebindStableFaultKey; lock order
+// r.mu → p.mu → gatesMu → gate.mu). The bind repoints p.gate, and the routing
+// sections that read p.gate and ACT on the verdict do so under p.mu — the
+// reservation commit from its admit re-check through the pending debit
+// (commitProviderReservation, ReserveNextFromPlan), the scan's gate chain
+// (gateStateReasonLocked), the alias resolver's routability read
+// (providerCanRouteBuildLocked) — so with the bind under the same lock none
+// of them can accept a clean gate and then act after the session has moved
+// to an identity that is quarantined. The map-keyed implementation had this
+// for free (the bind and the commit shared r.mu.Lock).
+//
+// Accumulated fault state migrates when the key changes: from the session id
+// on the FIRST bind (strikes recorded pre-attestation live on the session
+// gate), or from the previous identity on a rebind (e.g. sekey: → serial:
+// after MDA enrichment). Without this, a machine near quarantine sheds its
+// history at the exact moment its identity improves. No-op on the common
+// re-attestation with an unchanged identity.
+func (r *Registry) bindStableFaultKey(p *Provider, stableID string) {
+	if p == nil || p.ID == "" {
+		return
+	}
+	now := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	if r.sessions[p.ID] != p {
+		return
+	}
+	targetKey := stableID
+	if targetKey == "" {
+		targetKey = p.ID
+	}
+	cur := p.gate.Load()
+	if cur != nil && cur.key == targetKey {
+		if stableID != "" {
+			cur.mu.Lock()
+			cur.noteIdentityVersionLocked(r, p.Version)
+			cur.updatedLocked(now)
+			cur.mu.Unlock()
+		}
+		return
+	}
+	target := r.ensureGateLocked(targetKey, now)
+	if cur != nil && stableID != "" {
+		// Migrate, and repoint the session INSIDE the migration's locked
+		// section: a lock-free reader that loads p.gate must find either cur's
+		// intact pre-migration view or a target that already carries the
+		// merged state, never an empty target; and a recorder that resolved
+		// cur before this rebind must, once it holds cur.mu, either have
+		// written before the merge (its outcome travels to target) or find
+		// p.gate moved and re-resolve (lockGate) — never write into the
+		// emptied cur. That matters most when cur is SHARED with another
+		// session (cur.live > 1): it stays in the index for that session and
+		// carries no forward, so the session's own pointer is the only thing
+		// that can tell a stale recorder its outcome now belongs to target.
+		// (An unbind never migrates: session keying resumes and the identity
+		// keeps its state.) cur is orphaned when this was its last live
+		// session.
+		r.migrateGateLocked(p, cur, target, cur.live <= 1)
+	} else {
+		p.gate.Store(target)
+	}
+	if stableID != "" {
+		target.mu.Lock()
+		target.noteIdentityVersionLocked(r, p.Version)
+		target.updatedLocked(now)
+		target.mu.Unlock()
+	}
+	target.live++
+	if cur != nil {
+		cur.live--
+	}
+}
+
+// migrateGateLocked re-keys accumulated fault state from src to dst (merge
+// policy in mergeLocked) and repoints p (the session being bound) at dst
+// while BOTH gates are locked, so no recorder can hold src.mu with p still
+// pointing at src after the merge. src is emptied afterwards; when no live
+// session still points at it (orphan) it is forwarded to dst and dropped from
+// the index so stale pointers land on the live state. The only place two gate
+// locks nest; caller holds gatesMu for writing, which serializes migrations.
+func (r *Registry) migrateGateLocked(p *Provider, src, dst *gateState, orphan bool) {
+	if src == dst {
+		p.gate.Store(dst)
+		return
+	}
+	src.mu.Lock()
+	dst.mu.Lock()
+	dst.mergeLocked(src)
+	dst.publishLocked()
+	p.gate.Store(dst)
+	// Redirect cached disconnected sessions while src.mu is still held, so
+	// a recorder that resolved src before this migration cannot write into
+	// the reset source when it remains live for an unenriched sibling.
+	r.retargetDisconnectedGateBindingsLocked(src.key, dst.key)
+	if orphan {
+		// Forward BEFORE resetting, and never republish the orphan: a
+		// lock-free reader that loaded src sees either its intact pre-merge
+		// atomics (stale but conservative — expiries merged by max into dst)
+		// or the forward, never zeros. Locked reads follow the forward.
+		src.forwardTo.Store(dst)
+		if r.gates[src.key] == src {
+			delete(r.gates, src.key)
+		}
+		src.resetLocked()
+	} else {
+		// Still bound to other sessions: it starts from nothing, visibly
+		// (rebind semantics in the file header). Published AFTER the repoint
+		// above, which is what lets a routing reader confirm a view of the
+		// zeros against p.gate (gateView) and a lock-free flag check trust a
+		// cleared flag (refHasPairState).
+		src.resetLocked()
+		src.publishLocked()
+	}
+	dst.mu.Unlock()
+	src.mu.Unlock()
+}

--- a/coordinator/registry/gate_migrate_test.go
+++ b/coordinator/registry/gate_migrate_test.go
@@ -1,0 +1,257 @@
+package registry
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the identity migration (gate_migrate.go): stale cached pointers
+// follow the forward, lock-free readers never see an empty gate mid-rebind,
+// and a shared identity gate stays in the index for its other sessions.
+
+// A recorder that resolved the session's gate just before attestation bound
+// the stable identity must land its outcome on the identity's gate, not on
+// the orphaned session gate: lockGate follows the forward set by the
+// migration, and the orphan is gone from the index.
+func TestStaleGatePointerFollowsIdentityMigration(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-stale", "m", 100)
+	ref := reg.gateForSession(p.ID)
+	stale := ref.g
+	if stale == nil || stale.key != p.ID {
+		t.Fatalf("pre-bind gate = %+v, want the session-keyed gate", stale)
+	}
+
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-STALE"})
+	target := reg.lookupGateForKey("serial:SER-STALE")
+	if target == nil || target.key != "serial:SER-STALE" {
+		t.Fatalf("bind did not file the identity's gate: %+v", target)
+	}
+	if rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("the orphaned session gate must leave the index")
+	}
+	if stale.resolve() != target {
+		t.Fatal("resolve() on the stale pointer must follow the migration forward")
+	}
+	hold := reg.lockGate(ref, "test")
+	if hold.g != target {
+		hold.unlock()
+		t.Fatal("lockGate on the stale pointer must lock the live gate")
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if got := providerBreakerTripsOf(reg, p.ID); got != 1 {
+		t.Fatalf("mutation through the stale pointer landed elsewhere: trips=%d", got)
+	}
+	if p.gate.Load() != target {
+		t.Fatal("the provider's cached gate must point at the identity's gate")
+	}
+}
+
+// During a live re-attestation that changes the identity, a lock-free reader
+// must never see the identity's fault state vanish: the orphaned session gate
+// keeps its (conservative) atomics — it is never republished after the reset
+// — and the provider's cached pointer is repointed only once the target
+// carries the merged state.
+func TestMigrationNeverExposesAnEmptyGateToLockFreeReaders(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-mig-view", "m", 100)
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 500, "internal error")
+	}
+	stale := p.gate.Load()
+	nowNS := time.Now().UnixNano()
+	if !stale.breakerOpenAt(nowNS) {
+		t.Fatal("precondition: breaker open on the session gate")
+	}
+
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-MIG-VIEW"})
+
+	target := p.gate.Load()
+	if target == stale || target.key != "serial:SER-MIG-VIEW" {
+		t.Fatalf("cached gate after bind = %+v, want the identity's gate", target)
+	}
+	if !target.breakerOpenAt(nowNS) {
+		t.Fatal("the target must carry the merged breaker state when the pointer is repointed")
+	}
+	if !stale.breakerOpenAt(nowNS) {
+		t.Fatal("the orphaned gate's atomics must stay conservative (never republished after the reset)")
+	}
+	if stale.forwardTo.Load() != target || !stale.resolve().breakerOpenAt(nowNS) {
+		t.Fatal("the orphan must forward to the live gate")
+	}
+	if !reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("the breaker must read open through the session after the rebind")
+	}
+}
+
+// A rebind that moves ONE of two sessions bound to the same identity must not
+// orphan the shared gate: the other session still points at it, so it stays
+// in the index (emptied, as the map-keyed implementation left the old key).
+func TestRebindKeepsSharedIdentityGateForOtherSessions(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "sess-shared-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-shared-2", "m", 100)
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED"})
+	p2.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED"})
+	shared := reg.lookupGateForKey("sekey:PK-SHARED")
+	if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+		t.Fatal("both sessions must share the identity's gate")
+	}
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+
+	// p1 enriches to a serial; p2 stays on the SE key.
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED", SerialNumber: "SER-ONE"})
+	if rawGateForKey(reg, "sekey:PK-SHARED") != shared {
+		t.Fatal("the shared gate must stay in the index while another session is bound to it")
+	}
+	if shared.forwardTo.Load() != nil {
+		t.Fatal("a gate with a live session must not be forwarded")
+	}
+	if p2.gate.Load() != shared {
+		t.Fatal("the other session's cached gate must be untouched")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-ONE") {
+		t.Fatal("the fault history must have moved to the enriched identity")
+	}
+	if gateHasBreakerWindow(reg, "sekey:PK-SHARED") {
+		t.Fatal("the source identity must start from nothing after the migration")
+	}
+	reg.gatesMu.RLock()
+	live := shared.live
+	reg.gatesMu.RUnlock()
+	if live != 1 {
+		t.Fatalf("shared gate live sessions = %d, want 1", live)
+	}
+}
+
+// A rebind repoints p.gate, and the reservation commit reads p.gate (the
+// admit re-check) and acts on the verdict (the pending debit) inside ONE p.mu
+// section — as do the scan's gate chain and the alias resolver's routability
+// read. If the bind ran outside p.mu, it could land in between: a commit that
+// accepted the session's clean gate would debit a session whose destination
+// gate already carries a breaker (a machine re-enriching to the serial that
+// tripped it last time). So the bind runs under p.mu, and p.gate never changes
+// underneath a p.mu holder: a section that read a clean gate debits that same
+// identity. Both entry points flap the session between a clean identity and a
+// breaker-open one while a "commit" keeps checking; the invariant is exact,
+// the interleaving is the race detector's. Once the flapping stops, the
+// identity's breaker gates the session end to end.
+func TestProviderGateNeverMovesUnderTheProviderLock(t *testing.T) {
+	const model = "m"
+	cases := []struct {
+		name   string
+		clean  func(p *Provider) // binds the session to the CLEAN identity
+		dirty  func(p *Provider) // rebinds it to the quarantined one
+		dstKey string
+	}{
+		{
+			name: "attestation enrichment",
+			clean: func(p *Provider) {
+				p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-BINDLOCK"})
+			},
+			dirty: func(p *Provider) {
+				p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-BINDLOCK", SerialNumber: "SER-BINDLOCK"})
+			},
+			dstKey: "serial:SER-BINDLOCK",
+		},
+		{
+			name: "account linkage",
+			clean: func(p *Provider) {
+				p.mu.Lock()
+				p.AccountID = "ACCT-CLEAN"
+				p.mu.Unlock()
+				p.RebindStableFaultKey()
+			},
+			dirty: func(p *Provider) {
+				p.mu.Lock()
+				p.AccountID = "ACCT-BINDLOCK"
+				p.mu.Unlock()
+				p.RebindStableFaultKey()
+			},
+			dstKey: "acct:ACCT-BINDLOCK",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p := makeSchedulerProvider(t, reg, "sess-bindlock", model, 100)
+			// A clean alternative, so the end-to-end check below is not the
+			// breaker fail-open (a lone breaker-open provider still serves).
+			other := makeSchedulerProvider(t, reg, "sess-bindlock-other", model, 100)
+			// The quarantined destination: its breaker tripped under a previous
+			// session of the same machine. The breaker travels with the session
+			// on every rebind (mergeLocked keeps the later expiry), so from the
+			// first dirty bind on the session is gated whichever identity it is
+			// on; what the checker asserts is that it never sees the identity
+			// CHANGE underneath it.
+			withGateForKey(reg, tc.dstKey, func(g *gateState) { g.breakerUntil = time.Now().Add(time.Hour) })
+			tc.clean(p)
+			if src := p.gate.Load(); src == nil || src.key == tc.dstKey {
+				t.Fatalf("precondition: the session must start on a gate other than %s, got %+v", tc.dstKey, src)
+			}
+			nowNS := time.Now().UnixNano()
+
+			var moved atomic.Int64
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(2)
+			// The commit: read the gate, decide, act — all under p.mu.
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					p.mu.Lock()
+					g := p.gate.Load()
+					_ = g.breakerOpenAt(nowNS) // the admit re-check
+					runtime.Gosched()
+					runtime.Gosched()
+					if p.gate.Load() != g { // the debit lands on a different identity
+						moved.Add(1)
+					}
+					p.mu.Unlock()
+				}
+			}()
+			// The rebinds.
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 3000; i++ {
+					tc.dirty(p)
+					tc.clean(p)
+				}
+				tc.dirty(p)
+				close(stop)
+			}()
+			wg.Wait()
+			if n := moved.Load(); n != 0 {
+				t.Fatalf("p.gate changed under p.mu %d times: a commit that accepted one identity debited another", n)
+			}
+			g := p.gate.Load()
+			if g == nil || g.key != tc.dstKey || !g.breakerOpenAt(nowNS) {
+				t.Fatalf("after the last rebind p.gate = %+v, want the breaker-open %s", g, tc.dstKey)
+			}
+			// From here the identity's breaker gates the session end to end.
+			pr := &PendingRequest{
+				RequestID:             "bindlock-" + tc.name,
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+			if got, _ := reg.ReserveProviderEx(model, pr); got != other {
+				t.Fatalf("reservation = %v, want %s (the rebound session's identity is breaker-open)", got, other.ID)
+			}
+		})
+	}
+}

--- a/coordinator/registry/gate_state.go
+++ b/coordinator/registry/gate_state.go
@@ -1,0 +1,231 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// gate_state.go — per-identity routing-gate state.
+//
+// Every fault tracker that gates routing — the node-health breaker
+// (provider_breaker.go), stable-identity health ejection (health_ejection.go),
+// the shape-keyed inference-error cooldown (error_cooldown.go), the capacity
+// cooldown / rate window / budget clamp (capacity_cooldown.go, capacity_rate.go,
+// budget_clamp.go) and the dispatch-load cooldown (registry.go) — used to live
+// in global maps guarded by Registry.mu. Recording an outcome therefore took
+// the registry WRITE lock: six times per served request, each acquisition
+// draining the whole batch of fleet-scan readers first (~190 ms in prod). The
+// holders were microseconds; the wait was structural.
+//
+// The state now lives in one gateState per fault key with its own mutex.
+// Recorders resolve the gate, take gate.mu, mutate, release — they never touch
+// r.mu. The scan reads the two hot booleans (breaker open, ejected) from
+// atomics and takes gate.mu only for providers that actually carry per-model
+// state (a flag word says which), so the common per-provider cost is a few
+// atomic loads.
+//
+// LOCK ORDER: r.mu → p.mu → r.gatesMu → gate.mu. Never acquire r.mu or p.mu
+// while holding gatesMu or a gate.mu. Recorders normally take gatesMu for
+// READING (session → gate resolution); first insertion and the rare exhausted
+// retry in lockGateWithIndex take it for writing. Register, Disconnect, the
+// attestation-time identity bind (under the session's p.mu) and the periodic
+// sweep also write the index. Only the identity
+// migration (migrateGateLocked, under gatesMu.Lock) ever holds two gate.mu at
+// once, so there is no ordering problem between gates. There is deliberately
+// NO walk-wide gates lock on the scan: a lock taken for the whole fleet walk
+// with per-completion writers would rebuild the exact convoy this removes.
+//
+// A recorder resolves its gate under gatesMu.RLock and locks it AFTER letting
+// go of gatesMu, so the index can change in between: the identity bind can
+// move the session to another gate, the sweep can drop the gate. The
+// map-keyed implementation had no such window (key resolution and the write
+// shared one r.mu.Lock section), so lockGate re-establishes it: after
+// acquiring gate.mu it checks that the gate is still the one the outcome
+// belongs to (not retired, still the session's cached gate) and otherwise
+// releases, re-resolves through the index and retries. Everything that can
+// invalidate a resolved gate — the forward, the retire flag, the session's
+// repoint — is therefore written while holding that gate's mu. The routing
+// READS are covered two ways. A rebind runs under the session's p.mu
+// (bindStableFaultKey's callers hold it), so a read made under p.mu — the
+// scan's gate chain, the reservation commit from its admit re-check through
+// the pending debit, the alias resolver's routability read — never sees
+// p.gate move mid-section. Independently of that lock, every read that feeds
+// a dispatch decision confirms its verdict against p.gate afterwards and
+// re-reads from the session's new gate when it moved (gateView,
+// gate_index.go); that is what covers the candidate cost read the scan makes
+// after it has released p.mu.
+//
+// Sections under gate.mu must stay per identity and microseconds long.
+//
+// The implementation is split by concern:
+//
+//	gate_state.go       — this header, the gateState struct, its lock-free view
+//	                      (publishLocked and the atomic readers)
+//	gate_index.go       — the registry-side index (r.gates / r.sessions under
+//	                      gatesMu), session → gate resolution, attach/detach
+//	gate_migrate.go     — identity binds and the state migration (forwards,
+//	                      merge and reset policy)
+//	gate_sweep.go       — the per-gate prune and the periodic index sweep
+//	gate_lock.go        — the recorders' validated lock (lockGate), the
+//	                      lock-free flag fast path and the wait observer
+//	gate_commit_mode.go — the EIGENINFERENCE_RESERVE_COMMIT_MODE kill switch
+
+// Bits of gateState.pairFlags: which per-model trackers hold ANY entry for this
+// identity. Published under gate.mu after every mutation; read lock-free by the
+// scan so a provider with no per-model state costs no lock section at all.
+const (
+	gateFlagDispatchLoad uint32 = 1 << iota
+	gateFlagErrorCooldown
+	gateFlagCapacityCooldown
+	gateFlagBudgetClamp
+)
+
+// modelShapeKey identifies an inference-error bucket inside one gate:
+// (model, request shape). Shape is RequestTraits.CooldownShape ("tools" /
+// "base"); see error_cooldown.go.
+type modelShapeKey struct {
+	Model string
+	Shape string
+}
+
+// gateState is the fault state of ONE identity (fault key: serial → SE key →
+// account → session id). Fields below the atomics are guarded by mu.
+type gateState struct {
+	// key is the fault key this state is filed under (immutable).
+	key string
+	mu  sync.Mutex
+
+	// forwardTo is set when this gate has been migrated into another (identity
+	// rebind) and is no longer in r.gates. Holders of a stale pointer follow it
+	// (resolve / lockResolved) so a recorder that resolved the gate just before
+	// the bind lands its outcome on the live state, not on the orphan.
+	forwardTo atomic.Pointer[gateState]
+
+	// live counts connected sessions bound to this gate. Guarded by r.gatesMu
+	// (Register / Disconnect / bind / sweep). A gate with live > 0 is never
+	// swept — deleting it would let the next lookup create a twin.
+	live int
+
+	// Lock-free routing view, published under mu after every mutation.
+	breakerOpenUntilNS atomic.Int64  // 0 when the breaker has never opened
+	ejectionUntilNS    atomic.Int64  // 0 when the identity has never been ejected
+	pairFlags          atomic.Uint32 // gateFlag* bits: which per-model maps are non-empty
+	newestRateRejectNS atomic.Int64  // newest capacity-503 rate reject across models; 0 = none
+
+	// retired is set (under mu, before the index delete) when the sweep drops
+	// this idle gate from r.gates. A recorder that resolved the gate before
+	// the sweep and locks it afterwards must not write here — no lookup will
+	// ever find this gate again — so lockGate re-resolves instead.
+	retired bool
+
+	// touched is when a recorder last mutated this gate, or when it was
+	// created (sweep grace anchor: a fresh gate is not idle-droppable before
+	// the first recorder that resolved it has had a chance to lock it).
+	touched time.Time
+
+	// Node-health breaker (provider_breaker.go).
+	outcomes     *providerHealthWindow // nil until the first recorded fault/success
+	breakerUntil time.Time
+	breakerTrips int
+
+	// Stable-identity health ejection (health_ejection.go).
+	ejection                 *providerHealthWindow
+	ejectionUntil            time.Time
+	ejectionTrips            int
+	ejectionCapacityStreak   capacityStreak
+	ejectionLastTripCapacity bool
+
+	// Inference-error breaker, per (model, shape) (error_cooldown.go).
+	inferenceErrorStrikes      map[modelShapeKey][]time.Time
+	inferenceErrorCooldowns    map[modelShapeKey]time.Time
+	inferenceErrorFlushStrikes map[modelShapeKey][]time.Time
+	identityVersion            string
+	versionResetAt             time.Time
+
+	// Per-model trackers, keyed by model id.
+	dispatchLoadCooldowns map[string]time.Time              // registry.go
+	capacityRejectStrikes map[string][]time.Time            // capacity_cooldown.go
+	capacityCooldowns     map[string]*capacityCooldownEntry // capacity_cooldown.go
+	capacityCooldownTrips map[string]int                    // capacity_cooldown.go
+	budgetClamps          map[string]*budgetClampEntry      // budget_clamp.go
+	capacityRateRejects   map[string][]time.Time            // capacity_rate.go
+	capacityRateAccepts   map[string][]time.Time            // capacity_rate.go
+}
+
+func newGateState(key string) *gateState {
+	return &gateState{
+		key:                     key,
+		inferenceErrorStrikes:   make(map[modelShapeKey][]time.Time),
+		inferenceErrorCooldowns: make(map[modelShapeKey]time.Time),
+		dispatchLoadCooldowns:   make(map[string]time.Time),
+		capacityRejectStrikes:   make(map[string][]time.Time),
+		capacityCooldowns:       make(map[string]*capacityCooldownEntry),
+		capacityCooldownTrips:   make(map[string]int),
+		budgetClamps:            make(map[string]*budgetClampEntry),
+		capacityRateRejects:     make(map[string][]time.Time),
+		capacityRateAccepts:     make(map[string][]time.Time),
+	}
+}
+
+// publishLocked refreshes the lock-free routing view from the guarded state.
+// Call after every mutation, before releasing mu.
+func (g *gateState) publishLocked() {
+	g.breakerOpenUntilNS.Store(unixNanoOrZero(g.breakerUntil))
+	g.ejectionUntilNS.Store(unixNanoOrZero(g.ejectionUntil))
+	var flags uint32
+	if len(g.dispatchLoadCooldowns) > 0 {
+		flags |= gateFlagDispatchLoad
+	}
+	if len(g.inferenceErrorCooldowns) > 0 {
+		flags |= gateFlagErrorCooldown
+	}
+	if len(g.capacityCooldowns) > 0 {
+		flags |= gateFlagCapacityCooldown
+	}
+	if len(g.budgetClamps) > 0 {
+		flags |= gateFlagBudgetClamp
+	}
+	g.pairFlags.Store(flags)
+	var newest int64
+	for _, rejects := range g.capacityRateRejects {
+		if n := len(rejects); n > 0 {
+			if ns := rejects[n-1].UnixNano(); ns > newest {
+				newest = ns
+			}
+		}
+	}
+	g.newestRateRejectNS.Store(newest)
+}
+
+// updatedLocked stamps the mutation time and publishes. Recorders call this at
+// the end of every mutating section.
+func (g *gateState) updatedLocked(now time.Time) {
+	g.touched = now
+	g.publishLocked()
+}
+
+func unixNanoOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// breakerOpenAt reports whether the node-health breaker is open at nowNS.
+// Lock-free; nil-safe (no gate = no state).
+func (g *gateState) breakerOpenAt(nowNS int64) bool {
+	return g != nil && nowNS < g.breakerOpenUntilNS.Load()
+}
+
+// ejectedAt reports whether the identity is health-ejected at nowNS.
+// Lock-free; nil-safe.
+func (g *gateState) ejectedAt(nowNS int64) bool {
+	return g != nil && nowNS < g.ejectionUntilNS.Load()
+}
+
+// hasPairState reports (lock-free) whether any of the flagged per-model
+// trackers holds an entry. Readers use it to skip the lock section entirely.
+func (g *gateState) hasPairState(flag uint32) bool {
+	return g != nil && g.pairFlags.Load()&flag != 0
+}

--- a/coordinator/registry/gate_state_helpers_test.go
+++ b/coordinator/registry/gate_state_helpers_test.go
@@ -1,0 +1,81 @@
+package registry
+
+// Test helpers for poking per-identity gate state (gate_state.go). The fault
+// trackers' tests used to reach into the global maps under r.mu; these give
+// them the same reach into a gate under gate.mu.
+
+// rawGateForKey returns the gate filed under key in the index WITHOUT
+// following a migration forward — nil when no gate is filed there. Use it to
+// assert that an old identity's state did (or did not) leave residue.
+func rawGateForKey(r *Registry, key string) *gateState {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return r.gates[key]
+}
+
+// withGateForKey runs fn on the gate for key (created on first use) under its
+// lock and republishes the lock-free view afterwards, so a direct field poke
+// is immediately visible to the routing reads. It does NOT stamp touched (a
+// test that backdates a gate's activity keeps its backdate); use the real
+// recorders to model activity.
+func withGateForKey(r *Registry, key string, fn func(g *gateState)) {
+	hold := r.lockGate(r.gateForKey(key), "test")
+	fn(hold.g)
+	hold.g.publishLocked()
+	hold.unlock()
+}
+
+// withGateForSession is withGateForKey resolving a session id the way the
+// recorders do (bound identity → disconnect cache → session id).
+func withGateForSession(r *Registry, sessionID string, fn func(g *gateState)) {
+	hold := r.lockGate(r.gateForSession(sessionID), "test")
+	fn(hold.g)
+	hold.g.publishLocked()
+	hold.unlock()
+}
+
+// readGateForKey runs fn on the gate filed under key under its lock. fn
+// receives nil when the identity has no gate (so callers can assert absence).
+func readGateForKey(r *Registry, key string, fn func(g *gateState)) {
+	g := r.lookupGateForKey(key)
+	if g == nil {
+		fn(nil)
+		return
+	}
+	g = g.lockResolved()
+	fn(g)
+	g.mu.Unlock()
+}
+
+// readGateForSession is readGateForKey resolving a session id.
+func readGateForSession(r *Registry, sessionID string, fn func(g *gateState)) {
+	g := r.lookupGateForSession(sessionID)
+	if g == nil {
+		fn(nil)
+		return
+	}
+	g = g.lockResolved()
+	fn(g)
+	g.mu.Unlock()
+}
+
+// sessionIndexed reports whether the session id is still in the live session
+// index (the fault-key binding the old faultKeyBySession map recorded).
+func sessionIndexed(r *Registry, sessionID string) bool {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	_, ok := r.sessions[sessionID]
+	return ok
+}
+
+// gateHasBreakerWindow reports whether the identity filed under key has a
+// node-health ring (the old providerOutcomes[key] presence check).
+func gateHasBreakerWindow(r *Registry, key string) bool {
+	g := rawGateForKey(r, key)
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.outcomes != nil
+}

--- a/coordinator/registry/gate_stress_test.go
+++ b/coordinator/registry/gate_stress_test.go
@@ -1,0 +1,191 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Recorders and routing reads racing identity rebinds (shared ↔ enriched) and
+// sweeps that keep retiring idle gates: interleaving coverage under -race for
+// lockGate's re-validation and gateView's confirmation. The deterministic
+// tests (gate_lock_test.go, gate_index_test.go) carry the outcome assertions;
+// here the invariants are "no retired gate is ever in the index", "the other
+// session's binding is never disturbed", a quiescent record lands on the
+// session's current gate — and, for a session that flaps between a shared
+// and an enriched identity while carrying a dispatch-load cooldown, the
+// routing read NEVER admits it: the cooldown follows the session through
+// every rebind (mergeLocked keeps the max expiry both ways), so a "not
+// gated" verdict could only come from trusting the emptied shared source.
+func TestGateRecordersRaceRebindsAndSweeps(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := makeSchedulerProvider(t, reg, "sess-stress-1", model, 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-stress-2", model, 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-STRESS"}
+	enriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-STRESS", SerialNumber: "SER-STRESS"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	// A disconnected identity that keeps faulting (never idle) and one that
+	// only ever sees successes (always idle: retired and re-created on every
+	// sweep once backdated).
+	gone := attestSchedulerProvider(t, reg, "sess-stress-gone", model, "SER-STRESS-GONE", 100)
+	quiet := attestSchedulerProvider(t, reg, "sess-stress-quiet", model, "SER-STRESS-QUIET", 100)
+	reg.Disconnect(gone.ID)
+	reg.Disconnect(quiet.ID)
+	// A second shared identity whose dispatch-load cooldown is armed once and
+	// never cleared (nothing in the mix below touches it): cooled flaps between
+	// the shared gate and its own serial while readers evaluate its routing
+	// gate. Its sibling keeps the shared gate live.
+	cooled := makeSchedulerProvider(t, reg, "sess-stress-cooled", model, 100)
+	sibling := makeSchedulerProvider(t, reg, "sess-stress-cooled-sibling", model, 100)
+	cooledPK := &attestation.VerificationResult{Valid: true, PublicKey: "PK-COOLED"}
+	cooledEnriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-COOLED", SerialNumber: "SER-COOLED"}
+	cooled.SetAttestationResult(cooledPK)
+	sibling.SetAttestationResult(cooledPK)
+	reg.RecordDispatchLoadFailure(cooled.ID, model)
+	if !reg.dispatchLoadCooled(cooled.ID, model, time.Now()) {
+		t.Fatal("precondition: the cooled session's pair must be dispatch-load cooled")
+	}
+
+	backdateAll := func() {
+		reg.gatesMu.RLock()
+		gates := make([]*gateState, 0, len(reg.gates))
+		for _, g := range reg.gates {
+			gates = append(gates, g)
+		}
+		reg.gatesMu.RUnlock()
+		past := time.Now().Add(-gateIdleGrace - time.Minute)
+		for _, g := range gates {
+			g.mu.Lock()
+			g.touched = past
+			g.mu.Unlock()
+		}
+	}
+
+	const iters = 1500
+	var wg sync.WaitGroup
+	recorders := []func(i int){
+		func(i int) { reg.RecordProviderOutcome(p1.ID, i%3 != 0, 500, "internal error") },
+		func(i int) { reg.RecordCapacityReject(p1.ID, model) },
+		func(i int) { reg.RecordCapacityAccept(p1.ID, model) },
+		func(i int) { reg.RecordInferenceError(p1.ID, model, 500, "base") },
+		func(i int) { reg.RecordInferenceSuccess(p1.ID, model, "base") },
+		func(i int) { reg.ClearDispatchLoadCooldown(p1.ID, model) },
+		func(i int) { reg.tryClaimCapacityProbe(p1, model, time.Now()) },
+		func(i int) { reg.RecordProviderServeOutcome("sekey:PK-STRESS", i%2 == 0, 500, "internal error") },
+		func(i int) { reg.RecordProviderOutcome(p2.ID, true, 200, "") },
+		func(i int) { reg.RecordProviderOutcome(gone.ID, false, 502, "provider disconnected") },
+		func(i int) { reg.RecordInferenceSuccess(quiet.ID, model, "base") },
+		func(i int) { reg.RecordProviderServeOutcome("serial:SER-STRESS-QUIET", true, 200, "") },
+	}
+	for _, rec := range recorders {
+		wg.Add(1)
+		go func(rec func(int)) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				rec(i)
+			}
+		}(rec)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				p1.SetAttestationResult(enriched)
+			} else {
+				p1.SetAttestationResult(pk)
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				cooled.SetAttestationResult(cooledEnriched)
+			} else {
+				cooled.SetAttestationResult(cooledPK)
+			}
+		}
+	}()
+	// Routing readers: the scan's gate evaluation for cooled, as the scan runs
+	// it (view loaded, then read under p.mu). admitted counts verdicts that let
+	// the cooled pair through; bounded counts evaluations that hit the re-read
+	// bound (documented fallback to the last view — not a verdict this test
+	// judges).
+	var admitted, bounded atomic.Int32
+	for reader := 0; reader < 2; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				view := reg.gateViewOf(cooled)
+				cooled.mu.Lock()
+				ok, reason := reg.gateStateReasonLocked(&view, model, RequestTraits{}, time.Now(), false, false)
+				cooled.mu.Unlock()
+				if view.rereads >= gateRelockMaxRetries {
+					bounded.Add(1)
+					continue
+				}
+				if ok || reason != GateDispatchLoadCooldown {
+					admitted.Add(1)
+				}
+			}
+		}()
+	}
+	stop := make(chan struct{})
+	sweeperDone := make(chan struct{})
+	go func() {
+		defer close(sweeperDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			backdateAll()
+			reg.sweepGates(time.Now())
+		}
+	}()
+	wg.Wait()
+	close(stop)
+	<-sweeperDone
+
+	reg.gatesMu.RLock()
+	for key, g := range reg.gates {
+		g.mu.Lock()
+		retired := g.retired
+		g.mu.Unlock()
+		if retired {
+			t.Errorf("retired gate %q is still in the index", key)
+		}
+	}
+	reg.gatesMu.RUnlock()
+	if g := p2.gate.Load(); g == nil || g.key != "sekey:PK-STRESS" || rawGateForKey(reg, "sekey:PK-STRESS") != g {
+		t.Fatalf("p2's binding was disturbed: %+v", g)
+	}
+	if n := admitted.Load(); n != 0 {
+		t.Fatalf("%d routing reads admitted the cooled session mid-rebind (want 0; %d hit the re-read bound)", n, bounded.Load())
+	}
+	if n := bounded.Load(); n != 0 {
+		t.Logf("%d routing reads hit the re-read bound", n)
+	}
+	if g := sibling.gate.Load(); g == nil || g.key != "sekey:PK-COOLED" || rawGateForKey(reg, "sekey:PK-COOLED") != g {
+		t.Fatalf("the cooled sibling's binding was disturbed: %+v", g)
+	}
+	if !reg.dispatchLoadCooled(cooled.ID, model, time.Now()) {
+		t.Fatal("the cooled session's pair must still read cooled through its current identity")
+	}
+	p1.SetAttestationResult(enriched)
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+	readGateForSession(reg, p1.ID, func(g *gateState) {
+		if g == nil || g.key != "serial:SER-STRESS" || g.outcomes == nil {
+			t.Fatalf("a quiescent fault must land on p1's current gate: %+v", g)
+		}
+	})
+}

--- a/coordinator/registry/gate_sweep.go
+++ b/coordinator/registry/gate_sweep.go
@@ -1,0 +1,143 @@
+package registry
+
+import "time"
+
+// gate_sweep.go — bounding the gate index: the per-gate prune of dead
+// per-model entries and the periodic sweep that retires idle gates no live
+// session references. Design, lock order and file map: gate_state.go.
+
+// gateIdleGrace is how long a gate with no live session must stay idle (every
+// tracker expired or empty and nothing recorded) before the sweep drops it. A
+// disconnected identity keeps its half-open trip memory for at least this long.
+const gateIdleGrace = 10 * time.Minute
+
+// gateSweepHighWater is the gate count above which an insert triggers an
+// inline sweep (rate-limited by gateSweepMinInterval) so the index stays
+// bounded even when the eviction loop is not running. The loop sweeps every
+// timeout/3 (30 s at the default), so with a 60 s minimum interval the inline
+// path — a walk of every gate under gatesMu.Lock, on a recorder's insert —
+// never fires in a process that runs the loop.
+const (
+	gateSweepHighWater   = 4096
+	gateSweepMinInterval = 60 * time.Second
+)
+
+// pruneLocked drops per-model entries that can no longer influence routing
+// and reports whether the whole gate is idle: nothing open, no windowed
+// history, no live per-model state. It mirrors what the old size-triggered
+// map sweeps removed — with one deliberate difference: half-open memory
+// (breaker/cooldown trip counts, an expired cooldown entry awaiting its
+// probe, a fault ring's consecutive-fault counter) is NEVER pruned from a gate
+// that still has a live session, because the old sweeps only ran past 1024
+// entries and the half-open re-arm semantics depend on that memory. Such
+// memory goes only when the whole gate is dropped. Caller holds g.mu.
+func (g *gateState) pruneLocked(r *Registry, now time.Time) (idle bool) {
+	idle = !g.versionHistoryActive(now)
+	for model, expiry := range g.dispatchLoadCooldowns {
+		if !now.Before(expiry) {
+			delete(g.dispatchLoadCooldowns, model)
+		}
+	}
+	for k, expiry := range g.inferenceErrorCooldowns {
+		if !now.Before(expiry) {
+			delete(g.inferenceErrorCooldowns, k)
+		}
+	}
+	for k, strikes := range g.inferenceErrorStrikes {
+		if len(strikes) == 0 || !strikes[len(strikes)-1].Add(inferenceErrorWindow).After(now) {
+			delete(g.inferenceErrorStrikes, k)
+			delete(g.inferenceErrorFlushStrikes, k)
+		}
+	}
+	window := r.capacityCooldownCfg.Window
+	for model, strikes := range g.capacityRejectStrikes {
+		if len(strikes) == 0 || !strikes[len(strikes)-1].Add(window).After(now) {
+			delete(g.capacityRejectStrikes, model)
+		}
+	}
+	for model, e := range g.budgetClamps {
+		if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+			delete(g.budgetClamps, model)
+		}
+	}
+	for model, outcomes := range g.capacityRateRejects {
+		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
+			delete(g.capacityRateRejects, model)
+		}
+	}
+	for model, outcomes := range g.capacityRateAccepts {
+		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
+			delete(g.capacityRateAccepts, model)
+		}
+	}
+
+	if len(g.dispatchLoadCooldowns)+len(g.inferenceErrorCooldowns)+len(g.inferenceErrorStrikes)+
+		len(g.capacityRejectStrikes)+len(g.budgetClamps)+len(g.capacityRateRejects)+len(g.capacityRateAccepts) > 0 {
+		idle = false
+	}
+	for _, e := range g.capacityCooldowns {
+		// An expired entry with a fresh probe claim is still gating (see
+		// capacityCooldownActiveLocked); one whose claim is stale or absent is
+		// half-open memory only.
+		if now.Before(e.expiry) || (!e.probeAt.IsZero() && now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))) {
+			idle = false
+		}
+	}
+	if now.Before(g.breakerUntil) || now.Before(g.ejectionUntil) {
+		idle = false
+	}
+	if g.outcomes != nil {
+		if total, _ := g.outcomes.windowStats(now, providerBreakerWindow); total > 0 {
+			idle = false
+		}
+	}
+	if g.ejection != nil {
+		if total, _ := g.ejection.windowStats(now, healthEjectionWindow); total > 0 {
+			idle = false
+		}
+	}
+	if g.ejectionCapacityStreak.n > 0 && now.Sub(g.ejectionCapacityStreak.last) <= healthEjectionWindow {
+		idle = false
+	}
+	return idle
+}
+
+// sweepGates bounds the gate index: it prunes dead per-model entries from
+// every gate and drops gates that no live session references once they have
+// been idle for gateIdleGrace. Called from the eviction loop (every
+// timeout/3) and inline from an insert past the high-water mark. Each gate is
+// locked for microseconds; gatesMu is held for the walk, which is why this
+// runs at most every few seconds and never on the request path.
+func (r *Registry) sweepGates(now time.Time) {
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	r.sweepGatesLocked(now)
+}
+
+func (r *Registry) sweepGatesLocked(now time.Time) {
+	r.gateSweepAt = now
+	for key, g := range r.gates {
+		g.mu.Lock()
+		idle := g.pruneLocked(r, now)
+		g.publishLocked()
+		drop := idle && g.live <= 0 && now.Sub(g.touched) > gateIdleGrace
+		if drop {
+			// Retire under g.mu BEFORE the index delete: a recorder that
+			// resolved this gate before the walk and locks it afterwards
+			// sees retired and re-resolves (lockGate) instead of writing a
+			// trailing fault into a gate no lookup will ever find again.
+			g.retired = true
+		}
+		g.mu.Unlock()
+		if drop {
+			delete(r.gates, key)
+		}
+	}
+	cutoff := now.Add(-disconnectedStableIDTTL)
+	for k, v := range r.disconnectedStableIDs {
+		if v.at.Before(cutoff) {
+			delete(r.disconnectedStableIDs, k)
+		}
+	}
+}

--- a/coordinator/registry/gate_sweep_test.go
+++ b/coordinator/registry/gate_sweep_test.go
@@ -1,0 +1,64 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the gate sweep (gate_sweep.go): the liveness rule and the idle
+// grace, including a fresh gate's creation counting as activity.
+
+// The sweep never drops a gate a connected session references, drops an
+// identity-less session's gate at Disconnect, and drops a disconnected
+// identity's gate only once it is idle AND past the idle grace.
+func TestGateSweepLivenessRule(t *testing.T) {
+	reg := New(testLogger())
+	anon := makeSchedulerProvider(t, reg, "sess-anon", "m", 100)
+	attested := attestSchedulerProvider(t, reg, "sess-att", "m", "SER-SWEEP", 100)
+	reg.RecordProviderOutcome(attested.ID, false, 500, "internal error")
+
+	reg.sweepGates(time.Now().Add(24 * time.Hour))
+	if rawGateForKey(reg, anon.ID) == nil || rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("gates with a connected session must survive any sweep")
+	}
+
+	reg.Disconnect(anon.ID)
+	if rawGateForKey(reg, anon.ID) != nil {
+		t.Fatal("an identity-less session's gate must be dropped at Disconnect")
+	}
+
+	reg.Disconnect(attested.ID)
+	if rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("a stable identity's gate must survive Disconnect")
+	}
+	// Inside the breaker window / idle grace: kept.
+	reg.sweepGates(time.Now().Add(time.Minute))
+	if rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("a recently active identity must not be swept")
+	}
+	// Past every window and the grace: gone.
+	reg.sweepGates(time.Now().Add(gateIdleGrace + providerBreakerWindow + time.Minute))
+	if rawGateForKey(reg, "serial:SER-SWEEP") != nil {
+		t.Fatal("an idle disconnected identity must be swept after the grace")
+	}
+}
+
+// A gate created for an identity with no live session (the trailing flush's
+// first fault, a serve outcome by stable id) counts its creation as activity:
+// it is not idle-droppable before the grace, so the recorder that created it
+// cannot lose the race against a sweep that runs before it takes the lock.
+func TestFreshGateIsNotSweptBeforeTheGrace(t *testing.T) {
+	reg := New(testLogger())
+	ref := reg.gateForSession("sess-ghost")
+	if ref.g == nil || ref.g.key != "sess-ghost" {
+		t.Fatalf("ref = %+v, want a fresh session-keyed gate", ref)
+	}
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, "sess-ghost") != ref.g {
+		t.Fatal("a just-created gate must survive the sweep until the grace")
+	}
+	reg.sweepGates(time.Now().Add(gateIdleGrace + time.Minute))
+	if rawGateForKey(reg, "sess-ghost") != nil {
+		t.Fatal("an idle unreferenced gate must be swept once past the grace")
+	}
+}

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -16,13 +16,13 @@ import (
 // to them) — is ejected from routing, re-probed after an exponential cooldown
 // (half-open), and auto-re-admitted on the first success.
 //
-// This file also owns the session→identity fault-key binding
-// (bindStableFaultKey / faultKeyLocked) that the OTHER fault trackers
-// (error_cooldown.go, provider_breaker.go, dispatchLoadCooldowns) key their
-// maps by, so ALL fault state re-attaches when a machine reconnects with a
-// fresh session UUID instead of being wiped (the prod zombie exploit: median
-// 18 sessions/machine/week reset every session-keyed breaker before it could
-// trip).
+// The session→identity fault-key binding (bindStableFaultKey /
+// faultKeyForSession, gate_state.go) that EVERY fault tracker keys by lives
+// with the per-identity gate index, so ALL fault state re-attaches when a
+// machine reconnects with a fresh session UUID instead of being wiped (the
+// prod zombie exploit: median 18 sessions/machine/week reset every
+// session-keyed breaker before it could trip). This file derives the stable
+// identity and owns the ejection breaker itself.
 //
 // FAIL OPEN, like provider_breaker.go: occasional capacity/client sheds never
 // count (only an unbroken zero-success capacity streak does), an un-attestable
@@ -125,288 +125,35 @@ func stableProviderIdentityLocked(p *Provider) string {
 
 // GetProviderStableIdentity resolves a live session providerID to its stable
 // identity, or "" if the provider is gone or un-attestable. For the consumer
-// note* hooks to feed RecordProviderServeOutcome without holding registry locks.
+// note* hooks to feed RecordProviderServeOutcome without holding registry locks:
+// the session index under gatesMu stands in for r.providers, so this never
+// queues behind a registry writer.
 func (r *Registry) GetProviderStableIdentity(providerID string) string {
 	if providerID == "" {
 		return ""
 	}
-	r.mu.RLock()
-	p := r.providers[providerID]
+	r.gatesMu.RLock()
+	p := r.sessions[providerID]
 	cached, hasCached := r.disconnectedStableIDs[providerID]
-	r.mu.RUnlock()
+	r.gatesMu.RUnlock()
 	if p != nil {
 		// This path does NOT hold p.mu (unlike the routing gate), so take it for the
 		// read — guarding against a concurrent SetAttestationResult (live re-attestation
-		// writes p.AttestationResult under p.mu). Not nested with r.mu, so no deadlock.
+		// writes p.AttestationResult under p.mu). Not nested with gatesMu, so no deadlock.
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		return stableProviderIdentityLocked(p)
 	}
-	// Provider already removed from r.providers — typically because Disconnect ran
-	// before the pending-request ErrorCh flush, which carries the 502 "provider
-	// disconnected" faults that characterize a reconnecting zombie. Fall back to the
-	// identity captured at disconnect so those faults are still recorded against the
-	// stable-identity breaker (otherwise the dominant zombie signal is never counted).
+	// Provider already removed from the session index — typically because
+	// Disconnect ran before the pending-request ErrorCh flush, which carries the
+	// 502 "provider disconnected" faults that characterize a reconnecting zombie.
+	// Fall back to the identity captured at disconnect so those faults are still
+	// recorded against the stable-identity breaker (otherwise the dominant zombie
+	// signal is never counted).
 	if hasCached && time.Since(cached.at) < disconnectedStableIDTTL {
 		return cached.id
 	}
 	return ""
-}
-
-// bindStableFaultKey binds a live session id to its stable identity so every
-// fault-tracking map (inference-error cooldowns, node-health breaker,
-// dispatch-load cooldowns) keys by identity and survives reconnects. Called by
-// SetAttestationResult on every (re-)attestation — i.e. BEFORE the session is
-// routable for public traffic — which is what re-attaches a reconnecting
-// machine's accumulated fault state to its fresh session id. An empty stableID
-// (attestation cleared / never valid) unbinds, falling back to session keying.
-func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
-	if sessionID == "" {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if stableID == "" {
-		delete(r.faultKeyBySession, sessionID)
-		return
-	}
-	// Only bind LIVE sessions: a re-attestation racing Disconnect must not
-	// re-insert an entry Disconnect already removed (it would leak forever —
-	// nothing cleans that session id again). The disconnectedStableIDs cache
-	// covers post-disconnect resolution.
-	p, live := r.providers[sessionID]
-	if !live {
-		return
-	}
-	// Migrate accumulated fault state when the key changes: from the session id
-	// on the FIRST bind (strikes recorded pre-attestation live under the
-	// faultKeyLocked session fallback), or from the previous identity on a
-	// rebind (e.g. sekey: → serial: after MDA enrichment). Without this, a
-	// machine near quarantine sheds its history at the exact moment its
-	// identity improves. No-op on the common re-attestation with an unchanged
-	// identity.
-	old := r.faultKeyBySession[sessionID]
-	if old == "" {
-		old = sessionID
-	}
-	if old != stableID {
-		r.migrateFaultStateLocked(old, stableID)
-	}
-	r.faultKeyBySession[sessionID] = stableID
-	// Version-changed reconnect reset (version_reset.go): a session that
-	// already reported its binary version binds here on re-attestation;
-	// registration-time binds happen before the version is stored and are
-	// covered by Provider.SetVersion. r.mu → p.mu is the established order.
-	p.mu.Lock()
-	version := p.Version
-	p.mu.Unlock()
-	r.noteIdentityVersionLocked(stableID, version)
-}
-
-// migrateFaultStateLocked re-keys every fault-tracking map entry from oldKey to
-// newKey so accumulated history follows an identity rebind. Merge policy where
-// both keys hold state: expiries and streak recency take the max, trip counts
-// take the max, timestamp histories merge chronologically (their bounded-map
-// sweeps use the tail as the newest entry), and health windows are merged in
-// timestamp order bounded by the ring size (providerHealthWindow.merge) so an
-// in-progress consecutive-fault streak survives the rebind. Caller holds r.mu.
-func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
-	if oldKey == "" || newKey == "" || oldKey == newKey {
-		return
-	}
-
-	// Late disconnect-flush outcomes must follow the same identity as the
-	// migrated windows and reset timestamp. Preserve each drop time so the
-	// migration neither extends the cache TTL nor changes reset ordering.
-	for sessionID, cached := range r.disconnectedStableIDs {
-		if cached.id == oldKey {
-			cached.id = newKey
-			r.disconnectedStableIDs[sessionID] = cached
-		}
-	}
-
-	// Dispatch-load cooldowns: struct keys per (fault key, model).
-	for k, expiry := range r.dispatchLoadCooldowns {
-		if k.FaultKey == oldKey {
-			nk := k
-			nk.FaultKey = newKey
-			if cur, ok := r.dispatchLoadCooldowns[nk]; !ok || expiry.After(cur) {
-				r.dispatchLoadCooldowns[nk] = expiry
-			}
-			delete(r.dispatchLoadCooldowns, k)
-		}
-	}
-
-	// Inference-error strikes/cooldowns: struct keys per (provider, model, shape).
-	for k, strikes := range r.inferenceErrorStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.inferenceErrorStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorStrikes[nk], strikes)
-			delete(r.inferenceErrorStrikes, k)
-		}
-	}
-	for k, expiry := range r.inferenceErrorCooldowns {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.inferenceErrorCooldowns[nk]; !ok || expiry.After(cur) {
-				r.inferenceErrorCooldowns[nk] = expiry
-			}
-			delete(r.inferenceErrorCooldowns, k)
-		}
-	}
-	// Disconnect-flush strike tags, the last-seen binary version, and the
-	// version-reset throttle timestamp follow the identity too
-	// (version_reset.go): an existing version under the new key is the more
-	// recent binding and wins; the later reset timestamp wins so a rebind can
-	// never hand the identity a second reset inside the interval.
-	for k, flush := range r.inferenceErrorFlushStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.inferenceErrorFlushStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorFlushStrikes[nk], flush)
-			delete(r.inferenceErrorFlushStrikes, k)
-		}
-	}
-	if v, ok := r.identityVersions[oldKey]; ok {
-		if _, exists := r.identityVersions[newKey]; !exists {
-			r.identityVersions[newKey] = v
-		}
-		delete(r.identityVersions, oldKey)
-	}
-	if at, ok := r.identityVersionSeenAt[oldKey]; ok {
-		if cur, exists := r.identityVersionSeenAt[newKey]; !exists || at.After(cur) {
-			r.identityVersionSeenAt[newKey] = at
-		}
-		delete(r.identityVersionSeenAt, oldKey)
-	}
-	if at, ok := r.identityVersionResetAt[oldKey]; ok {
-		if cur, exists := r.identityVersionResetAt[newKey]; !exists || at.After(cur) {
-			r.identityVersionResetAt[newKey] = at
-		}
-		delete(r.identityVersionResetAt, oldKey)
-	}
-
-	// Node-health breaker.
-	if w, ok := r.providerOutcomes[oldKey]; ok {
-		if dst, exists := r.providerOutcomes[newKey]; exists {
-			dst.merge(w)
-		} else {
-			r.providerOutcomes[newKey] = w
-		}
-		delete(r.providerOutcomes, oldKey)
-	}
-	if expiry, ok := r.providerBreakerOpenUntil[oldKey]; ok {
-		if cur, exists := r.providerBreakerOpenUntil[newKey]; !exists || expiry.After(cur) {
-			r.providerBreakerOpenUntil[newKey] = expiry
-		}
-		delete(r.providerBreakerOpenUntil, oldKey)
-	}
-	if trips, ok := r.providerBreakerTrips[oldKey]; ok {
-		if cur, exists := r.providerBreakerTrips[newKey]; !exists || trips > cur {
-			r.providerBreakerTrips[newKey] = trips
-		}
-		delete(r.providerBreakerTrips, oldKey)
-	}
-
-	// Capacity-reject cooldown (pair-scoped struct keys).
-	for k, strikes := range r.capacityRejectStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRejectStrikes[nk] = mergeChronologicalTimestamps(r.capacityRejectStrikes[nk], strikes)
-			delete(r.capacityRejectStrikes, k)
-		}
-	}
-	for k, entry := range r.capacityCooldowns {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.capacityCooldowns[nk]; !ok || entry.expiry.After(cur.expiry) {
-				r.capacityCooldowns[nk] = entry
-			}
-			delete(r.capacityCooldowns, k)
-		}
-	}
-	for k, trips := range r.capacityCooldownTrips {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.capacityCooldownTrips[nk]; !ok || trips > cur {
-				r.capacityCooldownTrips[nk] = trips
-			}
-			delete(r.capacityCooldownTrips, k)
-		}
-	}
-
-	// Gray-box budget clamp: the entry with the LATER clamp time wins whole
-	// (its clampedAt anchors both the TTL and the release-freshness check, and
-	// its acceptedSince belongs to that clamp window).
-	for k, entry := range r.budgetClamps {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.budgetClamps[nk]; !ok || entry.clampedAt.After(cur.clampedAt) {
-				r.budgetClamps[nk] = entry
-			}
-			delete(r.budgetClamps, k)
-		}
-	}
-
-	// Capacity-503 rate windows: union the outcome slices chronologically. The
-	// large-map sweep uses the tail as the newest timestamp, so appending an older
-	// source history after a fresh destination would otherwise delete live state.
-	for k, outcomes := range r.capacityRateRejects {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRateRejects[nk] = mergeChronologicalTimestamps(r.capacityRateRejects[nk], outcomes)
-			delete(r.capacityRateRejects, k)
-		}
-	}
-	for k, outcomes := range r.capacityRateAccepts {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRateAccepts[nk] = mergeChronologicalTimestamps(r.capacityRateAccepts[nk], outcomes)
-			delete(r.capacityRateAccepts, k)
-		}
-	}
-
-	// Stable-identity health ejection.
-	if w, ok := r.healthEjectionWindows[oldKey]; ok {
-		if dst, exists := r.healthEjectionWindows[newKey]; exists {
-			dst.merge(w)
-		} else {
-			r.healthEjectionWindows[newKey] = w
-		}
-		delete(r.healthEjectionWindows, oldKey)
-	}
-	if until, ok := r.healthEjectionUntil[oldKey]; ok {
-		if cur, exists := r.healthEjectionUntil[newKey]; !exists || until.After(cur) {
-			r.healthEjectionUntil[newKey] = until
-		}
-		delete(r.healthEjectionUntil, oldKey)
-	}
-	if trips, ok := r.healthEjectionTrips[oldKey]; ok {
-		if cur, exists := r.healthEjectionTrips[newKey]; !exists || trips > cur {
-			r.healthEjectionTrips[newKey] = trips
-		}
-		delete(r.healthEjectionTrips, oldKey)
-	}
-	if streak, ok := r.healthEjectionCapacityStreaks[oldKey]; ok {
-		if cur, exists := r.healthEjectionCapacityStreaks[newKey]; !exists || streak.n > cur.n {
-			r.healthEjectionCapacityStreaks[newKey] = streak
-		}
-		delete(r.healthEjectionCapacityStreaks, oldKey)
-	}
-	if lastCap, ok := r.healthEjectionLastTripCapacity[oldKey]; ok {
-		if _, exists := r.healthEjectionLastTripCapacity[newKey]; !exists {
-			r.healthEjectionLastTripCapacity[newKey] = lastCap
-		}
-		delete(r.healthEjectionLastTripCapacity, oldKey)
-	}
 }
 
 // mergeChronologicalTimestamps returns the oldest-to-newest union of two
@@ -437,27 +184,14 @@ func mergeChronologicalTimestamps(dst, src []time.Time) []time.Time {
 	return merged
 }
 
-// faultKeyLocked resolves a session provider id to the key its fault state
-// lives under: the bound stable identity (serial/SE-key/account), the identity
-// cached at Disconnect for the trailing ErrorCh flush, or — when no identity
-// was ever available — the session id itself. READ-ONLY (no map writes), so it
-// is safe under r.mu held in either mode; the routing gates call it under
-// r.mu.RLock.
-func (r *Registry) faultKeyLocked(sessionID string) string {
-	if k, ok := r.faultKeyBySession[sessionID]; ok && k != "" {
-		return k
-	}
-	if c, ok := r.disconnectedStableIDs[sessionID]; ok && c.id != "" && time.Since(c.at) < disconnectedStableIDTTL {
-		return c.id
-	}
-	return sessionID
-}
-
 // disconnectedStableID caches a provider's stable identity at Disconnect time so
 // the trailing pending-request ErrorCh flush can still resolve it.
 type disconnectedStableID struct {
 	id string
 	at time.Time
+	// binding is shared only with short-lived recorder refs, not Provider.
+	// Identity migration updates it under the old gate's mutex before reset.
+	binding *disconnectedGateBinding
 }
 
 // disconnectedStableIDTTL bounds how long a disconnected provider's cached stable
@@ -466,8 +200,8 @@ type disconnectedStableID struct {
 const disconnectedStableIDTTL = 2 * time.Minute
 
 // rememberDisconnectedStableIDLocked caches a provider's stable identity keyed by
-// its about-to-be-removed session id. Caller holds r.mu.
-func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string) {
+// its about-to-be-removed session id. Caller holds gatesMu for writing.
+func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string, disconnectedAt time.Time) {
 	if r.disconnectedStableIDs == nil {
 		r.disconnectedStableIDs = make(map[string]disconnectedStableID)
 	}
@@ -479,9 +213,7 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 			}
 		}
 	}
-	disconnectedAt := time.Now()
-	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: disconnectedAt}
-	r.touchIdentityVersionLocked(stableID, disconnectedAt)
+	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: disconnectedAt, binding: newDisconnectedGateBinding(stableID)}
 }
 
 // RecordProviderServeOutcome feeds one terminal outcome into the stable-identity
@@ -499,65 +231,57 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 //     can never trip;
 //   - everything else (client 4xx, request-shape context overflows,
 //     unattributed codes): neutral.
+//
+// State lives on the identity's gate (gate_state.go), filed under the stable
+// id itself; only gate.mu is taken, never r.mu.
 func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
 	if stableID == "" || !healthEjectionEnabled() {
 		return false, false
 	}
-	hold := r.lockWrite("health_ejection")
+	hold := r.lockGate(r.gateForKey(stableID), "health_ejection")
 	defer hold.unlock()
-	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+	g := hold.g
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
 }
 
-// RecordProviderSessionServeOutcome retains the source session through the
-// ejection mutation so a version reset cannot be followed by an old flush strike.
 func (r *Registry) RecordProviderSessionServeOutcome(sessionID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
-	if sessionID == "" || !healthEjectionEnabled() {
+	if sessionID == "" || !healthEjectionEnabled() || r.faultKeyForSession(sessionID) == sessionID {
 		return false, false
 	}
-	hold := r.lockWrite("health_ejection")
+	source := r.captureDisconnectSource(sessionID)
+	hold := r.lockGate(r.gateForSession(sessionID), "health_ejection")
 	defer hold.unlock()
-	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(sessionID) {
+	g := hold.g
+	if g == nil || g.key == sessionID || (!ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g)) {
 		return false, false
 	}
-	stableID := ""
-	if p := r.providers[sessionID]; p != nil {
-		p.mu.Lock()
-		stableID = stableProviderIdentityLocked(p)
-		p.mu.Unlock()
-	} else if cached, exists := r.disconnectedStableIDs[sessionID]; exists && time.Since(cached.at) < disconnectedStableIDTTL {
-		stableID = cached.id
-	}
-	if stableID == "" {
-		return false, false
-	}
-	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
 }
 
-// recordProviderServeOutcomeLocked requires r.mu and a nonempty stable identity.
-func (r *Registry) recordProviderServeOutcomeLocked(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+func (r *Registry) recordProviderServeOutcomeOnGateLocked(g *gateState, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
 	now := time.Now()
-	r.healthEjectionSweepLocked(now)
+	defer g.updatedLocked(now)
 
 	if ok {
-		r.healthEjectionWindowLocked(stableID).record(true, now)
-		delete(r.healthEjectionCapacityStreaks, stableID)
-		if _, had := r.healthEjectionUntil[stableID]; had {
-			delete(r.healthEjectionUntil, stableID)
-			delete(r.healthEjectionTrips, stableID)
-			delete(r.healthEjectionLastTripCapacity, stableID)
+		g.ejectionWindowLocked().record(true, now)
+		g.ejectionCapacityStreak = capacityStreak{}
+		if !g.ejectionUntil.IsZero() {
+			g.ejectionUntil = time.Time{}
+			g.ejectionTrips = 0
+			g.ejectionLastTripCapacity = false
 			return false, true // half-open probe succeeded → recover
 		}
 		return false, false
 	}
 
 	if providerOutcomeIsFault(statusCode, errStr) {
-		w := r.healthEjectionWindowLocked(stableID)
+		w := g.ejectionWindowLocked()
 		w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
-		if until, had := r.healthEjectionUntil[stableID]; had && now.Before(until) {
+		if now.Before(g.ejectionUntil) {
 			return false, false // already ejected; in-flight faults don't re-arm until cooldown
 		}
-		trips := r.healthEjectionTrips[stableID]
+		trips := g.ejectionTrips
 		halfOpen := trips > 0
 		total, fails := w.windowStats(now, healthEjectionWindow)
 		rateTrip := total >= healthEjectionMinSample &&
@@ -565,104 +289,81 @@ func (r *Registry) recordProviderServeOutcomeLocked(stableID string, ok bool, st
 		if !halfOpen && w.consecFail < healthEjectionConsecTrip && !rateTrip {
 			return false, false
 		}
-		r.healthEjectionUntil[stableID] = now.Add(healthEjectionBackoff(trips))
-		r.healthEjectionTrips[stableID] = trips + 1
-		r.healthEjectionLastTripCapacity[stableID] = false
+		g.ejectionUntil = now.Add(healthEjectionBackoff(trips))
+		g.ejectionTrips = trips + 1
+		g.ejectionLastTripCapacity = false
 		return true, false
 	}
 
 	if isNodeCapacityRejectStrike(statusCode, errStr) {
-		s := r.healthEjectionCapacityStreaks[stableID]
+		s := g.ejectionCapacityStreak
 		if s.n > 0 && now.Sub(s.last) > healthEjectionWindow {
 			s.n = 0 // stale streak: never combine old strikes with a fresh blip
 		}
 		s.n++
 		s.last = now
-		r.healthEjectionCapacityStreaks[stableID] = s
+		g.ejectionCapacityStreak = s
 
-		if until, had := r.healthEjectionUntil[stableID]; had && now.Before(until) {
+		if now.Before(g.ejectionUntil) {
 			return false, false // already ejected; stragglers don't re-arm until cooldown
 		}
-		trips := r.healthEjectionTrips[stableID]
+		trips := g.ejectionTrips
 		// Half-open instant re-arm applies ONLY when the previous trip was
 		// itself capacity-shaped (the black-hole probe failing again): a single
 		// capacity shed is legitimate for a healthy-but-full box and must not
 		// re-arm a FAULT ejection whose cooldown just expired — that identity
 		// needs the full zero-success streak like a fresh one.
-		capacityHalfOpen := trips > 0 && r.healthEjectionLastTripCapacity[stableID]
+		capacityHalfOpen := trips > 0 && g.ejectionLastTripCapacity
 		if !capacityHalfOpen && s.n < healthEjectionCapacityConsecTrip {
 			return false, false
 		}
-		r.healthEjectionUntil[stableID] = now.Add(healthEjectionBackoff(trips))
-		r.healthEjectionTrips[stableID] = trips + 1
-		r.healthEjectionLastTripCapacity[stableID] = true
+		g.ejectionUntil = now.Add(healthEjectionBackoff(trips))
+		g.ejectionTrips = trips + 1
+		g.ejectionLastTripCapacity = true
 		return true, false
 	}
 
 	return false, false
 }
 
-// healthEjectionOpenLocked reports whether routing should skip this stable
-// identity. READ-ONLY (no lazy delete); caller holds r.mu in either mode.
-func (r *Registry) healthEjectionOpenLocked(stableID string, now time.Time) bool {
+// ejectionOpen reports whether routing should skip this stable identity.
+// Resolves the identity's gate; the scan reads the cached p.gate atomically
+// (ejectionOpenFor) and never comes here.
+func (r *Registry) ejectionOpen(stableID string, now time.Time) bool {
 	if stableID == "" {
 		return false
 	}
-	until, ok := r.healthEjectionUntil[stableID]
-	return ok && now.Before(until)
+	return r.lookupGateForKey(stableID).ejectedAt(now.UnixNano())
+}
+
+// ejectionOpenFor is the scan's ejection check for provider p whose stable
+// identity is sid: when the session's cached gate IS the identity's gate (the
+// steady state — bindStableFaultKey filed the session under sid) the answer is
+// one atomic load; only a session whose bind has not caught up with its
+// identity pays a gatesMu.RLock lookup.
+func (r *Registry) ejectionOpenFor(g *gateState, sid string, nowNS int64) bool {
+	if sid == "" {
+		return false
+	}
+	if g != nil && g.key == sid {
+		return g.ejectedAt(nowNS)
+	}
+	return r.lookupGateForKey(sid).ejectedAt(nowNS)
 }
 
 // HealthEjectionOpen reports whether a stable identity is currently ejected.
 // Exposed for tests/observability.
 func (r *Registry) HealthEjectionOpen(stableID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.healthEjectionOpenLocked(stableID, time.Now())
+	return r.ejectionOpen(stableID, time.Now())
 }
 
-func (r *Registry) healthEjectionWindowLocked(stableID string) *providerHealthWindow {
-	w := r.healthEjectionWindows[stableID]
-	if w == nil {
-		w = &providerHealthWindow{}
-		r.healthEjectionWindows[stableID] = w
+// ejectionWindowLocked returns the gate's ejection ring, creating it on first
+// use. Caller holds g.mu.
+func (g *gateState) ejectionWindowLocked() *providerHealthWindow {
+	if g.ejection == nil {
+		g.ejection = &providerHealthWindow{}
 	}
-	return w
-}
-
-// healthEjectionSweepLocked bounds the maps. Stable ids persist across reconnects
-// by design, so only entries idle for longer than the window (no windowed
-// outcomes, no fresh capacity streak, not currently ejected) are reaped, once
-// the maps grow large.
-func (r *Registry) healthEjectionSweepLocked(now time.Time) {
-	if len(r.healthEjectionWindows) > 2048 {
-		for id, w := range r.healthEjectionWindows {
-			if until, had := r.healthEjectionUntil[id]; had && now.Before(until) {
-				continue
-			}
-			if s, ok := r.healthEjectionCapacityStreaks[id]; ok && now.Sub(s.last) <= healthEjectionWindow {
-				continue
-			}
-			if total, _ := w.windowStats(now, healthEjectionWindow); total == 0 {
-				delete(r.healthEjectionWindows, id)
-				delete(r.healthEjectionUntil, id)
-				delete(r.healthEjectionTrips, id)
-				delete(r.healthEjectionCapacityStreaks, id)
-				delete(r.healthEjectionLastTripCapacity, id)
-			}
-		}
-	}
-	// Capacity-only identities (pure black holes) never touch the fault ring,
-	// so their streaks need their own staleness sweep.
-	if len(r.healthEjectionCapacityStreaks) > 2048 {
-		for id, s := range r.healthEjectionCapacityStreaks {
-			if until, had := r.healthEjectionUntil[id]; had && now.Before(until) {
-				continue
-			}
-			if now.Sub(s.last) > healthEjectionWindow {
-				delete(r.healthEjectionCapacityStreaks, id)
-			}
-		}
-	}
+	return g.ejection
 }
 
 // healthEjectionBackoff: base * 2^trips capped at the max (mirrors providerBreakerBackoff).

--- a/coordinator/registry/health_ejection_test.go
+++ b/coordinator/registry/health_ejection_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 )
 
+// expireHealthEjection rewinds the identity's ejection expiry into the past,
+// simulating the cooldown elapsing (ejected -> half-open) without sleeping.
+func expireHealthEjection(reg *Registry, sid string) {
+	withGateForKey(reg, sid, func(g *gateState) { g.ejectionUntil = time.Now().Add(-time.Second) })
+}
+
+func healthEjectionTripsOf(reg *Registry, sid string) (trips int) {
+	readGateForKey(reg, sid, func(g *gateState) {
+		if g != nil {
+			trips = g.ejectionTrips
+		}
+	})
+	return trips
+}
+
 func TestStableProviderIdentityLocked_Precedence(t *testing.T) {
 	if got := stableProviderIdentityLocked(&Provider{AttestationResult: &attestation.VerificationResult{Valid: true, SerialNumber: "SER1", PublicKey: "PK1"}, AccountID: "acct1"}); got != "serial:SER1" {
 		t.Errorf("serial must win; got %q", got)
@@ -116,9 +131,7 @@ func TestHealthEjection_CapacityBlackHoleEjects(t *testing.T) {
 
 	// Half-open: after the cooldown elapses, a probe that capacity-rejects
 	// re-arms immediately with a doubled backoff...
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if reg.HealthEjectionOpen(sid) {
 		t.Fatal("cooldown expiry must allow a half-open probe")
 	}
@@ -126,9 +139,7 @@ func TestHealthEjection_CapacityBlackHoleEjects(t *testing.T) {
 		t.Fatal("a capacity reject on the half-open probe must re-arm the ejection")
 	}
 	// ...and a probe that SUCCEEDS recovers the node and clears the streak.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if _, recovered := reg.RecordProviderServeOutcome(sid, true, 200, ""); !recovered {
 		t.Fatal("a successful probe must recover the ejected identity")
 	}
@@ -277,9 +288,7 @@ func TestHealthEjection_CapacityShedDoesNotRearmFaultEjection(t *testing.T) {
 	}
 
 	// Cooldown expires; the half-open probe hits a legitimately full box.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if ejected, _ := reg.RecordProviderServeOutcome(sid, false, 503, capacityReject); ejected {
 		t.Fatal("one capacity shed must not re-arm a fault ejection")
 	}
@@ -324,9 +333,7 @@ func TestHealthEjection_FirstContentDisarmsCapacityHalfOpen(t *testing.T) {
 	}
 
 	// Cooldown expires (half-open) and the probe produces FIRST CONTENT.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	reg.RecordCapacityAccept(p.ID, model)
 
 	// One straggling capacity reject must NOT re-eject a node that just
@@ -371,10 +378,8 @@ func TestHealthEjection_FirstContentPreservesFaultHalfOpen(t *testing.T) {
 
 	reg.RecordCapacityAccept(p.ID, model)
 
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	trips := reg.healthEjectionTrips[sid]
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
+	trips := healthEjectionTripsOf(reg, sid)
 	if trips == 0 {
 		t.Fatal("first content must not wipe a fault ejection's trip count")
 	}

--- a/coordinator/registry/lock_wait.go
+++ b/coordinator/registry/lock_wait.go
@@ -28,9 +28,9 @@ type writeHold struct {
 	obs  *func(site string, wait time.Duration)
 }
 
-// lockWrite is r.mu.Lock() for the request-path recorders (commit, capacity
-// accept/reject, error cooldown, breaker, health ejection, dispatch-load
-// cooldown). With no observer registered it costs one atomic load; with one,
+// lockWrite measures the remaining global write acquisitions, including
+// reservation commits in global compatibility mode. Per-identity recorders
+// use lockGate and its separate observer. With no observer registered it costs one atomic load; with one,
 // it measures the acquisition wait for the returned hold to report on unlock.
 func (r *Registry) lockWrite(site string) writeHold {
 	obs := r.lockWaitObserver.Load()

--- a/coordinator/registry/lock_wait_observer_test.go
+++ b/coordinator/registry/lock_wait_observer_test.go
@@ -37,58 +37,50 @@ func (r *lockWaitRecorder) bySite(site string) []lockWaitSample {
 	return out
 }
 
-// TestLockWriteReportsWaitBySite: every request-path recorder reports its
-// write-lock acquisition to the observer tagged with its own site, and the
-// reported wait reflects time actually spent blocked behind a reader.
+// Global compatibility mode retains the write-wait observer. Per-identity
+// recorders use their separate gate observer in both commit modes.
 func TestLockWriteReportsWaitBySite(t *testing.T) {
+	t.Setenv(envReserveCommitMode, "global")
 	reg := New(testLogger())
 	model := "lock-wait-model"
 	p := planTestProvider(t, reg, "lock-wait-provider", model, 0)
-
-	// No observer registered: the sites still work.
-	reg.ClearDispatchLoadCooldown(p.ID, model)
-
+	other := planTestProvider(t, reg, "lock-wait-other", model, 400)
 	rec := &lockWaitRecorder{}
 	reg.SetLockWaitObserver(rec.observe)
-
-	// Hold the lock for reading while a recorder tries to write.
-	held := make(chan struct{})
-	release := make(chan struct{})
-	go func() {
-		reg.mu.RLock()
-		close(held)
-		<-release
-		reg.mu.RUnlock()
-	}()
-	<-held
-	const hold = 100 * time.Millisecond
-	go func() {
-		time.Sleep(hold)
-		close(release)
-	}()
-	reg.ClearDispatchLoadCooldown(p.ID, model)
-	got := rec.bySite("dispatch_load_cooldown")
-	if len(got) != 1 {
-		t.Fatalf("dispatch_load_cooldown samples = %d, want 1", len(got))
+	reg.mu.RLock()
+	go func() { time.Sleep(100 * time.Millisecond); reg.mu.RUnlock() }()
+	lock := reg.commitLock("commit")
+	lock.lock()
+	lock.unlock()
+	got := rec.bySite("commit")
+	if len(got) != 1 || got[0].wait < 30*time.Millisecond {
+		t.Fatalf("global commit wait: %+v", got)
 	}
-	// Generous floor: the acquisition blocks for close to the whole hold, but
-	// a loaded -race run can delay the caller a few tens of milliseconds.
-	if got[0].wait < 30*time.Millisecond {
-		t.Fatalf("reported wait %s, want at least 30ms (the acquisition blocked behind a reader for %s)", got[0].wait, hold)
+	primary, _, plan := reg.ReserveProviderWithPlan(model, planTestRequest("global-primary", 10, 10))
+	if primary == nil || plan == nil {
+		t.Fatal("primary reservation failed")
 	}
-
-	// Each recorder reports under its own site tag.
+	next, _, _ := reg.ReserveNextFromPlan(planTestRequest("global-next", 10, 10), plan, primary.ID)
+	if next == nil {
+		t.Fatal("plan reservation failed")
+	}
+	if len(rec.bySite("commit_plan")) != 1 {
+		t.Fatal("global plan commit omitted write-wait sample")
+	}
 	reg.RecordCapacityAcceptOutcome(p.ID, model, true)
 	reg.RecordInferenceSuccess(p.ID, model, RequestTraits{}.CooldownShape())
 	reg.RecordProviderOutcome(p.ID, true, 200, "")
 	reg.RecordProviderServeOutcome("stable-"+p.ID, true, 200, "")
-	reg.ReserveProviderWithPlan(model, planTestRequest("lock-wait-req", 10, 10))
-	for _, site := range []string{"capacity_accept", "inference_success", "breaker", "health_ejection", "commit"} {
-		if len(rec.bySite(site)) == 0 {
-			t.Fatalf("site %q reported no lock-wait sample", site)
+	reg.ClearDispatchLoadCooldown(p.ID, model)
+	for _, site := range []string{"capacity_accept", "inference_success", "breaker", "health_ejection", "dispatch_load_cooldown"} {
+		if len(rec.bySite(site)) != 0 {
+			t.Fatalf("gate recorder %s reported a global write wait", site)
 		}
 	}
-	p.RemovePending("lock-wait-req")
+	for _, provider := range []*Provider{p, other} {
+		provider.RemovePending("global-primary")
+		provider.RemovePending("global-next")
+	}
 }
 
 // TestReserveProviderCountsScans: a clean reservation is one scan, a failed
@@ -167,14 +159,16 @@ func TestReserveProviderCountsScans(t *testing.T) {
 	}
 }
 
-func TestDispatchLoadFailureReportsLockWait(t *testing.T) {
+func TestDispatchLoadFailureReportsGateWait(t *testing.T) {
 	reg := New(testLogger())
 	rec := &lockWaitRecorder{}
-	reg.SetLockWaitObserver(rec.observe)
+	reg.SetGateWaitObserver(rec.observe)
+	release := reg.HoldGateForTest("load-failure")
+	go func() { time.Sleep(30 * time.Millisecond); release() }()
 	if !reg.RecordDispatchLoadFailure("load-failure", "model") {
 		t.Fatal("first failure did not start a cooldown")
 	}
 	if got := rec.bySite("dispatch_load_failure"); len(got) != 1 {
-		t.Fatalf("failure lock samples = %d, want 1", len(got))
+		t.Fatalf("failure gate samples = %d, want 1", len(got))
 	}
 }

--- a/coordinator/registry/model_index_test.go
+++ b/coordinator/registry/model_index_test.go
@@ -257,10 +257,7 @@ func TestRoutingWalksIdenticalWithFaultStateWithAndWithoutIndex(t *testing.T) {
 	for i := 0; i < f.reg.capacityCooldownCfg.Threshold+1; i++ {
 		f.reg.RecordCapacityReject(cooledID, model)
 	}
-	f.reg.mu.RLock()
-	cooled := f.reg.capacityCooldownActiveLocked(cooledID, model, benchPendingRequest(model, 0).FirstContentDeadline)
-	f.reg.mu.RUnlock()
-	if !cooled {
+	if !f.reg.capacityCooled(cooledID, model, benchPendingRequest(model, 0).FirstContentDeadline) {
 		t.Fatal("precondition: advertiser capacity-cooled")
 	}
 

--- a/coordinator/registry/pair_keys.go
+++ b/coordinator/registry/pair_keys.go
@@ -2,20 +2,11 @@ package registry
 
 // pair_keys.go — struct keys for the per-(provider, model) maps that used to
 // be "providerID:modelID" string concatenations. A struct key is built with
-// no allocation on the routing hot path (the dispatch-load cooldown gate runs
-// once per provider per scan) and cannot alias across ids that contain the
-// delimiter — the same reasoning as capacityRejectKey and inferenceErrorKey.
-// Iteration-time filtering by provider (Disconnect, pending-load sweeps, the
-// fault-key migration) compares the field instead of parsing a prefix.
-
-// dispatchLoadKey identifies a dispatch-load cooldown bucket
-// (Registry.dispatchLoadCooldowns). FaultKey is the provider's STABLE fault
-// key (faultKeyLocked: serial/SE-key when bound, the session id otherwise) so
-// the cooldown survives a reconnect within its TTL.
-type dispatchLoadKey struct {
-	FaultKey string
-	ModelID  string
-}
+// no allocation and cannot alias across ids that contain the delimiter.
+// Iteration-time filtering by provider (Disconnect, pending-load sweeps)
+// compares the field instead of parsing a prefix. The fault trackers' pair
+// keys are gone: their state is per identity (gate_state.go), keyed inside
+// the gate by model (or modelShapeKey for the inference-error breaker).
 
 // modelLoadKey identifies a pending load_model command
 // (Registry.pendingModelLoads / pendingModelLoadStarted). ProviderID is the

--- a/coordinator/registry/pair_keys_test.go
+++ b/coordinator/registry/pair_keys_test.go
@@ -5,9 +5,10 @@ import (
 	"time"
 )
 
-// TestPairKeysCannotAliasAcrossDelimiter pins the struct-key guarantee the
-// old "providerID:modelID" strings lacked: ("a:b", "c") and ("a", "b:c") are
-// different pairs for both the dispatch-load cooldown and pending model loads.
+// TestPairKeysCannotAliasAcrossDelimiter pins the guarantee the old
+// "providerID:modelID" strings lacked: ("a:b", "c") and ("a", "b:c") are
+// different pairs for both the dispatch-load cooldown (now a per-identity gate
+// keyed inside by model) and pending model loads (a struct key).
 func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 	r := New(testLogger())
 	makeSchedulerProvider(t, r, "a:b", "c", 50)
@@ -16,10 +17,8 @@ func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 	if !r.RecordDispatchLoadFailure("a:b", "c") {
 		t.Fatal("first failure must start a cooldown")
 	}
-	r.mu.RLock()
-	aliased := r.dispatchLoadCooldownActiveLocked("a", "b:c", time.Now())
-	direct := r.dispatchLoadCooldownActiveLocked("a:b", "c", time.Now())
-	r.mu.RUnlock()
+	aliased := r.dispatchLoadCooled("a", "b:c", time.Now())
+	direct := r.dispatchLoadCooled("a:b", "c", time.Now())
 	if aliased || !direct {
 		t.Fatalf("dispatch-load cooldown aliased across ':' (aliased=%v direct=%v)", aliased, direct)
 	}
@@ -34,20 +33,28 @@ func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 }
 
 // TestDispatchLoadCooldownGateAllocatesNothing pins the hot-path contract for
-// the per-provider cooldown gate.
+// the per-provider cooldown gate, on both the scan's cached-gate path and the
+// session-resolving path.
 func TestDispatchLoadCooldownGateAllocatesNothing(t *testing.T) {
 	r := New(testLogger())
-	makeSchedulerProvider(t, r, "p1", "m", 50)
+	p1 := makeSchedulerProvider(t, r, "p1", "m", 50)
+	p2 := makeSchedulerProvider(t, r, "p2", "m", 50)
 	r.RecordDispatchLoadFailure("p1", "m")
 	now := time.Now()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	hits := 0
 	allocs := testing.AllocsPerRun(200, func() {
-		if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+		if r.gateOf(p1).dispatchLoadCooled("m", now) {
 			hits++
 		}
-		if r.dispatchLoadCooldownActiveLocked("p2", "m", now) {
+		if r.gateOf(p2).dispatchLoadCooled("m", now) {
+			hits++
+		}
+		if r.dispatchLoadCooled("p1", "m", now) {
+			hits++
+		}
+		if r.dispatchLoadCooled("p2", "m", now) {
 			hits++
 		}
 	})
@@ -84,12 +91,10 @@ func TestDisconnectDropsOnlyThatProvidersPendingLoads(t *testing.T) {
 	if !r.HasPendingModelLoad("p10", "m") {
 		t.Fatal("prefix-sharing provider's pending load was dropped")
 	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+	if r.dispatchLoadCooled("p1", "m", now) {
 		t.Fatal("identity-less disconnected provider's cooldown residue survived")
 	}
-	if !r.dispatchLoadCooldownActiveLocked("p10", "m", now) {
+	if !r.dispatchLoadCooled("p10", "m", now) {
 		t.Fatal("prefix-sharing provider's cooldown was dropped")
 	}
 }

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -21,7 +21,7 @@ import (
 // target and keeps feeding it (one box failed 99/99 for 15+ minutes in prod).
 //
 // This breaker is keyed by NODE only (across every model and shape), via the
-// stable fault key (faultKeyLocked: serial/SE-key when attestation has bound
+// stable fault key (faultKeyForSession: serial/SE-key when attestation has bound
 // one, the session id otherwise) so its state survives reconnect churn: a
 // node returning faults for ~all requests is sick regardless of cause, so it is
 // quarantined fleet-wide, re-probed after an exponential cooldown, and
@@ -34,8 +34,9 @@ import (
 // with the breaker bypassed (see selectBestCandidateLockedFull) so routing can
 // never be zeroed out — mirroring servability.go's fail-open philosophy.
 //
-// r.mu discipline, opportunistic >1024 map sweep, and the transition-bool
-// return all mirror error_cooldown.go.
+// State lives on the identity's gateState (gate_state.go) under gate.mu; the
+// old opportunistic >1024 map sweep is the periodic gate sweep. The
+// transition-bool return mirrors error_cooldown.go.
 const (
 	// providerBreakerConsecTrip: consecutive FAULT outcomes (no success in
 	// between) that open the breaker. A node failing this many in a row is
@@ -195,50 +196,37 @@ func (w *providerHealthWindow) windowStats(now time.Time, window time.Duration) 
 //   - Fault (COUNTED): 500/502/504 always; a 503 whose message indicates a real
 //     fault, and — by default — any 503 not recognized as a capacity shed.
 //   - Success (ok==true): clears the breaker if it had tripped.
+//
+// State lives on the identity's gate (gate_state.go): keyed by the stable
+// fault key (serial/SE-key when bound, session id otherwise) so it survives
+// reconnect churn — a zombie that bounces its connection between faults must
+// keep accumulating. Only gate.mu is taken; never r.mu.
 func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode int, errStr string) (opened bool, closed bool) {
 	if providerID == "" {
 		return false, false
 	}
-
-	hold := r.lockWrite("breaker")
+	var source disconnectSource
+	if !ok && statusCode == disconnectFlushStatusCode {
+		source = r.captureDisconnectSource(providerID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "breaker")
 	defer hold.unlock()
-	// Recheck under the mutation lock: a version reset can race any API-side check.
-	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+	g := hold.g
+	if !ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
 		return false, false
 	}
-	now := time.Now()
-	// Key by the stable fault key (serial/SE-key when bound, session id
-	// otherwise) so breaker state survives reconnect churn — a zombie that
-	// bounces its connection between faults must keep accumulating.
-	providerID = r.faultKeyLocked(providerID)
 
-	// Opportunistic sweep (mirrors error_cooldown.go): churned identities are
-	// never re-keyed — bound the maps by dropping expired/idle entries once
-	// they grow.
-	if len(r.providerBreakerOpenUntil) > 1024 {
-		for id, until := range r.providerBreakerOpenUntil {
-			if !now.Before(until) {
-				delete(r.providerBreakerOpenUntil, id)
-				delete(r.providerBreakerTrips, id)
-			}
-		}
-	}
-	if len(r.providerOutcomes) > 1024 {
-		for id, w := range r.providerOutcomes {
-			if total, _ := w.windowStats(now, providerBreakerWindow); total == 0 {
-				delete(r.providerOutcomes, id)
-			}
-		}
-	}
+	now := time.Now()
+	defer g.updatedLocked(now)
 
 	// SUCCESS: a served request proves the node is healthy. Record it, reset the
 	// consecutive-fault counter, and CLOSE the breaker (clearing the exponential
 	// backoff) if it had ever tripped — this is the auto-re-admit on recovery.
 	if ok {
-		r.providerHealthWindowLocked(providerID).record(true, now)
-		if _, had := r.providerBreakerOpenUntil[providerID]; had {
-			delete(r.providerBreakerOpenUntil, providerID)
-			delete(r.providerBreakerTrips, providerID)
+		g.healthWindowLocked().record(true, now)
+		if !g.breakerUntil.IsZero() {
+			g.breakerUntil = time.Time{}
+			g.breakerTrips = 0
 			return false, true
 		}
 		return false, false
@@ -250,13 +238,13 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 	if !providerOutcomeIsFault(statusCode, errStr) {
 		return false, false
 	}
-	w := r.providerHealthWindowLocked(providerID)
+	w := g.healthWindowLocked()
 	w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
 	// Already open: the gate is derouting new traffic. In-flight faults are
 	// still recorded above, but must not re-arm until the cooldown elapses
 	// (the half-open probe handles that below).
-	if until, had := r.providerBreakerOpenUntil[providerID]; had && now.Before(until) {
+	if now.Before(g.breakerUntil) {
 		return false, false
 	}
 
@@ -266,7 +254,7 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 	//     still bad, so re-arm with the next, larger backoff.
 	//   - closed: trip on either the consecutive-fault or the sustained
 	//     fail-rate threshold.
-	trips := r.providerBreakerTrips[providerID]
+	trips := g.breakerTrips
 	halfOpen := trips > 0
 	total, fails := w.windowStats(now, providerBreakerWindow)
 	rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
@@ -274,20 +262,18 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 		return false, false
 	}
 
-	r.providerBreakerOpenUntil[providerID] = now.Add(providerBreakerBackoff(trips))
-	r.providerBreakerTrips[providerID] = trips + 1
+	g.breakerUntil = now.Add(providerBreakerBackoff(trips))
+	g.breakerTrips = trips + 1
 	return true, false
 }
 
-// providerHealthWindowLocked returns the provider's health ring, creating it on
-// first use. Caller holds r.mu.
-func (r *Registry) providerHealthWindowLocked(providerID string) *providerHealthWindow {
-	w := r.providerOutcomes[providerID]
-	if w == nil {
-		w = &providerHealthWindow{}
-		r.providerOutcomes[providerID] = w
+// healthWindowLocked returns the gate's node-health ring, creating it on first
+// use. Caller holds g.mu.
+func (g *gateState) healthWindowLocked() *providerHealthWindow {
+	if g.outcomes == nil {
+		g.outcomes = &providerHealthWindow{}
 	}
-	return w
+	return g.outcomes
 }
 
 // providerBreakerBackoff returns the cooldown for a provider that has already
@@ -304,24 +290,19 @@ func providerBreakerBackoff(trips int) time.Duration {
 	return cooldown
 }
 
-// providerBreakerOpenLocked reports whether routing should skip this provider
-// because its node-health breaker is OPEN. True iff now is before the open
-// expiry; once now >= expiry it returns false so the next request is allowed
-// through as a half-open probe. READ-ONLY (no lazy delete) so it is safe under
-// r.mu held in either mode — mirrors inferenceErrorCooldownActiveLocked. Caller
-// holds r.mu.
-func (r *Registry) providerBreakerOpenLocked(providerID string, now time.Time) bool {
-	until, ok := r.providerBreakerOpenUntil[r.faultKeyLocked(providerID)]
-	return ok && now.Before(until)
+// breakerOpen reports whether routing should skip this provider because its
+// node-health breaker is OPEN. True iff now is before the open expiry; once
+// now >= expiry it returns false so the next request is allowed through as a
+// half-open probe. Resolves the session's gate; the scan itself reads the
+// cached p.gate atomically (gateState.breakerOpenAt) and never comes here.
+func (r *Registry) breakerOpen(providerID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).breakerOpenAt(now.UnixNano())
 }
 
 // ProviderBreakerOpen reports whether the per-provider node-health breaker is
-// currently quarantining the provider. Exposed for tests/observability; the
-// routing hot path uses providerBreakerOpenLocked under the already-held r.mu.
+// currently quarantining the provider. Exposed for tests/observability.
 func (r *Registry) ProviderBreakerOpen(providerID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenLocked(providerID, time.Now())
+	return r.breakerOpen(providerID, time.Now())
 }
 
 // providerOutcomeIsFault classifies a FAILED provider terminal (ok==false) for

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -11,29 +11,42 @@ import (
 // error_cooldown_test.go) ---
 
 func providerBreakerOpenAt(r *Registry, id string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenLocked(id, now)
+	return r.breakerOpen(id, now)
 }
 
-func providerBreakerTripsOf(r *Registry, id string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerTrips[id]
+func providerBreakerTripsOf(r *Registry, id string) (trips int) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			trips = g.breakerTrips
+		}
+	})
+	return trips
 }
 
-func providerBreakerOpenUntilOf(r *Registry, id string) time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenUntil[id]
+func providerBreakerOpenUntilOf(r *Registry, id string) (until time.Time) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			until = g.breakerUntil
+		}
+	})
+	return until
 }
 
 // expireProviderBreaker rewinds a provider's open expiry into the past,
 // simulating the cooldown elapsing (open -> half-open) without sleeping.
 func expireProviderBreaker(r *Registry, id string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
+	withGateForSession(r, id, func(g *gateState) { g.breakerUntil = time.Now().Add(-time.Second) })
+}
+
+// providerHealthWindowOf returns the provider's node-health ring (nil when no
+// fault or success was ever recorded).
+func providerHealthWindowOf(r *Registry, id string) (w *providerHealthWindow) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			w = g.outcomes
+		}
+	})
+	return w
 }
 
 // seedProviderHealthWindow records a fixed sequence of outcomes (true=success,
@@ -42,12 +55,12 @@ func expireProviderBreaker(r *Registry, id string) {
 // a low consecutive-fault counter) that monotonic RecordProviderOutcome calls
 // could not reach before the consecutive-fault path fires.
 func seedProviderHealthWindow(r *Registry, id string, pattern []bool, now time.Time) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	w := r.providerHealthWindowLocked(id)
-	for _, ok := range pattern {
-		w.record(ok, now)
-	}
+	withGateForSession(r, id, func(g *gateState) {
+		w := g.healthWindowLocked()
+		for _, ok := range pattern {
+			w.record(ok, now)
+		}
+	})
 }
 
 // --- classifier unit tests ---
@@ -368,10 +381,7 @@ func TestProviderBreakerIgnoresHealthySheds(t *testing.T) {
 		t.Fatal("100 healthy sheds must not quarantine a provider")
 	}
 	// Healthy sheds are ignored entirely — no health window is even created.
-	r.mu.RLock()
-	w := r.providerOutcomes[id]
-	r.mu.RUnlock()
-	if w != nil {
+	if w := providerHealthWindowOf(r, id); w != nil {
 		t.Fatalf("healthy sheds must not record into the health ring, got %+v", w)
 	}
 }
@@ -550,8 +560,8 @@ func TestQuickCapacityCheckFailsOpenOnProviderBreaker(t *testing.T) {
 	}
 }
 
-// Disconnect must drop every per-provider breaker map entry so a per-session
-// UUID leaves no residue.
+// Disconnect must drop an identity-less session's breaker state (its gate was
+// keyed by the session UUID, which never recurs) so it leaves no residue.
 func TestDisconnectClearsProviderBreaker(t *testing.T) {
 	reg := New(testLogger())
 	model := "disconnect-breaker-model"
@@ -559,29 +569,30 @@ func TestDisconnectClearsProviderBreaker(t *testing.T) {
 	for i := 0; i < providerBreakerConsecTrip; i++ {
 		reg.RecordProviderOutcome(p.ID, false, 500, "")
 	}
-	reg.mu.RLock()
-	_, hasWin := reg.providerOutcomes[p.ID]
-	_, hasOpen := reg.providerBreakerOpenUntil[p.ID]
-	_, hasTrips := reg.providerBreakerTrips[p.ID]
-	reg.mu.RUnlock()
+	var hasWin, hasOpen, hasTrips bool
+	readGateForKey(reg, p.ID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		hasWin, hasOpen, hasTrips = g.outcomes != nil, !g.breakerUntil.IsZero(), g.breakerTrips > 0
+	})
 	if !hasWin || !hasOpen || !hasTrips {
 		t.Fatalf("expected breaker state before disconnect: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
 	}
 
 	reg.Disconnect(p.ID)
 
-	reg.mu.RLock()
-	_, hasWin = reg.providerOutcomes[p.ID]
-	_, hasOpen = reg.providerBreakerOpenUntil[p.ID]
-	_, hasTrips = reg.providerBreakerTrips[p.ID]
-	reg.mu.RUnlock()
-	if hasWin || hasOpen || hasTrips {
-		t.Fatalf("Disconnect must drop all breaker state: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
+	if g := rawGateForKey(reg, p.ID); g != nil {
+		t.Fatalf("Disconnect must drop the session-keyed gate, got %+v", g)
+	}
+	if reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("Disconnect must drop all breaker state")
 	}
 }
 
-// The opportunistic >1024 sweep (mirroring error_cooldown.go) must bound the
-// breaker maps by dropping expired/idle entries.
+// The periodic gate sweep (gate_state.go) must bound the index by dropping
+// identities whose breaker has expired and whose ring has aged out, once no
+// live session references them.
 func TestProviderBreakerMapsBounded(t *testing.T) {
 	r := New(testLogger())
 	for i := 0; i < 1100; i++ {
@@ -590,37 +601,22 @@ func TestProviderBreakerMapsBounded(t *testing.T) {
 			r.RecordProviderOutcome(id, false, 500, "")
 		}
 	}
-	r.mu.Lock()
-	for id := range r.providerBreakerOpenUntil {
-		r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
-	}
-	for _, w := range r.providerOutcomes {
-		for i := range w.outcomes {
-			if !w.outcomes[i].ts.IsZero() {
-				w.outcomes[i].ts = w.outcomes[i].ts.Add(-(providerBreakerWindow + time.Second))
-			}
-		}
-	}
-	openCount := len(r.providerBreakerOpenUntil)
-	winCount := len(r.providerOutcomes)
-	r.mu.Unlock()
-	if openCount < 1000 || winCount < 1000 {
-		t.Fatalf("setup produced too few distinct entries: open=%d win=%d", openCount, winCount)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
 
-	// A live record triggers the >1024 sweep before recording.
-	r.RecordProviderOutcome("live", false, 500, "")
+	// Past the breaker cooldown, the ring window and the idle grace, every
+	// dead identity is idle. A connected provider's gate stays regardless.
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordProviderOutcome(live.ID, false, 500, "")
+	r.sweepGates(time.Now().Add(gateIdleGrace + providerBreakerMaxCooldown + time.Second))
 
-	r.mu.RLock()
-	openAfter := len(r.providerBreakerOpenUntil)
-	tripsAfter := len(r.providerBreakerTrips)
-	winAfter := len(r.providerOutcomes)
-	r.mu.RUnlock()
-	if openAfter != 0 {
-		t.Fatalf("expired-breaker sweep should drop every entry (live pair has no open breaker yet), got %d", openAfter)
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
 	}
-	if tripsAfter != 0 {
-		t.Fatalf("trip counts must be swept alongside expired breakers, got %d", tripsAfter)
+	winAfter := 0
+	if providerHealthWindowOf(r, live.ID) != nil {
+		winAfter = 1
 	}
 	if winAfter != 1 {
 		t.Fatalf("stale-window sweep should leave only the live entry, got %d", winAfter)

--- a/coordinator/registry/race_disabled_test.go
+++ b/coordinator/registry/race_disabled_test.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package registry
+
+// raceDetectorEnabled is false when the test binary was built without -race.
+const raceDetectorEnabled = false

--- a/coordinator/registry/race_enabled_test.go
+++ b/coordinator/registry/race_enabled_test.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package registry
+
+// raceDetectorEnabled is true when the test binary was built with -race. The
+// detector serializes goroutines heavily enough that throughput assertions
+// (parallel speed-up guards) are meaningless under it.
+const raceDetectorEnabled = true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1042,9 +1042,17 @@ type Provider struct {
 
 	// registry back-pointer, set once in Register (nil for bare test Providers).
 	// SetAttestationResult uses it to bind this session's id to its stable
-	// identity so the fault-tracking maps (breakers/cooldowns) key by identity
-	// and survive reconnect churn. Read-only after Register.
+	// identity so the fault-tracking state (breakers/cooldowns) keys by identity
+	// and survives reconnect churn. Read-only after Register.
 	registry *Registry
+	// gate is this session's current routing-gate state (gate_state.go): the
+	// session-keyed gate from Register until attestation binds the stable
+	// identity, then the identity's gate. Atomic so the scan (under p.mu) and
+	// the recorders (without p.mu) read it without another lock; written only
+	// under r.gatesMu (attachSessionGate / bindStableFaultKey). nil for a bare
+	// test Provider — every gate read treats nil as "no state".
+	gate                 atomic.Pointer[gateState]
+	gateDisconnectedAtNS atomic.Int64
 }
 
 // providerSupportsPrivateTextLocked is the SINGLE routing chokepoint for
@@ -1918,6 +1926,7 @@ func (p *Provider) HardUntrustEpoch() uint64 {
 // marshal the Provider snapshot.
 func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	if result == nil {
 		p.AttestationResult = nil
 	} else {
@@ -1926,16 +1935,17 @@ func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) 
 			[]string(nil), result.RuntimeCapabilities...)
 		p.AttestationResult = &snapshot
 	}
-	// Re-derive the stable identity while p.mu is held, then bind it OUTSIDE
-	// p.mu (bindStableFaultKey takes r.mu; the established order is r.mu →
-	// p.mu, so taking r.mu here while holding p.mu could deadlock). Binding at
-	// attestation time is what re-attaches a reconnecting machine's fault
-	// state (breakers/cooldowns keyed by serial/SE-key) to its fresh session
-	// id BEFORE it becomes routable — public routing requires attestation.
-	id, stableID, r := p.ID, stableProviderIdentityLocked(p), p.registry
-	p.mu.Unlock()
-	if r != nil {
-		r.bindStableFaultKey(id, stableID)
+	// Re-derive the stable identity and bind it while p.mu is STILL held
+	// (lock order r.mu → p.mu → gatesMu → gate.mu; bindStableFaultKey takes the
+	// last two). The bind — which repoints p.gate — must not land inside a
+	// section that reads p.gate and acts on it under p.mu: the reservation
+	// commit's admit re-check through its pending debit, the scan's gate chain,
+	// the alias resolver's routability read. Binding at attestation time is what
+	// re-attaches a reconnecting machine's fault state (breakers/cooldowns keyed
+	// by serial/SE-key) to its fresh session id BEFORE it becomes routable —
+	// public routing requires attestation.
+	if r := p.registry; r != nil {
+		r.bindStableFaultKey(p, stableProviderIdentityLocked(p))
 	}
 }
 
@@ -1946,14 +1956,12 @@ func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) 
 // identity resolves to the ACCOUNT fallback — attestation absent (Open Mode)
 // or invalid — would otherwise never bind: all its fault state would key by
 // session UUID and be wiped on reconnect. Same lock discipline as
-// SetAttestationResult: derive under p.mu, bind OUTSIDE it (bindStableFaultKey
-// takes r.mu; the established order is r.mu → p.mu).
+// SetAttestationResult: derive AND bind under p.mu.
 func (p *Provider) RebindStableFaultKey() {
 	p.mu.Lock()
-	id, stableID, r := p.ID, stableProviderIdentityLocked(p), p.registry
-	p.mu.Unlock()
-	if r != nil {
-		r.bindStableFaultKey(id, stableID)
+	defer p.mu.Unlock()
+	if r := p.registry; r != nil {
+		r.bindStableFaultKey(p, stableProviderIdentityLocked(p))
 	}
 }
 
@@ -2256,143 +2264,45 @@ type Registry struct {
 	pendingModelLoads       map[modelLoadKey]time.Time // value: expiry (see pair_keys.go)
 	pendingModelLoadStarted map[modelLoadKey]time.Time
 
-	// dispatchLoadCooldowns: provider-model pairs that rejected a dispatch with a
-	// load failure ("insufficient memory"). Routing skips the pair until expiry —
-	// it would instant-503 again, and without this the scheduler re-picks it
-	// (looks idle), causing the dispatch→503→retry storms seen in prod. Cleared
-	// on re-registration and on a served request for the pair.
-	dispatchLoadCooldowns map[dispatchLoadKey]time.Time // value: expiry (see pair_keys.go)
-
-	// inferenceErrorStrikes / inferenceErrorCooldowns implement the error-class
-	// circuit breaker for provider-side inference failures: a (provider, model,
-	// shape) triple that returns repeated 5xx errors (e.g. the deterministic
-	// Gemma chat-template render crash on tool schemas) enters a routing
-	// cool-down so retries fall to OTHER providers instead of burning every
-	// attempt on the same broken pair. 4xx (client-shape) errors never count.
-	//
-	// The key is SHAPE-KEYED (inferenceErrorKey) rather than a "providerID:modelID"
-	// string concat. Shape-keying fixes the root bug where a clean non-tool
-	// success reset the SHARED strike counter, so in mixed traffic a deterministic
-	// tool/template failure interleaved with text successes never reached the
-	// 2-strike threshold and the broken provider was never quarantined for tools.
-	// Strikes now accumulate per shape ("tools" independent of "base"), a success
-	// clears only its own shape bucket, and the struct key also closes the
-	// threat-model colon-collision note (a provider or model id containing ':'
-	// could previously alias another pair). Strikes slide over inferenceErrorWindow.
-	// Guarded by r.mu like dispatchLoadCooldowns. See error_cooldown.go.
-	inferenceErrorStrikes   map[inferenceErrorKey][]time.Time // recent 5xx strike times per (provider, model, shape)
-	inferenceErrorCooldowns map[inferenceErrorKey]time.Time   // cool-down expiry per (provider, model, shape)
-
-	// providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips
-	// implement the per-provider (node-health) circuit breaker, SEPARATE from
-	// and ADDITIONAL to the shape-keyed inference-error breaker above. It
-	// quarantines a whole provider that returns GENUINE-FAULT errors
-	// (500/502/504, or a fault-shaped 503 — internal error, crash, the opaque
-	// Foundation string) for ~all of its requests, regardless
-	// of model/shape — the case the inference-error breaker misses because it
-	// skips 503. After an exponential cooldown it re-probes and auto-re-admits
-	// on the first success. Capacity-class sheds (4xx/429 and token-budget /
-	// KV-headroom / draining 503s) never count — a healthy-but-busy provider.
-	// The breaker FAILS OPEN: when it would deroute every provider for a model,
-	// selection re-scans with it bypassed (selectBestCandidateLockedFull) so a
-	// bad fleet-wide rollout cannot zero out routing. Guarded by r.mu like the
-	// maps above. Keyed by the stable fault key (faultKeyLocked) and NOT
-	// cleared on Disconnect — state re-attaches on reconnect; only a provider
-	// with no stable identity has its session-keyed residue dropped. See
-	// provider_breaker.go.
-	providerOutcomes         map[string]*providerHealthWindow // per-provider sliding fault/success ring
-	providerBreakerOpenUntil map[string]time.Time             // breaker-open expiry per provider
-	providerBreakerTrips     map[string]int                   // trip count per provider (exponential backoff)
-
-	// capacityRejectStrikes / capacityCooldowns / capacityCooldownTrips
-	// implement the capacity-reject routing cooldown (capacity_cooldown.go),
-	// SEPARATE from every breaker above — all of which deliberately IGNORE
-	// capacity-class rejections (sound for occasional sheds from a busy box,
-	// catastrophic for a box that capacity-rejects EVERYTHING while its
-	// idle-looking heartbeats keep winning the cost scheduler: the 2026-07
-	// black-hole incident, 7 boxes, ~9k rejects/30min, zero successes). A
-	// (provider, model) pair that accumulates threshold-many capacity rejects
-	// inside the window with ZERO interleaved accepts enters a routing
-	// cooldown with exponential re-trip backoff; any accept (first content
-	// chunk or clean completion) clears all three entries. Config is
-	// env-tunable (EIGENINFERENCE_CAPACITY_COOLDOWN_*), loaded at
-	// construction. Guarded by r.mu like the maps above.
-	capacityCooldownCfg   capacityCooldownConfig
-	capacityRejectStrikes map[capacityRejectKey][]time.Time            // recent capacity-reject strikes per (provider, model)
-	capacityCooldowns     map[capacityRejectKey]*capacityCooldownEntry // cooldown expiry + half-open probe claim per (provider, model)
-	capacityCooldownTrips map[capacityRejectKey]int                    // trip count per (provider, model) (exponential backoff)
-
-	// budgetClamps implements the gray-box budget clamp (budget_clamp.go):
-	// after a capacity-shaped 503, admission stops believing the pair's
-	// stale-optimistic heartbeat budget and treats the slot as FULL until the
-	// provider proves recovery (fresh heartbeat with headroom + an accept) or
-	// the clamp TTL fail-opens. Keyed by stable fault identity; migrated on
-	// rebind; NOT cleared on Disconnect. Guarded by r.mu.
-	budgetClampCfg budgetClampConfig
-	budgetClamps   map[capacityRejectKey]*budgetClampEntry
-
-	// capacityRateRejects / capacityRateAccepts implement the capacity-503
-	// rate penalty (capacity_rate.go): sliding windows of capacity rejects and
-	// served dispatches per (stable identity, model). Unlike every breaker
-	// above there is NO accept-triggered reset — the rate is exactly the
-	// gray-box signal the zero-interleaved-accepts discriminators are blind
-	// to. Keyed by stable fault identity; migrated on rebind; NOT cleared on
-	// Disconnect. Guarded by r.mu.
-	capacityRateCfg     capacityRateConfig
-	capacityRateRejects map[capacityRejectKey][]time.Time
-	capacityRateAccepts map[capacityRejectKey][]time.Time
-
-	// Stable-identity health ejection (health_ejection.go). Keyed by a STABLE
-	// identity (serial/SE-key/account), NOT the session UUID, and DELIBERATELY
-	// NOT deleted on Disconnect — so a zombie that fails ~every request while
-	// reconnecting constantly still accumulates to the ejection threshold.
-	healthEjectionWindows map[string]*providerHealthWindow // stable-id sliding fault/success ring
-	healthEjectionUntil   map[string]time.Time             // ejection-open expiry per stable id
-	healthEjectionTrips   map[string]int                   // trip count per stable id (exponential backoff)
-	// healthEjectionCapacityStreaks counts CONSECUTIVE capacity-shaped 5xx
-	// rejections (zero interleaved successes) per stable identity — the
-	// capacity black-hole signature that every fault breaker deliberately
-	// ignores (prod: 13,333 "token_budget"-shaped 503s, 100% error rate, 90
-	// min, never ejected). Any success clears the streak, so a busy-but-
-	// serving box can never trip. See health_ejection.go.
-	healthEjectionCapacityStreaks map[string]capacityStreak
-	// healthEjectionLastTripCapacity records whether an identity's most recent
-	// ejection came from the capacity streak (true) or the fault path (false).
-	// The capacity branch's half-open instant re-arm applies only to capacity
-	// trips: a single capacity shed — legitimate for a healthy-but-full box —
-	// must not re-arm a FAULT ejection whose cooldown just expired.
-	healthEjectionLastTripCapacity map[string]bool
-	// disconnectedStableIDs caches a provider's stable identity at Disconnect time,
-	// keyed by its (now-removed) session id, so the pending-request ErrorCh flush —
-	// which runs AFTER Disconnect deletes the provider and carries the 502 "provider
-	// disconnected" faults that define a reconnecting zombie — can still resolve the
-	// identity and record those faults against the stable-identity breaker. The
-	// entry also dates the drop: a flush strike from a session dropped at or
-	// before the identity's last version-changed reset is discarded as already
-	// accounted for (version_reset.go, IsSupersededDisconnectFlush).
+	// Per-identity routing-gate state (gate_state.go). Every fault tracker —
+	// the dispatch-load cooldown, the shape-keyed inference-error breaker
+	// (error_cooldown.go), the node-health breaker (provider_breaker.go), the
+	// capacity cooldown / rate window / budget clamp (capacity_cooldown.go,
+	// capacity_rate.go, budget_clamp.go) and stable-identity health ejection
+	// (health_ejection.go) — lives on the gateState of the provider's STABLE
+	// fault key (serial → SE key → account → session id), each gate with its
+	// own mutex. Recorders take gate.mu only, never r.mu: the six per-request
+	// write acquisitions of r.mu that convoyed behind the fleet-scan readers
+	// are gone. gates is keyed by fault key; sessions indexes LIVE session ids
+	// to their Provider (whose p.gate caches the current gate) so recorders
+	// resolve a session without r.mu; disconnectedStableIDs caches a
+	// provider's stable identity at Disconnect time, keyed by its now-removed
+	// session id, so the trailing pending-request ErrorCh flush — which
+	// carries the 502 "provider disconnected" faults that define a
+	// reconnecting zombie — still resolves the identity. All three under
+	// gatesMu: RLock to resolve, Lock only in Register / Disconnect / the
+	// attestation-time bind / the periodic sweep. Fault state is keyed by
+	// identity and NOT cleared on Disconnect — it re-attaches on reconnect
+	// (the prod zombie exploit: median 18 sessions/machine/week reset every
+	// session-keyed breaker before it could trip).
+	gatesMu               sync.RWMutex
+	gates                 map[string]*gateState
+	sessions              map[string]*Provider
 	disconnectedStableIDs map[string]disconnectedStableID
-	// faultKeyBySession maps a LIVE session id to its stable identity
-	// (serial/SE-key/account). Bound by SetAttestationResult, removed on
-	// Disconnect (the disconnectedStableIDs cache covers the trailing flush).
-	// Every fault-tracking map above (inference-error cooldowns, node-health
-	// breaker, dispatch-load cooldowns) keys by faultKeyLocked(sessionID) —
-	// the stable identity when bound, the session id itself otherwise — so a
-	// reconnecting machine re-attaches its accumulated fault state instead of
-	// wiping it (the prod zombie exploit: median 18 sessions/machine/week
-	// reset every session-keyed breaker before it could trip).
-	faultKeyBySession map[string]string
-	// identityVersions / inferenceErrorFlushStrikes back the version-changed
-	// reconnect reset (version_reset.go): the last binary version seen per
-	// stable identity, the time of its last reset (rate limit), and the subset
-	// of inferenceErrorStrikes that came from the disconnect flush (502) so
-	// exactly those can be removed when the identity returns on a new binary.
-	// Lazily created; guarded by r.mu; migrated on rebind; NOT cleared on
-	// Disconnect.
-	identityVersions           map[string]string
-	identityVersionResetAt     map[string]time.Time
-	identityVersionSeenAt      map[string]time.Time
-	identityVersionSweepAt     time.Time
-	inferenceErrorFlushStrikes map[inferenceErrorKey][]time.Time
+	gateSweepAt           time.Time
+	// gateWaitObserver, when set, is told about gate.mu acquisition waits above
+	// gateWaitReportThreshold, tagged by recorder site (SetGateWaitObserver).
+	gateWaitObserver atomic.Pointer[func(site string, wait time.Duration)]
+
+	// reserveCommitMode selects whether the reservation commit holds r.mu for
+	// reading (shared, default) or writing (global — the kill switch). Read
+	// once from EIGENINFERENCE_RESERVE_COMMIT_MODE at construction.
+	reserveCommitMode reserveCommitMode
+
+	// Env-tunable tracker configs, read once at construction.
+	capacityCooldownCfg capacityCooldownConfig
+	budgetClampCfg      budgetClampConfig
+	capacityRateCfg     capacityRateConfig
 
 	// evictStrikes counts consecutive eviction sweeps a provider has been stale.
 	// A provider is only evicted after STALE on two sweeps in a row, so a single
@@ -2471,42 +2381,27 @@ type modelLoadAction struct {
 // New creates a new Registry.
 func New(logger *slog.Logger) *Registry {
 	return &Registry{
-		providers:                      make(map[string]*Provider),
-		queue:                          NewRequestQueueFromEnv(),
-		MinTrustLevel:                  TrustHardware,
-		tpsRegistry:                    NewTPSRegistry(),
-		modelProviders:                 make(map[string]*atomic.Int64),
-		pendingModelLoads:              make(map[modelLoadKey]time.Time),
-		pendingModelLoadStarted:        make(map[modelLoadKey]time.Time),
-		dispatchLoadCooldowns:          make(map[dispatchLoadKey]time.Time),
-		inferenceErrorStrikes:          make(map[inferenceErrorKey][]time.Time),
-		inferenceErrorCooldowns:        make(map[inferenceErrorKey]time.Time),
-		providerOutcomes:               make(map[string]*providerHealthWindow),
-		providerBreakerOpenUntil:       make(map[string]time.Time),
-		providerBreakerTrips:           make(map[string]int),
-		capacityCooldownCfg:            loadCapacityCooldownConfig(),
-		capacityRejectStrikes:          make(map[capacityRejectKey][]time.Time),
-		capacityCooldowns:              make(map[capacityRejectKey]*capacityCooldownEntry),
-		capacityCooldownTrips:          make(map[capacityRejectKey]int),
-		budgetClampCfg:                 loadBudgetClampConfig(),
-		budgetClamps:                   make(map[capacityRejectKey]*budgetClampEntry),
-		capacityRateCfg:                loadCapacityRateConfig(),
-		capacityRateRejects:            make(map[capacityRejectKey][]time.Time),
-		capacityRateAccepts:            make(map[capacityRejectKey][]time.Time),
-		healthEjectionWindows:          make(map[string]*providerHealthWindow),
-		healthEjectionUntil:            make(map[string]time.Time),
-		healthEjectionTrips:            make(map[string]int),
-		healthEjectionCapacityStreaks:  make(map[string]capacityStreak),
-		healthEjectionLastTripCapacity: make(map[string]bool),
-		disconnectedStableIDs:          make(map[string]disconnectedStableID),
-		faultKeyBySession:              make(map[string]string),
-		evictStrikes:                   make(map[string]int),
-		cacheRouting:                   newCacheRoutingTracker(defaultCacheRoutingTTL, defaultCacheRoutingMaxHolders),
-		cacheActivation:                newCacheActivationGate(defaultCacheRoutingActivationPct, defaultCacheRoutingMaxPlanQPS),
-		cacheRoutingMode:               CacheRoutingOff,
-		cacheRoutingMaxDiscountMs:      defaultCacheRoutingMaxDiscountMs,
-		cacheRoutingMaxCostFraction:    defaultCacheRoutingMaxCostFraction,
-		logger:                         logger,
+		providers:                   make(map[string]*Provider),
+		queue:                       NewRequestQueueFromEnv(),
+		MinTrustLevel:               TrustHardware,
+		tpsRegistry:                 NewTPSRegistry(),
+		modelProviders:              make(map[string]*atomic.Int64),
+		pendingModelLoads:           make(map[modelLoadKey]time.Time),
+		pendingModelLoadStarted:     make(map[modelLoadKey]time.Time),
+		gates:                       make(map[string]*gateState),
+		sessions:                    make(map[string]*Provider),
+		disconnectedStableIDs:       make(map[string]disconnectedStableID),
+		reserveCommitMode:           loadReserveCommitMode(logger),
+		capacityCooldownCfg:         loadCapacityCooldownConfig(),
+		budgetClampCfg:              loadBudgetClampConfig(),
+		capacityRateCfg:             loadCapacityRateConfig(),
+		evictStrikes:                make(map[string]int),
+		cacheRouting:                newCacheRoutingTracker(defaultCacheRoutingTTL, defaultCacheRoutingMaxHolders),
+		cacheActivation:             newCacheActivationGate(defaultCacheRoutingActivationPct, defaultCacheRoutingMaxPlanQPS),
+		cacheRoutingMode:            CacheRoutingOff,
+		cacheRoutingMaxDiscountMs:   defaultCacheRoutingMaxDiscountMs,
+		cacheRoutingMaxCostFraction: defaultCacheRoutingMaxCostFraction,
+		logger:                      logger,
 	}
 }
 
@@ -2562,42 +2457,56 @@ func (r *Registry) CacheRoutingConfigSnapshot() CacheRoutingConfig {
 // RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down
 // after the provider rejected a dispatch with a load failure. Returns true
 // when this call started a new cool-down (false when one was already live),
-// so callers can emit metrics without double-counting the retry storm. Keyed
-// by the provider's stable fault key (faultKeyLocked) so the cool-down
-// survives a reconnect within its TTL.
+// so callers can emit metrics without double-counting the retry storm. Lives
+// on the provider's stable-identity gate (gate_state.go) so the cool-down
+// survives a reconnect within its TTL; takes only gate.mu.
 func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
-	hold := r.lockWrite("dispatch_load_failure")
+	hold := r.lockGate(r.gateForSession(providerID), "dispatch_load_failure")
 	defer hold.unlock()
+	g := hold.g
 	now := time.Now()
-	// Opportunistic sweep: bound the map by dropping expired entries when it
-	// grows (churned identities are never re-keyed).
-	if len(r.dispatchLoadCooldowns) > 1024 {
-		for key, expiry := range r.dispatchLoadCooldowns {
-			if !now.Before(expiry) {
-				delete(r.dispatchLoadCooldowns, key)
-			}
-		}
-	}
-	key := dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}
-	expiry, active := r.dispatchLoadCooldowns[key]
+	expiry, active := g.dispatchLoadCooldowns[modelID]
 	active = active && now.Before(expiry)
-	r.dispatchLoadCooldowns[key] = now.Add(dispatchLoadCooldownTTL)
+	g.dispatchLoadCooldowns[modelID] = now.Add(dispatchLoadCooldownTTL)
+	g.updatedLocked(now)
 	return !active
 }
 
 // ClearDispatchLoadCooldown removes the cool-down for one provider-model pair
 // (called when the pair serves a request successfully — it can load after all).
+// Runs at request completion; takes only the identity's gate.mu.
 func (r *Registry) ClearDispatchLoadCooldown(providerID, modelID string) {
-	hold := r.lockWrite("dispatch_load_cooldown")
+	ref, has := r.refHasPairState(r.lookupSessionGateRef(providerID), gateFlagDispatchLoad)
+	if !has {
+		return // nothing to clear — the common case, one lock-free flag load
+	}
+	hold := r.lockGate(ref, "dispatch_load_clear")
 	defer hold.unlock()
-	delete(r.dispatchLoadCooldowns, dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID})
+	g := hold.g
+	if g == nil {
+		return
+	}
+
+	delete(g.dispatchLoadCooldowns, modelID)
+	g.updatedLocked(time.Now())
 }
 
-// dispatchLoadCooldownActiveLocked reports whether routing should skip the pair.
-// READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
-// r.mu in either mode.
-func (r *Registry) dispatchLoadCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	expiry, ok := r.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}]
+// dispatchLoadCooled reports whether routing should skip the pair. Resolves
+// the session's gate; the scan uses the cached p.gate directly.
+func (r *Registry) dispatchLoadCooled(providerID, modelID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).dispatchLoadCooled(modelID, now)
+}
+
+// dispatchLoadCooled is the gate-level check: lock-free "no cooldown on any
+// model" fast path, otherwise one short gate.mu section. READ-ONLY (no lazy
+// delete). nil-safe.
+func (g *gateState) dispatchLoadCooled(modelID string, now time.Time) bool {
+	if !g.hasPairState(gateFlagDispatchLoad) {
+		return false
+	}
+	g = g.lockResolved()
+	expiry, ok := g.dispatchLoadCooldowns[modelID]
+	g.mu.Unlock()
 	return ok && now.Before(expiry)
 }
 
@@ -2982,7 +2891,15 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 	) {
 		return false
 	}
-	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
+	// The session's current gate, read under p.mu — which the identity bind
+	// also holds (bindStableFaultKey) — so a rebind cannot repoint p.gate, or
+	// migrate the cooldown away from the gate read here, mid-check. Without
+	// that, a read of a shared source gate emptied by this session's own
+	// rebind would say "not cooled" and let an alias resolve to a Desired
+	// build whose only provider is cooled (the request then queues or 429s
+	// instead of taking the routable Previous build). No gateView
+	// confirmation is needed under p.mu.
+	if r.gateOf(p).dispatchLoadCooled(buildID, now) {
 		return false
 	}
 	if p.BackendCapacity != nil {
@@ -3879,6 +3796,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		return existing
 	}
 	r.providers[id] = p
+	r.attachSessionGate(p)
 	p.mu.Lock()
 	r.modelIndex.sync(p)
 	p.mu.Unlock()
@@ -5099,47 +5017,18 @@ func (r *Registry) disconnectProvider(id string, expected *Provider, timeout tim
 			}
 		}
 		p.detachModelIndexLocked(r)
-		// FAULT STATE IS NOT CLEARED ON DISCONNECT. Every fault-tracking map
+		// FAULT STATE IS NOT CLEARED ON DISCONNECT. Every fault tracker
 		// (node-health breaker, inference-error cooldowns, dispatch-load
-		// cooldowns, health ejection) keys by the STABLE identity when one is
-		// bound, so it must survive reconnect churn — wiping it here was the
-		// zombie exploit. Only when the provider never had a stable identity
-		// (sid == "": its fault key WAS this session id, which never recurs)
-		// is the session-keyed residue dropped for hygiene.
-		//
-		// Cache the stable identity (keyed by this session id) before the pending
-		// flush below: GetProviderStableIdentity and faultKeyLocked fall back to it
-		// so the 502 "provider disconnected" faults — the dominant reconnecting-
-		// zombie signal — are still recorded against the stable-identity state even
-		// though the provider is already gone from r.providers.
-		if sid := stableProviderIdentityLocked(p); sid != "" {
-			r.rememberDisconnectedStableIDLocked(id, sid)
-		} else {
-			delete(r.providerOutcomes, id)
-			delete(r.providerBreakerOpenUntil, id)
-			delete(r.providerBreakerTrips, id)
-			for key := range r.inferenceErrorStrikes {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorStrikes, key)
-				}
-			}
-			for key := range r.inferenceErrorCooldowns {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorCooldowns, key)
-				}
-			}
-			for key := range r.inferenceErrorFlushStrikes {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorFlushStrikes, key)
-				}
-			}
-			for key := range r.dispatchLoadCooldowns {
-				if key.FaultKey == id {
-					delete(r.dispatchLoadCooldowns, key)
-				}
-			}
-		}
-		delete(r.faultKeyBySession, id)
+		// cooldowns, health ejection, capacity trackers) lives on the STABLE
+		// identity's gate when one is bound, so it must survive reconnect
+		// churn — wiping it here was the zombie exploit. detachSessionGate
+		// caches the identity (keyed by this session id) before the pending
+		// flush below so the 502 "provider disconnected" faults — the dominant
+		// reconnecting-zombie signal — still resolve to it even though the
+		// provider is already gone from r.providers; only a provider that never
+		// had a stable identity (sid == "": its gate WAS this session id, which
+		// never recurs) has its session-keyed residue dropped for hygiene.
+		r.detachSessionGate(p, stableProviderIdentityLocked(p))
 		disconnectedModels = make([]string, 0, len(p.Models))
 		for _, m := range p.Models {
 			disconnectedModels = append(disconnectedModels, m.ID)
@@ -6517,7 +6406,6 @@ func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration)
 				return
 			case <-ticker.C:
 				r.evictStale(timeout)
-				r.sweepIdentityVersionHistory(time.Now())
 			}
 		}
 	})
@@ -6601,6 +6489,11 @@ func (r *Registry) evictStale(timeout time.Duration) {
 			r.logger.Warn("evicted stale provider", "provider_id", p.ID, "timeout", timeout)
 		}
 	}
+
+	// Bound the per-identity gate index on the same cadence (gate_state.go):
+	// prunes dead per-model entries and drops gates no live session references
+	// once idle. Off the request path and outside r.mu.
+	r.sweepGates(now)
 }
 
 // evictStrikeThreshold is how many consecutive stale sweeps trigger eviction.

--- a/coordinator/registry/request_path_probe_test.go
+++ b/coordinator/registry/request_path_probe_test.go
@@ -1,0 +1,136 @@
+package registry
+
+// Request-path lock probes. They reuse the fleet fixture from
+// fleet_scale_bench_test.go and separate three questions:
+//   A. do RLock-only fleet walks parallelize?               (RequestPathWalkParallel)
+//   B. what does one writer wait under N concurrent walks?  (RequestPathWalkParallelWithWriter)
+//   C. scan+commit+per-request recorders, serial vs parallel (RequestPathSerial / RequestPathParallel)
+//
+// C is the one that measures the change this branch makes: before it, every
+// commit and every completion recorder took the registry WRITE lock, so the
+// parallel variant ran at ~1x the serial one (each writer drained the whole
+// reader batch). TestRequestPathParallelSpeedup (reserve_commit_test.go) pins
+// the ratio so a walk-wide lock cannot sneak back.
+//
+//	go test ./registry/ -run xxx -bench 'RequestPath' -benchtime 2s -benchmem
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func BenchmarkRequestPathWalkParallel(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			model := f.models[n%len(f.models)]
+			c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false)
+			if c == 0 {
+				b.Fatal("no candidates")
+			}
+			n++
+		}
+	})
+}
+
+// One background writer records a provider outcome every 2 ms (~500/s, the
+// prod per-request recorder rate) while RunParallel walkers scan the fleet.
+// Reports the mean and max writer wait.
+func BenchmarkRequestPathWalkParallelWithWriter(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	var waitNS, waitMax, calls atomic.Int64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(2 * time.Millisecond)
+		defer t.Stop()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				id := f.ids[i%len(f.ids)]
+				i++
+				t0 := time.Now()
+				f.reg.RecordProviderOutcome(id, true, 200, "")
+				d := time.Since(t0).Nanoseconds()
+				waitNS.Add(d)
+				calls.Add(1)
+				for {
+					m := waitMax.Load()
+					if d <= m || waitMax.CompareAndSwap(m, d) {
+						break
+					}
+				}
+			}
+		}
+	}()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			model := f.models[n%len(f.models)]
+			c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false)
+			if c == 0 {
+				b.Fatal("no candidates")
+			}
+			n++
+		}
+	})
+	b.StopTimer()
+	close(stop)
+	<-done
+	if n := calls.Load(); n > 0 {
+		b.ReportMetric(float64(waitNS.Load())/float64(n)/1e3, "writer_wait_us/op")
+		b.ReportMetric(float64(waitMax.Load())/1e3, "writer_wait_max_us")
+	}
+}
+
+// requestPathOnce mirrors the per-request registry write sequence of a served
+// request: commit (inside ReserveProviderEx) + first-content accept + the
+// three completion recorders + the completion-time cooldown clear.
+func requestPathOnce(tb testing.TB, f *benchFleet, model string, n int) {
+	pr := benchPendingRequest(model, n)
+	p, _ := f.reg.ReserveProviderEx(model, pr)
+	if p == nil {
+		tb.Fatal("no provider reserved")
+	}
+	f.reg.RecordCapacityAccept(p.ID, model)
+	f.reg.RecordInferenceSuccess(p.ID, model, "")
+	f.reg.RecordCapacityAcceptOutcome(p.ID, model, false)
+	f.reg.RecordProviderOutcome(p.ID, true, 200, "")
+	if sid := f.reg.GetProviderStableIdentity(p.ID); sid != "" {
+		f.reg.RecordProviderServeOutcome(sid, true, 200, "")
+	}
+	f.reg.ClearDispatchLoadCooldown(p.ID, model)
+	p.RemovePending(pr.RequestID)
+}
+
+func BenchmarkRequestPathSerial(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestPathOnce(b, f, f.models[i%len(f.models)], i)
+	}
+}
+
+func BenchmarkRequestPathParallel(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			requestPathOnce(b, f, f.models[n%len(f.models)], n)
+			n++
+		}
+	})
+}

--- a/coordinator/registry/reserve_commit_test.go
+++ b/coordinator/registry/reserve_commit_test.go
@@ -1,0 +1,666 @@
+package registry
+
+import (
+	"fmt"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the reservation commit without the global write lock (shared
+// mode) against the fleet-wide serialized commit (global mode, the kill
+// switch): the two must admit exactly the same amount, the routing gates must
+// decide identically under concurrent recorders, and the request path must
+// actually parallelize — the whole point of the change.
+
+// setReserveCommitModeForTest switches the reservation commit lock mode on a
+// registry that already exists (the env is read once at construction).
+func setReserveCommitModeForTest(r *Registry, mode reserveCommitMode) {
+	r.reserveCommitMode = mode
+}
+
+func TestParseReserveCommitMode(t *testing.T) {
+	cases := map[string]struct {
+		mode  reserveCommitMode
+		known bool
+	}{
+		"":         {reserveCommitShared, true},
+		"shared":   {reserveCommitShared, true},
+		"anything": {reserveCommitShared, false}, // a typo falls back to shared AND is reported
+		"global":   {reserveCommitGlobal, true},
+		" GLOBAL ": {reserveCommitGlobal, true},
+	}
+	for raw, want := range cases {
+		mode, known := parseReserveCommitMode(raw)
+		if mode != want.mode || known != want.known {
+			t.Errorf("parseReserveCommitMode(%q) = (%s, %v), want (%s, %v)", raw, mode, known, want.mode, want.known)
+		}
+	}
+	t.Setenv(envReserveCommitMode, "")
+	if New(testLogger()).reserveCommitMode != reserveCommitShared {
+		t.Fatal("a registry built without EIGENINFERENCE_RESERVE_COMMIT_MODE must default to shared")
+	}
+}
+
+func forEachCommitMode(t *testing.T, body func(t *testing.T, mode reserveCommitMode)) {
+	for _, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+		t.Run(mode.String(), func(t *testing.T) { body(t, mode) })
+	}
+}
+
+func pendingCountOf(p *Provider) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.pendingCount()
+}
+
+// TestReserveCommitAdmitsExactlyTheSerialCapacityUnderConcurrency: N
+// goroutines committing against ONE provider admit exactly as many requests
+// as a serial loop does (the provider's capacity), the pending set holds
+// exactly those requests, and releasing them returns the count to zero — in
+// both commit modes. This is the no-double-booking invariant: the admit
+// re-check and the pending debit share one p.mu section.
+func TestReserveCommitAdmitsExactlyTheSerialCapacityUnderConcurrency(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "commit-cap-model"
+		p := makeSchedulerProvider(t, reg, "capped", model, 100)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].MaxConcurrency = 4
+		p.mu.Unlock()
+		newReq := func(i int) *PendingRequest {
+			return &PendingRequest{
+				RequestID:             fmt.Sprintf("%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+		}
+
+		// The provider's capacity, measured serially.
+		var serial []*PendingRequest
+		for i := 0; i < 64; i++ {
+			pr := newReq(i)
+			got, _ := reg.ReserveProviderEx(model, pr)
+			if got == nil {
+				break
+			}
+			serial = append(serial, pr)
+		}
+		capacity := len(serial)
+		if capacity < 2 || capacity > 4 {
+			t.Fatalf("serial capacity = %d, want 2..4 (MaxConcurrency 4) for the test to mean anything", capacity)
+		}
+		for _, pr := range serial {
+			p.RemovePending(pr.RequestID)
+		}
+		if n := pendingCountOf(p); n != 0 {
+			t.Fatalf("pending after release = %d, want 0", n)
+		}
+
+		const workers = 32
+		for round := 0; round < 5; round++ {
+			reqs := make([]*PendingRequest, workers)
+			var admitted atomic.Int32
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			for i := range reqs {
+				reqs[i] = newReq(1000 + round*workers + i)
+				wg.Add(1)
+				go func(pr *PendingRequest) {
+					defer wg.Done()
+					<-start
+					got, _ := reg.ReserveProviderEx(model, pr)
+					if got == nil {
+						return
+					}
+					if got != p {
+						t.Errorf("reserved a stranger: %v", got)
+					}
+					admitted.Add(1)
+				}(reqs[i])
+			}
+			close(start)
+			wg.Wait()
+			if int(admitted.Load()) != capacity {
+				t.Fatalf("round %d: %d admitted concurrently, serial capacity is %d", round, admitted.Load(), capacity)
+			}
+			if n := pendingCountOf(p); n != capacity {
+				t.Fatalf("round %d: pending set holds %d, want %d", round, n, capacity)
+			}
+			released := 0
+			for _, pr := range reqs {
+				if pr.ProviderID != p.ID {
+					continue
+				}
+				if p.RemovePending(pr.RequestID) == nil {
+					t.Fatalf("round %d: admitted request %s missing from the pending set", round, pr.RequestID)
+				}
+				released++
+			}
+			if released != capacity {
+				t.Fatalf("round %d: %d requests carry the provider id, %d were admitted", round, released, capacity)
+			}
+			if n := pendingCountOf(p); n != 0 {
+				t.Fatalf("round %d: pending after release = %d, want 0", round, n)
+			}
+		}
+	})
+}
+
+// TestReserveNextFromPlanAdmitsExactlyTheSerialCapacityUnderConcurrency is the
+// plan-path twin of the test above: N goroutines, each consuming its own plan
+// whose next entry is the same capped alternate, admit exactly the serial
+// capacity — the snapshot, admit re-check, probe claim and debit share one
+// p.mu hold in tryReserve too, in both commit modes.
+func TestReserveNextFromPlanAdmitsExactlyTheSerialCapacityUnderConcurrency(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "plan-cap-model"
+		// The winner is only there to be excluded from every plan; the
+		// alternate is the capped provider every plan consumes next.
+		winner := makeSchedulerProvider(t, reg, "plan-winner", model, 100)
+		alt := makeSchedulerProvider(t, reg, "plan-alt", model, 100)
+		alt.mu.Lock()
+		alt.BackendCapacity.Slots[0].MaxConcurrency = 4
+		alt.mu.Unlock()
+		newReq := func(i int) *PendingRequest {
+			return &PendingRequest{
+				RequestID:             fmt.Sprintf("plan-%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+		}
+		planFor := func(pr *PendingRequest) *DispatchPlan {
+			reg.mu.RLock()
+			scan := reg.scanCandidatesLocked(model, pr, false)
+			reg.mu.RUnlock()
+			var w *routingCandidate
+			for _, c := range scan.pool {
+				if c.provider == winner {
+					w = c
+				}
+			}
+			if w == nil {
+				t.Fatal("winner missing from the scan pool")
+			}
+			// The alternate is the plan's only entry while it has headroom and
+			// drops out of the scan pool (hence the plan) once it is full.
+			plan := newDispatchPlan(model, scan, w)
+			if plan.Len() > 1 || (plan.Len() == 1 && plan.entries[0].provider != alt) {
+				t.Fatalf("plan must hold at most the alternate, got %d entries", plan.Len())
+			}
+			return plan
+		}
+
+		var serial []*PendingRequest
+		for i := 0; i < 64; i++ {
+			pr := newReq(i)
+			plan := planFor(pr)
+			if plan.Len() == 0 {
+				break
+			}
+			got, _, _ := reg.ReserveNextFromPlan(pr, plan)
+			if got == nil {
+				break
+			}
+			serial = append(serial, pr)
+		}
+		capacity := len(serial)
+		if capacity < 2 || capacity > 4 {
+			t.Fatalf("serial plan capacity = %d, want 2..4", capacity)
+		}
+		for _, pr := range serial {
+			alt.RemovePending(pr.RequestID)
+		}
+
+		const workers = 32
+		for round := 0; round < 5; round++ {
+			reqs := make([]*PendingRequest, workers)
+			plans := make([]*DispatchPlan, workers)
+			for i := range reqs {
+				reqs[i] = newReq(1000 + round*workers + i)
+				plans[i] = planFor(reqs[i])
+				if plans[i].Len() != 1 {
+					t.Fatalf("round %d: plan %d must hold the idle alternate", round, i)
+				}
+			}
+			var admitted atomic.Int32
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			for i := range reqs {
+				wg.Add(1)
+				go func(pr *PendingRequest, plan *DispatchPlan) {
+					defer wg.Done()
+					<-start
+					got, _, _ := reg.ReserveNextFromPlan(pr, plan)
+					if got == nil {
+						return
+					}
+					if got != alt {
+						t.Errorf("plan reserved a stranger: %v", got)
+					}
+					admitted.Add(1)
+				}(reqs[i], plans[i])
+			}
+			close(start)
+			wg.Wait()
+			if int(admitted.Load()) != capacity {
+				t.Fatalf("round %d: %d admitted concurrently through plans, serial capacity is %d", round, admitted.Load(), capacity)
+			}
+			if n := pendingCountOf(alt); n != capacity {
+				t.Fatalf("round %d: pending set holds %d, want %d", round, n, capacity)
+			}
+			for _, pr := range reqs {
+				if pr.ProviderID == alt.ID {
+					alt.RemovePending(pr.RequestID)
+				}
+			}
+			if n := pendingCountOf(alt); n != 0 {
+				t.Fatalf("round %d: pending after release = %d, want 0", round, n)
+			}
+		}
+	})
+}
+
+// TestCommitProbeClaimAdmitsExactlyOneAcrossSessions drives the half-open
+// probe claim end to end through ReserveProviderEx: two sessions of ONE
+// identity serve the model, the identity's capacity cooldown has expired, and
+// N concurrent reservations must admit exactly one request — the probe — with
+// the gate closed to everyone else afterwards. Commits on different providers
+// do not share p.mu; only the check-and-claim under gate.mu makes this exact.
+func TestCommitProbeClaimAdmitsExactlyOneAcrossSessions(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "probe-race-model"
+		p1 := attestSchedulerProvider(t, reg, "probe-sess-1", model, "SER-PROBE-RACE", 100)
+		p2 := attestSchedulerProvider(t, reg, "probe-sess-2", model, "SER-PROBE-RACE", 100)
+		for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+			reg.RecordCapacityReject(p1.ID, model)
+		}
+		if !reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("precondition: the identity's cooldown must gate both sessions")
+		}
+		expireCapacityCooldown(reg, p1.ID, model)
+
+		const workers = 16
+		reqs := make([]*PendingRequest, workers)
+		var admitted atomic.Int32
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := range reqs {
+			reqs[i] = &PendingRequest{
+				RequestID:             fmt.Sprintf("probe-%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+			wg.Add(1)
+			go func(pr *PendingRequest) {
+				defer wg.Done()
+				<-start
+				if got, _ := reg.ReserveProviderEx(model, pr); got != nil {
+					admitted.Add(1)
+				}
+			}(reqs[i])
+		}
+		close(start)
+		wg.Wait()
+		if admitted.Load() != 1 {
+			t.Fatalf("%d reservations admitted through an expired cooldown, want exactly the one probe", admitted.Load())
+		}
+		if n := pendingCountOf(p1) + pendingCountOf(p2); n != 1 {
+			t.Fatalf("pending across the identity's sessions = %d, want 1", n)
+		}
+		if !reg.CapacityCooldownActive(p1.ID, model) || !reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("the claimed probe must close the gate for both sessions")
+		}
+	})
+}
+
+// commitModeFleets builds one fleet-scale fixture per commit mode with the same
+// fault script applied: a breaker-open advertiser, a health-ejected advertiser,
+// a capacity-cooled advertiser, a dispatch-load-cooled advertiser, a
+// tools-shape inference-error-cooled advertiser and a budget-clamped
+// advertiser (one that reports a token budget). Returns the fleets and the
+// faulted provider ids by fault kind.
+func commitModeFleets(t *testing.T, model string) (map[reserveCommitMode]*benchFleet, map[string]string) {
+	t.Helper()
+	fleets := map[reserveCommitMode]*benchFleet{}
+	for _, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+		f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+		setReserveCommitModeForTest(f.reg, mode)
+		fleets[mode] = f
+	}
+	ref := fleets[reserveCommitShared]
+	var budgeted, others []int
+	for i := range ref.ids {
+		if !benchProviderAdvertises(ref, i, model) {
+			continue
+		}
+		// Even providers carry a live token budget for their primary model
+		// (benchHeartbeat), which is what the clamp gates.
+		if i%2 == 0 && ref.models[i%benchFleetModels] == model && len(budgeted) < 1 {
+			budgeted = append(budgeted, i)
+		} else {
+			others = append(others, i)
+		}
+	}
+	if len(budgeted) < 1 || len(others) < 8 {
+		t.Fatalf("fixture too small: budgeted=%d others=%d", len(budgeted), len(others))
+	}
+	faulted := map[string]string{
+		"breaker":           ref.ids[others[0]],
+		"ejected":           ref.ids[others[1]],
+		"capacity_cooldown": ref.ids[others[2]],
+		"dispatch_load":     ref.ids[others[3]],
+		"error_cooldown":    ref.ids[others[4]],
+		"budget_clamp":      ref.ids[budgeted[0]],
+	}
+	for _, f := range fleets {
+		r := f.reg
+		for i := 0; i < providerBreakerConsecTrip; i++ {
+			r.RecordProviderOutcome(faulted["breaker"], false, 500, "internal error")
+		}
+		r.mu.RLock()
+		ejectedP := r.providers[faulted["ejected"]]
+		r.mu.RUnlock()
+		ejectedP.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-MODE-EJECT"})
+		for i := 0; i < healthEjectionConsecTrip+1; i++ {
+			r.RecordProviderServeOutcome("serial:SER-MODE-EJECT", false, 500, "boom")
+		}
+		for i := 0; i < r.capacityCooldownCfg.Threshold+1; i++ {
+			r.RecordCapacityReject(faulted["capacity_cooldown"], model)
+		}
+		r.RecordDispatchLoadFailure(faulted["dispatch_load"], model)
+		for i := 0; i < inferenceErrorThreshold; i++ {
+			r.RecordInferenceError(faulted["error_cooldown"], model, 500, RequestTraits{HasTools: true}.CooldownShape())
+		}
+		r.RecordCapacityReject(faulted["budget_clamp"], model)
+		if !r.ProviderBreakerOpen(faulted["breaker"]) || !r.HealthEjectionOpen("serial:SER-MODE-EJECT") ||
+			!r.CapacityCooldownActive(faulted["capacity_cooldown"], model) ||
+			!r.dispatchLoadCooled(faulted["dispatch_load"], model, time.Now()) ||
+			!r.InferenceErrorCooldownActive(faulted["error_cooldown"], model, RequestTraits{HasTools: true}.CooldownShape()) ||
+			!r.BudgetClampActive(faulted["budget_clamp"], model) {
+			t.Fatal("precondition: every fault kind must be armed")
+		}
+	}
+	return fleets, faulted
+}
+
+// TestGateDecisionsIdenticalAcrossCommitModesUnderConcurrentRecorders: with
+// the same fault script the routing walks (eligible pool, tallies, preflight
+// verdicts) are identical in both commit modes, before and after a phase of
+// concurrent scans, reservations and recorders — the recorders never touch
+// r.mu, so the race detector is what proves the interleavings are safe, and
+// the gate-level outcomes of every faulted provider match across modes.
+func TestGateDecisionsIdenticalAcrossCommitModesUnderConcurrentRecorders(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	fleets, faulted := commitModeFleets(t, benchFleetModelID(0))
+	model := benchFleetModelID(0)
+	shapes := []struct {
+		name   string
+		traits RequestTraits
+	}{
+		{name: "plain"},
+		{name: "tools", traits: RequestTraits{HasTools: true}},
+	}
+	compareWalks := func(stage string) {
+		t.Helper()
+		for _, shape := range shapes {
+			var want walkOutcome
+			for i, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+				pr := benchPendingRequest(model, 0)
+				pr.Traits = shape.traits
+				got := runWalks(fleets[mode].reg, model, pr, shape.traits, false)
+				if i == 0 {
+					want = got
+					continue
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("%s/%s: walks differ across commit modes\n shared: %+v\n global: %+v", stage, shape.name, want, got)
+				}
+			}
+			for kind, id := range faulted {
+				pr := benchPendingRequest(model, 0)
+				pr.Traits = shape.traits
+				got := runWalks(fleets[reserveCommitShared].reg, model, pr, shape.traits, false)
+				for _, poolID := range got.pool {
+					if poolID == id && (kind != "error_cooldown" || shape.name == "tools") {
+						t.Fatalf("%s/%s: %s provider %s is in the eligible pool", stage, shape.name, kind, id)
+					}
+				}
+			}
+		}
+		now := time.Now()
+		for kind, id := range faulted {
+			var want gateOutcomes
+			for i, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+				r := fleets[mode].reg
+				r.mu.RLock()
+				p := r.providers[id]
+				r.mu.RUnlock()
+				got := collectGateOutcomes(r, p, model, now)
+				if i == 0 {
+					want = got
+					continue
+				}
+				if got != want {
+					t.Fatalf("%s: %s provider gate outcomes differ across commit modes\n shared: %+v\n global: %+v", stage, kind, want, got)
+				}
+			}
+		}
+	}
+	compareWalks("before")
+
+	// Concurrent phase: scans, reservations and every per-request recorder on
+	// HEALTHY advertisers (their gate decisions cannot change), interleaved
+	// with the faulted providers' state being read by every scan. Identical
+	// scripts on both fleets; the interleaving itself is what the race
+	// detector checks.
+	healthy := func(f *benchFleet) []string {
+		var out []string
+		for i, id := range f.ids {
+			if !benchProviderAdvertises(f, i, model) {
+				continue
+			}
+			isFaulted := false
+			for _, fid := range faulted {
+				if fid == id {
+					isFaulted = true
+				}
+			}
+			if !isFaulted {
+				out = append(out, id)
+			}
+		}
+		return out
+	}
+	for mode, f := range fleets {
+		r := f.reg
+		ids := healthy(f)
+		const workers, iters = 8, 120
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				for i := 0; i < iters; i++ {
+					id := ids[(w*iters+i)%len(ids)]
+					switch i % 7 {
+					case 0:
+						pr := benchPendingRequest(model, 100_000+w*iters+i)
+						if p, _ := r.ReserveProviderEx(model, pr); p != nil {
+							p.RemovePending(pr.RequestID)
+						}
+					case 1:
+						r.QuickCapacityCheckForRequest(model, 600, 512, RequestTraits{HasTools: i%2 == 0}, false)
+					case 2:
+						r.RecordProviderOutcome(id, true, 200, "")
+					case 3:
+						r.RecordCapacityAccept(id, model)
+					case 4:
+						r.RecordInferenceSuccess(id, model, "base")
+					case 5:
+						if sid := r.GetProviderStableIdentity(id); sid != "" {
+							r.RecordProviderServeOutcome(sid, true, 200, "")
+						}
+						r.ClearDispatchLoadCooldown(id, model)
+					case 6:
+						r.PredictServable(model, 600, 600, 512, 128_000, RequestTraits{}, false)
+					}
+				}
+			}(w)
+		}
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("%s: concurrent phase failed", mode)
+		}
+	}
+	compareWalks("after")
+}
+
+// TestRequestPathParallelSpeedup guards against the walk-wide-lock regression:
+// scan + commit + the five per-request recorders must parallelize. Before this
+// branch the parallel variant ran at ~1.0–1.3x the serial one (every writer
+// drained the fleet-scan reader batch) while a read-only fleet walk on the
+// same box parallelized ~3.5x; with per-identity gates and the read-locked
+// commit the request path must reach at least 4x at 16 threads.
+//
+// The machine's own parallel ceiling is measured alongside (a pure RLock
+// fleet walk, no writers): a box busy with other work cannot show 4x for ANY
+// lock design, so on such a box the guard falls back to the relative
+// property — the request path parallelizes at least 60% as well as the
+// read-only walk — which the old global-write-lock path fails by a wide
+// margin (1.2x vs 3.5x). Each quantity is the best of three interleaved
+// fixed-work measurements so load drifting between them does not fake a
+// ratio. A box
+// whose 1-minute load average exceeds twice GOMAXPROCS cannot measure
+// parallelism at all (lock-holder preemption dominates every scheme); the
+// numbers are logged and the guard skips. Also skipped under the race
+// detector (it serializes goroutines) and on small machines.
+func TestRequestPathParallelSpeedup(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("throughput guard is meaningless under the race detector")
+	}
+	if testing.Short() {
+		t.Skip("-short")
+	}
+	procs := runtime.GOMAXPROCS(0)
+	if procs < 8 {
+		t.Skipf("GOMAXPROCS=%d; the speed-up guard needs >= 8", procs)
+	}
+	f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+	walk := func(n int) {
+		model := f.models[n%len(f.models)]
+		if c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false); c == 0 {
+			t.Fatal("no candidates")
+		}
+	}
+	var seq atomic.Int64
+	path := func(n int) {
+		requestPathOnce(t, f, f.models[n%len(f.models)], n)
+	}
+	// Fixed work per measurement (no iteration search): ops calls, serially or
+	// split evenly across GOMAXPROCS goroutines; the result is ns per op.
+	const ops = 2000
+	timeOps := func(op func(int), parallel bool) int64 {
+		start := time.Now()
+		if !parallel {
+			for i := 0; i < ops; i++ {
+				op(int(seq.Add(1)))
+			}
+			return time.Since(start).Nanoseconds() / ops
+		}
+		var wg sync.WaitGroup
+		per := ops / procs
+		for w := 0; w < procs; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < per; i++ {
+					op(int(seq.Add(1)))
+				}
+			}()
+		}
+		wg.Wait()
+		return time.Since(start).Nanoseconds() / int64(per*procs)
+	}
+	measure := map[string]func() int64{
+		"read serial":   func() int64 { return timeOps(walk, false) },
+		"read parallel": func() int64 { return timeOps(walk, true) },
+		"path serial":   func() int64 { return timeOps(path, false) },
+		"path parallel": func() int64 { return timeOps(path, true) },
+	}
+	order := []string{"read serial", "read parallel", "path serial", "path parallel"}
+	best := map[string]int64{}
+	for round := 0; round < 3; round++ {
+		for _, name := range order {
+			ns := measure[name]()
+			if cur, ok := best[name]; !ok || ns < cur {
+				best[name] = ns
+			}
+		}
+	}
+	readSpeedup := float64(best["read serial"]) / float64(best["read parallel"])
+	pathSpeedup := float64(best["path serial"]) / float64(best["path parallel"])
+	load, load1 := loadAverage()
+	t.Logf("read-only walk: serial %v/op, parallel %v/op, speed-up %.2fx (the box's ceiling)",
+		time.Duration(best["read serial"]), time.Duration(best["read parallel"]), readSpeedup)
+	t.Logf("request path: serial %v/op, parallel %v/op at %d threads, speed-up %.2fx (%s)",
+		time.Duration(best["path serial"]), time.Duration(best["path parallel"]), procs, pathSpeedup, load)
+	if load1 > 2*float64(procs) {
+		t.Skipf("box saturated (1-minute load %.0f on %d procs): parallelism cannot be measured here", load1, procs)
+	}
+	if readSpeedup >= 4 {
+		if pathSpeedup < 4 {
+			t.Fatalf("request path parallel speed-up %.2fx at %d threads, want >= 4x (a walk-wide lock is back?)", pathSpeedup, procs)
+		}
+		return
+	}
+	// Busy box: hold the relative property instead.
+	if pathSpeedup < 0.6*readSpeedup {
+		t.Fatalf("request path parallel speed-up %.2fx is below 60%% of the read-only walk's %.2fx on this box (a walk-wide lock is back?)",
+			pathSpeedup, readSpeedup)
+	}
+	t.Logf("busy box (read-only ceiling %.2fx < 4x): asserted the relative property only", readSpeedup)
+}
+
+// loadAverage returns uptime's load-average text and the parsed 1-minute
+// value (0 when unavailable).
+func loadAverage() (text string, load1 float64) {
+	out, err := exec.Command("uptime").Output()
+	if err != nil {
+		return "load n/a", 0
+	}
+	text = "load n/a"
+	if i := strings.Index(string(out), "load"); i >= 0 {
+		text = strings.TrimSpace(string(out)[i:])
+	}
+	// "load averages: 1.23 4.56 7.89" (darwin) / "load average: 1.23, 4.56, 7.89" (linux)
+	fields := strings.Fields(strings.NewReplacer(",", " ", ":", " ").Replace(text))
+	for i, fld := range fields {
+		if strings.HasPrefix(fld, "average") && i+1 < len(fields) {
+			fmt.Sscanf(fields[i+1], "%f", &load1)
+			break
+		}
+	}
+	return text, load1
+}

--- a/coordinator/registry/routing_rejection_classification.go
+++ b/coordinator/registry/routing_rejection_classification.go
@@ -1,0 +1,28 @@
+package registry
+
+import "time"
+
+// classifyRejectedProvider identifies the rejection states that control the
+// fail-open rescan and the capacity/no-provider response. These are routing
+// decisions, so a view loaded before a shared-identity rebind must be confirmed
+// before its now-empty source gate can suppress either classification.
+// Caller holds r.mu and no p.mu; p.mu stays held through the reads and their
+// confirmation, preventing another rebind from invalidating the new view.
+func (r *Registry) classifyRejectedProvider(view gateView, model string, traits RequestTraits, selfRouteOwner, ignoreProviderBreaker bool, now time.Time) (breaker, capacity bool) {
+	p := view.p
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for {
+		g := view.g
+		breaker = !ignoreProviderBreaker && (g.breakerOpenAt(now.UnixNano()) ||
+			(healthEjectionEnabled() && r.ejectionOpenFor(g, stableProviderIdentityLocked(p), now.UnixNano())))
+		// Only a pair that otherwise passes routing is transient capacity.
+		// A simultaneous structural failure must remain no-provider, and drain
+		// marks use the same capacity path as a provider's reject cooldown.
+		capacity = (providerDrainingLocked(p, now) || g.capacityCooled(model, now)) &&
+			r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, true)
+		if !view.moved() {
+			return breaker, capacity
+		}
+	}
+}

--- a/coordinator/registry/routing_rejection_classification_test.go
+++ b/coordinator/registry/routing_rejection_classification_test.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestRejectedProviderClassificationFollowsSharedRebind(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	for _, tc := range []struct {
+		name              string
+		set               func(*gateState, time.Time)
+		breaker, capacity bool
+	}{
+		{"breaker", func(g *gateState, until time.Time) { g.breakerUntil = until }, true, false},
+		{"ejection", func(g *gateState, until time.Time) { g.ejectionUntil = until }, true, false},
+		{"capacity", func(g *gateState, until time.Time) {
+			g.capacityCooldowns["m"] = &capacityCooldownEntry{expiry: until}
+		}, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p1 := makeSchedulerProvider(t, reg, "classify-rebind-1", "m", 100)
+			p2 := makeSchedulerProvider(t, reg, "classify-rebind-2", "m", 100)
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-CLASSIFY"}
+			p1.SetAttestationResult(identity)
+			p2.SetAttestationResult(identity)
+			now := time.Now()
+			withGateForSession(reg, p1.ID, func(g *gateState) { tc.set(g, now.Add(time.Minute)) })
+			// The snapshot rejected p1, then classification loaded its shared
+			// gate. Enrichment occurs before classification reads that gate.
+			reg.mu.RLock()
+			var snapshot routingSnapshot
+			ok, _ := reg.snapshotProviderIntoLockedEx(&snapshot, p1, "m", RequestTraits{}, false, false, now)
+			reg.mu.RUnlock()
+			if ok {
+				t.Fatal("precondition: the snapshot must reject the provider")
+			}
+			view := reg.gateViewOf(p1)
+			p1.SetAttestationResult(&attestation.VerificationResult{
+				Valid: true, PublicKey: identity.PublicKey, SerialNumber: "SER-CLASSIFY",
+			})
+			if view.g == p1.gate.Load() || view.g != p2.gate.Load() ||
+				view.g.breakerOpenAt(now.UnixNano()) || view.g.ejectedAt(now.UnixNano()) || view.g.capacityCooled("m", now) {
+				t.Fatal("precondition: the loaded source must be the sibling's emptied gate")
+			}
+			reg.mu.RLock()
+			breaker, capacity := reg.classifyRejectedProvider(view, "m", RequestTraits{}, false, false, now)
+			reg.mu.RUnlock()
+			if breaker != tc.breaker || capacity != tc.capacity {
+				t.Fatalf("classification = breaker:%v capacity:%v, want %v/%v", breaker, capacity, tc.breaker, tc.capacity)
+			}
+			breakerCount, capacityCount := 0, 0
+			if breaker {
+				breakerCount++
+			}
+			if capacity {
+				capacityCount++
+			}
+			if shouldBypassBreakerFailOpen(nil, breakerCount, capacityCount, 0) != tc.breaker {
+				t.Fatal("moved gate produced the wrong fail-open rescan decision")
+			}
+		})
+	}
+}
+
+func TestRejectedProviderClassificationKeepsDrainTransient(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "classify-draining", "m", 100)
+	p.mu.Lock()
+	p.drainingUntil = time.Now().Add(time.Minute)
+	p.mu.Unlock()
+	reg.mu.RLock()
+	scan := reg.scanCandidatesLocked("m", &PendingRequest{Model: "m", RequestedMaxTokens: 32}, false)
+	reg.mu.RUnlock()
+	if scan.candidateCount != 0 || scan.capacityRejections != 1 || scan.breakerRejected != 0 {
+		t.Fatalf("draining scan = candidates:%d capacity:%d breaker:%d", scan.candidateCount, scan.capacityRejections, scan.breakerRejected)
+	}
+	p.mu.Lock()
+	p.RuntimeVerified = false
+	p.mu.Unlock()
+	reg.mu.RLock()
+	scan = reg.scanCandidatesLocked("m", &PendingRequest{Model: "m", RequestedMaxTokens: 32}, false)
+	reg.mu.RUnlock()
+	if scan.capacityRejections != 0 {
+		t.Fatal("a draining provider that also fails structural gates counted as transient capacity")
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -492,8 +492,10 @@ type providerReservationScan struct {
 //
 // In-flight token-budget ledger: the reservation itself IS the debit. Expensive
 // fleet scans share r.mu for reading; the winner is then re-snapshotted and
-// committed inside a short r.mu WRITE section. addPendingLocked records the
-// request before that section ends, so every later commit sees the debit through
+// committed inside a short section under the winner's p.mu (r.mu is only read
+// — see commitProviderReservation; the global mode is the kill switch).
+// addPendingLocked records the request before that section ends, so every
+// later commit on that provider sees the debit through
 // fillSnapshotPendingAndPool and freeMemoryAdmits (including the reconstructed
 // whole-box pool) before it can reserve. Concurrent scans therefore do not
 // double-spend reported headroom across models. Heartbeat re-sync remains safe:
@@ -537,7 +539,7 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 			return nil, failedDecision(), nil
 		}
 
-		// AdmitUS covers the commit phase: the write-lock wait plus the
+		// AdmitUS covers the commit phase: the lock waits plus the
 		// current-state re-check and the pending debit.
 		tCommitStart := time.Now()
 		provider, candidate, outcome, rejected := r.commitProviderReservation(
@@ -575,8 +577,8 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 
 // scanProviderReservation performs the expensive fleet walk under a shared
 // registry lock. Concurrent requests may scan together; no provider capacity is
-// consumed until commitProviderReservation acquires the short write section and
-// revalidates the winner against current cross-model pending debits.
+// consumed until commitProviderReservation takes the winner's p.mu and
+// revalidates it against current cross-model pending debits.
 func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, excludeIDs ...string) providerReservationScan {
 	// Profiler stamps: scan-lock wait (from here to the scan RLock) and the
 	// scan itself land on the decision as LockWaitUS / ScanUS; ~25 ns each.
@@ -640,19 +642,34 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 	return result
 }
 
-// commitProviderReservation is the short serialized phase. It repeats the full
+// commitProviderReservation is the short commit phase. It repeats the full
 // current-state capacity chain before adding the pending debit, so concurrent
 // scans cannot double-spend a provider's shared cross-model token pool.
+//
+// Locking (reserveCommitShared, the default): r.mu is held for READING — the
+// commit needs the provider identity, catalog and cache-routing configuration
+// to be stable, not the fleet to be frozen — and everything that decides the
+// reservation runs under the winner's p.mu in ONE section: the fresh snapshot,
+// the cost rebuild, the "winner unchanged since scan" compare, the admit
+// re-check, the probe claim and the pending debit. Double-booking is prevented
+// where it always was (providerCanAdmitLockedEx + addPendingLocked under
+// p.mu); the herd compare is exact because it compares the winner's own
+// counters read under the same p.mu that debits them; the half-open probe
+// claim is check-and-claim under gate.mu. Nothing here drains the fleet-scan
+// reader batch, which is what each write acquisition cost before.
+// reserveCommitGlobal takes r.mu for writing instead — the previous
+// fleet-wide serialization, kept as the kill switch.
 func (r *Registry) commitProviderReservation(
 	model string,
 	pr *PendingRequest,
 	scan providerReservationScan,
 	excludeIDs ...string,
 ) (*Provider, *routingCandidate, reservationCommitOutcome, RoutingDecision) {
-	hold := r.lockWrite("commit")
-	defer hold.unlock()
+	lock := r.commitLock("commit")
+	lock.lock()
+	defer lock.unlock()
 
-	// The shared scan and write-lock wait consume the same absolute request
+	// The shared scan and any lock wait consume the same absolute request
 	// clock as queueing and provider handoff. Never debit capacity for work whose
 	// first-content budget is already gone. One clock read serves the whole
 	// commit section (deadline, re-snapshot, cost, admit, probe claim).
@@ -677,8 +694,8 @@ func (r *Registry) commitProviderReservation(
 
 	// A breaker bypass is valid only while breaker-open providers remain the
 	// sole route. Re-run the normal pass at commit time; this rare emergency path
-	// may scan under the write lock so a newly healthy provider cannot race the
-	// fail-open decision.
+	// re-scans under the commit lock so a newly healthy provider is preferred
+	// over the fail-open choice.
 	if scan.candidates.ignoreProviderBreaker {
 		normalWinner, normal := r.selectBestCandidateScanLocked(
 			model, pr, false, excludeIDs...)
@@ -689,6 +706,8 @@ func (r *Registry) commitProviderReservation(
 		}
 	}
 
+	// Ownership / serial filters take p.mu themselves — evaluate them before
+	// the commit section below acquires it.
 	owned := providerOwnedBy(p, pr.OwnerAccountID)
 	if pr.SelfRouteOnly && !owned {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
@@ -703,19 +722,20 @@ func (r *Registry) commitProviderReservation(
 		}
 	}
 	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-	snapshot, ok := r.snapshotProviderLockedEx(
-		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now)
-	if !ok {
+
+	// Commit section: snapshot, cost, compare, admit and debit under ONE p.mu
+	// hold, so no other commit can change this provider between the compare
+	// and the debit.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var snapshot routingSnapshot
+	if ok, _ := r.snapshotProviderIntoPLockedEx(
+		&snapshot, p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now); !ok {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
-	if pr.RequiresVision {
-		p.mu.Lock()
-		servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
-		p.mu.Unlock()
-		if !servesVision {
-			return nil, nil, reservationCandidateRejected,
-				routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
-		}
+	if pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust) {
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
 	}
 	candidate, reason, ok := r.buildCandidateWithReason(snapshot, pr, now)
 	if !ok {
@@ -727,11 +747,13 @@ func (r *Registry) commitProviderReservation(
 		return nil, nil, reservationCandidateRejected,
 			routingDecisionForCommitRejection(model, rejectNone, true)
 	}
-	r.applyCacheRoutingDiscount(p, model, pr, candidate)
+	r.applyCacheRoutingDiscountPLocked(p, model, pr, candidate)
 
 	// Another reservation changed this winner after the shared scan. Re-scan the
 	// fleet so cost ranking observes that debit instead of herding the whole scan
-	// cohort onto the formerly-cheapest provider.
+	// cohort onto the formerly-cheapest provider. The counters compared here
+	// were read under the p.mu this section still holds, so a concurrent commit
+	// on the same provider is either fully before (and visible) or fully after.
 	if snapshot.pendingForModel != selected.snapshot.pendingForModel ||
 		snapshot.totalPending != selected.snapshot.totalPending ||
 		candidate.effectiveQueue != selected.effectiveQueue ||
@@ -739,17 +761,21 @@ func (r *Registry) commitProviderReservation(
 		return nil, nil, reservationNeedsRescan, RoutingDecision{}
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	if !r.providerCanAdmitLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
+	// Half-open capacity probe: check-and-claim under gate.mu (p.mu → gate.mu).
+	// A pair whose expired cooldown was claimed by a concurrent commit for the
+	// same identity is closed again; reject rather than leak a second probe.
+	if !r.tryClaimCapacityProbe(p, model, now) {
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, rejectCapacity, false)
+	}
 
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
-	r.claimCapacityProbeLocked(p.ID, model, now)
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
@@ -881,15 +907,27 @@ func routingDecisionForCandidate(model string, provider *Provider, candidate *ro
 }
 
 // applyCacheRoutingDiscount reads the candidate's own snapshot (the scan
-// builds it in place; no copy is taken).
+// builds it in place; no copy is taken). The caller does NOT hold p.mu (the
+// scan): the hint currency check takes it.
 func (r *Registry) applyCacheRoutingDiscount(p *Provider, model string, pr *PendingRequest, candidate *routingCandidate) {
-	if len(pr.cacheRoutingHints) == 0 {
-		return
-	}
 	hint, ok := pr.cacheRoutingHints[p.ID]
 	if !ok || !hint.currentForProvider(p, model) {
 		return
 	}
+	r.applyCacheHintDiscount(hint, candidate)
+}
+
+// applyCacheRoutingDiscountPLocked is applyCacheRoutingDiscount for a caller
+// that already holds p.mu (the reservation commit).
+func (r *Registry) applyCacheRoutingDiscountPLocked(p *Provider, model string, pr *PendingRequest, candidate *routingCandidate) {
+	hint, ok := pr.cacheRoutingHints[p.ID]
+	if !ok || !hint.currentForProviderLocked(p, model) {
+		return
+	}
+	r.applyCacheHintDiscount(hint, candidate)
+}
+
+func (r *Registry) applyCacheHintDiscount(hint cacheRoutingHint, candidate *routingCandidate) {
 	prefillTPS := resolvePrefillTPS(&candidate.snapshot)
 	if prefillTPS <= 0 || math.IsNaN(prefillTPS) || math.IsInf(prefillTPS, 0) {
 		return
@@ -1174,41 +1212,12 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		if !ok {
 			arena.release(c)
 			scan.tallyGate(gateReason)
-			// Count providers a breaker-bypassed fail-open re-scan COULD rescue: those
-			// dropped by the node-health breaker OR the stable-identity health-ejection
-			// gate (both are bypassed when ignoreProviderBreaker is set). Without
-			// counting ejection here, ejecting EVERY provider for a model would leave
-			// winner==nil with breakerRejected==0, so shouldBypassBreakerFailOpen would
-			// NOT fire and the model would be zeroed out. Only meaningful on the normal pass.
-			if !ignoreProviderBreaker {
-				if r.providerBreakerOpenLocked(p.ID, now) {
-					breakerRejected++
-				} else if healthEjectionEnabled() {
-					// p.mu is not held here (snapshot released it); take it for the
-					// identity read (r.mu→p.mu is the established order).
-					p.mu.Lock()
-					sid := stableProviderIdentityLocked(p)
-					p.mu.Unlock()
-					if sid != "" && r.healthEjectionOpenLocked(sid, now) {
-						breakerRejected++
-					}
-				}
+			breaker, capacity := r.classifyRejectedProvider(
+				r.gateViewOf(p), model, pr.Traits, relaxTrust, ignoreProviderBreaker, now)
+			if breaker {
+				breakerRejected++
 			}
-			// A pair dropped ONLY by the capacity-reject cooldown is TRANSIENT
-			// capacity, not structural absence — count it as a capacityRejection
-			// (mirroring quickCapacityCheck) so an all-cooled model classifies as
-			// over_capacity (429/queue material) rather than no_provider. The
-			// ignoreCapacityCooldown re-run of the shared gate keeps a pair that
-			// ALSO fails a structural gate out of the count; both checks are
-			// cheap and only run on the already-rare drop path.
-			// A draining provider (drain_state.go) is the same transient
-			// class: present, serving the model, back after its restart.
-			p.mu.Lock()
-			transient := r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)
-			otherwiseRoutable := transient &&
-				r.providerPassesRoutingGatesLockedEx(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker, true)
-			p.mu.Unlock()
-			if otherwiseRoutable {
+			if capacity {
 				capacityRejections++
 			}
 			continue
@@ -1695,58 +1704,17 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	if ok, reason := r.providerServesRoutableModelReasonLocked(p, model, selfRouteOwner); !ok {
 		return false, reason
 	}
-	// Skip a provider-model pair cooling down after a dispatch-time load
-	// failure ("insufficient memory") — it would instant-503 again, burning a
-	// dispatch attempt.
-	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
-		return false, GateDispatchLoadCooldown
-	}
-	// Skip a triple quarantined by the inference-error circuit breaker for THIS
-	// request shape: repeated provider-side (5xx) failures — e.g. a deterministic
-	// chat-template render crash on tool schemas — mean a retry here fails
-	// identically, so routing must fall to a different provider. Shape-keyed so a
-	// tool failure does not deroute clean text traffic. Cleared by
-	// RecordInferenceSuccess (same shape) or by TTL expiry.
-	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
-		return false, GateErrorCooldown
-	}
-	// Skip a (provider, model) pair quarantined by the capacity-reject cooldown:
-	// it kept capacity-rejecting with ZERO interleaved accepts (the black-hole
-	// signature — e.g. a box whose engine misreports its token budget), so a
-	// dispatch here is a guaranteed bounce while its idle-looking heartbeats
-	// keep winning the cost scheduler. A busy box that is also SERVING never
-	// trips this (any accept resets the streak), and the pair is re-probed once
-	// its TTL expires. See capacity_cooldown.go.
-	// A DRAINING provider (heartbeat status "draining" or a typed draining
-	// rejection — drain_state.go) rides the same transient branch: it refuses
-	// every dispatch until it restarts, so it is skipped here and counted as
-	// a capacityRejection by the scan/preflight re-check, never as absence.
-	// It is tallied under GateCapacityCooldown on the routing record.
-	if !ignoreCapacityCooldown &&
-		(r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) {
+	// The identity's fault-tracker gates (gate_state.go): cached on the
+	// connected provider, so the five reads are atomic loads for a provider
+	// with no fault state and one short gate.mu section per tracker that has
+	// state — and confirmed against p.gate afterwards (gateView), so a rebind
+	// landing mid-read cannot hand the scan an emptied gate.
+	if !ignoreCapacityCooldown && providerDrainingLocked(p, now) {
 		return false, GateCapacityCooldown
 	}
-	// Skip a provider quarantined by the per-provider node-health breaker: a
-	// node returning GENUINE-FAULT errors (500/502/504 or a
-	// fault-shaped 503) for ~all of its requests is sick regardless of model or
-	// shape, so it is derouted fleet-wide. This catches the node that fault-503s
-	// every request — invisible to the shape-keyed inference-error breaker above
-	// (which skips 503 as a capacity signal). Honored on the normal routing
-	// path; the selectBestCandidateLockedFull fail-open pass sets
-	// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
-	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
-		return false, GateBreaker
-	}
-	// Skip a provider EJECTED by the stable-identity health breaker (health_ejection.go):
-	// a node whose serial/SE-key/account has collapsed to a near-total served-fault
-	// rate is derouted even across reconnects (the session breaker above is wiped on
-	// every disconnect, which the constantly-disconnecting zombies exploit). Same
-	// fail-open contract: skipped on the ignoreProviderBreaker rescan, and an
-	// un-attestable provider (empty stable id) is never ejected.
-	if !ignoreProviderBreaker && healthEjectionEnabled() {
-		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, now) {
-			return false, GateEjection
-		}
+	view := r.gateViewOf(p)
+	if ok, reason := r.gateStateReasonLocked(&view, model, traits, now, ignoreProviderBreaker, ignoreCapacityCooldown); !ok {
+		return false, reason
 	}
 	// Liveness/trust/privacy core. selfRouteOwner relaxes ONLY the hardware-trust
 	// floor (to TrustNone) and private-only admission for a caller's own
@@ -1767,36 +1735,86 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	return true, GateReasonCount
 }
 
-// snapshotProviderLockedEx builds a routing snapshot for p, returning ok=false
-// when p fails any structural/privacy/capacity/trait gate. selfRouteOwner is
-// true when this is a self-route request and p is owned by the requesting
-// account. It (1) drops the hardware-trust floor to TrustNone — a personal Mac
-// will not be MDM/MDA enrolled, so without this it would be unroutable to its
-// own owner — and (2) admits a private-only machine, which is otherwise
-// excluded from the public fleet. Every privacy-critical gate (RuntimeVerified,
-// private-text support, challenge freshness) still applies, so plaintext is
-// never exposed and only the genuinely-signed provider binary serves. traits
-// carry the request shape into the shape-keyed inference-error cooldown and the
-// render-broken / version-floor eligibility gates.
-//
-// ignoreProviderBreaker is threaded into the routing gate: only the
-// selectBestCandidateLockedFull fail-open fallback pass sets it true (to bypass
-// the node-health breaker); every other caller passes false. (The former
-// breaker-honored wrapper snapshotProviderLocked is gone — the fleet walks use
-// snapshotProviderIntoLockedEx directly.) now is the scan clock: hot-path callers
-// walk the whole fleet and must read the wall clock ONCE per scan, not once
-// per provider (runtime.walltime was ~35% of the reservation scan at fleet
-// scale); every time-keyed gate below (challenge freshness, cooldowns,
-// breaker, clamp) evaluates against that single instant.
-func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (routingSnapshot, bool) {
-	var snap routingSnapshot
-	ok, _ := r.snapshotProviderIntoLockedEx(&snap, p, model, traits, selfRouteOwner, ignoreProviderBreaker, now)
-	return snap, ok
+// gateStateReasonLocked evaluates the five fault-tracker gates for the session
+// behind view against its identity's gate and returns the first closed one
+// (GateReasonCount when all pass), in the documented gate precedence. The
+// verdict is confirmed against p.gate (gateView.moved) and re-read from the
+// session's new gate when a rebind landed between the view's load and the
+// reads — the scan, the commit's admit re-check and the preflight all come
+// through here, so none of them can dispatch a session past a breaker or
+// cooldown that moved with it. Caller holds p.mu (for the identity read).
+func (r *Registry) gateStateReasonLocked(view *gateView, model string, traits RequestTraits, now time.Time, ignoreProviderBreaker, ignoreCapacityCooldown bool) (bool, GateReason) {
+	nowNS := now.UnixNano()
+	for {
+		g := view.g
+		reason := GateReasonCount
+		switch {
+		// Skip a provider-model pair cooling down after a dispatch-time load
+		// failure ("insufficient memory") — it would instant-503 again, burning a
+		// dispatch attempt.
+		case g.dispatchLoadCooled(model, now):
+			reason = GateDispatchLoadCooldown
+		// Skip a triple quarantined by the inference-error circuit breaker for THIS
+		// request shape: repeated provider-side (5xx) failures — e.g. a deterministic
+		// chat-template render crash on tool schemas — mean a retry here fails
+		// identically, so routing must fall to a different provider. Shape-keyed so a
+		// tool failure does not deroute clean text traffic. Cleared by
+		// RecordInferenceSuccess (same shape) or by TTL expiry.
+		case g.inferenceErrorCooled(model, traits.CooldownShape(), now):
+			reason = GateErrorCooldown
+		// Skip a (provider, model) pair quarantined by the capacity-reject cooldown:
+		// it kept capacity-rejecting with ZERO interleaved accepts (the black-hole
+		// signature — e.g. a box whose engine misreports its token budget), so a
+		// dispatch here is a guaranteed bounce while its idle-looking heartbeats
+		// keep winning the cost scheduler. A busy box that is also SERVING never
+		// trips this (any accept resets the streak), and the pair is re-probed once
+		// its TTL expires. See capacity_cooldown.go.
+		case !ignoreCapacityCooldown && g.capacityCooled(model, now):
+			reason = GateCapacityCooldown
+		// Skip a provider quarantined by the per-provider node-health breaker: a
+		// node returning GENUINE-FAULT errors (500/502/504 or a
+		// fault-shaped 503) for ~all of its requests is sick regardless of model or
+		// shape, so it is derouted fleet-wide. This catches the node that fault-503s
+		// every request — invisible to the shape-keyed inference-error breaker above
+		// (which skips 503 as a capacity signal). Honored on the normal routing
+		// path; the selectBestCandidateLockedFull fail-open pass sets
+		// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
+		case !ignoreProviderBreaker && g.breakerOpenAt(nowNS):
+			reason = GateBreaker
+		// Skip a provider EJECTED by the stable-identity health breaker (health_ejection.go):
+		// a node whose serial/SE-key/account has collapsed to a near-total served-fault
+		// rate is derouted even across reconnects (the session breaker above is wiped on
+		// every disconnect, which the constantly-disconnecting zombies exploit). Same
+		// fail-open contract: skipped on the ignoreProviderBreaker rescan, and an
+		// un-attestable provider (empty stable id) is never ejected.
+		case !ignoreProviderBreaker && healthEjectionEnabled() && r.ejectionOpenFor(g, stableProviderIdentityLocked(view.p), nowNS):
+			reason = GateEjection
+		}
+		if !view.moved() {
+			return reason == GateReasonCount, reason
+		}
+	}
 }
 
-// snapshotProviderIntoLockedEx is snapshotProviderLockedEx writing into
-// caller-owned storage instead of returning the (large) snapshot by value,
-// and naming WHICH gate dropped a failing provider. The fleet walks
+// snapshotProviderIntoLockedEx builds a routing snapshot for p into
+// caller-owned storage, returning ok=false and the closed GateReason when p
+// fails any structural/privacy/capacity/trait gate. selfRouteOwner is true
+// when this is a self-route request and p is owned by the requesting account:
+// it (1) drops the hardware-trust floor to TrustNone — a personal Mac will not
+// be MDM/MDA enrolled, so without this it would be unroutable to its own owner
+// — and (2) admits a private-only machine, which is otherwise excluded from
+// the public fleet. Every privacy-critical gate (RuntimeVerified, private-text
+// support, challenge freshness) still applies. traits carry the request shape
+// into the shape-keyed inference-error cooldown and the render-broken /
+// version-floor eligibility gates. ignoreProviderBreaker is threaded into the
+// routing gate: only the selectBestCandidateLockedFull fail-open fallback pass
+// sets it true. now is the scan clock: hot-path callers walk the whole fleet
+// and must read the wall clock ONCE per scan, not once per provider; every
+// time-keyed gate (challenge freshness, cooldowns, breaker, clamp) evaluates
+// against that single instant.
+//
+// Writes into caller-owned storage instead of returning the (large) snapshot
+// by value, and names WHICH gate dropped a failing provider. The fleet walks
 // (scanCandidatesLocked, PredictServable) and the fleet sampler
 // (slotEligibilityReasonLocked) hand it the final resting place of the
 // snapshot — a candidate-arena slot or a reused buffer — so a routable
@@ -1810,7 +1828,15 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 func (r *Registry) snapshotProviderIntoLockedEx(dst *routingSnapshot, p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (bool, GateReason) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return r.snapshotProviderIntoPLockedEx(dst, p, model, traits, selfRouteOwner, ignoreProviderBreaker, now)
+}
 
+// snapshotProviderIntoPLockedEx is snapshotProviderIntoLockedEx for a caller
+// that ALREADY holds p.mu — the reservation commit and the plan consumption,
+// which take the snapshot, rebuild the cost, compare and debit inside one p.mu
+// section so nothing can change the provider in between. Caller holds r.mu
+// (either mode) and p.mu.
+func (r *Registry) snapshotProviderIntoPLockedEx(dst *routingSnapshot, p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (bool, GateReason) {
 	if ok, reason := r.providerRoutingGateReasonLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false); !ok {
 		return false, reason
 	}
@@ -1890,9 +1916,11 @@ func (r *Registry) snapshotProviderIntoLockedEx(dst *routingSnapshot, p *Provide
 	// p.LastHeartbeat is when the CURRENT BackendCapacity was delivered
 	// (Heartbeat stamps both in one critical section), which is what the
 	// release-freshness check compares against the clamp time. p.mu and r.mu
-	// are both held here (see lock discipline above).
+	// are both held here (see lock discipline above); the clamp read is one
+	// lock-free flag load unless the identity actually carries a clamp, and is
+	// confirmed against p.gate like the gates above (gateView).
 	rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-	snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+	snap.budgetClamped = r.budgetClampedFor(p, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 	return true, GateReasonCount
 }
@@ -2262,7 +2290,7 @@ func (r *Registry) buildCandidateInto(c *routingCandidate, pr *PendingRequest, n
 	// proportionally to its windowed reject rate. A soft derater, never an
 	// ejection: the candidate stays in the pool, so a degraded-but-only fleet
 	// still serves, and the penalty decays as outcomes age out of the window.
-	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyLocked(snap.provider.ID, snap.model, now)
+	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyFor(snap.provider, snap.model, now)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs + capacityRateMs
 
 	// Estimated time-to-first-token for this candidate. Used for the
@@ -2848,7 +2876,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			// never fit the hardware counts as modelTooLarge — never as
 			// transient capacity, or a fleet of undersized cooled boxes would
 			// read as "busy, retry" for a model that will never fit.
-			if (r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) &&
+			if (r.gateOf(p).capacityCooled(model, now) || providerDrainingLocked(p, now)) &&
 				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) &&
 				p.SystemMetrics.ThermalState != "critical" &&
 				(!requiresVision || r.providerServesVisionModelLocked(p, model, false)) {
@@ -2952,7 +2980,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// (including the budgetless-snapshot hold for reconnecting sessions)
 		// so the preflight cannot report capacity that routing then refuses.
 		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+		snap.budgetClamped = r.budgetClampedFor(p, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/stable_fault_key_test.go
+++ b/coordinator/registry/stable_fault_key_test.go
@@ -29,12 +29,10 @@ func attestSchedulerProvider(t *testing.T, reg *Registry, sessionID, model, seri
 }
 
 func faultKeyOf(r *Registry, sessionID string) string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.faultKeyLocked(sessionID)
+	return r.faultKeyForSession(sessionID)
 }
 
-// faultKeyLocked precedence: bound identity → disconnect cache → session id.
+// faultKeyForSession precedence: bound identity → disconnect cache → session id.
 func TestFaultKeyBindingLifecycle(t *testing.T) {
 	reg := New(testLogger())
 	p := attestSchedulerProvider(t, reg, "sess-bind", "m", "SER-BIND", 50)
@@ -61,10 +59,7 @@ func TestFaultKeyBindingLifecycle(t *testing.T) {
 	// resolves the trailing ErrorCh-flush faults.
 	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-BIND"})
 	reg.Disconnect("sess-bind")
-	reg.mu.RLock()
-	_, hasBinding := reg.faultKeyBySession["sess-bind"]
-	reg.mu.RUnlock()
-	if hasBinding {
+	if sessionIndexed(reg, "sess-bind") {
 		t.Fatal("Disconnect must remove the live session binding")
 	}
 	if got := faultKeyOf(reg, "sess-bind"); got != "serial:SER-BIND" {
@@ -96,10 +91,8 @@ func TestInvalidAttestationDoesNotBindStableFaultKey(t *testing.T) {
 	for i := 0; i < providerBreakerConsecTrip; i++ {
 		reg.RecordProviderOutcome("sess-evil", false, 500, "internal error")
 	}
-	reg.mu.RLock()
-	_, victimPoisoned := reg.providerOutcomes["serial:"+victim]
-	_, sessionKeyed := reg.providerOutcomes["sess-evil"]
-	reg.mu.RUnlock()
+	victimPoisoned := gateHasBreakerWindow(reg, "serial:"+victim)
+	sessionKeyed := gateHasBreakerWindow(reg, "sess-evil")
 	if victimPoisoned {
 		t.Fatal("faults from an invalid attestation poisoned the victim's serial-keyed state")
 	}
@@ -113,10 +106,7 @@ func TestInvalidAttestationDoesNotBindStableFaultKey(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-evil"); got != "serial:SER-REAL" {
 		t.Fatalf("valid attestation must bind, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["serial:SER-REAL"]
-	reg.mu.RUnlock()
-	if !migrated {
+	if !gateHasBreakerWindow(reg, "serial:SER-REAL") {
 		t.Fatal("session-keyed fault state must migrate on the first valid bind")
 	}
 
@@ -167,10 +157,8 @@ func TestFaultStateMigratesOnIdentityRebind(t *testing.T) {
 	}
 
 	// Old keys must not retain orphaned state.
-	reg.mu.RLock()
-	_, sekeyOrphan := reg.providerOutcomes["sekey:PK-MIG"]
-	_, sessOrphan := reg.providerOutcomes["sess-mig"]
-	reg.mu.RUnlock()
+	sekeyOrphan := gateHasBreakerWindow(reg, "sekey:PK-MIG")
+	sessOrphan := gateHasBreakerWindow(reg, "sess-mig")
 	if sekeyOrphan || sessOrphan {
 		t.Fatalf("fault state orphaned under old keys (sekey=%v session=%v)", sekeyOrphan, sessOrphan)
 	}
@@ -338,14 +326,20 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.Disconnect("sess-1")
 
 	stableKey := "serial:" + serial
+	var hasWin, hasOpen, hasStrikes, hasDLC bool
+	readGateForKey(reg, stableKey, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		hasWin = g.outcomes != nil
+		hasOpen = !g.breakerUntil.IsZero()
+		_, hasStrikes = g.inferenceErrorStrikes[modelShapeKey{Model: model, Shape: "base"}]
+		_, hasDLC = g.dispatchLoadCooldowns[model]
+	})
 	reg.mu.RLock()
-	_, hasWin := reg.providerOutcomes[stableKey]
-	_, hasOpen := reg.providerBreakerOpenUntil[stableKey]
-	_, hasStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: stableKey, ModelID: model, Shape: "base"}]
-	_, hasDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: stableKey, ModelID: model}]
 	_, hasPending := reg.pendingModelLoads[modelLoadKey{ProviderID: "sess-1", ModelID: model}]
-	_, hasBinding := reg.faultKeyBySession["sess-1"]
 	reg.mu.RUnlock()
+	hasBinding := sessionIndexed(reg, "sess-1")
 	if !hasWin || !hasOpen || !hasStrikes || !hasDLC {
 		t.Fatalf("identity-keyed fault state must survive Disconnect: win=%v open=%v strikes=%v dlc=%v",
 			hasWin, hasOpen, hasStrikes, hasDLC)
@@ -363,43 +357,39 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.RecordInferenceError("sess-anon", model, 500, "base")
 	reg.RecordDispatchLoadFailure("sess-anon", model)
 	reg.Disconnect("sess-anon")
-	reg.mu.RLock()
-	_, anonWin := reg.providerOutcomes["sess-anon"]
-	_, anonStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: "sess-anon", ModelID: model, Shape: "base"}]
-	_, anonDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: "sess-anon", ModelID: model}]
-	reg.mu.RUnlock()
-	if anonWin || anonStrikes || anonDLC {
-		t.Fatalf("session-keyed residue of an identity-less provider must be dropped: win=%v strikes=%v dlc=%v",
-			anonWin, anonStrikes, anonDLC)
+	if g := rawGateForKey(reg, "sess-anon"); g != nil {
+		t.Fatalf("session-keyed residue of an identity-less provider must be dropped, gate still filed: %+v", g)
+	}
+	if reg.ProviderBreakerOpen("sess-anon") || reg.InferenceErrorCooldownActive("sess-anon", model, "base") ||
+		reg.dispatchLoadCooled("sess-anon", model, time.Now()) {
+		t.Fatal("session-keyed residue of an identity-less provider must not gate")
 	}
 }
 
-// REQUIRED: stale identities expire — the capacity-streak map is bounded by
-// the health-ejection sweep once it grows past its cap.
+// REQUIRED: stale identities expire — an identity whose only state is a
+// capacity streak older than the window is idle, and the gate sweep drops it
+// once no live session references it and the idle grace has passed.
 func TestHealthEjectionCapacityStreakSweep(t *testing.T) {
 	reg := New(testLogger())
 	const rejectStr = "token_budget_exhausted: request exceeds active token budget"
 	for i := 0; i < 2100; i++ {
 		reg.RecordProviderServeOutcome(fmt.Sprintf("serial:churned-%d", i), false, 503, rejectStr)
 	}
-	reg.mu.Lock()
-	for id, s := range reg.healthEjectionCapacityStreaks {
-		s.last = s.last.Add(-(healthEjectionWindow + time.Second))
-		reg.healthEjectionCapacityStreaks[id] = s
-	}
-	size := len(reg.healthEjectionCapacityStreaks)
-	reg.mu.Unlock()
-	if size < 2050 {
-		t.Fatalf("setup produced too few streak entries: %d", size)
+	if n := reg.gateCount(); n < 2050 {
+		t.Fatalf("setup produced too few streak gates: %d", n)
 	}
 
-	// The next record sweeps the stale identities before recording.
-	reg.RecordProviderServeOutcome("serial:live", false, 503, rejectStr)
+	// A live identity records just before the sweep runs far enough in the
+	// future for the churned streaks to have aged out; its own fresh streak
+	// (touched now) keeps it.
+	future := time.Now().Add(gateIdleGrace + healthEjectionWindow + time.Second)
+	withGateForKey(reg, "serial:live", func(g *gateState) {
+		g.ejectionCapacityStreak = capacityStreak{n: 1, last: future}
+		g.touched = future
+	})
+	reg.sweepGates(future)
 
-	reg.mu.RLock()
-	after := len(reg.healthEjectionCapacityStreaks)
-	reg.mu.RUnlock()
-	if after != 1 {
+	if after := reg.gateCount(); after != 1 {
 		t.Fatalf("sweep must drop every stale identity, leaving only the live one; got %d", after)
 	}
 }
@@ -413,11 +403,9 @@ func TestHealthEjectionCapacityStreakStaleReset(t *testing.T) {
 	for i := 0; i < healthEjectionCapacityConsecTrip-1; i++ {
 		reg.RecordProviderServeOutcome(sid, false, 503, rejectStr)
 	}
-	reg.mu.Lock()
-	s := reg.healthEjectionCapacityStreaks[sid]
-	s.last = s.last.Add(-(healthEjectionWindow + time.Second))
-	reg.healthEjectionCapacityStreaks[sid] = s
-	reg.mu.Unlock()
+	withGateForKey(reg, sid, func(g *gateState) {
+		g.ejectionCapacityStreak.last = g.ejectionCapacityStreak.last.Add(-(healthEjectionWindow + time.Second))
+	})
 
 	if ejected, _ := reg.RecordProviderServeOutcome(sid, false, 503, rejectStr); ejected {
 		t.Fatal("a fresh strike after a stale streak must restart the count, not eject")
@@ -452,10 +440,8 @@ func TestAccountLinkageBindsStableFaultKey(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-acct-1"); got != "acct:"+acct {
 		t.Fatalf("account linkage must bind the acct: fallback, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["acct:"+acct]
-	_, sessOrphan := reg.providerOutcomes["sess-acct-1"]
-	reg.mu.RUnlock()
+	migrated := gateHasBreakerWindow(reg, "acct:"+acct)
+	sessOrphan := gateHasBreakerWindow(reg, "sess-acct-1")
 	if !migrated || sessOrphan {
 		t.Fatalf("pre-link session-keyed faults must migrate to the acct: key (migrated=%v orphan=%v)", migrated, sessOrphan)
 	}
@@ -508,10 +494,7 @@ func TestInvalidReattestationKeepsAccountBinding(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-acct-reatt"); got != "serial:SER-REAL-REATT" {
 		t.Fatalf("valid attestation must upgrade the binding, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["serial:SER-REAL-REATT"]
-	reg.mu.RUnlock()
-	if !migrated {
+	if !gateHasBreakerWindow(reg, "serial:SER-REAL-REATT") {
 		t.Fatal("acct:-keyed fault state must migrate to the upgraded serial: key")
 	}
 }
@@ -549,12 +532,19 @@ func TestFaultStreakSurvivesIdentityEnrichmentMidStreak(t *testing.T) {
 		t.Fatalf("enrichment must rebind to the serial key, got %q", got)
 	}
 
-	reg.mu.RLock()
-	w := reg.providerOutcomes["serial:"+serial]
-	he := reg.healthEjectionWindows["serial:"+serial]
-	_, orphan := reg.providerOutcomes["sekey:PK-MERGE"]
-	_, heOrphan := reg.healthEjectionWindows["sekey:PK-MERGE"]
-	reg.mu.RUnlock()
+	var w, he *providerHealthWindow
+	readGateForKey(reg, "serial:"+serial, func(g *gateState) {
+		if g != nil {
+			w, he = g.outcomes, g.ejection
+		}
+	})
+	orphan := gateHasBreakerWindow(reg, "sekey:PK-MERGE")
+	heOrphan := false
+	if g := rawGateForKey(reg, "sekey:PK-MERGE"); g != nil {
+		g.mu.Lock()
+		heOrphan = g.ejection != nil
+		g.mu.Unlock()
+	}
 	if orphan || heOrphan {
 		t.Fatalf("source windows must be deleted after the merge (breaker=%v ejection=%v)", orphan, heOrphan)
 	}

--- a/coordinator/registry/version_history.go
+++ b/coordinator/registry/version_history.go
@@ -2,94 +2,14 @@ package registry
 
 import "time"
 
-// Keep departed identities beyond both the disconnect-cache TTL and the reset
-// throttle/fault windows. Live identities and active quarantines are retained.
+// Version history shares the existing identity gate and its periodic sweep.
+// Retain departed versions beyond the disconnect-cache and reset windows;
+// live sessions and active faults also keep their gate through pruneLocked.
 const identityVersionRetention = 20 * time.Minute
-const identityVersionSweepInterval = time.Minute
 
-func (r *Registry) touchIdentityVersionLocked(stableID string, now time.Time) {
-	if _, exists := r.identityVersions[stableID]; !exists {
-		return
-	}
-	if r.identityVersionSeenAt == nil {
-		r.identityVersionSeenAt = make(map[string]time.Time)
-	}
-	r.identityVersionSeenAt[stableID] = now
-}
-
-// sweepIdentityVersionHistory also runs from the eviction loop, so departed
-// identities expire even when new registrations stop. Registration runs the
-// same sweep opportunistically; both paths share the rate limit under r.mu.
-func (r *Registry) sweepIdentityVersionHistory(now time.Time) {
-	r.mu.RLock()
-	due := len(r.identityVersions) > 0 && now.Sub(r.identityVersionSweepAt) >= identityVersionSweepInterval
-	r.mu.RUnlock()
-	if !due {
-		return
-	}
-	hold := r.lockWrite("version_history")
-	defer hold.unlock()
-	r.pruneIdentityVersionsLocked(now)
-}
-
-func (r *Registry) pruneIdentityVersionsLocked(now time.Time) {
-	if now.Sub(r.identityVersionSweepAt) < identityVersionSweepInterval {
-		return
-	}
-	r.identityVersionSweepAt = now
-	retained := make(map[string]bool, len(r.faultKeyBySession))
-	for _, stableID := range r.faultKeyBySession {
-		retained[stableID] = true
-	}
-	for key, until := range r.inferenceErrorCooldowns {
-		if now.Before(until) {
-			retained[key.ProviderID] = true
-		}
-	}
-	for stableID, until := range r.providerBreakerOpenUntil {
-		if now.Before(until) {
-			retained[stableID] = true
-		}
-	}
-	for stableID, until := range r.healthEjectionUntil {
-		if now.Before(until) {
-			retained[stableID] = true
-		}
-	}
-	for key, strikes := range r.inferenceErrorStrikes {
-		if len(strikes) > 0 && now.Sub(strikes[len(strikes)-1]) < inferenceErrorWindow {
-			retained[key.ProviderID] = true
-		}
-	}
-	for stableID, window := range r.providerOutcomes {
-		if total, _ := window.windowStats(now, providerBreakerWindow); total > 0 {
-			retained[stableID] = true
-		}
-	}
-	for stableID, window := range r.healthEjectionWindows {
-		if total, _ := window.windowStats(now, healthEjectionWindow); total > 0 {
-			retained[stableID] = true
-		}
-	}
-	for stableID, streak := range r.healthEjectionCapacityStreaks {
-		if streak.n > 0 && now.Sub(streak.last) < healthEjectionWindow {
-			retained[stableID] = true
-		}
-	}
-	cutoff := now.Add(-identityVersionRetention)
-	for stableID := range r.identityVersions {
-		seen, known := r.identityVersionSeenAt[stableID]
-		if !known {
-			// Bare test registries or pre-populated history get one full grace
-			// window rather than being discarded at their first sweep.
-			r.touchIdentityVersionLocked(stableID, now)
-			continue
-		}
-		if retained[stableID] || !seen.Before(cutoff) || !r.identityVersionResetAt[stableID].Before(cutoff) {
-			continue
-		}
-		delete(r.identityVersions, stableID)
-		delete(r.identityVersionResetAt, stableID)
-		delete(r.identityVersionSeenAt, stableID)
-	}
+// Caller holds gate.mu. touched records both outcome activity and disconnect,
+// so even a long-lived idle session receives a full reconnect grace window.
+func (g *gateState) versionHistoryActive(now time.Time) bool {
+	return g.identityVersion != "" && (now.Sub(g.touched) <= identityVersionRetention ||
+		(!g.versionResetAt.IsZero() && now.Sub(g.versionResetAt) <= identityVersionRetention))
 }

--- a/coordinator/registry/version_history_test.go
+++ b/coordinator/registry/version_history_test.go
@@ -11,38 +11,31 @@ func TestVersionHistoryRetentionKeepsLiveRecentAndQuarantinedIdentities(t *testi
 	live := bindVersionedSession(t, r, "live-history", "0.9.0", false)
 	now := time.Now()
 	stale := now.Add(-identityVersionRetention - time.Minute)
-	r.mu.Lock()
-	r.identityVersionSeenAt[versionResetStable] = stale
-	for _, id := range []string{"departed", "recent", "quarantined", "recent-reset", "fault-window"} {
-		r.identityVersions[id] = "0.9.0"
-		r.identityVersionSeenAt[id] = stale
+	for _, id := range []string{versionResetStable, "departed", "recent", "quarantined", "recent-reset", "fault-window"} {
+		withGateForKey(r, id, func(g *gateState) {
+			g.identityVersion = "0.9.0"
+			g.touched = stale
+		})
 	}
-	r.identityVersionSeenAt["recent"] = now
-	r.identityVersionResetAt = map[string]time.Time{"departed": stale, "recent-reset": now}
-	r.providerBreakerOpenUntil["quarantined"] = now.Add(time.Minute)
-	r.providerOutcomes["fault-window"] = &providerHealthWindow{}
-	r.providerOutcomes["fault-window"].recordFault(now, false)
-	r.identityVersionSweepAt = time.Time{}
-	r.mu.Unlock()
-	r.sweepIdentityVersionHistory(now)
-	r.mu.RLock()
+	withGateForKey(r, "recent", func(g *gateState) { g.touched = now })
+	withGateForKey(r, "departed", func(g *gateState) { g.versionResetAt = stale })
+	withGateForKey(r, "recent-reset", func(g *gateState) { g.versionResetAt = now })
+	withGateForKey(r, "quarantined", func(g *gateState) { g.breakerUntil = now.Add(time.Minute) })
+	withGateForKey(r, "fault-window", func(g *gateState) { g.healthWindowLocked().recordFault(now, false) })
+	r.sweepGates(now)
 	for _, id := range []string{versionResetStable, "recent", "quarantined", "recent-reset", "fault-window"} {
-		if _, kept := r.identityVersions[id]; !kept {
+		if rawGateForKey(r, id) == nil {
 			t.Errorf("active or recent identity %q was removed", id)
 		}
 	}
-	if _, kept := r.identityVersions["departed"]; kept || len(r.identityVersionResetAt) != 1 {
+	if rawGateForKey(r, "departed") != nil {
 		t.Error("departed version/reset history was retained")
 	}
-	r.mu.RUnlock()
-	// A long-lived session starts its reconnect grace when it disconnects,
-	// not when it originally announced the version.
+	// The reconnect grace starts at disconnect, even if the live provider's
+	// last version observation and outcome were older than the retention.
 	r.Disconnect(live.ID)
-	r.sweepIdentityVersionHistory(now.Add(identityVersionSweepInterval))
-	r.mu.RLock()
-	_, kept := r.identityVersions[versionResetStable]
-	r.mu.RUnlock()
-	if !kept {
+	r.sweepGates(now.Add(time.Minute))
+	if rawGateForKey(r, versionResetStable) == nil {
 		t.Fatal("disconnect did not preserve the recent reconnect window")
 	}
 }
@@ -50,27 +43,23 @@ func TestVersionHistoryRetentionKeepsLiveRecentAndQuarantinedIdentities(t *testi
 func TestVersionHistoryChurnDoesNotRetainDepartedVersionsForever(t *testing.T) {
 	r := New(testLogger())
 	now := time.Now()
-	r.mu.Lock()
-	r.identityVersions = make(map[string]string)
-	r.identityVersionResetAt = make(map[string]time.Time)
 	for minute := range 120 {
 		at := now.Add(time.Duration(minute) * time.Minute)
 		for i := range 100 {
 			id := fmt.Sprintf("departed-%d-%d", minute, i)
-			r.identityVersions[id] = "0.9.1"
-			r.identityVersionResetAt[id] = at
-			r.touchIdentityVersionLocked(id, at)
+			withGateForKey(r, id, func(g *gateState) {
+				g.identityVersion = "0.9.1"
+				g.touched = at
+				g.versionResetAt = at
+			})
 		}
-		r.pruneIdentityVersionsLocked(at)
-		if len(r.identityVersions) > 2100 {
-			t.Fatalf("version history grew past its retention window: %d", len(r.identityVersions))
+		r.sweepGates(at)
+		if count := r.gateCount(); count > 2100 {
+			t.Fatalf("version history grew past its retention window: %d", count)
 		}
 	}
-	r.mu.Unlock()
-	r.sweepIdentityVersionHistory(now.Add(3 * time.Hour))
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if len(r.identityVersions)+len(r.identityVersionSeenAt)+len(r.identityVersionResetAt) != 0 {
+	r.sweepGates(now.Add(3 * time.Hour))
+	if r.gateCount() != 0 {
 		t.Fatal("idle sweep did not release departed version metadata")
 	}
 }

--- a/coordinator/registry/version_reset.go
+++ b/coordinator/registry/version_reset.go
@@ -2,220 +2,133 @@ package registry
 
 import "time"
 
-// Version-changed reconnect reset (R1, upgrade waves).
-//
-// The Swift provider's auto-update restart exits the process without a
-// WebSocket close frame (ProcessLifecycle.restartAfterUpdate → launchctl
-// kickstart -k → exit), so the coordinator books it as an ABRUPT drop and the
-// flush of every in-flight request lands as a 502 strike on the provider's
-// STABLE identity — deliberately, because that flush is the reconnecting-
-// zombie signal. A fleet upgrade therefore returned every box quarantined
-// (2026-08-31: inference-error cooldowns for 5 min, node breakers, ejections).
-//
-// The distinguishing fact is only known on RECONNECT: the same identity comes
-// back running a DIFFERENT binary version. When that happens, exactly the
-// disconnect-flush strikes — the 502s — are removed from the identity's
-// windows and each quarantine is re-evaluated against what remains, so:
-//   - a healthy box that died mid-upgrade with work in flight comes back
-//     clean;
-//   - genuine 500/504 faults recorded BEFORE the restart are kept, and a
-//     breaker whose trip still holds without the 502s stays open;
-//   - a zombie that churns on the SAME version keeps every strike — the
-//     reset never fires without a version change.
-//
-// The 502 status is the flush marker throughout the registry (see
-// RecordInferenceError: "502 — disconnect flush"). Providers do not originate
-// 502s except the rare encryption_failure terminal, which is acceptable
-// collateral: it says nothing about the NEW binary either.
-//
-// Two seams observe the version because registration binds the identity
-// BEFORE the api layer stores RegisterMessage.Version: bindStableFaultKey
-// (re-attestation on an already-versioned session) and Provider.SetVersion
-// (registration on an already-bound session). Both funnel into
-// noteIdentityVersionLocked; only a CHANGE from the last version seen for the
-// identity triggers the reset. State lives in identityVersions and
-// inferenceErrorFlushStrikes (Registry, guarded by r.mu; lazily created so
-// bare test registries work). The flush tags live exactly as long as the
-// strikes they mark: RecordInferenceError slides them out of the breaker
-// window with the strikes and RecordInferenceSuccess drops them with the
-// history, so an identity that never changes version cannot accumulate them.
-//
-// The flush strikes are recorded by the request goroutines that drain the
-// flushed ErrorCh, not by Disconnect itself, so they can land AFTER the reset:
-// registration evicts a same-serial predecessor (DisconnectDuplicatesBySerial)
-// and stores the new version on the same goroutine, and a slow consumer can
-// trail a normal reconnect. A reset that ran first cleared nothing, consumed
-// the interval, and the late strikes would then quarantine the NEW binary for
-// the old one's death. IsSupersededDisconnectFlush closes that order: a 502
-// attributed to a session that was dropped at or before its identity's last
-// reset (disconnectedStableIDs dates every drop) is discarded under each
-// tracker mutation lock, with an API-side early return as an optimization — exactly the
-// strikes the reset would have removed, and none from a session that died
-// after it (same-version churn and a throttled version change keep striking).
-
-// disconnectFlushStatusCode is the status the pending-request flush injects
-// (registry.disconnectWithCause) and the marker the fault windows tag.
+// Version changes clear only disconnect-flush faults, at most once per
+// identityVersionResetMinInterval. Reset history and fault mutations share
+// gate.mu so a trailing old-session 502 cannot re-poison a new binary.
 const disconnectFlushStatusCode = 502
-
-// identityVersionResetMinInterval bounds how often one stable identity can
-// have its flush strikes cleared by a version change. RegisterMessage.Version
-// is provider-asserted and observed before release evidence, so a modified
-// binary alternating two version strings could otherwise launder every
-// reconnect's flush strikes; a genuine upgrade (or rollback) changes version
-// once per rollout, and the strikes it would clear expire within the 5-minute
-// cooldown anyway, so one reset per interval loses nothing legitimate.
 const identityVersionResetMinInterval = 10 * time.Minute
 
-// SetVersion stores the provider's reported binary version and, when the
-// session is already bound to a stable identity, runs the version-changed
-// reset for that identity. Registration calls it after attestation has bound
-// the session, which is why the check lives here as well as in
-// bindStableFaultKey.
+// SetVersion observes the bound identity while p.mu excludes a concurrent
+// rebind. The index lock stabilizes lookup until the gate has been acquired.
 func (p *Provider) SetVersion(version string) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.Version = version
-	id, r := p.ID, p.registry
-	p.mu.Unlock()
+	r := p.registry
 	if r == nil || version == "" {
 		return
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if stableID := r.faultKeyBySession[id]; stableID != "" {
-		r.noteIdentityVersionLocked(stableID, version)
+	r.gatesMu.RLock()
+	if r.sessions[p.ID] != p {
+		r.gatesMu.RUnlock()
+		return
 	}
+	g := p.gate.Load()
+	if g == nil || g.key == p.ID {
+		r.gatesMu.RUnlock()
+		return
+	}
+	g = g.lockResolved()
+	r.gatesMu.RUnlock()
+	defer g.mu.Unlock()
+	now := time.Now()
+	g.noteIdentityVersionLocked(r, version)
+	g.updatedLocked(now)
 }
 
-// IsSupersededDisconnectFlush reports whether a disconnect-flush strike
-// (statusCode 502) attributed to sessionID comes from a session that was
-// dropped at or before its stable identity's most recent version-changed
-// reset — a strike the reset would have removed had the consumer recorded it
-// first. The api layer discards such a strike before it reaches any tracker.
-// Anything else — a live session, a session the registry never dated (no
-// stable identity at disconnect), an identity that has never reset, or a drop
-// that happened after the last reset — is not superseded and records as usual,
-// which keeps the once-per-interval throttle intact: a throttled version
-// change stamps no new reset, so the strikes of the session that died after
-// the consumed reset still land.
+// disconnectSource captures the session while holding the index lock. A live
+// reference can disconnect after lookup; its atomic timestamp then supplies
+// the drop time without taking p.mu while a recorder holds gate.mu.
+type disconnectSource struct {
+	p  *Provider
+	at time.Time
+}
+
+func (r *Registry) captureDisconnectSource(sessionID string) disconnectSource {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	if p := r.sessions[sessionID]; p != nil {
+		return disconnectSource{p: p}
+	}
+	return disconnectSource{at: r.disconnectedStableIDs[sessionID].at}
+}
+func (source disconnectSource) supersededBy(g *gateState) bool {
+	at := source.at
+	if source.p != nil {
+		if ns := source.p.gateDisconnectedAtNS.Load(); ns != 0 {
+			at = time.Unix(0, ns)
+		}
+	}
+	return g != nil && !at.IsZero() && !g.versionResetAt.IsZero() && !g.versionResetAt.Before(at)
+}
 func (r *Registry) IsSupersededDisconnectFlush(sessionID string, statusCode int) bool {
 	if statusCode != disconnectFlushStatusCode || sessionID == "" {
 		return false
 	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.supersededDisconnectFlushLocked(sessionID)
-}
-
-// supersededDisconnectFlushLocked is IsSupersededDisconnectFlush's check under
-// r.mu (either mode): read-only against disconnectedStableIDs and
-// identityVersionResetAt.
-func (r *Registry) supersededDisconnectFlushLocked(sessionID string) bool {
-	if _, live := r.providers[sessionID]; live {
+	source := r.captureDisconnectSource(sessionID)
+	ref := r.lookupSessionGateRef(sessionID)
+	if ref.g == nil {
 		return false
 	}
-	c, ok := r.disconnectedStableIDs[sessionID]
-	if !ok || c.id == "" {
-		return false
-	}
-	resetAt, ok := r.identityVersionResetAt[c.id]
-	return ok && !resetAt.Before(c.at)
+	hold := r.lockGate(ref, "disconnect_flush")
+	defer hold.unlock()
+	return source.supersededBy(hold.g)
 }
 
-// noteIdentityVersionLocked records the binary version now running under a
-// stable identity and clears the identity's disconnect-flush strikes when it
-// differs from the last version seen. A first observation only records.
-// Caller holds r.mu.
-func (r *Registry) noteIdentityVersionLocked(stableID, version string) {
-	if stableID == "" || version == "" {
+func (g *gateState) noteIdentityVersionLocked(r *Registry, version string) {
+	if version == "" {
 		return
 	}
-	if r.identityVersions == nil {
-		r.identityVersions = make(map[string]string)
+	previous := g.identityVersion
+	g.identityVersion = version
+	if previous == "" || previous == version {
+		return
 	}
+	// Date the reset at its mutation boundary, after gate acquisition. A bind
+	// can wait behind a disconnect on the index; its earlier lookup timestamp
+	// must not make a reset performed afterward predate that disconnect.
 	now := time.Now()
-	r.pruneIdentityVersionsLocked(now)
-	prev, seen := r.identityVersions[stableID]
-	r.identityVersions[stableID] = version
-	r.touchIdentityVersionLocked(stableID, now)
-	if !seen || prev == version {
-		return
-	}
-	if r.identityVersionResetAt == nil {
-		r.identityVersionResetAt = make(map[string]time.Time)
-	}
-	if last, ok := r.identityVersionResetAt[stableID]; ok && now.Sub(last) < identityVersionResetMinInterval {
+	if !g.versionResetAt.IsZero() && now.Sub(g.versionResetAt) < identityVersionResetMinInterval {
 		r.logger.Warn("provider version changed again within the reset interval: disconnect-flush strikes retained",
-			"stable_id", stableID, "previous_version", prev, "version", version, "since_last_reset", now.Sub(last))
+			"stable_id", g.key, "previous_version", previous, "version", version, "since_last_reset", now.Sub(g.versionResetAt))
 		return
 	}
-	r.identityVersionResetAt[stableID] = now
-	if r.clearDisconnectFlushStrikesLocked(stableID, now) {
+	g.versionResetAt = now
+	if g.clearDisconnectFlushStrikesLocked(now) {
 		r.logger.Info("provider reconnected on a new binary version: disconnect-flush strikes cleared from its fault trackers",
-			"stable_id", stableID, "previous_version", prev, "version", version)
+			"stable_id", g.key, "previous_version", previous, "version", version)
 	}
 }
 
-// noteInferenceFlushStrikeLocked tags one inference-error strike as a
-// disconnect flush so the version reset can remove exactly that strike later.
-// Caller holds r.mu; key is already stable-keyed.
-func (r *Registry) noteInferenceFlushStrikeLocked(key inferenceErrorKey, at time.Time) {
-	if r.inferenceErrorFlushStrikes == nil {
-		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+func (g *gateState) noteInferenceFlushStrikeLocked(key modelShapeKey, at time.Time) {
+	if g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
 	}
-	if len(r.inferenceErrorFlushStrikes) > 1024 {
-		for k := range r.inferenceErrorFlushStrikes {
-			if _, live := r.inferenceErrorStrikes[k]; !live {
-				delete(r.inferenceErrorFlushStrikes, k)
-			}
-		}
-	}
-	r.inferenceErrorFlushStrikes[key] = append(r.inferenceErrorFlushStrikes[key], at)
+	g.inferenceErrorFlushStrikes[key] = append(g.inferenceErrorFlushStrikes[key], at)
 }
-
-// pruneInferenceFlushStrikesLocked drops the key's flush tags that have left
-// the breaker window, mirroring RecordInferenceError's slide of the main
-// strike list so a tag never outlives the strike it marks. Deletes the key
-// when nothing remains. Caller holds r.mu; key is already stable-keyed.
-func (r *Registry) pruneInferenceFlushStrikesLocked(key inferenceErrorKey, now time.Time) {
-	flush, ok := r.inferenceErrorFlushStrikes[key]
-	if !ok {
-		return
-	}
+func (g *gateState) pruneInferenceFlushStrikesLocked(key modelShapeKey, now time.Time) {
+	flush := g.inferenceErrorFlushStrikes[key]
 	kept := flush[:0]
-	for _, ts := range flush {
-		if now.Sub(ts) < inferenceErrorWindow {
-			kept = append(kept, ts)
+	for _, stamp := range flush {
+		if now.Sub(stamp) < inferenceErrorWindow {
+			kept = append(kept, stamp)
 		}
 	}
 	if len(kept) == 0 {
-		delete(r.inferenceErrorFlushStrikes, key)
-		return
+		delete(g.inferenceErrorFlushStrikes, key)
+	} else {
+		g.inferenceErrorFlushStrikes[key] = kept
 	}
-	r.inferenceErrorFlushStrikes[key] = kept
 }
 
-// clearDisconnectFlushStrikesLocked removes the disconnect-flush (502)
-// strikes recorded under stableID from the inference-error breaker, the
-// node-health breaker, and the health-ejection window, then re-evaluates each
-// quarantine against the remaining history: one that no longer meets its own
-// trip condition closes (trip counters reset so the next genuine fault does
-// not re-arm as a half-open probe); one still justified by other faults stays.
-// Returns whether anything was removed. Caller holds r.mu.
-func (r *Registry) clearDisconnectFlushStrikesLocked(stableID string, now time.Time) (cleared bool) {
-	// Inference-error breaker: (identity, model, shape) buckets.
-	for key, flush := range r.inferenceErrorFlushStrikes {
-		if key.ProviderID != stableID {
-			continue
-		}
-		delete(r.inferenceErrorFlushStrikes, key)
-		if len(flush) == 0 {
-			continue
-		}
-		strikes := r.inferenceErrorStrikes[key]
-		kept := make([]time.Time, 0, len(strikes))
-		for _, ts := range strikes {
-			if !containsTimestamp(flush, ts) {
-				kept = append(kept, ts)
+func (g *gateState) clearDisconnectFlushStrikesLocked(now time.Time) (cleared bool) {
+	for key, flush := range g.inferenceErrorFlushStrikes {
+		delete(g.inferenceErrorFlushStrikes, key)
+		strikes := g.inferenceErrorStrikes[key]
+		kept := strikes[:0]
+		for _, stamp := range strikes {
+			if !containsTimestamp(flush, stamp) {
+				kept = append(kept, stamp)
 			}
 		}
 		if len(kept) == len(strikes) {
@@ -223,44 +136,37 @@ func (r *Registry) clearDisconnectFlushStrikesLocked(stableID string, now time.T
 		}
 		cleared = true
 		if len(kept) == 0 {
-			delete(r.inferenceErrorStrikes, key)
+			delete(g.inferenceErrorStrikes, key)
 		} else {
-			r.inferenceErrorStrikes[key] = kept
+			g.inferenceErrorStrikes[key] = kept
 		}
 		inWindow := 0
-		for _, ts := range kept {
-			if now.Sub(ts) < inferenceErrorWindow {
+		for _, stamp := range kept {
+			if now.Sub(stamp) < inferenceErrorWindow {
 				inWindow++
 			}
 		}
 		if inWindow < inferenceErrorThreshold {
-			delete(r.inferenceErrorCooldowns, key)
+			delete(g.inferenceErrorCooldowns, key)
 		}
 	}
-
-	// Node-health breaker.
-	if w := r.providerOutcomes[stableID]; w != nil && w.dropFlushFaults() {
+	if w := g.outcomes; w != nil && w.dropFlushFaults() {
 		cleared = true
 		total, fails := w.windowStats(now, providerBreakerWindow)
 		rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
 		if w.consecFail < providerBreakerConsecTrip && !rateTrip {
-			delete(r.providerBreakerOpenUntil, stableID)
-			delete(r.providerBreakerTrips, stableID)
+			g.breakerUntil = time.Time{}
+			g.breakerTrips = 0
 		}
 	}
-
-	// Stable-identity health ejection (fault path only: a capacity-streak
-	// ejection was never fed by 502s and is left alone).
-	if w := r.healthEjectionWindows[stableID]; w != nil && w.dropFlushFaults() {
+	if w := g.ejection; w != nil && w.dropFlushFaults() {
 		cleared = true
 		total, fails := w.windowStats(now, healthEjectionWindow)
-		rateTrip := total >= healthEjectionMinSample &&
-			float64(total-fails) < healthEjectionMinSuccessRate*float64(total)
-		if !r.healthEjectionLastTripCapacity[stableID] &&
-			w.consecFail < healthEjectionConsecTrip && !rateTrip {
-			delete(r.healthEjectionUntil, stableID)
-			delete(r.healthEjectionTrips, stableID)
-			delete(r.healthEjectionLastTripCapacity, stableID)
+		rateTrip := total >= healthEjectionMinSample && float64(total-fails) < healthEjectionMinSuccessRate*float64(total)
+		if !g.ejectionLastTripCapacity && w.consecFail < healthEjectionConsecTrip && !rateTrip {
+			g.ejectionUntil = time.Time{}
+			g.ejectionTrips = 0
+			g.ejectionLastTripCapacity = false
 		}
 	}
 	return cleared

--- a/coordinator/registry/version_reset_gate_test.go
+++ b/coordinator/registry/version_reset_gate_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Reset and all three trailing-fault recorders must remain independent of the
+// fleet lock in both reservation modes. Otherwise the wave integration puts
+// the old write-lock convoy back on request completion.
+func TestVersionResetAndLateFlushDoNotWaitForRegistryLock(t *testing.T) {
+	for _, mode := range []string{"shared", "global"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv(envReserveCommitMode, mode)
+			r := New(testLogger())
+			bindVersionedSession(t, r, "old", "0.9.0", true)
+			dieAbruptlyWithFlush(t, r, "old")
+			p := bindVersionedSession(t, r, "new", "0.9.0", true)
+			r.mu.Lock()
+			done := make(chan bool, 1)
+			go func() {
+				p.SetVersion("0.9.1")
+				for range 8 {
+					r.RecordInferenceError("old", "m", 502, "base")
+					r.RecordProviderOutcome("old", false, 502, "provider disconnected")
+					r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected")
+				}
+				done <- r.IsSupersededDisconnectFlush("old", 502)
+			}()
+			select {
+			case superseded := <-done:
+				r.mu.Unlock()
+				if !superseded {
+					t.Fatal("old-session flush was not superseded by the version reset")
+				}
+			case <-time.After(2 * time.Second):
+				r.mu.Unlock()
+				<-done
+				t.Fatal("version reset or late-flush recorder waited for the registry lock")
+			}
+			assertIdentityQuarantine(t, r, "new", false)
+		})
+	}
+}

--- a/coordinator/registry/version_reset_test.go
+++ b/coordinator/registry/version_reset_test.go
@@ -200,9 +200,7 @@ func TestVersionChangedReconnect_ResetIsRateLimitedPerIdentity(t *testing.T) {
 	assertIdentityQuarantine(t, r, "s3", true)
 
 	// Once the interval has elapsed the reset is available again.
-	r.mu.Lock()
-	r.identityVersionResetAt[versionResetStable] = time.Now().Add(-identityVersionResetMinInterval - time.Second)
-	r.mu.Unlock()
+	withGateForKey(r, versionResetStable, func(g *gateState) { g.versionResetAt = time.Now().Add(-identityVersionResetMinInterval - time.Second) })
 	bindVersionedSession(t, r, "s4", "0.9.3", false)
 	assertIdentityQuarantine(t, r, "s4", false)
 }
@@ -218,7 +216,8 @@ func TestVersionChangedReconnect_ResetIsRateLimitedPerIdentity(t *testing.T) {
 func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 	r := New(testLogger())
 	bindVersionedSession(t, r, "s1", "0.9.0", true)
-	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+	key := modelShapeKey{Model: "m", Shape: "base"}
+	g := r.gateForSession("s1").g
 
 	const flushed = 10_000
 	now := time.Now()
@@ -228,20 +227,22 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 		// breaker window, the rest are hours old.
 		seed = append(seed, now.Add(-time.Duration(flushed-i)*2*time.Second))
 	}
-	r.mu.Lock()
-	r.inferenceErrorStrikes[key] = append([]time.Time(nil), seed...)
-	if r.inferenceErrorFlushStrikes == nil {
-		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+	g.mu.Lock()
+	g.inferenceErrorStrikes[key] = append([]time.Time(nil), seed...)
+	if g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
 	}
-	r.inferenceErrorFlushStrikes[key] = append([]time.Time(nil), seed...)
-	r.mu.Unlock()
+	g.inferenceErrorFlushStrikes[key] = append([]time.Time(nil), seed...)
+	g.publishLocked()
+	g.mu.Unlock()
 
 	r.RecordInferenceError("s1", "m", 502, "base")
 
-	r.mu.Lock()
-	strikes := append([]time.Time(nil), r.inferenceErrorStrikes[key]...)
-	flush := append([]time.Time(nil), r.inferenceErrorFlushStrikes[key]...)
-	r.mu.Unlock()
+	g.mu.Lock()
+	strikes := append([]time.Time(nil), g.inferenceErrorStrikes[key]...)
+	flush := append([]time.Time(nil), g.inferenceErrorFlushStrikes[key]...)
+	g.publishLocked()
+	g.mu.Unlock()
 	if len(strikes) == 0 {
 		t.Fatal("main strike list is empty after a recorded flush")
 	}
@@ -268,10 +269,11 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 
 	// A served request clears the shape's history — tags included.
 	r.RecordInferenceSuccess("s1", "m", "base")
-	r.mu.Lock()
-	_, strikesLeft := r.inferenceErrorStrikes[key]
-	_, flushLeft := r.inferenceErrorFlushStrikes[key]
-	r.mu.Unlock()
+	g.mu.Lock()
+	_, strikesLeft := g.inferenceErrorStrikes[key]
+	_, flushLeft := g.inferenceErrorFlushStrikes[key]
+	g.publishLocked()
+	g.mu.Unlock()
 	if strikesLeft || flushLeft {
 		t.Fatalf("after success: strikes present=%v flush tags present=%v, want both cleared", strikesLeft, flushLeft)
 	}
@@ -283,19 +285,22 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 func TestInferenceFlushStrikes_NonFlushStrikePrunesTags(t *testing.T) {
 	r := New(testLogger())
 	bindVersionedSession(t, r, "s1", "0.9.0", true)
-	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+	key := modelShapeKey{Model: "m", Shape: "base"}
+	g := r.gateForSession("s1").g
 
 	stale := time.Now().Add(-2 * inferenceErrorWindow)
-	r.mu.Lock()
-	r.inferenceErrorStrikes[key] = []time.Time{stale}
-	r.inferenceErrorFlushStrikes = map[inferenceErrorKey][]time.Time{key: {stale}}
-	r.mu.Unlock()
+	g.mu.Lock()
+	g.inferenceErrorStrikes[key] = []time.Time{stale}
+	g.inferenceErrorFlushStrikes = map[modelShapeKey][]time.Time{key: {stale}}
+	g.publishLocked()
+	g.mu.Unlock()
 
 	r.RecordInferenceError("s1", "m", 500, "base")
 
-	r.mu.Lock()
-	flush, present := r.inferenceErrorFlushStrikes[key]
-	r.mu.Unlock()
+	g.mu.Lock()
+	flush, present := g.inferenceErrorFlushStrikes[key]
+	g.publishLocked()
+	g.mu.Unlock()
 	if present {
 		t.Fatalf("stale flush tag survived a non-flush strike: %v", flush)
 	}
@@ -389,10 +394,9 @@ func TestVersionResetThrottle_FollowsIdentityRebind(t *testing.T) {
 	s3.SetVersion("0.9.2")
 	assertIdentityQuarantineKeyed(t, r, "s3", serialID, true)
 
-	r.mu.RLock()
-	_, orphan := r.identityVersionResetAt[sekeyID]
-	_, moved := r.identityVersionResetAt[serialID]
-	r.mu.RUnlock()
+	orphan := rawGateForKey(r, sekeyID) != nil
+	moved := false
+	readGateForKey(r, serialID, func(g *gateState) { moved = g != nil && !g.versionResetAt.IsZero() })
 	if orphan || !moved {
 		t.Fatalf("reset timestamp after rebind: under old key=%v, under new key=%v; want moved", orphan, moved)
 	}
@@ -412,12 +416,14 @@ func TestMigrateFaultState_ResetTimestampKeepsLater(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := New(testLogger())
-			r.mu.Lock()
-			r.identityVersionResetAt = map[string]time.Time{"old": tc.src, "new": tc.dst}
-			r.migrateFaultStateLocked("old", "new")
-			got, ok := r.identityVersionResetAt["new"]
-			_, orphan := r.identityVersionResetAt["old"]
-			r.mu.Unlock()
+			withGateForKey(r, "old", func(g *gateState) { g.versionResetAt = tc.src })
+			withGateForKey(r, "new", func(g *gateState) { g.versionResetAt = tc.dst })
+			r.gatesMu.Lock()
+			r.migrateGateLocked(&Provider{}, r.gates["old"], r.gates["new"], true)
+			got := r.gates["new"].versionResetAt
+			ok := !got.IsZero()
+			_, orphan := r.gates["old"]
+			r.gatesMu.Unlock()
 			if !ok || !got.Equal(newer) {
 				t.Fatalf("merged reset timestamp = %v (present=%v), want %v", got, ok, newer)
 			}

--- a/coordinator/registry/version_reset_timestamp_test.go
+++ b/coordinator/registry/version_reset_timestamp_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDisconnectSourcesAgreeAtVersionResetBoundary(t *testing.T) {
+	r := New(testLogger())
+	p := bindVersionedSession(t, r, "disconnect-timestamp", "0.8.1", false)
+	// A recorder can resolve the live Provider before Disconnect, then reach
+	// the gate after another recorder has resolved the disconnect cache.
+	liveSource := r.captureDisconnectSource(p.ID)
+	r.DisconnectWithReason(p.ID, DisconnectReasonReadError)
+	cachedSource := r.captureDisconnectSource(p.ID)
+	if liveSource.p != p || cachedSource.p != nil || cachedSource.at.IsZero() {
+		t.Fatal("expected one live reference and one cached disconnect source")
+	}
+	droppedNS := p.gateDisconnectedAtNS.Load()
+	if droppedNS == 0 {
+		t.Fatal("disconnect did not date the live reference")
+	}
+	g := r.lookupGateForKey(versionResetStable)
+	if g == nil {
+		t.Fatal("disconnect lost the stable identity's gate")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	// Model the exact cutoff of a reset concurrent with detachment. With two
+	// clock reads, the live source is superseded here but the later cache
+	// timestamp lets the same old 502 poison the reset gate. A single event
+	// timestamp gives both recorder paths the same decision at the boundary.
+	g.versionResetAt = time.Unix(0, droppedNS)
+	if !liveSource.supersededBy(g) || !cachedSource.supersededBy(g) {
+		t.Fatalf("sources disagree at reset cutoff: live=%v cached=%v live_at=%s cached_at=%s",
+			liveSource.supersededBy(g), cachedSource.supersededBy(g), g.versionResetAt, cachedSource.at)
+	}
+	// A reset preceding that disconnect must retain both strikes, preserving
+	// same-version churn and the version-reset throttle's later-fault rule.
+	g.versionResetAt = time.Unix(0, droppedNS-1)
+	if liveSource.supersededBy(g) || cachedSource.supersededBy(g) {
+		t.Fatal("a reset before the disconnect suppressed a later flush")
+	}
+}

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -688,7 +688,7 @@ func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now 
 	if p.Status == StatusOffline || p.Status == StatusUntrusted || p.PrivateOnly {
 		return warmPoolCandidate{}, warmColdOfflineUntrust
 	}
-	if r.providerHasPendingLoad(p.ID) || r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+	if r.providerHasPendingLoad(p.ID) || r.gateOf(p).dispatchLoadCooled(model, now) {
 		return warmPoolCandidate{}, warmColdPendingLoad
 	}
 	if p.pendingCount() != 0 || warmPoolBackendSlotBusyLocked(p) {

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-04 · commit `45c310e00`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-04 · commit `4e7a68739`
+> Last updated: 2026-09-04 · commit `45c310e00`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -436,12 +436,114 @@ outcome exactly once at first content or completion.
 
 Fault state keys by the provider's stable identity when one is bound, so it
 survives disconnect and reconnect (`Disconnect`, `coordinator/registry/registry.go`).
+Every tracker in this table and in [gray-box capacity signals](#gray-box-capacity-signals)
+stores its state in one `gateState` per identity
+([below](#concurrency-scan-commit-and-fault-state-gates)).
 
 **Fail-open.** If the scan produced no winner, at least one provider was
 rejected only by the breaker or ejection, and there were no capacity or TTFT
 rejections, `shouldBypassBreakerFailOpen` re-runs the scan with
 `ignoreProviderBreaker` so a degraded-but-only fleet still serves rather than
 returning `no_provider`.
+
+### Concurrency: scan, commit and fault-state gates
+
+`Registry.mu` is a writer-preferring `sync.RWMutex`: a pending writer blocks
+every new reader and drains the active batch of fleet scans first. Nothing on
+the request path takes it for writing.
+
+| Lock | Guards | Request-path holders |
+|---|---|---|
+| `Registry.mu` (`sync.RWMutex`, `coordinator/registry/registry.go`) | The provider map, catalog, aliases and routing configuration. | The scan and the commit, for READING (`scanProviderReservation`, `commitLock`). Writers are `Register`, `Disconnect`, `evictStale`, the swap planner and the config setters. |
+| `Provider.mu` | One provider's heartbeat state, pending set, attestation and cached gate pointer (`Provider.gate`). | The scan per provider (`snapshotProviderIntoLockedEx`); the commit's whole decide-and-debit section; the identity bind (`bindStableFaultKey`). |
+| `Registry.gatesMu` (`sync.RWMutex`) | The gate index: fault key → `gateState`, session → `Provider` (`coordinator/registry/gate_index.go`). | Recorders for READING (session → gate resolution), first insertion (`ensureGateLocked`), and the rare validated retry fallback (`lockGateWithIndex`). Also written by `attachSessionGate`, `detachSessionGate`, `bindStableFaultKey` and `sweepGates`. |
+| `gateState.mu` | One identity's fault trackers (`coordinator/registry/gate_state.go`). | Recorders (`lockGate`), the commit's probe claim (`tryClaimCapacityProbe`), the per-model gate reads. Microseconds, per identity. |
+
+Lock order: `r.mu → p.mu → gatesMu → gate.mu`. `r.mu` or `p.mu` is never
+acquired while `gatesMu` or a `gate.mu` is held, and there is no walk-wide
+gates lock on the scan (`gate_state.go` header).
+
+**Two-phase reservation** (`coordinator/registry/scheduler.go`).
+`scanProviderReservation` walks the fleet under `r.mu.RLock`; concurrent
+requests scan together and no capacity is consumed. `commitProviderReservation`
+holds `r.mu` for reading — the provider identity, catalog and cache-routing
+configuration must be stable, not the fleet frozen — and does everything that
+decides the reservation inside ONE `p.mu` section on the winner: the fresh
+snapshot (`snapshotProviderIntoPLockedEx`), the cost rebuild, the "winner
+unchanged since scan" compare (a change re-scans so the cohort does not herd
+onto the formerly cheapest provider), the admit re-check
+(`providerCanAdmitLockedEx`), the half-open capacity-probe claim
+(`tryClaimCapacityProbe`, check-and-claim under `gate.mu`) and the pending
+debit (`addPendingLocked`). `ReserveNextFromPlan`
+(`coordinator/registry/dispatch_plan.go`) commits each plan entry the same
+way. `commitLock` (`coordinator/registry/gate_commit_mode.go`) selects the
+mode: `reserveCommitShared` as described, or `reserveCommitGlobal`, which
+takes `r.mu.Lock()` for the commit — the previous fleet-wide serialization,
+kept as the kill switch behind
+[`EIGENINFERENCE_RESERVE_COMMIT_MODE`](../reference/configuration.md#routing-admission-and-ttft).
+
+**Per-identity gates.** Each fault tracker's state lives in a `gateState`
+keyed by fault key (serial → SE key → account → session id) with its own
+mutex; a connected provider caches its gate in `Provider.gate` (an atomic
+pointer). Recorders (`RecordProviderOutcome`, `RecordProviderServeOutcome`,
+`RecordProviderSessionServeOutcome`, `RecordInferenceError`,
+`RecordInferenceSuccess`, `RecordCapacityReject`, `RecordCapacityAcceptObserved`,
+`RecordCapacityAcceptOutcome`, `RecordDispatchLoadFailure`,
+`ClearDispatchLoadCooldown`) resolve the gate and take `gate.mu` through
+`lockGate` (`coordinator/registry/gate_lock.go`), never `r.mu`; `lockGate`
+re-validates under the lock that the gate is still the session's current one
+and not retired, and re-resolves otherwise. A missing identity makes a
+clear operation a no-op. After `gateRelockMaxRetries` optimistic retries,
+`lockGateWithIndex` holds `gatesMu` through resolution and gate acquisition
+so a recorder always writes to a validated identity. The scan reads the breaker and
+ejection verdicts from atomics (`breakerOpenAt`, `ejectedAt`) and takes
+`gate.mu` only for a provider whose flag word (`pairFlags`) says it holds
+per-model state, so a provider with no fault state costs a few atomic loads.
+
+Version-reset history and disconnect-flush tags live under the same identity
+mutex (`coordinator/registry/version_reset.go`). `disconnectSource` captures
+the session before acquiring the gate and compares its disconnect timestamp
+with `gateState.versionResetAt` while the mutation lock is held. This preserves
+the [restart behavior](scheduling.md#disconnect) without returning terminal
+recorders to the fleet lock. `RecordCapacityAcceptObserved` likewise replays
+only rejection strikes newer than the accepted observation, retaining a newer
+cooldown or clamp even when accept bookkeeping arrives late.
+
+**Identity rebinds** (`coordinator/registry/gate_migrate.go`). `bindStableFaultKey`
+runs at every (re-)attestation and at account linkage, under the session's
+`p.mu` and `gatesMu`. When the key changes it MOVES the identity's accumulated
+state to the refined identity (`migrateGateLocked`; merge policy
+`mergeLocked`: expiries and trip counts take the max, histories merge
+chronologically) and empties the source: an orphaned source is forwarded
+(`forwardTo`) so stale pointers land on the live state; a source still bound
+to a sibling session is reset and republished. Cached disconnected identities
+follow the refined identity without changing their disconnect timestamps.
+Their recorder references carry a `disconnectedGateBinding`
+(`coordinator/registry/gate_disconnected_binding.go`), updated under the source
+gate's mutex and validated on acquisition, so an in-flight late flush cannot
+recreate or write into the former identity after a shared-source migration.
+Because the bind holds
+`p.mu`, a section that reads `p.gate` under `p.mu` — the scan's gate chain,
+the commit through its debit, the alias resolver's `providerCanRouteBuildLocked`
+— never sees the identity change underneath it. The one dispatch-deciding
+read made without `p.mu`, the candidate's capacity-rate penalty
+(`capacityRatePenaltyFor`), confirms its verdict against `p.gate` afterwards
+and re-reads on a move (`gateView`, `coordinator/registry/gate_index.go`); the
+other gate reads confirm the same way as defence in depth.
+
+**Sweep** (`coordinator/registry/gate_sweep.go`). `sweepGates` runs from the
+eviction loop: it prunes per-model entries that can no longer gate routing
+and drops a gate with no live session once it has been idle for
+`gateIdleGrace = 10 * time.Minute`, marking it `retired` under `gate.mu`
+before the index delete so a recorder holding a stale pointer re-resolves.
+Version metadata additionally keeps its gate for `identityVersionRetention`
+after activity, disconnect or reset (`coordinator/registry/version_history.go`);
+see [disconnect and reconnect](scheduling.md#disconnect). Half-open trip memory
+of a live gate is never pruned.
+
+**Observability.** `registry.gate.wait_ms` (DogStatsD histogram tagged
+`site:`, via `SetGateWaitObserver`) records a recorder's `gate.mu`
+acquisition wait when it exceeds `gateWaitReportThreshold = time.Millisecond`.
 
 ### Reputation
 
@@ -543,7 +645,25 @@ must not run in parallel with other scheduler tests in the same process.
 9. **Exactly one attempt of a race commits; the other is cancelled** —
    `runRace` calls `cancelDispatch` on the loser before committing.
 10. **Fault memory survives reconnects** — `Disconnect` preserves breaker,
-    cooldown and ejection state keyed by stable identity.
+    cooldown and ejection state keyed by stable identity
+    (`detachSessionGate`, `coordinator/registry/gate_index.go`).
+11. **The admit re-check and the pending debit are atomic per provider, and
+    no request-path commit takes `r.mu` for writing** —
+    `commitProviderReservation` and `ReserveNextFromPlan` snapshot, compare,
+    admit (`providerCanAdmitLockedEx`), claim the probe
+    (`tryClaimCapacityProbe`) and debit (`addPendingLocked`) under one `p.mu`
+    hold; `commitLock` takes `r.mu` for reading unless the kill switch is set.
+12. **A dispatch decision never straddles an identity rebind** —
+    `bindStableFaultKey` runs under the session's `p.mu`, so a section that
+    read `p.gate` under `p.mu` acts on that same identity; a read made without
+    `p.mu` confirms against `p.gate` (`gateView.moved`).
+13. **Fault state moves with the identity and is never double-counted** —
+    `migrateGateLocked` merges the source into the destination (`mergeLocked`)
+    and empties the source; the state is not copied.
+14. **One capacity probe at a time per cooled (identity, model) pair** —
+    `tryClaimCapacityProbeLocked` is check-and-claim under `gate.mu`: a
+    second commit within `capacityProbeOutcomeWindow` of an outstanding claim
+    is rejected instead of leaking a second probe.
 
 ## Failure modes
 
@@ -565,6 +685,8 @@ must not run in parallel with other scheduler tests in the same process.
 | Shared gate primitives | `coordinator/registry/routing_eligibility.go` — `providerLivenessGateReasonLocked`, `providerServesRoutableModelLocked` |
 | Closed vocabularies | `coordinator/registry/gate_reason.go` — `GateReason`, `SelectionPath`, `SlotState` |
 | Trust floor, challenge failures, dispatch-load cooldown, `Disconnect` | `coordinator/registry/registry.go` — `MinTrustLevel`, `MaxFailedChallenges`, `RecordChallengeFailure`, `dispatchLoadCooldownTTL` |
+| Two-phase reservation (scan, commit, plan consumption) | `coordinator/registry/scheduler.go` — `scanProviderReservation`, `commitProviderReservation`, `providerCanAdmitLockedEx`; `coordinator/registry/dispatch_plan.go` — `ReserveNextFromPlan` |
+| Per-identity fault-state gates | `coordinator/registry/gate_state.go` — `gateState`, `publishLocked`, `breakerOpenAt`, `ejectedAt`; `coordinator/registry/gate_index.go` — `gateOf`, `gateView`, `attachSessionGate`, `detachSessionGate`; `coordinator/registry/gate_migrate.go` — `bindStableFaultKey`, `migrateGateLocked`, `mergeLocked`; `coordinator/registry/gate_lock.go` — `lockGate`, `gateRef`, `SetGateWaitObserver`; `coordinator/registry/gate_sweep.go` — `sweepGates`, `gateIdleGrace`; `coordinator/registry/gate_commit_mode.go` — `reserveCommitMode`, `commitLock` |
 | Bounded dispatch plan | `coordinator/registry/dispatch_plan.go` — `dispatchPlanMaxAlternates`, `PlanEntry` |
 | Servability predictor | `coordinator/registry/servability.go` — `PredictServable`, `coldTokenBudgetEstimate`, `servabilityActivationFloor` |
 | Budget clamp | `coordinator/registry/budget_clamp.go` — `recordBudgetClampLocked`, `releaseBudgetClampsOnHeartbeat` |

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -451,16 +451,18 @@ at most once per `identityVersionResetMinInterval = 10 * time.Minute`.
 Genuine 500/504 faults survive. Each tracker discards a late 502 from a session
 dropped before that reset while holding its mutation lock; request goroutines
 cannot reopen the new binary's quarantine after the reset. Same-version churn
-and a drop after a throttled reset keep their strikes. Cached disconnected
-identities follow identity enrichment without changing their original drop
-time, so a later weaker-identity reconnect cannot resurrect superseded faults
-(`coordinator/registry/version_reset.go`, `supersededDisconnectFlushLocked`;
-`coordinator/registry/health_ejection.go`, `migrateFaultStateLocked`).
-Version metadata for departed identities expires after
-`identityVersionRetention = 20 * time.Minute`; live identities, recent reset
-throttles, active fault windows and quarantines are retained. Disconnect
-starts a fresh reconnect grace window, and the eviction loop performs
-periodic cleanup (`coordinator/registry/version_history.go`).
+and a drop after a throttled reset keep their strikes
+(`coordinator/registry/version_reset.go`, `disconnectSource.supersededBy`).
+The reset and each fault mutation share the identity's `gateState.mu`; both
+live references and the disconnect cache use the same timestamp recorded by
+`detachSessionGate`. These request terminal paths never acquire `Registry.mu`.
+Cached disconnected identities follow enrichment without changing their drop
+times. Version metadata for departed identities remains for
+`identityVersionRetention = 20 * time.Minute` after the last activity or
+disconnect; live identities, recent resets and active fault state retain their
+gate. The existing eviction-loop gate sweep handles this cleanup
+(`coordinator/registry/version_history.go`, `versionHistoryActive`;
+`coordinator/registry/gate_sweep.go`, `sweepGates`).
 
 ## Invariants
 
@@ -487,6 +489,10 @@ periodic cleanup (`coordinator/registry/version_history.go`).
 9. **Control frames never wait behind queued data frames** — lane priority
    in `providerWriter`.
 10. **Disconnect preserves stable-identity fault state** — `Disconnect`.
+11. **A provider is never double-booked** — the admit re-check and the
+    pending debit run under one `p.mu` hold in `commitProviderReservation`
+    and `ReserveNextFromPlan`; the locking model is in
+    [`routing.md`](routing.md#concurrency-scan-commit-and-fault-state-gates).
 
 ## Failure modes
 

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `a50f61560`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-04 · commit `6a64f71a8`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-04 · commit `4e7a68739`
+> Last updated: 2026-09-04 · commit `6a64f71a8`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -151,6 +151,12 @@ Capacity breakers:
 | `EIGENINFERENCE_CAPACITY_COOLDOWN_TTL_SECONDS` | seconds | `120` | `coordinator/registry/capacity_cooldown.go` | Initial cooldown; doubles on each failed probe. |
 | `EIGENINFERENCE_CAPACITY_COOLDOWN_MAX_TTL_SECONDS` | seconds | `600` | `coordinator/registry/capacity_cooldown.go` | Ceiling of the exponential cooldown. |
 | `EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS` | milliseconds (≤ 0 disables) | `15000` | `coordinator/registry/capacity_rate.go` | Scores a penalty proportional to a provider's recent capacity-reject rate. |
+
+Reservation commit lock:
+
+| Variable | Values / type | Default | Read in | Effect |
+|---|---|---|---|---|
+| `EIGENINFERENCE_RESERVE_COMMIT_MODE` | `shared`, `global` (trimmed, case-insensitive; any other value is treated as `shared` and logged as unknown) | `shared` | `coordinator/registry/gate_commit_mode.go` (`loadReserveCommitMode`, `parseReserveCommitMode`); read once at `registry.New` | How the reservation commit (`commitProviderReservation`, `ReserveNextFromPlan`) holds the registry lock. `shared` commits under `r.mu.RLock` plus the winner's `p.mu`; `global` is the kill switch that restores the fleet-wide `r.mu.Lock()` commit serialization. The fault-tracker recorders stay on their per-identity gates in both modes; see [`../architecture/routing.md`](../architecture/routing.md). |
 
 Quality concurrency cap:
 

--- a/docs/reports/2026-09-03-perf-pr-c-tier3-body.md
+++ b/docs/reports/2026-09-03-perf-pr-c-tier3-body.md
@@ -1,0 +1,347 @@
+# perf(registry): take the global write lock off the per-request path (Tier 3)
+
+> Last updated: 2026-09-04 · commit `6a1d1eb27`
+
+Stacks on `perf/coordinator-registry-scan-2026-09-03` (PR B: per-model index, arena snapshots,
+cached medians). **Merge after it and after PR #818** (`perf/coordinator-tier1-2026-09-03`, the
+`lockWrite(site)` observer and `ScanCount` stamp); this branch is rebased onto #818 once it lands —
+the six recorder bodies #818 instruments are rewritten wholesale here, so the conflicts resolve
+to this branch. Two things to do **at that rebase**:
+
+- #818's `TestRegistryLockWaitHistogramTaggedBySite` (api) drives a `registry.mu.write_wait_ms`
+  sample through `reg.ClearDispatchLoadCooldown` behind `HoldWriteLockForTest`. On this branch that
+  recorder never touches `r.mu`, so the test must be retargeted at a remaining `r.mu` writer (a
+  config setter, or the commit in `global` mode) or it hangs.
+- Route `commitLock.lock()` in `global` mode through `r.lockWrite("commit")` /
+  `("commit_plan")` so the kill switch keeps its write-wait histogram; in `shared` mode the commit
+  takes `r.mu.RLock` and has no write wait to report.
+
+Design and evidence: `docs/reports/2026-09-03-coordinator-perf-proposal/01-registry-lock.md`
+(E1–E4), README §3 Tier 3 and §6.
+
+## What was wrong
+
+`Registry.mu` is a writer-preferring `sync.RWMutex`. Every served request took it for **writing six
+times** — the reservation commit, the first-content capacity accept, and at completion
+`RecordInferenceSuccess`, `RecordProviderOutcome`, `RecordProviderServeOutcome`,
+`ClearDispatchLoadCooldown` — plus `ReserveNextFromPlan` held it across its whole loop. Each
+holder ran for microseconds (0.007 core in total), but a pending writer blocks every new reader
+and must drain the active batch of fleet scans first: **≈190 ms per acquisition in prod**, 152
+writers queued behind one scanning reader, two of the six acquisitions before the first byte.
+Commits that lost the race rescanned the fleet (10–14 iterations per reservation). Coordinator-caused
+TTFB at the median: ≈2.4 s.
+
+## What changed
+
+Two halves, shipped together (neither helps alone — see 01 "Why not (a) alone"):
+
+**(a) Per-identity gate state.** The node-health breaker, stable-identity health ejection, the
+shape-keyed inference-error cooldown, the capacity cooldown / rate window / budget clamp and the
+dispatch-load cooldown moved out of the global maps into one `gateState` per fault key
+(`registry/gate_state.go` — the struct and its lock-free view; the index, migration, sweep, recorder lock
+and commit-mode switch live in `gate_index.go`, `gate_migrate.go`, `gate_sweep.go`, `gate_lock.go`,
+`gate_commit_mode.go`), each with its own `sync.Mutex`. Recorders resolve the gate, take
+`gate.mu`, mutate, release — **they never touch `r.mu`**. Connected providers cache their gate
+(`p.gate`, atomic); the disconnected trailing-flush path does one `gatesMu.RLock` lookup. The scan
+reads the two hot booleans (breaker open, ejected) from atomics and a per-gate flag word says which
+per-model trackers hold state, so a provider with no fault state costs the scan a few atomic loads and
+no lock section. The size-triggered map sweeps (>1024 / >2048 walks under the write lock) became a
+periodic per-gate sweep from the eviction loop. Identity rebinds migrate a gate's state and forward the
+orphan, so a recorder holding a stale pointer still lands on the live state; and because a recorder
+resolves its gate under `gatesMu.RLock` but locks it only after letting go of `gatesMu`, it re-validates
+the gate under `gate.mu` once acquired (not retired by the sweep, still the session's cached gate) and
+re-resolves through the index otherwise. The routing READS are covered two ways: the identity bind runs under the session's `p.mu`
+(third review pass), so the scan's gate chain, the commit through its debit and the alias resolver — all under
+`p.mu` — never see `p.gate` move mid-section; and every read that feeds a dispatch decision also confirms its
+verdict against `p.gate` afterwards and re-reads from the session's new gate when it moved (`gateView`; see
+"Review follow-ups"), which is what covers the candidate cost read the scan makes after releasing `p.mu`.
+
+**(a′) Commit without the global write lock.** `commitProviderReservation` and
+`ReserveNextFromPlan` hold `r.mu` for **reading** (identity, catalog and cache-routing config only)
+and do everything that decides the reservation — fresh snapshot, cost rebuild, the "winner unchanged
+since scan" compare, admit re-check, probe claim, pending debit — inside **one `p.mu` section** on the
+winner. The half-open capacity probe is check-and-claim under `gate.mu`. The breaker-bypass re-scan is
+a read.
+
+Lock order: `r.mu → p.mu → gatesMu → gate.mu`. Never `r.mu` or `p.mu` while holding `gatesMu` or a
+`gate.mu`. There is deliberately **no walk-wide gates lock** on the scan; the parallel speed-up guard
+below is what keeps it out.
+
+## Before / after
+
+### Behaviour
+
+```mermaid
+flowchart LR
+  subgraph Before["Before (master / PR B)"]
+    A1[attempt] --> S1["scan under r.mu.RLock<br/>(whole fleet)"]
+    S1 --> W1["wait for r.mu.Lock<br/>≈190 ms: drain the reader batch"]
+    W1 --> C1["commit: re-snapshot + compare"]
+    C1 -->|winner changed| S1
+    C1 -->|ok| D1[dispatch]
+    D1 --> F1["first content:<br/>RecordCapacityAccept → r.mu.Lock (≈190 ms)"]
+    F1 --> B1[first byte to client]
+    B1 --> E1["completion: 4 × r.mu.Lock<br/>(success, outcome, serve outcome, cooldown clear)"]
+  end
+  subgraph After["After (this branch, shared mode)"]
+    A2[attempt] --> S2["scan under r.mu.RLock<br/>(gate reads: atomics + flag word)"]
+    S2 --> C2["commit under r.mu.RLock + p.mu:<br/>snapshot · cost · compare · admit · probe claim (gate.mu) · debit"]
+    C2 -->|winner changed on this provider| S2
+    C2 -->|ok| D2[dispatch]
+    D2 --> F2["first content:<br/>RecordCapacityAccept → gate.mu (µs)"]
+    F2 --> B2[first byte to client]
+    B2 --> E2["completion: 4 recorders → gate.mu (µs each)<br/>r.mu never taken"]
+  end
+```
+
+### Code
+
+```mermaid
+flowchart TB
+  subgraph Before["Before"]
+    direction TB
+    RB["Registry.mu (RWMutex)"]
+    RB --- M1["providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips"]
+    RB --- M2["healthEjection* (5 maps)"]
+    RB --- M3["inferenceErrorStrikes / inferenceErrorCooldowns"]
+    RB --- M4["capacityRejectStrikes / capacityCooldowns / capacityCooldownTrips"]
+    RB --- M5["budgetClamps · capacityRateRejects / Accepts"]
+    RB --- M6["dispatchLoadCooldowns · faultKeyBySession · disconnectedStableIDs"]
+    RecB["RecordProviderOutcome · RecordProviderServeOutcome · RecordInferenceError/Success<br/>recordCapacityReject · RecordCapacityAcceptOutcome · RecordDispatchLoadFailure · ClearDispatchLoadCooldown"] -- "r.mu.Lock()" --> RB
+    ComB["commitProviderReservation · ReserveNextFromPlan"] -- "r.mu.Lock()" --> RB
+    ScanB["providerRoutingGateReasonLockedEx · snapshot · buildCandidateInto"] -- "r.mu.RLock() + map reads" --> RB
+  end
+  subgraph After["After"]
+    direction TB
+    RA["Registry.mu (RWMutex)<br/>writers: Register · Disconnect · evictStale · swap planner · config"]
+    GI["gatesMu (RWMutex, insert-only)<br/>gates map[faultKey]*gateState · sessions · disconnectedStableIDs"]
+    G["gateState (one per identity, own mutex)<br/>breaker · ejection · error cooldown · capacity cooldown/rate/clamp · dispatch-load<br/>atomics: breakerOpenUntilNS · ejectionUntilNS · pairFlags · newestRateRejectNS"]
+    GI --> G
+    P["Provider.gate (atomic.Pointer)"] --> G
+    RecA["same 8 recorders"] -- "gateForSession → lockGate(site) → gate.mu" --> G
+    ComA["commitProviderReservation · ReserveNextFromPlan<br/>(commitLock: RLock in shared, Lock in global)"] -- "r.mu.RLock()" --> RA
+    ComA -- "p.mu: snapshotProviderIntoPLockedEx · buildCandidate · compare · canAdmit · tryClaimCapacityProbe · addPendingLocked" --> P
+    ScanA["providerRoutingGateReasonLockedEx · snapshotProviderIntoLockedEx · buildCandidateInto"] -- "gateOf(p): atomic loads; gate.mu only for pairs with state" --> P
+    Sweep["evictStale → sweepGates"] -- "gatesMu.Lock (periodic, off the request path)" --> GI
+  end
+```
+
+## Invariants (from 01, with how each is protected now)
+
+| Invariant `r.mu.Lock()` protected before | Now |
+|---|---|
+| No double-booking of a provider | `providerCanAdmitLockedEx` + `addPendingLocked` under **`p.mu`** — unchanged, and now in the same `p.mu` section as the fresh snapshot (`snapshotProviderIntoPLockedEx`), so nothing on the provider changes between the check and the debit. Test: N goroutines vs one capped provider admit exactly the serial capacity, both modes, `-race`. |
+| Probe claim atomic w.r.t. other commits | `gateState.tryClaimCapacityProbe`: check **and** claim in one `gate.mu` section, per identity; a closed gate rejects the reservation instead of leaking a second probe. Test: two sessions of one identity racing → exactly one claim. |
+| Fleet-wide serialization makes the "unchanged since scan" compare exact (herd avoidance) | The four-field compare runs against a snapshot taken under the **same `p.mu` hold that debits**; only the winner's own counters are compared, so `p.mu` suffices. A concurrent commit on the same provider is either fully before (visible → rescan) or fully after. |
+| Stale gate state seen by a scan | Already tolerated between scan RUnlock and commit; the commit re-checks under `p.mu`/`gate.mu`. A gate being migrated is read two ways. An ORPHANED source (its last session left) is forwarded before it is reset and never republished, so lock-free readers see its intact pre-merge view or the forward, never zeros. A SHARED source (a sibling session still bound to it) IS reset and republished — the state moved with the rebinding session — so every read that feeds a dispatch decision (the five routing gates in `gateStateReasonLocked`: scan, commit admit re-check and preflight; the snapshot's budget clamp on both snapshot paths; the candidate's capacity-rate penalty) confirms its verdict against `p.gate` after the read and re-reads from the session's new gate when it moved (`gateView`, bounded like `lockGate`'s re-resolve). Sound without a lock because the migration repoints `p.gate` BEFORE it resets and republishes the source, and Go's atomics are sequentially consistent. Tallies, classification counts, fleet_sample rows and warm-pool planning read unconfirmed: a stale sample there miscounts once and dispatches nothing. Test: a scan that loaded the shared gate before the rebind is gated on the new gate (breaker — atomic path — and dispatch-load cooldown — locked per-model path; both modes), an unconfirmed read of the stale gate says clean, the sibling's view reads not gated, and the end-to-end reservation never lands on the rebound session; a `-race` stress variant with a flapping session carrying a permanent cooldown. |
+| Identity rebind moves accumulated fault state | `bindStableFaultKey` migrates `gateState` → `gateState` under the session's `p.mu` and `gatesMu.Lock` (the only place two gate locks nest); stale pointers follow `forwardTo`; a recorder holding a stale pointer re-validates under `gate.mu` (not retired, still the session's cached gate) and re-resolves through the index otherwise; the session is repointed inside the migration's two-gate locked section, so a recorder holding the source either wrote before the merge (its outcome travels) or sees the pointer moved. A shared identity gate with other live sessions is emptied, not orphaned — the repointed `p.gate` is what tells a stale holder its outcome now belongs to the new gate. The lock-free "no per-model state" fast paths (probe claim, the clear recorders) trust a cleared flag only while `p.gate` still points at the gate it was read from (`refHasPairState`). **Semantics (written down in `gate_migrate.go`): the state MOVES, it is not copied.** The source identity — and a sibling session still bound to it (the same machine connected twice: one SE key, two sessions) — starts from nothing, exactly as the map-keyed `migrateFaultStateLocked` left the old key; the sibling lands on the moved state at its own enrichment. A copy was rejected: the merge does not deduplicate histories, so it would double-count every fault (strike lists, health rings, consecutive-fault streaks) the moment the sibling enriches to the same serial. |
+| Fault state survives Disconnect; identity-less residue is dropped | `detachSessionGate`: caches the stable id for the trailing flush and keeps the identity's gate; a session-keyed gate (no identity) is dropped at Disconnect. |
+| Bounded maps | Periodic `sweepGates` from the eviction loop (plus a rate-limited inline sweep past 4096 gates): prunes dead per-model entries; drops gates with no live session once idle for 10 min, marking them `retired` under `gate.mu` before the index delete so a recorder that resolved the gate before the walk re-resolves instead of writing into it. A gate's **creation counts as activity** for the idle grace, so a gate filed for a disconnected identity (the trailing flush's first fault, a serve outcome by stable id) cannot be swept before the recorder that created it takes the lock — an untouched disconnected identity therefore lingers ≤ 10 min instead of dropping on the first sweep (negligible: one empty `gateState`). Half-open trip memory of a **live** gate is never pruned (the old size-triggered sweeps only ran past 1024 entries). |
+
+## Mode flag
+
+`EIGENINFERENCE_RESERVE_COMMIT_MODE` = `shared` (default) | `global`, read once at construction.
+
+- `shared`: commit and plan consumption hold `r.mu.RLock` + `p.mu` (this change).
+- `global`: they take `r.mu.Lock()` — the previous fleet-wide serialization, kept as the **kill
+  switch** for (a′). The recorders stay on their per-identity gates in **both** modes: that half is
+  safe on its own, and the flag exists for a defect in the shared commit.
+
+The request-path suites run in both modes (`forEachCommitMode`).
+
+## Observability
+
+- `registry.gate.wait_ms` — DogStatsD histogram tagged `site:` (`breaker`, `health_ejection`,
+  `inference_error`, `inference_success`, `capacity_reject`, `capacity_accept`,
+  `dispatch_load_failure`, `dispatch_load_clear`, `clamp_heartbeat`), emitted only when a `gate.mu`
+  wait exceeds 1 ms (uncontended path: one `TryLock`, no clock reads). Distinct from #818's
+  `registry.mu.write_wait_ms`. The commit-path probe claim (`capacity_probe` site) takes the same
+  gate lock but does not report its wait: it runs under `p.mu` (and `r.mu` in `global` mode), where the
+  emit must not happen; the recorders' waits on the same gates cover it.
+- The #809 per-attempt stamps (`lock_wait_us`, `scan_us`, `admit_us`) are the acceptance metric.
+
+## Bench (this box: M-series, 16 threads, `-benchtime 2s -count 2`; load average 330–380 on 16 cores during both runs — treat absolute numbers as ±30%, ratios within a run as the signal)
+
+| Benchmark | PR B (base) | this branch |
+|---|---:|---:|
+| RequestPathWalkParallel-16 (RLock-only fleet walk) | 158–176 µs/op | 100–109 µs/op |
+| RequestPathWalkParallelWithWriter-16 — one recorder at 500/s under 16 walkers: **writer wait mean** | **1.7–2.6 ms** | **39–72 µs** |
+| … writer wait max | 18–100 ms | 31–68 ms (scheduler noise at this load) |
+| RequestPathSerial (scan+commit+5 recorders+release) | 424–537 µs/op | 346–351 µs/op |
+| RequestPathParallel-16 (same, 16 threads) | 353–386 µs/op | 145–157 µs/op |
+| **parallel speed-up (serial ÷ parallel)** | **≈1.2×** | **≈2.3×** (read-only walk ceiling on this box at that moment: 2.6×) |
+| FleetReserveProviderExParallel-16 | 311–351 µs/op | 312 µs/op (fixture herds every goroutine onto model 0 with colliding request ids → rescans dominate; not a lock signal) |
+
+`TestRequestPathParallelSpeedup` pins the guard. **Deviation from the proposal's "asserts ≥ 4× at
+16 threads":** the absolute 4× is asserted only when the box's own read-only fleet walk (RLock, no
+writers) reaches 4× — an unloaded machine; on a busy box it asserts the relative property instead
+(request path ≥ 60% of the read-only walk's speed-up; the base branch sits at ≈45%), and above a
+1-minute load of 2×GOMAXPROCS it skips with the numbers logged, because lock-holder preemption
+defeats every locking scheme there. Each quantity is the best of three interleaved fixed-work runs.
+On the development box (load 449–459 on 16 cores) it therefore **skipped**, measuring read-only
+4.75× vs request path 3.50× (74%). The request path's ceiling sits below the read-only walk's
+because of three pre-existing global write locks the read walk does not pay: `ttftCalibration.
+notePrediction` per warm commit, the warm-pool `recordEvent` per cold dispatch, and the cache
+tracker on `RemovePending`. None of them is `r.mu`.
+
+## Acceptance metrics (prod, via #809 stamps)
+
+- `admit_us` p99 < 10 ms; attempt-start → first-lock p90 < 50 ms, for 24 h.
+- `registry.mu.write_wait_ms` (#818) collapses to the non-request writers (Register/Disconnect/
+  evictStale/swap planner/config: tens per second); `registry.gate.wait_ms` stays empty or
+  single-digit ms.
+- Rescans per attempt (`ScanCount`, #818) → ~1.
+
+## Rollout
+
+1. Deploy with the default (`shared`). Kill switch: `EIGENINFERENCE_RESERVE_COMMIT_MODE=global`
+   restores the fleet-wide commit serialization without touching the recorders.
+2. **Not in this branch (deploy knob):** the #799 routing semaphore is still sized to host
+   `runtime.NumCPU()` and its slots were held across the write-lock wait. With the wait gone, re-size
+   `EIGENINFERENCE_ROUTING_CONCURRENCY` to the container's CPU quota so it bounds scan CPU as
+   designed.
+3. Re-profile 30 s after landing and diff against 00.
+
+## Behaviour-neutral changes worth knowing about
+
+- `ClearDispatchLoadCooldown` returns without taking any lock when the identity has no dispatch-load
+  state (one flag load) — the common completion case.
+- `RecordCapacityAcceptOutcome(_, _, false)` lost its read-only no-state probe; every accept now takes
+  one uncontended `gate.mu` (microseconds, per identity) instead of an `r.mu.RLock` probe.
+- `Disconnect` of an identity-less session drops **all** of that session's fault residue (capacity
+  trackers included); before, only breaker / inference-error / dispatch-load residue was dropped.
+- `TestReserveProviderWithPlanPrimarySelectionUnchanged` compared candidate summaries including
+  their wall-clock `HBAgeMs`; it flaked 4/40 under `-race` on the loaded box (0/40 on base at that
+  moment). The summaries' heartbeat ages are now zeroed like the decision's own `SnapshotAgeMs`.
+  Test-only; revert if preferred.
+- `ReserveNextFromPlan` is exercised concurrently with one plan per goroutine (the plan itself is
+  single-consumer); the existing sequential plan suite covers the rest under `-race`.
+
+## Remaining `r.mu` writers
+
+Register, Disconnect, `evictStale` (strike map install), the swap planner
+(`expirePendingModelLoads`/`reservePendingModelLoads`), `markUntrusted`, config setters, hook
+setters. **No `r.mu.Lock()` remains on any request path.** The recorders take `r.mu` in no mode; the
+only read-side touch left near a recorder is the budget snapshot for the clamp
+(`providerReportsTokenBudget`/`providerBudgetSnapshot`), which reads `p.BackendCapacity` under
+`p.mu` via the `sessions` index — no `r.mu` at all.
+
+## Review follow-ups
+
+### Third pass
+
+Codex's third review left five findings; all legitimate.
+
+- **F1 [P1] — a landed report was edited.** The "Follow-on" cross-link added to the PR-B body (landed on
+  the parent branch; reports are frozen) is removed; the Tier 3 body is indexed in `docs/reports/README.md`
+  instead. Commit `6a64f71a8`.
+- **F2 [P1] — `EIGENINFERENCE_RESERVE_COMMIT_MODE` documented only here.** Row added to
+  `docs/reference/configuration.md` (values, default, read-once at construction, what each mode holds).
+  Commit `9d2138db3`.
+- **F3 [P2] — a rebind could land between the commit's final gate check and its debit.**
+  `bindStableFaultKey` ran after `SetAttestationResult` / `RebindStableFaultKey` had released `p.mu`, while
+  the commit reads `p.gate` (the admit re-check) and debits inside one `p.mu` section in both modes;
+  `gateView` closes a rebind that lands during the reads, not one after `moved()` has confirmed them, so a
+  commit could accept a clean source gate and dispatch to a session whose destination identity already
+  carried a breaker or cooldown. The map-keyed code had no window (bind and commit shared `r.mu.Lock`).
+  Both entry points now derive the identity and bind while `p.mu` is still held; lock order unchanged
+  (`r.mu → p.mu → gatesMu → gate.mu` — the bind takes the last two, and no recorder takes `p.mu` under a
+  gate lock). `gateView` stays for the capacity-rate read the scan makes after releasing `p.mu`. Test:
+  `p.gate` never changes under a `p.mu` holder while the session flaps identities through either entry
+  point (`-race`; 2000+ moves per run without the fix, zero with it). Commit `dd936c097`.
+- **F4 [P2] — the alias resolver's cooldown read was unconfirmed.** `providerCanRouteBuildLocked`
+  (`ResolveModel` → `anyProviderCanRouteBuildLocked`) read `gateOf(p).dispatchLoadCooled` with no
+  confirmation, so a shared source reset by this session's own rebind could read "not cooled" and resolve
+  the alias to a Desired build whose only provider was cooled. Closed by F3: the read runs under `p.mu`,
+  which the bind now holds; said so at the read site. Test: a Desired-only session flapping identities with
+  a travelling cooldown while every concurrent `ResolveModel` must pick Previous (`-race`; ~2400 wrong
+  resolutions per run without the fix, zero with it). Commit `d789d1723`.
+- **F5 [P1] — the locking model was documented only here.** `docs/architecture/routing.md` gains
+  "Concurrency: scan, commit and fault-state gates" (lock table and order, two-phase reservation, the
+  per-identity gates and recorders, rebinds, sweep, observability), four invariants and the code-map rows
+  for the `gate_*.go` files; `scheduling.md` carries the double-booking invariant with a link. This commit.
+
+### Second pass
+
+Codex's second review left two findings; both legitimate.
+
+- **F1 [P1] — split the gate implementation** (`gate_state.go` had grown to 1,013 lines across six
+  concerns; repo policy asks for small single-responsibility files and a modular pass after large work).
+  Split by concern: `gate_state.go` (design header with lock order and file map, the `gateState` struct,
+  `publishLocked` and the atomic readers), `gate_index.go` (`r.gates` / `r.sessions` under `gatesMu`,
+  `gateRef` resolution, `gateOf`, attach/detach), `gate_migrate.go` (`resolve`, merge and reset policy,
+  `bindStableFaultKey`, `migrateGateLocked`), `gate_sweep.go` (`pruneLocked`, `sweepGates`),
+  `gate_lock.go` (`lockResolved`, `lockGate`, `refHasPairState`, the wait observer),
+  `gate_commit_mode.go` (the kill switch). Tests split the same way (`gate_index_test.go`,
+  `gate_migrate_test.go`, `gate_sweep_test.go`, `gate_lock_test.go`, `gate_stress_test.go`). Pure
+  moves — verified by a sorted-line diff of the old file against the concatenated new ones (only each
+  file's header and the file map are new). Commit `829849ee9`.
+- **F2 [P2] — the routing read path trusted an emptied shared source** (the residual the first pass
+  documented). The scan loads `p.gate` and reads it holding no lock a rebind respects; a rebind landing
+  in between moves the session's state and, for a SHARED source, resets and republishes it as zeros, so
+  the scan — and the commit's admit re-check, which reads the same way — admitted a session whose
+  breaker or cooldown had just moved. Closed by confirming every dispatch-deciding read against `p.gate`
+  after the read (`gateView`, details in the invariants table). Also settled the semantics question the
+  reset raised — move, not copy — and wrote it into `gate_migrate.go`. Commit `4001286bf`.
+
+### First pass
+
+Codex left two P2 findings on the gate index; both were legitimate and share one root cause — a
+recorder resolves its gate under `gatesMu.RLock` but locks it only after releasing `gatesMu`, a
+window the map-keyed code never had (key resolution and the write shared one `r.mu.Lock` section
+with the bind). Fixed by re-validating the gate under `gate.mu` after acquiring it and re-resolving
+through the index otherwise (`gateRef` / `lockGate`, `retired`, the repoint inside the migration's
+locked section, creation-counts-as-touched):
+
+- **F1 — recorders racing a shared-identity rebind** (`migrateGateLocked(..., false)` reset the shared
+  gate without a forward; a recorder holding the old pointer wrote into the emptied gate that now
+  belonged to the other session — a success left the migrated clamp/cooldown unreleased, a fault
+  poisoned the other identity's breaker). The removed comment claiming parity with the map-keyed
+  implementation was wrong. Commit `d21e0d48f`.
+- **F2 — the sweep dropping in-flight recorder updates** (the sweep decided under `gate.mu`, unlocked,
+  deleted; a trailing-flush recorder that had already resolved the pointer wrote the disconnect 502
+  into a gate no lookup would find — `evictStale` runs `Disconnect` then `sweepGates` in the same
+  pass, and a gate created for a disconnected identity had `touched == 0`). Commit `d21e0d48f`.
+- **Adjacent gap found while fixing F1 — the commit-path probe claim** (`tryClaimCapacityProbe` via
+  `gateOf(p).lockResolved()` mutated `probeAt` with no session check, so a rebind racing a commit could
+  leak one probe through a cooled pair; the lock-free "no state" fast path had the same hole one layer
+  up — an emptied source gate's flag says "nothing" because the state moved). Now claimed through the
+  same validated lock, both commit modes, with `refHasPairState` confirming a cleared flag against
+  `p.gate`. Commit `020fac64f`.
+
+Deliberately unchanged: `detachSessionGate` does not retire the session-keyed gate it drops at
+Disconnect — a recorder racing it writes into residue that is dropped by design (see "Disconnect of
+an identity-less session drops all of that session's fault residue" above).
+
+## Tests
+
+- `reserve_commit_test.go`: exact-capacity concurrent commit through `ReserveProviderEx` AND through
+  `ReserveNextFromPlan` (both modes, `-race`); the half-open probe race end to end — two sessions of
+  one identity, N concurrent reservations, exactly one admitted (both modes); identical routing walks
+  and per-provider gate outcomes across modes before/after concurrent scans + recorders over the
+  fault-state fixture (breaker-open, ejected, capacity-cooled, dispatch-load-cooled, error-cooled,
+  budget-clamped — the recorders in the concurrent phase target healthy providers, so this is
+  `-race` interleaving coverage plus "faulted stay excluded", not a decision-changing script); the
+  parallel speed-up guard; the mode-flag parser (unknown values fall back to `shared` and are logged).
+- `gate_migrate_test.go` / `gate_sweep_test.go` / `gate_index_test.go` / `gate_lock_test.go` /
+  `gate_stress_test.go` (split from `gate_state_test.go`): stale-pointer migration, no empty-gate
+  window for lock-free readers during a live re-attestation, shared-identity rebind, sweep liveness
+  rule, trailing-flush resolution, exclusive probe claim, nil-safety, wait observer, recorders never
+  block behind `r.mu.Lock`; from the first review pass: a stale ref across a shared-identity rebind
+  lands on the session's new gate and leaves the other identity untouched; a stale ref across a sweep
+  of a disconnected gate lands on the gate a fresh lookup finds (by session and by stable id); a clear
+  keeps the retired gate and files nothing; a fresh gate survives the first sweep; a rebind between
+  the probe's resolution and its claim lands the claim on the new gate in both commit modes; the
+  lock-free fast path follows the rebind; from the second pass:
+  `TestScanRevalidatesGateAcrossSharedRebind` (a scan that loaded the shared gate before the rebind is
+  gated on the session's new gate — breaker and dispatch-load cooldown, both commit modes — while an
+  unconfirmed read of the stale gate says clean, the sibling's view reads not gated, and the
+  end-to-end reservation never lands on the rebound session; fails with the confirmation stubbed out);
+  `TestGateRecordersRaceRebindsAndSweeps` now also runs routing reads against a session flapping
+  between a shared and an enriched identity with a permanent dispatch-load cooldown and asserts no read
+  ever admits it, alongside the recorders and probe claims racing rebinds and sweeps under `-race`.
+- `request_path_probe_test.go`: the probe benches from 01.
+- Existing tracker suites adapted to the gate API (helpers only; assertions unchanged); index ==
+  brute-force, routing_context, fleet_sample and gate-tally suites untouched and green.
+- `api`: `TestRegistryGateWaitHistogramTaggedBySite`; full `go test ./api/` green against the new
+  registry.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-04 · commit `d96255acc`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-04 · commit `c54b40e18`
+> Last updated: 2026-09-04 · commit `d96255acc`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -63,6 +63,7 @@ Plans and decision memos live in [`../design/`](../design/README.md).
 | 2026-09-02 | [coordinator-performance-pr-body](2026-09-02-coordinator-performance-pr-body.md) | Original PR body of the 75-commit program branch, kept as the record |
 | 2026-09-03 | [perf-pr-a-body](2026-09-03-perf-pr-a-body.md) | Landing the store/api half of the program on master (read-through cache, batched route sink, parse-once bodies, relay coalescing) |
 | 2026-09-03 | [perf-pr-b-body](2026-09-03-perf-pr-b-body.md) | PR description for the routing-scan landing (PR B): per-model provider index, in-place snapshots, TPS median caches, version memos, heartbeat swap-plan coalescing; before/after benchmarks and the `scanned` semantics change |
+| 2026-09-03 | [perf-pr-c-tier3-body](2026-09-03-perf-pr-c-tier3-body.md) | PR description for the Tier 3 lock restructure (PR C, stacked on PR B): per-identity `gateState` fault trackers off the global write lock, the reservation commit under `r.mu.RLock` + `p.mu`, the `EIGENINFERENCE_RESERVE_COMMIT_MODE` kill switch; invariants, benchmarks and the review follow-ups |
 | 2026-09-03 | [perf-pr-cd-body](2026-09-03-perf-pr-cd-body.md) | Wave fixes following the A+B base: WebSocket fragmentation, bounded queue drains, restart/drain/cancel lifecycle and telemetry |
 
 ## Raw benchmark outputs


### PR DESCRIPTION
## What changes

Reservation commits and terminal fault bookkeeping currently contend on the fleet-wide registry write lock. This PR gives each stable provider identity its own fault-state gate and commits reservations under the registry read lock plus the selected provider's lock. Requests keep the existing admission, billing, cooldown, and retry behavior while avoiding that write-lock queue in the reservation and fault-recorder paths.

**Stack:** Merge order: #821 → #820 → #819 → #823 → #822. Each PR targets its immediate parent; retarget to master as its parent lands. This PR targets #823 and contains only the Tier 3 delta. All branches are rebased on current master.

- Keep snapshot, admission check, half-open probe claim, and pending debit inside one provider-lock section. Attestation/account rebinds respect that same lock, including alias selection and rejected-provider classification.
- Validate gate references after locking. Follow migrations and swept gates; missing clear-only targets are no-ops. Exhausted optimistic retries resolve and acquire the current gate while holding the index lock.
- Preserve Tier 1's delayed capacity-accept ordering: later rejection strikes, cooldowns, and clamps survive an older accept observation. Keep global-mode write-wait metrics and separate per-gate wait metrics.
- Move Tier 2's version-reset and disconnect-flush state into the identity gate. Compare the same disconnect timestamp in live references and the disconnect cache, and recheck suppression inside each fault mutation. Genuine faults and reset throttling remain intact. Cached disconnected identities and in-flight recorder references follow enrichment; version metadata expires through the gate sweep after its reconnect grace.
- Keep the gate implementation split by concern; update canonical routing/scheduling/configuration documentation and the combined stack changelog. The parent PR-B report remains frozen.

## Before

```mermaid
flowchart LR
  R[Request] --> S[scanProviderReservation under registry RLock]
  S --> C[commitProviderReservation or ReserveNextFromPlan waits for registry Lock]
  C --> P[Provider admission and pending debit]
  P --> D[Dispatch and streamed response]
  D --> A[Async capacity accept and terminal recorders acquire registry Lock]
  V[Version change and old disconnect flush] --> A
  A --> G[Global fault maps and quarantine state]
```

## After

```mermaid
flowchart LR
  R[Request] --> S[scanProviderReservation under registry RLock]
  S --> C[Commit under registry RLock and selected provider mutex]
  C --> P[Snapshot, admit, probe claim, pending debit]
  P --> D[Dispatch and streamed response]
  B[Identity rebind] --> L[Same provider mutex protects check through debit]
  L --> C
  D --> A[Async accept and terminal recorders]
  A --> Q[Resolve and validate identity gate]
  Q --> G[Per-identity gate mutex and fault state]
  V[Version reset and dated old-session flush] --> G
  G --> O[Preserve later faults and discard superseded flushes]
```

`EIGENINFERENCE_RESERVE_COMMIT_MODE=shared` is the default. `global` restores the fleet-wide write lock for reservation commits; fault recorders remain on per-identity gates in both modes. Lock order is `registry.mu → provider.mu → gatesMu → gate.mu`.

## Validation

- Full registry suite under `-race` in both `shared` and `global` modes, including exact-capacity reservations, one-probe admission, alias routing, stale/shared/disconnected references, and bounded version retention.
- Focused API and Datadog race suites: delayed accepts, lock metrics, drain/restart/reset behavior, cancel enqueue/terminal interleavings, genuine-versus-neutral fault classification, and both MLX metric transports.
- The API breaker fixture now uses the same account-identity binding step as registration. Parent scheduler and timestamp fixtures use deterministic dispatch control and a frozen clock for exact boundary coverage.
- Coordinator build, `go vet`, golangci-lint (`0 issues`), formatting, and documentation checks passed. Parent #820 also passed isolated PostgreSQL store tests under the race detector.
- The normal pre-push hook runs the complete coordinator test suite; GitHub CI checks the pushed head separately. Final follow-ups also passed targeted race tests and the Swift drain-awareness suite.

Historical profiling motivated this change; final-stack production TTFT improvement has not been measured. Deployment and production configuration changes remain separate human-approved operations. The previously reported Threat Model Review secret failure is deferred by the maintainer; the benchmark environment's manual approval gate remains in place.
