### PR TITLE
perf(coordinator): bound lifecycle work and isolate reservation gates (Tiers 2–3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased — provider lifecycle and bounded coordinator work
+
+- Fragment large provider WebSocket messages, bound queue-drain work, and keep control traffic responsive.
+- Fence typed draining refusals at ingress before releasing the request slot; preserve newer recovery heartbeats. Graceful restarts remain health-neutral, and late disconnect errors follow identity enrichment without re-quarantining an upgraded provider.
+- Correlate cancel sends and terminals atomically, bound version history and telemetry tags, and retain MLX metrics on HTTP-only Datadog deployments.
+
 ## Unreleased (2026-09-04) — console redesign
 
 - Provider onboarding specifies macOS 26 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased — coordinator performance Tiers 2 and 3
+
+- Cache repeated user and model lookups, batch route telemetry writes, and credit balances in one database statement. Invalidate model caches without allowing older in-flight reads to republish stale entries.
+- Coalesce streaming output within a byte cap and parse request bodies once.
+- Reduce routing scan work with per-model provider indexes, maintained medians, reusable snapshots, bounded version memoization, and coalesced swap and queue-drain planning.
+- Commit reservations under the registry read lock and the selected provider's lock. Keep fault tracking on per-identity gates, with validated rebind and sweep handling; retain `EIGENINFERENCE_RESERVE_COMMIT_MODE=global` as the reservation rollback switch.
+- Preserve newer rejection state when capacity-accept bookkeeping arrives late.
+- Make scheduler, attestation timestamp, and reputation persistence test fixtures deterministic.
+
 ## Unreleased — provider lifecycle and bounded coordinator work
 
 - Fragment large provider WebSocket messages, bound queue-drain work, and keep control traffic responsive.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Unreleased — provider lifecycle and bounded coordinator work
 
+- Keep genuine provider 502 faults across version changes; only coordinator-marked disconnect flushes are eligible for reset. Count first-scan TTFT rejections in request outcome telemetry.
+- Evict capped zombie tracker entries in constant time, preserving recent activity without per-insertion full-map scans.
 - Fragment large provider WebSocket messages, bound queue-drain work, and keep control traffic responsive.
 - Fence typed draining refusals at ingress before releasing the request slot; preserve newer recovery heartbeats. Graceful restarts remain health-neutral, and late disconnect errors follow identity enrichment without re-quarantining an upgraded provider.
 - Correlate cancel sends and terminals atomically, bound version history and telemetry tags, and retain MLX metrics on HTTP-only Datadog deployments.

--- a/coordinator/api/attempt_outcome_metrics.go
+++ b/coordinator/api/attempt_outcome_metrics.go
@@ -1,0 +1,392 @@
+package api
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Attempt-level outcome + OpenRouter-view request outcome instrumentation.
+//
+// During the 2026-08-31 cascade the operator could not see, per model, the
+// first-content kill rate or the retry amplification ratio: the only
+// attempt-level series (inference.dispatches{status}) has no model tag, and
+// inference.error{model,reason} collapses first-chunk kills into
+// provider_error. This file adds two low-cardinality counters:
+//
+//   - inference.attempt_outcome{model,class} — exactly one increment per
+//     dispatched attempt, at the single route-outcome funnel every terminal
+//     outcome flows through (updateInferenceRouteOutcomeWithModel). class is
+//     derived from the persisted final_status / error_class / error_reason, so
+//     the metric and the inference_routes row cannot disagree. Kill rate is
+//     first_chunk_timeout / sum(attempt_outcome); amplification is
+//     sum(attempt_outcome) / sum(request_outcome), both per model.
+//
+//   - inference.queue_outcome{model,class} — a request that left the
+//     coordinator queue WITHOUT a provider attempt being dispatched (client
+//     gone, queue_deadline, queue_timeout, ttft_too_slow, tool-constraint
+//     unavailable). Its route row still reaches the funnel, flagged
+//     store.InferenceRouteOutcome.QueueExit by dispatchState.queuedExitOutcome,
+//     and is counted here instead of on attempt_outcome: during a queue
+//     incident thousands of queue expiries would otherwise inflate the
+//     amplification denominator with attempts no provider ever received.
+//
+//   - inference.request_outcome_or_view{model,class} — the number OpenRouter
+//     is intended to estimate. It keeps request_outcome's classes and adds the two
+//     failure kinds request_outcome cannot see: a client that left before the
+//     first token AT or PAST the upstream first-content budget (OpenRouter's
+//     504) is a `timeout`, and a stream that failed after commit is
+//     `mid_stream` (request_outcome counts it as success at commit time). Early
+//     client aborts are tracked as the EXCLUDED class `client_gone`, so the
+//     counter still fires exactly once per client request. The existing
+//     request_outcome semantics are untouched.
+//
+// Both are mirrored on the in-process registry (GET /v1/admin/metrics) so
+// they are readable without a Datadog agent.
+const (
+	metricAttemptOutcome        = "inference.attempt_outcome"
+	metricAttemptOutcomeCounter = "inference_attempt_outcome_total"
+
+	metricRequestOutcomeORView        = "inference.request_outcome_or_view"
+	metricRequestOutcomeORViewCounter = "inference_request_outcome_or_view_total"
+
+	metricQueueOutcome        = "inference.queue_outcome"
+	metricQueueOutcomeCounter = "inference_queue_outcome_total"
+)
+
+// attempt_outcome classes. A fixed vocabulary: anything the mapping does not
+// recognise lands in `other` rather than minting a new tag value.
+const (
+	attemptClassSuccess             = "success"
+	attemptClassFirstChunkTimeout   = "first_chunk_timeout"
+	attemptClassDeadlineUnreachable = "deadline_unreachable"
+	attemptClassCapacity            = "capacity"
+	attemptClassClientError         = "client_error"
+	attemptClassFault               = "fault"
+	attemptClassSendFailed          = "send_failed"
+	attemptClassDisconnect          = "disconnect"
+	attemptClassClientGone          = "client_gone"
+	attemptClassSpeculativeLoser    = "speculative_loser"
+	attemptClassOther               = "other"
+)
+
+// queue_outcome classes: the queue-wait exits that never dispatched an attempt
+// (dispatchState.queuedExitOutcome), keyed by the error_class those exits
+// persist. A fixed vocabulary: anything else lands in `other`.
+const (
+	queueClassClientGone            = "client_gone"
+	queueClassQueueDeadline         = rejectionReasonQueueDeadline
+	queueClassQueueTimeout          = "queue_timeout"
+	queueClassTTFTTooSlow           = "ttft_too_slow"
+	queueClassCapabilityUnsupported = "model_capability_unsupported"
+	queueClassOther                 = "other"
+)
+
+// orClassClientGone is the OR-view class for a client that left before the
+// first token well inside the upstream budget (an application abort, not our
+// slowness) and for post-commit client disconnects. EXCLUDED from the uptime
+// formula, like rate_limited / client_error.
+const orClassClientGone = "client_gone"
+
+// deadline_bucket tag values on routing.client_gone: elapsed time at the
+// cancel relative to the request's first-content budget (d.deadline, the
+// coordinator-side mirror of the upstream first-content deadline).
+const (
+	deadlineBucketUnderHalf     = "under_half"     // < 0.5 x budget: application abort
+	deadlineBucketMid           = "mid"            // 0.5 .. 0.8 x budget
+	deadlineBucketNearDeadline  = "near_deadline"  // >= 0.8 x budget: upstream was about to time out
+	deadlineBucketOver          = "over"           // >= budget: upstream already timed out (its 504)
+	deadlineBucketUnknown       = "unknown"        // no request clock on this dispatch
+	deadlineBucketNotApplicable = "not_applicable" // after-commit phase: the budget was met
+)
+
+// isCapacityClassErrorReason reports whether a persisted error_reason names a
+// capacity / admission condition (the provider is healthy but full, the
+// request cannot fit, or the provider is draining ahead of a restart and
+// refusing new work — routing counts that as transient capacity too) rather
+// than a fault.
+func isCapacityClassErrorReason(reason string) bool {
+	switch normalizeInferenceErrorReason(reason) {
+	case errorReasonCapacityBusy, errorReasonCapacityTimeout, errorReasonQueueFull,
+		errorReasonTokenBudgetExhaust, errorReasonRequestExceedsContext,
+		errorReasonRequestExceedsNode, errorReasonRequestExceedsNodeBudget,
+		errorReasonRequestExceedsBatchBudget, errorReasonModelLoad,
+		errorReasonDraining:
+		return true
+	default:
+		return false
+	}
+}
+
+// attemptOutcomeClass maps a TERMINAL route outcome to its attempt_outcome
+// class. Returns "" for a non-terminal (commit-time pre-fill) outcome, which
+// must not be counted. partial_success is an attempt that DID deliver first
+// content (the ladder succeeded); its post-commit failure is measured on
+// inference.in_band_error and request_outcome_or_view{mid_stream}, not here.
+func attemptOutcomeClass(outcome *store.InferenceRouteOutcome) string {
+	if outcome == nil {
+		return ""
+	}
+	status := strings.ToLower(strings.TrimSpace(outcome.FinalStatus))
+	class := strings.ToLower(strings.TrimSpace(outcome.ErrorClass))
+	switch status {
+	case "":
+		return ""
+	case finalStatusSuccess, finalStatusPartialSuccess:
+		return attemptClassSuccess
+	case finalStatusCancelled:
+		if class == "speculative_loser" {
+			return attemptClassSpeculativeLoser
+		}
+		return attemptClassClientGone
+	case finalStatusTimeout:
+		// Queue expiries never dispatched to a provider: they are fleet
+		// capacity, not a first-content kill, and must not inflate the
+		// per-model kill rate the alert sketch keys on.
+		if class == "queue_timeout" || class == "queue_deadline" {
+			return attemptClassCapacity
+		}
+		return attemptClassFirstChunkTimeout
+	case finalStatusError:
+		return attemptErrorOutcomeClass(class, outcome)
+	default:
+		return attemptClassOther
+	}
+}
+
+func attemptErrorOutcomeClass(class string, outcome *store.InferenceRouteOutcome) string {
+	switch class {
+	case "first_chunk_timeout":
+		return attemptClassFirstChunkTimeout
+	case errorClassDeadlineUnreachable:
+		return attemptClassDeadlineUnreachable
+	case errorClassClientError:
+		return attemptClassClientError
+	case "provider_disconnect_pre_commit", "provider_disconnect_before_response":
+		return attemptClassDisconnect
+	case "ttft_too_slow", "queue_timeout", errorReasonQueueFull:
+		return attemptClassCapacity
+	}
+	if isCapacityClassErrorReason(outcome.ErrorReason) {
+		return attemptClassCapacity
+	}
+	switch class {
+	case errorReasonProviderError:
+		// providerFailedRoutingOutcomeFor stamps AdmittedButFailed on every
+		// provider-executed failure; a bare provider_error row without it is a
+		// coordinator-side dispatch failure ("failed to send request to
+		// provider", request preparation) — the attempt never reached the engine.
+		if !outcome.AdmittedButFailed {
+			return attemptClassSendFailed
+		}
+		return attemptClassFault
+	case "provider_error_before_response", "provider_incomplete_before_response":
+		return attemptClassFault
+	}
+	return attemptClassOther
+}
+
+// queueOutcomeClass maps the terminal outcome of a queue-wait exit (an
+// outcome flagged QueueExit) to its queue_outcome class. Returns "" for a
+// non-terminal outcome, which must not be counted.
+func queueOutcomeClass(outcome *store.InferenceRouteOutcome) string {
+	if outcome == nil || strings.TrimSpace(outcome.FinalStatus) == "" {
+		return ""
+	}
+	switch class := strings.ToLower(strings.TrimSpace(outcome.ErrorClass)); class {
+	case queueClassClientGone, queueClassQueueDeadline, queueClassQueueTimeout,
+		queueClassTTFTTooSlow, queueClassCapabilityUnsupported:
+		return class
+	default:
+		return queueClassOther
+	}
+}
+
+// emitAttemptOutcomeMetric records one attempt_outcome increment for a
+// terminal route outcome. Called from the route-outcome funnel only. A
+// queue-wait exit (outcome.QueueExit) dispatched nothing and is counted on
+// queue_outcome instead, so attempt_outcome stays one-per-dispatched-attempt.
+func (s *Server) emitAttemptOutcomeMetric(model string, outcome *store.InferenceRouteOutcome) {
+	if s == nil || outcome == nil {
+		return
+	}
+	if outcome.QueueExit {
+		s.emitQueueOutcomeMetric(model, outcome)
+		return
+	}
+	class := attemptOutcomeClass(outcome)
+	if class == "" {
+		return
+	}
+	if model == "" {
+		model = "unknown"
+	}
+	if s.metrics != nil {
+		s.metrics.IncCounter(metricAttemptOutcomeCounter,
+			MetricLabel{"model", model}, MetricLabel{"class", class})
+	}
+	if s.dd == nil {
+		return
+	}
+	s.ddIncr(metricAttemptOutcome, []string{"model:" + model, "class:" + class})
+}
+
+// emitQueueOutcomeMetric records one queue_outcome increment for the terminal
+// route outcome of a queue-wait exit that never dispatched an attempt.
+func (s *Server) emitQueueOutcomeMetric(model string, outcome *store.InferenceRouteOutcome) {
+	class := queueOutcomeClass(outcome)
+	if s == nil || class == "" {
+		return
+	}
+	if model == "" {
+		model = "unknown"
+	}
+	if s.metrics != nil {
+		s.metrics.IncCounter(metricQueueOutcomeCounter,
+			MetricLabel{"model", model}, MetricLabel{"class", class})
+	}
+	if s.dd == nil {
+		return
+	}
+	s.ddIncr(metricQueueOutcome, []string{"model:" + model, "class:" + class})
+}
+
+// orViewClassForCommittedOutcome maps the terminal outcome of a COMMITTED
+// attempt (the request delivered first content) to its OR-view class. ok is
+// false for pre-content terminals, which are counted at the exhausted ladder /
+// client-gone arms instead.
+func orViewClassForCommittedOutcome(outcome *store.InferenceRouteOutcome) (class string, ok bool) {
+	if outcome == nil {
+		return "", false
+	}
+	switch strings.ToLower(strings.TrimSpace(outcome.FinalStatus)) {
+	case finalStatusSuccess:
+		return orClassSuccess, true
+	case finalStatusPartialSuccess:
+		errClass := strings.ToLower(strings.TrimSpace(outcome.ErrorClass))
+		if strings.HasPrefix(errClass, "client_gone_after_commit") || errClass == "no_terminal_after_cancel" {
+			// The consumer left after content had flowed: the upstream is the
+			// one that hung up, so it is not graded against us.
+			return orClassClientGone, true
+		}
+		// provider_error/disconnect/incomplete_after_commit, stream_timeout_after_commit.
+		return orClassMidStream, true
+	default:
+		return "", false
+	}
+}
+
+// emitCommittedRequestOutcomeORView records the OR-view outcome for a
+// committed attempt's terminal route outcome. Called from the route-outcome
+// funnel; no-op for pre-content terminals.
+func (s *Server) emitCommittedRequestOutcomeORView(model string, outcome *store.InferenceRouteOutcome) {
+	class, ok := orViewClassForCommittedOutcome(outcome)
+	if !ok {
+		return
+	}
+	s.recordRequestOutcomeORView(model, class)
+}
+
+// recordRequestOutcomeORView emits one request_outcome_or_view increment.
+// Unlike recordRequestOutcome it carries no kv_backend tag and is scoped to
+// every inference endpoint (the committed arm fires from the route-outcome
+// funnel, which does not know the consumer endpoint).
+func (s *Server) recordRequestOutcomeORView(model, class string) {
+	if s == nil || class == "" {
+		return
+	}
+	if model == "" {
+		model = "unknown"
+	}
+	if s.metrics != nil {
+		s.metrics.IncCounter(metricRequestOutcomeORViewCounter,
+			MetricLabel{"model", model}, MetricLabel{"class", class})
+	}
+	if s.dd == nil {
+		return
+	}
+	s.ddIncr(metricRequestOutcomeORView, []string{"model:" + model, "class:" + class})
+}
+
+// deadlineBucket buckets a pre-content client cancel by how much of the
+// first-content budget had elapsed when the client left.
+func deadlineBucket(elapsed, budget time.Duration) string {
+	if budget <= 0 || elapsed < 0 {
+		return deadlineBucketUnknown
+	}
+	ratio := float64(elapsed) / float64(budget)
+	switch {
+	case ratio < 0.5:
+		return deadlineBucketUnderHalf
+	case ratio < 0.8:
+		return deadlineBucketMid
+	case ratio < 1.0:
+		return deadlineBucketNearDeadline
+	default:
+		return deadlineBucketOver
+	}
+}
+
+// orViewClassForClientGone maps a pre-content client-gone deadline bucket to
+// the OR-view class: at or past ~the upstream budget the upstream timed out on
+// us (its 504 → timeout); earlier is an application abort (excluded).
+func orViewClassForClientGone(bucket string) string {
+	switch bucket {
+	case deadlineBucketNearDeadline, deadlineBucketOver:
+		return orClassTimeout
+	default:
+		return orClassClientGone
+	}
+}
+
+// clientGoneDeadlineBucket is the deadline bucket for a pre-content cancel on
+// this dispatch, measured on the request clock (ReceivedAt + deadline).
+func (d *dispatchState) clientGoneDeadlineBucket() string {
+	if d == nil || d.timing == nil || d.timing.ReceivedAt.IsZero() || d.deadline <= 0 {
+		return deadlineBucketUnknown
+	}
+	return deadlineBucket(time.Since(d.timing.ReceivedAt), d.deadline)
+}
+
+func (d *dispatchState) recordRequestOutcomeORView(class string) {
+	if d == nil {
+		return
+	}
+	d.s.recordRequestOutcomeORView(d.model, class)
+}
+
+// metricRouteLatency is the per-request scheduler selection latency
+// (reserve → routed) sampled at attempt-0 selection time, so routing distress
+// is visible while requests are still in flight rather than only at their
+// terminal (inference.timing.route_ms). Queued requests are skipped: their
+// RoutedAt includes the queue wait, which the request_queue gauges cover.
+const metricRouteLatency = "routing.route_latency_ms"
+
+// emitRouteLatency records the attempt-0 route segment. Called once the
+// primary attempt's provider is selected (RoutedAt stamped).
+func (d *dispatchState) emitRouteLatency() {
+	if d == nil || d.s == nil || d.s.dd == nil || d.attempt != 0 || d.timing == nil {
+		return
+	}
+	t := d.timing
+	if !t.QueuedAt.IsZero() || t.RoutedAt.IsZero() {
+		return
+	}
+	anchor := t.ReservedAt
+	if !t.MediaFetchedAt.IsZero() {
+		anchor = t.MediaFetchedAt
+	}
+	if anchor.IsZero() || t.RoutedAt.Before(anchor) {
+		return
+	}
+	// Fractional milliseconds: a healthy scan takes well under 1ms, and the
+	// signal this series exists for is that floor rising toward seconds, so
+	// sub-millisecond samples must not be truncated to 0 and dropped.
+	ms := float64(t.RoutedAt.Sub(anchor)) / float64(time.Millisecond)
+	if ms < 0 || math.IsNaN(ms) || math.IsInf(ms, 0) {
+		return
+	}
+	d.s.ddHistogram(metricRouteLatency, ms, []string{"model:" + d.model})
+}

--- a/coordinator/api/attempt_outcome_metrics_test.go
+++ b/coordinator/api/attempt_outcome_metrics_test.go
@@ -1,0 +1,686 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// metricSampleValue parses the numeric value out of a DogStatsD packet
+// ("d_inference.<name>:<value>|<type>|#tags"). The client aggregates identical
+// counter samples inside a flush window into one packet whose value is the
+// sum, so tests must add values rather than count packets.
+func metricSampleValue(t *testing.T, packet string) float64 {
+	t.Helper()
+	colon := strings.Index(packet, ":")
+	pipe := strings.Index(packet, "|")
+	if colon < 0 || pipe < 0 || pipe <= colon {
+		t.Fatalf("unparseable DogStatsD packet %q", packet)
+	}
+	v, err := strconv.ParseFloat(packet[colon+1:pipe], 64)
+	if err != nil {
+		t.Fatalf("packet %q: bad value: %v", packet, err)
+	}
+	return v
+}
+
+// sumMetric adds the values of every packet that carries the metric name and
+// ALL of the given tag substrings.
+func sumMetric(t *testing.T, packets []string, metric string, tags ...string) float64 {
+	t.Helper()
+	total := 0.0
+	for _, p := range packets {
+		if !strings.Contains(p, metric+":") {
+			continue
+		}
+		match := true
+		for _, tag := range tags {
+			if !strings.Contains(p, tag) {
+				match = false
+				break
+			}
+		}
+		if match {
+			total += metricSampleValue(t, p)
+		}
+	}
+	return total
+}
+
+func counterKey(name string, labels ...MetricLabel) string {
+	return metricKey(name, labels)
+}
+
+func TestAttemptOutcomeClass_Mapping(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome store.InferenceRouteOutcome
+		want    string
+	}{
+		{"pre-fill (non-terminal) is not counted", store.InferenceRouteOutcome{}, ""},
+		{"success", store.InferenceRouteOutcome{FinalStatus: finalStatusSuccess}, attemptClassSuccess},
+		{"partial_success is a committed attempt", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "provider_error_after_commit"}, attemptClassSuccess},
+		{"client_gone", store.InferenceRouteOutcome{FinalStatus: finalStatusCancelled, ErrorClass: "client_gone"}, attemptClassClientGone},
+		{"speculative loser", store.InferenceRouteOutcome{FinalStatus: finalStatusCancelled, ErrorClass: "speculative_loser"}, attemptClassSpeculativeLoser},
+		{"first_chunk_timeout (timeout status)", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "first_chunk_timeout", ErrorReason: errorReasonProviderError}, attemptClassFirstChunkTimeout},
+		{"accepted_timeout", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "accepted_timeout"}, attemptClassFirstChunkTimeout},
+		{"preamble_liveness_timeout", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "preamble_liveness_timeout"}, attemptClassFirstChunkTimeout},
+		{"queue_timeout is capacity", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "queue_timeout"}, attemptClassCapacity},
+		{"queue_deadline is capacity, not a kill", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "queue_deadline"}, attemptClassCapacity},
+		{"first_chunk_timeout via dispatch error class", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "first_chunk_timeout"}, attemptClassFirstChunkTimeout},
+		{"deadline_unreachable", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorClassDeadlineUnreachable, ErrorReason: errorReasonDeadlineUnreachable}, attemptClassDeadlineUnreachable},
+		{"client_error (jinja)", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorClassClientError, ErrorReason: errorReasonJinjaTemplate}, attemptClassClientError},
+		{"provider disconnect pre-commit", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "provider_disconnect_pre_commit", ErrorReason: errorReasonProviderError, AdmittedButFailed: true}, attemptClassDisconnect},
+		{"ttft_too_slow is capacity", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "ttft_too_slow"}, attemptClassCapacity},
+		{"provider capacity 503 (token budget)", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonTokenBudgetExhaust, AdmittedButFailed: true, ErrorCode: 503}, attemptClassCapacity},
+		{"provider capacity 503 (busy)", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonCapacityBusy, AdmittedButFailed: true, ErrorCode: 503}, attemptClassCapacity},
+		{"model load failure is capacity", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonModelLoad, AdmittedButFailed: true}, attemptClassCapacity},
+		{"typed draining refusal (chat pre-commit) is capacity, not a fault", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonDraining, AdmittedButFailed: true, ErrorCode: 503}, attemptClassCapacity},
+		{"typed draining refusal (generic endpoint) is capacity, not a fault", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "provider_error_before_response", ErrorReason: errorReasonDraining, AdmittedButFailed: true, ErrorCode: 503}, attemptClassCapacity},
+		{"genuine provider fault", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonProviderError, AdmittedButFailed: true, ErrorCode: 500}, attemptClassFault},
+		{"failed to send (never admitted)", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: errorReasonProviderError, ErrorReason: errorReasonProviderError}, attemptClassSendFailed},
+		{"generic endpoint provider error before response", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "provider_error_before_response", AdmittedButFailed: true}, attemptClassFault},
+		{"encryption_missing is other", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "encryption_missing"}, attemptClassOther},
+		{"unknown status is other", store.InferenceRouteOutcome{FinalStatus: "weird"}, attemptClassOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attemptOutcomeClass(&tc.outcome); got != tc.want {
+				t.Fatalf("attemptOutcomeClass = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	if got := attemptOutcomeClass(nil); got != "" {
+		t.Fatalf("nil outcome class = %q, want empty", got)
+	}
+}
+
+func TestORViewClassForCommittedOutcome(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome store.InferenceRouteOutcome
+		want    string
+		wantOK  bool
+	}{
+		{"success", store.InferenceRouteOutcome{FinalStatus: finalStatusSuccess}, orClassSuccess, true},
+		{"provider error after commit is mid_stream", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "provider_error_after_commit"}, orClassMidStream, true},
+		{"provider disconnect after commit is mid_stream", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "provider_disconnect_after_commit"}, orClassMidStream, true},
+		{"stream timeout after commit is mid_stream", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "stream_timeout_after_commit"}, orClassMidStream, true},
+		{"provider incomplete after commit is mid_stream", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "provider_incomplete_after_commit"}, orClassMidStream, true},
+		{"client gone after commit (completed) is excluded", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: errorClassClientGoneAfterCommitCompleted}, orClassClientGone, true},
+		{"client gone after commit (error) is excluded", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "client_gone_after_commit_provider_error"}, orClassClientGone, true},
+		{"no terminal after cancel is excluded", store.InferenceRouteOutcome{FinalStatus: finalStatusPartialSuccess, ErrorClass: "no_terminal_after_cancel"}, orClassClientGone, true},
+		{"pre-content error is not a committed outcome", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "provider_error"}, "", false},
+		{"pre-content timeout is not a committed outcome", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "first_chunk_timeout"}, "", false},
+		{"pre-fill is not counted", store.InferenceRouteOutcome{}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := orViewClassForCommittedOutcome(&tc.outcome)
+			if got != tc.want || ok != tc.wantOK {
+				t.Fatalf("orViewClassForCommittedOutcome = (%q, %v), want (%q, %v)", got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestDeadlineBucket_AndORViewClass(t *testing.T) {
+	budget := 10 * time.Second
+	cases := []struct {
+		elapsed time.Duration
+		budget  time.Duration
+		want    string
+		wantOR  string
+	}{
+		{0, 0, deadlineBucketUnknown, orClassClientGone},
+		{time.Second, budget, deadlineBucketUnderHalf, orClassClientGone},
+		{4999 * time.Millisecond, budget, deadlineBucketUnderHalf, orClassClientGone},
+		{5 * time.Second, budget, deadlineBucketMid, orClassClientGone},
+		{7999 * time.Millisecond, budget, deadlineBucketMid, orClassClientGone},
+		{8 * time.Second, budget, deadlineBucketNearDeadline, orClassTimeout},
+		{9800 * time.Millisecond, budget, deadlineBucketNearDeadline, orClassTimeout},
+		{10 * time.Second, budget, deadlineBucketOver, orClassTimeout},
+		{30 * time.Second, budget, deadlineBucketOver, orClassTimeout},
+		{-time.Second, budget, deadlineBucketUnknown, orClassClientGone},
+	}
+	for _, tc := range cases {
+		got := deadlineBucket(tc.elapsed, tc.budget)
+		if got != tc.want {
+			t.Errorf("deadlineBucket(%s, %s) = %q, want %q", tc.elapsed, tc.budget, got, tc.want)
+		}
+		if or := orViewClassForClientGone(got); or != tc.wantOR {
+			t.Errorf("orViewClassForClientGone(%q) = %q, want %q", got, or, tc.wantOR)
+		}
+	}
+	if got := orViewClassForClientGone(deadlineBucketNotApplicable); got != orClassClientGone {
+		t.Errorf("not_applicable bucket must be excluded, got %q", got)
+	}
+}
+
+func TestSanitizeVersionTag(t *testing.T) {
+	cases := map[string]string{
+		"":                       "unknown",
+		"  ":                     "unknown",
+		"0.6.20":                 "0.6.x",
+		"v0.8.16":                "0.8.x",
+		"0.8.16-rc.1":            "prerelease",
+		"0.8.16-beta.2":          "prerelease",
+		"build-a1":               "other",
+		"0.8.16-abc123":          "other",
+		"0.8.16-rc":              "other",
+		"0.8.16+build.5":         "other",
+		"1.2":                    "other",
+		"1.2.3.4":                "other",
+		"01.2.3":                 "other",
+		"0.6.20 evil:tag":        "other",
+		"0.6,20":                 "other",
+		strings.Repeat("9", 40):  "other",
+		strings.Repeat("a", 200): "other",
+	}
+	for in, want := range cases {
+		if got := sanitizeVersionTag(in); got != want {
+			t.Errorf("sanitizeVersionTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := providerVersionTag(nil); got != "unknown" {
+		t.Errorf("providerVersionTag(nil) = %q, want unknown", got)
+	}
+}
+
+// waitForCounter polls the in-process metrics snapshot until pred holds or
+// the deadline passes; returns the final snapshot.
+func waitForCounters(t *testing.T, srv *Server, timeout time.Duration, pred func(MetricsSnapshot) bool) MetricsSnapshot {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		snap := srv.metrics.Snapshot()
+		if pred(snap) || time.Now().After(deadline) {
+			return snap
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestAttemptOutcome_SilentProviderLadder: every provider stays silent, so the
+// request-absolute first-content clock kills each dispatched attempt and the
+// ladder ends in one uptime-neutral 429. Asserts the attempt-level funnel:
+// exactly one attempt_outcome per dispatched attempt (amplification is
+// computable), at least one first_chunk_timeout kill, exactly one
+// request_outcome{rate_limited} and one request_outcome_or_view{rate_limited},
+// a Retry-After sample from the exhausted writer, and an attempt-0 route
+// latency sample — through the real HTTP + WebSocket path and a real UDP
+// DogStatsD collector.
+func TestAttemptOutcome_SilentProviderLadder(t *testing.T) {
+	reg, _, srv, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{
+		FirstContentDeadlineBase: 400 * time.Millisecond,
+	})
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	const model = "attempt-outcome-silent-model"
+	silent := func(context.Context, *failoverProvider, protocol.InferenceRequestMessage, []byte) {}
+	providers := make([]*failoverProvider, 0, 3)
+	for i := range 3 {
+		providers = append(providers, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name: fmt.Sprintf("silent-%d", i), Version: "0.6.20", DecodeTPS: 100,
+			Models: []failoverModelSpec{{ID: model}}, Script: silent,
+		}))
+	}
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 (first-content clock exhausted); body = %s", status, body)
+	}
+
+	dispatched := 0
+	for _, fp := range providers {
+		dispatched += fp.dispatchCount()
+	}
+	if dispatched == 0 {
+		t.Fatal("no provider was dispatched")
+	}
+	classes := []string{
+		attemptClassSuccess, attemptClassFirstChunkTimeout, attemptClassDeadlineUnreachable,
+		attemptClassCapacity, attemptClassClientError, attemptClassFault, attemptClassSendFailed,
+		attemptClassDisconnect, attemptClassClientGone, attemptClassSpeculativeLoser, attemptClassOther,
+	}
+	attemptTotal := func(snap MetricsSnapshot) int64 {
+		var total int64
+		for _, class := range classes {
+			total += snap.Counters[counterKey(metricAttemptOutcomeCounter,
+				MetricLabel{"model", model}, MetricLabel{"class", class})]
+		}
+		return total
+	}
+	snap := waitForCounters(t, srv, 3*time.Second, func(s MetricsSnapshot) bool {
+		return attemptTotal(s) >= int64(dispatched)
+	})
+	if got := attemptTotal(snap); got != int64(dispatched) {
+		t.Fatalf("attempt_outcome total = %d, want exactly one per dispatched attempt (%d); counters=%v",
+			got, dispatched, snap.Counters)
+	}
+	kills := snap.Counters[counterKey(metricAttemptOutcomeCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", attemptClassFirstChunkTimeout})]
+	if kills < 1 {
+		t.Fatalf("attempt_outcome{first_chunk_timeout} = %d, want >= 1; counters=%v", kills, snap.Counters)
+	}
+	if got := snap.Counters[counterKey(metricRequestOutcomeORViewCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", orClassRateLimited})]; got != 1 {
+		t.Fatalf("request_outcome_or_view{rate_limited} = %d, want 1; counters=%v", got, snap.Counters)
+	}
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := sumMetric(t, packets, metricAttemptOutcome, "model:"+model, "class:"+attemptClassFirstChunkTimeout); got != float64(kills) {
+		t.Errorf("UDP attempt_outcome{first_chunk_timeout} = %v, want %d; packets=%v", got, kills, findMetrics(packets, metricAttemptOutcome))
+	}
+	if got := sumMetric(t, packets, metricAttemptOutcome, "model:"+model); got != float64(dispatched) {
+		t.Errorf("UDP attempt_outcome total = %v, want %d", got, dispatched)
+	}
+	if got := sumMetric(t, packets, metricRequestOutcome, "model:"+model, "class:"+orClassRateLimited); got != 1 {
+		t.Errorf("UDP request_outcome{rate_limited} = %v, want 1; packets=%v", got, findMetrics(packets, metricRequestOutcome))
+	}
+	if got := sumMetric(t, packets, metricRequestOutcomeORView, "model:"+model, "class:"+orClassRateLimited); got != 1 {
+		t.Errorf("UDP request_outcome_or_view{rate_limited} = %v, want 1", got)
+	}
+	if !hasMetric(findMetrics(packets, metricRouteLatency), "model:"+model) {
+		t.Errorf("missing routing.route_latency_ms{model} sample; packets=%v", packets)
+	}
+	for _, p := range packets {
+		if strings.Contains(p, "provider_id:") &&
+			(strings.Contains(p, metricAttemptOutcome) || strings.Contains(p, metricRequestOutcomeORView) ||
+				strings.Contains(p, metricRouteLatency)) {
+			t.Errorf("new series must never carry a provider id: %q", p)
+		}
+	}
+}
+
+// TestDispatch_ClientGoneBetweenAttempts_RecordsClientGone (D2): the client
+// has left by the time the ladder moves to its second attempt. Before the
+// fix this fell through to the exhausted arm, wrote a 429 to a dead socket
+// and counted the request as rate_limited on the OR-uptime counter. It must
+// instead be recorded as a pre-content client_gone (with a deadline bucket),
+// refund exactly once, and write nothing.
+func TestDispatch_ClientGoneBetweenAttempts_RecordsClientGone(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "d2-client-gone-model"
+	// Socketless providers: the dispatch funnel reserves, encrypts, then fails
+	// the write deterministically ("failed to send request to provider"), so
+	// attempt 0 is a retryable send failure and the ladder reaches attempt 1.
+	registerBuildsProvider(srv, "d2-p1", model)
+	registerBuildsProvider(srv, "d2-p2", model)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the client is already gone
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}")).WithContext(ctx)
+	refunds := 0
+	deadline := 5 * time.Second
+	d := &dispatchState{
+		s:                     srv,
+		w:                     w,
+		r:                     r,
+		model:                 model,
+		publicModel:           model,
+		rawBody:               []byte(`{"model":"` + model + `"}`),
+		consumerKey:           "test-key",
+		estimatedPromptTokens: 6,
+		requestedMaxTokens:    64,
+		timing:                &registry.RequestTiming{ReceivedAt: time.Now()},
+		deadline:              deadline,
+		speculativeAt:         deadline / 2,
+		refundReservation:     func() { refunds++ },
+		excludeProviders:      make(map[string]struct{}),
+	}
+	d.run()
+
+	if refunds != 1 {
+		t.Errorf("reservation refunds = %d, want exactly 1", refunds)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("wrote a response to a dead socket: %s", w.Body.String())
+	}
+	if d.attempt != 1 {
+		t.Errorf("ladder stopped at attempt %d, want the client-gone exit at attempt 1", d.attempt)
+	}
+
+	snap := srv.metrics.Snapshot()
+	if got := snap.Counters[counterKey(metricRequestOutcomeORViewCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", orClassClientGone})]; got != 1 {
+		t.Errorf("request_outcome_or_view{client_gone} = %d, want 1; counters=%v", got, snap.Counters)
+	}
+	if got := snap.Counters[counterKey(metricAttemptOutcomeCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", attemptClassSendFailed})]; got != 1 {
+		t.Errorf("attempt_outcome{send_failed} = %d, want 1 (attempt 0's socketless write); counters=%v", got, snap.Counters)
+	}
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	gone := findMetrics(packets, "routing.client_gone")
+	if len(gone) != 1 {
+		t.Fatalf("routing.client_gone packets = %d, want 1; packets=%v", len(gone), packets)
+	}
+	if !strings.Contains(gone[0], "phase:"+phaseBeforeFirstToken) || !strings.Contains(gone[0], "deadline_bucket:"+deadlineBucketUnderHalf) {
+		t.Errorf("client_gone tags: %q, want phase:before_first_token and deadline_bucket:under_half", gone[0])
+	}
+	// metricRequestOutcome is a prefix of the OR-view name: match the sample
+	// separator so only the legacy counter is inspected.
+	if out := findMetrics(packets, metricRequestOutcome+":"); len(out) != 0 {
+		t.Errorf("a client that left mid-ladder must not be counted on request_outcome: %v", out)
+	}
+	if got := sumMetric(t, packets, metricRequestOutcomeORView, "model:"+model, "class:"+orClassClientGone); got != 1 {
+		t.Errorf("UDP request_outcome_or_view{client_gone} = %v, want 1", got)
+	}
+}
+
+// TestRecordRejection_MirrorsORView: the pre-dispatch rejection arm emits one
+// request_outcome_or_view increment per rejection, classed like
+// request_outcome and tagged with the RESOLVED model only (the requested name
+// is client-controlled and must never mint a tag value).
+func TestRecordRejection_MirrorsORView(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "or-view-mirror-model"
+	srv.recordRejection(rejectionInfo{
+		stage: "preflight_capacity", reasonCode: "machine_busy", httpStatus: http.StatusTooManyRequests,
+		requestedModel: "client-typed-alias", resolvedModel: model, retryAfterMs: 7000,
+	})
+	srv.recordRejection(rejectionInfo{
+		stage: "validation", reasonCode: "bad_request", httpStatus: http.StatusBadRequest,
+		requestedModel: "client-typed-alias", resolvedModel: model,
+	})
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := sumMetric(t, packets, metricRequestOutcomeORView, "model:"+model, "class:"+orClassRateLimited); got != 1 {
+		t.Errorf("request_outcome_or_view{rate_limited} = %v, want 1; packets=%v", got, findMetrics(packets, metricRequestOutcomeORView))
+	}
+	if got := sumMetric(t, packets, metricRequestOutcomeORView, "model:"+model, "class:"+orClassClientError); got != 1 {
+		t.Errorf("request_outcome_or_view{client_error} = %v, want 1; packets=%v", got, findMetrics(packets, metricRequestOutcomeORView))
+	}
+	for _, p := range findMetrics(packets, metricRequestOutcomeORView) {
+		if strings.Contains(p, "client-typed-alias") {
+			t.Errorf("request_outcome_or_view must tag the RESOLVED model only: %q", p)
+		}
+	}
+}
+
+// TestUnknownFrames_CountedByKindAndVersion: a provider sends chunk /
+// complete / error frames for a request the coordinator does not know. Each
+// must be counted on inference.unknown_frames by frame kind and the provider's
+// binary version — never its id.
+func TestUnknownFrames_CountedByKindAndVersion(t *testing.T) {
+	reg, _, srv, ts := setupTTFTFailoverServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "unknown-frames-model"
+	const version = "0.6.20"
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "zombie", Version: version, DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: model}},
+	})
+	const bogus = "no-such-request-id"
+	frames := []any{
+		protocol.InferenceResponseChunkMessage{Type: protocol.TypeInferenceResponseChunk, RequestID: bogus, Data: "data: {}\n\n"},
+		protocol.InferenceCompleteMessage{Type: protocol.TypeInferenceComplete, RequestID: bogus},
+		protocol.InferenceErrorMessage{Type: protocol.TypeInferenceError, RequestID: bogus, Error: "zombie", StatusCode: 500},
+	}
+	for _, frame := range frames {
+		data, err := json.Marshal(frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := fp.conn.Write(ctx, websocket.MessageText, data); err != nil {
+			t.Fatalf("write frame: %v", err)
+		}
+	}
+
+	key := func(kind string) string {
+		return counterKey(metricUnknownFramesCounter,
+			MetricLabel{"kind", kind}, MetricLabel{"provider_version", "0.6.x"})
+	}
+	snap := waitForCounters(t, srv, 3*time.Second, func(s MetricsSnapshot) bool {
+		return s.Counters[key(unknownFrameKindChunk)] == 1 &&
+			s.Counters[key(unknownFrameKindComplete)] == 1 &&
+			s.Counters[key(unknownFrameKindError)] == 1
+	})
+	for _, kind := range []string{unknownFrameKindChunk, unknownFrameKindComplete, unknownFrameKindError} {
+		if got := snap.Counters[key(kind)]; got != 1 {
+			t.Errorf("unknown_frames{kind=%s,provider_version=%s} = %d, want 1; counters=%v", kind, version, got, snap.Counters)
+		}
+	}
+
+	_ = dd.Statsd.Flush()
+	packets := findMetrics(collector.drain(), metricUnknownFrames)
+	for _, kind := range []string{unknownFrameKindChunk, unknownFrameKindComplete, unknownFrameKindError} {
+		if got := sumMetric(t, packets, metricUnknownFrames, "kind:"+kind, "provider_version:0.6.x"); got != 1 {
+			t.Errorf("UDP unknown_frames{kind:%s} = %v, want 1; packets=%v", kind, got, packets)
+		}
+	}
+	for _, p := range packets {
+		if strings.Contains(p, "provider_id:") || strings.Contains(p, fp.registryID) || strings.Contains(p, bogus) {
+			t.Errorf("unknown_frames must not carry provider or request identity: %q", p)
+		}
+	}
+}
+
+// TestFleetGauges_QueueDepth exercises the gauge emitter StartDDGaugeLoop
+// calls: a queued request shows up on the per-model depth / oldest-age gauges.
+func TestFleetGauges_QueueDepth(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "fleet-gauge-model"
+	registerBuildsProvider(srv, "fg-healthy", model)
+
+	q := srv.registry.Queue()
+	queued := &registry.QueuedRequest{RequestID: "fg-queued-1", Model: model}
+	if err := q.Enqueue(queued); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	defer q.Remove(queued.RequestID, model)
+	time.Sleep(20 * time.Millisecond)
+
+	srv.emitPerModelQueueGauges(srv.registry.ModelProviderSnapshot())
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := sumMetric(t, packets, metricQueueDepthByModel, "model:"+model); got != 1 {
+		t.Errorf("request_queue.depth_by_model{%s} = %v, want 1; packets=%v", model, got, findMetrics(packets, metricQueueDepthByModel))
+	}
+	ages := findMetrics(packets, metricQueueOldestAgeMs)
+	if !hasMetric(ages, "model:"+model) {
+		t.Errorf("missing request_queue.oldest_age_ms{model}; packets=%v", packets)
+	}
+	for _, p := range ages {
+		if strings.Contains(p, "model:"+model) && metricSampleValue(t, p) < 10 {
+			t.Errorf("oldest_age_ms should reflect the 20ms-old waiter: %q", p)
+		}
+	}
+}
+
+func TestQueueOutcomeClass_Mapping(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome store.InferenceRouteOutcome
+		want    string
+	}{
+		{"pre-fill (non-terminal) is not counted", store.InferenceRouteOutcome{}, ""},
+		{"client gone while queued", store.InferenceRouteOutcome{FinalStatus: finalStatusCancelled, ErrorClass: "client_gone"}, queueClassClientGone},
+		{"queue_deadline", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: rejectionReasonQueueDeadline}, queueClassQueueDeadline},
+		{"queue_timeout", store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: "queue_timeout"}, queueClassQueueTimeout},
+		{"ttft_too_slow", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "ttft_too_slow"}, queueClassTTFTTooSlow},
+		{"tool constraint unavailable", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "model_capability_unsupported"}, queueClassCapabilityUnsupported},
+		{"unknown exit class is other", store.InferenceRouteOutcome{FinalStatus: finalStatusError, ErrorClass: "something_new"}, queueClassOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := queueOutcomeClass(&tc.outcome); got != tc.want {
+				t.Fatalf("queueOutcomeClass = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	if got := queueOutcomeClass(nil); got != "" {
+		t.Fatalf("nil outcome class = %q, want empty", got)
+	}
+}
+
+// TestEmitAttemptOutcomeMetric_QueueExitIsNotAnAttempt: the same terminal
+// outcome reaches the funnel twice — once flagged as a queue-wait exit (no
+// provider attempt was dispatched) and once as a dispatched attempt. Only the
+// latter may increment attempt_outcome; the former lands on queue_outcome.
+// Both the in-process registry and the DogStatsD sink are asserted.
+func TestEmitAttemptOutcomeMetric_QueueExitIsNotAnAttempt(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "queue-exit-unit-model"
+	attemptTotal := func(snap MetricsSnapshot) int64 {
+		var total int64
+		for key, v := range snap.Counters {
+			if strings.HasPrefix(key, metricAttemptOutcomeCounter) && strings.Contains(key, "model="+model) {
+				total += v
+			}
+		}
+		return total
+	}
+
+	queued := &store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: rejectionReasonQueueDeadline, ErrorCode: http.StatusGatewayTimeout, QueueExit: true}
+	srv.emitAttemptOutcomeMetric(model, queued)
+	snap := srv.metrics.Snapshot()
+	if got := attemptTotal(snap); got != 0 {
+		t.Fatalf("attempt_outcome after a queue exit = %d, want 0; counters=%v", got, snap.Counters)
+	}
+	if got := snap.Counters[counterKey(metricQueueOutcomeCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", queueClassQueueDeadline})]; got != 1 {
+		t.Fatalf("queue_outcome{queue_deadline} = %d, want 1; counters=%v", got, snap.Counters)
+	}
+
+	// A queue exit that never became terminal is not counted anywhere.
+	srv.emitAttemptOutcomeMetric(model, &store.InferenceRouteOutcome{QueueExit: true})
+
+	// The same class from a DISPATCHED attempt still counts as an attempt.
+	dispatched := &store.InferenceRouteOutcome{FinalStatus: finalStatusTimeout, ErrorClass: rejectionReasonQueueDeadline, ErrorCode: http.StatusGatewayTimeout}
+	srv.emitAttemptOutcomeMetric(model, dispatched)
+	snap = srv.metrics.Snapshot()
+	if got := attemptTotal(snap); got != 1 {
+		t.Fatalf("attempt_outcome after a dispatched terminal = %d, want 1; counters=%v", got, snap.Counters)
+	}
+	if got := snap.Counters[counterKey(metricAttemptOutcomeCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", attemptClassCapacity})]; got != 1 {
+		t.Fatalf("attempt_outcome{capacity} = %d, want 1; counters=%v", got, snap.Counters)
+	}
+	var queueTotal int64
+	for key, v := range snap.Counters {
+		if strings.HasPrefix(key, metricQueueOutcomeCounter) && strings.Contains(key, "model="+model) {
+			queueTotal += v
+		}
+	}
+	if queueTotal != 1 {
+		t.Fatalf("queue_outcome total = %d, want exactly the one queue exit; counters=%v", queueTotal, snap.Counters)
+	}
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := sumMetric(t, packets, metricQueueOutcome, "model:"+model, "class:"+queueClassQueueDeadline); got != 1 {
+		t.Errorf("UDP queue_outcome{queue_deadline} = %v, want 1; packets=%v", got, findMetrics(packets, metricQueueOutcome))
+	}
+	if got := sumMetric(t, packets, metricAttemptOutcome, "model:"+model); got != 1 {
+		t.Errorf("UDP attempt_outcome total = %v, want 1 (the dispatched terminal only); packets=%v", got, findMetrics(packets, metricAttemptOutcome))
+	}
+}
+
+// TestQueuedExit_LiveQueueDeadline_CountsOnQueueOutcome drives the REAL HTTP
+// + WebSocket path: the single slot is saturated, the request queues, and the
+// first-content clock expires inside the queue wait. Nothing was dispatched,
+// so attempt_outcome must stay at zero for the model while queue_outcome
+// records exactly one queue_deadline — the amplification denominator must not
+// move for a request no provider ever received.
+func TestQueuedExit_LiveQueueDeadline_CountsOnQueueOutcome(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	const model = "queue-exit-live-model"
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	// Install the client before any provider connects: heartbeat telemetry
+	// reads s.dd on the provider read loop, so setting it afterwards races.
+	srv, _, _, ts := queuedFleetHarnessConfigured(t, ctx, ServerConfig{FirstContentDeadlineBase: 400 * time.Millisecond}, model, func(s *Server) {
+		s.SetDatadog(dd)
+	})
+
+	res := chatRequestWithID(ctx, ts.URL, model, "queue-exit-live")
+	if res.err != nil {
+		t.Fatalf("chat request: %v", res.err)
+	}
+	if res.status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", res.status, res.body)
+	}
+
+	queueKey := counterKey(metricQueueOutcomeCounter, MetricLabel{"model", model}, MetricLabel{"class", queueClassQueueDeadline})
+	snap := waitForCounters(t, srv, 3*time.Second, func(s MetricsSnapshot) bool {
+		return s.Counters[queueKey] >= 1
+	})
+	if got := snap.Counters[queueKey]; got != 1 {
+		t.Fatalf("queue_outcome{queue_deadline} = %d, want 1; counters=%v", got, snap.Counters)
+	}
+	for key, v := range snap.Counters {
+		if strings.HasPrefix(key, metricAttemptOutcomeCounter) && strings.Contains(key, "model="+model) && v != 0 {
+			t.Fatalf("attempt_outcome incremented for a queue-only request: %s=%d; counters=%v", key, v, snap.Counters)
+		}
+	}
+
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := sumMetric(t, packets, metricQueueOutcome, "model:"+model, "class:"+queueClassQueueDeadline); got != 1 {
+		t.Errorf("UDP queue_outcome{queue_deadline} = %v, want 1; packets=%v", got, findMetrics(packets, metricQueueOutcome))
+	}
+	if got := sumMetric(t, packets, metricAttemptOutcome, "model:"+model); got != 0 {
+		t.Errorf("UDP attempt_outcome total = %v, want 0 for a queue-only request; packets=%v", got, findMetrics(packets, metricAttemptOutcome))
+	}
+}

--- a/coordinator/api/cancel_lifecycle.go
+++ b/coordinator/api/cancel_lifecycle.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Cancel causes: the bounded set of reasons the coordinator sends a WS cancel.
+// A cancel is sent ONLY when the attempt's pending record still existed when
+// it was abandoned — i.e. no provider terminal had been seen — so a provider
+// error or a clean completion never produces one.
+const (
+	cancelCauseFirstChunkTimeout = "first_chunk_timeout"
+	cancelCauseHedgeLoser        = "hedge_loser"
+	cancelCauseClientGonePre     = "client_gone_pre"
+	cancelCauseClientGonePost    = "client_gone_post"
+	// cancelCauseStreamTimeout covers every other post-commit exit without a
+	// terminal — the idle stream timeout in practice.
+	cancelCauseStreamTimeout = "stream_timeout"
+	cancelCauseOverflow      = "overflow"
+	cancelCauseLateContent   = "late_content"
+	// cancelCauseStrayChunk is a cancel triggered by a chunk for an id no
+	// abandon path recorded (genuinely unknown, or predating a restart).
+	cancelCauseStrayChunk = "stray_chunk"
+)
+
+const (
+	metricCancelSent         = "inference.cancel_sent"
+	metricCancelSendFailed   = "inference.cancel_send_failed"
+	metricCancelToTerminalMs = "inference.cancel_to_terminal_ms"
+	metricCancelledTerminal  = "inference.cancelled_terminal"
+	metricCancelUnresolved   = "inference.cancel_unresolved"
+	metricZombieStreamCancel = "inference.zombie_stream_cancel"
+
+	cancelTerminalComplete   = "complete"
+	cancelTerminalError      = "error"
+	cancelTerminalStrayChunk = "stray_chunk"
+
+	cancelledOutcomeCompletePartial = "complete_partial"
+	cancelledOutcomeErrorCancelled  = "error_cancelled"
+	cancelledOutcomeErrorOther      = "error_other"
+)
+
+func modelTag(model string) string {
+	if model == "" {
+		return "unknown"
+	}
+	return model
+}
+
+func cancelLatencyMs(d time.Duration) float64 {
+	if d < 0 {
+		return 0
+	}
+	return float64(d) / float64(time.Millisecond)
+}
+
+// sendAbandonCancel is the cancel primitive for an abandon path whose pending
+// record was removed elsewhere (post-commit defer, handleChunk's overflow and
+// late-content aborts): it records the request for terminal correlation and
+// zombie re-sends, counts the cause, and sends the frame.
+func (s *Server) sendAbandonCancel(provider *registry.Provider, requestID, model, cause string) {
+	now := time.Now()
+	_, expired := s.zombieCanceller.record(requestID, model, cause, now)
+	s.emitExpiredCancelEntries(expired)
+	s.sendRecordedCancel(provider, requestID, model, cause)
+}
+
+// sendRecordedCancel sends the cancel for a request already recorded in the
+// zombie tracker. The send is marked and counted on inference.cancel_sent only
+// once the frame was handed to the provider writer: a control lane that is
+// full or a writer that has stopped delivered nothing, so the entry is kept
+// unsent (sent == 0) for the next stray chunk to retry, and a terminal that
+// arrives meanwhile is not reported as cancel-to-terminal.
+func (s *Server) sendRecordedCancel(provider *registry.Provider, requestID, model, cause string) {
+	resendIndex, sent := s.zombieCanceller.send(requestID, func() bool {
+		return s.sendProviderCancel(provider, requestID)
+	})
+	if !sent {
+		return
+	}
+	if resendIndex > 0 {
+		// A stray chunk can deliver the first cancel while the abandon
+		// path releases capacity. This frame is then a resend too.
+		s.ddIncr(metricZombieStreamCancel, []string{"resend_index:" + strconv.Itoa(resendIndex)})
+		return
+	}
+	s.ddIncr(metricCancelSent, []string{"cause:" + cause, "model:" + modelTag(model)})
+}
+
+// cancelSendFailureReason maps an EnqueueText error to a bounded tag value.
+func cancelSendFailureReason(err error) string {
+	switch {
+	case errors.Is(err, registry.ErrProviderWriterQueueFull):
+		return "queue_full"
+	case errors.Is(err, registry.ErrProviderWriterStopped):
+		return "writer_stopped"
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		return "ctx"
+	default:
+		return "other"
+	}
+}
+
+// noteStrayChunk handles a chunk for a request the coordinator no longer
+// tracks. For a request the coordinator cancelled it is the expected tail of
+// that cancel: the cancel is re-sent on the escalating zombie schedule (the
+// provider treats duplicates as free) and the log line is rate-limited per
+// provider. An id nobody abandoned is counted as an unknown frame and
+// cancelled immediately.
+func (s *Server) noteStrayChunk(provider *registry.Provider, providerID, requestID string, now time.Time) {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	res := s.zombieCanceller.strayChunk(requestID, now)
+	s.emitExpiredCancelEntries(res.expired)
+	if res.cause == cancelCauseStrayChunk {
+		s.emitUnknownFrame(unknownFrameKindChunk, provider)
+	}
+	// request_id stays out of the log: until it matches coordinator state it is
+	// provider-controlled and an arbitrary log-exfiltration channel.
+	if allow, suppressed := s.zombieCanceller.allowStrayWarn(providerID, now); allow {
+		s.logger.Warn("chunk for unknown request",
+			"provider_id", providerID,
+			"suppressed", suppressed,
+		)
+	}
+	if !res.send {
+		return
+	}
+	resendIndex, sent := s.zombieCanceller.send(requestID, func() bool {
+		return s.sendProviderCancel(provider, requestID)
+	})
+	if !sent {
+		return
+	}
+	if resendIndex < 0 {
+		// Untracked (zero-value Server): the frame went out, nothing to count.
+		return
+	}
+	if resendIndex == 0 {
+		// First cancel DELIVERED for this id: cause stray_chunk when no abandon
+		// path recorded one, or the abandon path's cause when its own send
+		// never reached the writer (or lost this race by microseconds).
+		s.ddIncr(metricCancelSent, []string{"cause:" + res.cause, "model:" + modelTag(res.model)})
+	}
+	s.ddIncr(metricZombieStreamCancel, []string{"resend_index:" + strconv.Itoa(resendIndex)})
+}
+
+// resolveCancelledTerminal correlates a provider terminal that found no live
+// pending record with the cancel the coordinator recorded for it. Metric-only:
+// billing for a parked post-commit record still settles in the caller, and a
+// pre-commit attempt was refunded when it was abandoned. Returns the entry so
+// the caller can classify the terminal instead of logging it as unknown.
+// inference.cancelled_terminal is tagged delivered:false when no cancel ever
+// reached the provider writer (every enqueue failed): the provider finished
+// on its own, and the cancel→terminal latency is not measured for it.
+func (s *Server) resolveCancelledTerminal(requestID, terminal, outcome string, now time.Time) (zombieEntry, bool) {
+	e, ok := s.zombieCanceller.terminal(requestID)
+	if !ok {
+		return zombieEntry{}, false
+	}
+	delivered := e.sent > 0
+	if delivered {
+		s.ddHistogram(metricCancelToTerminalMs, cancelLatencyMs(now.Sub(e.firstSentAt)),
+			[]string{"terminal:" + terminal, "model:" + modelTag(e.model), "cause:" + e.cause})
+	}
+	s.ddIncr(metricCancelledTerminal, []string{"outcome:" + outcome, "cause:" + e.cause,
+		"delivered:" + strconv.FormatBool(delivered)})
+	return e, true
+}
+
+// cancelledErrorOutcome classifies an error terminal for a cancelled request.
+func cancelledErrorOutcome(msg *protocol.InferenceErrorMessage) string {
+	if msg == nil {
+		return cancelledOutcomeErrorOther
+	}
+	if msg.StatusCode == 499 ||
+		msg.FailureCode == protocol.FailureCodeCancelled ||
+		msg.TerminalCause == terminalCauseCancelled {
+		return cancelledOutcomeErrorCancelled
+	}
+	return cancelledOutcomeErrorOther
+}
+
+// emitExpiredCancelEntries reports cancels that never got a terminal. One
+// that delivered a cancel and produced subsequent stray chunks contributes
+// its last chunk as the terminal (terminal:stray_chunk). Every other entry
+// is counted unresolved —
+// the provider honored the cancel silently, disconnected, or never saw it.
+func (s *Server) emitExpiredCancelEntries(expired []zombieEntry) {
+	for i := range expired {
+		e := &expired[i]
+		if e.sent > 0 && !e.lastStrayAt.IsZero() && !e.lastStrayAt.Before(e.firstSentAt) {
+			s.ddHistogram(metricCancelToTerminalMs, cancelLatencyMs(e.lastStrayAt.Sub(e.firstSentAt)),
+				[]string{"terminal:" + cancelTerminalStrayChunk, "model:" + modelTag(e.model), "cause:" + e.cause})
+			continue
+		}
+		s.ddIncr(metricCancelUnresolved, []string{"cause:" + e.cause, "model:" + modelTag(e.model)})
+	}
+}

--- a/coordinator/api/cancel_lifecycle_test.go
+++ b/coordinator/api/cancel_lifecycle_test.go
@@ -1,0 +1,328 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+func TestCancelSendFailureReason(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{registry.ErrProviderWriterQueueFull, "queue_full"},
+		{registry.ErrProviderWriterStopped, "writer_stopped"},
+		{context.DeadlineExceeded, "ctx"},
+		{context.Canceled, "ctx"},
+		{errors.New("boom"), "other"},
+	}
+	for _, c := range cases {
+		if got := cancelSendFailureReason(c.err); got != c.want {
+			t.Errorf("cancelSendFailureReason(%v) = %q, want %q", c.err, got, c.want)
+		}
+	}
+}
+
+// TestSendProviderCancelMetersDeliveryFailure: a cancel that cannot be handed
+// to the provider writer is no longer Debug-only — it is counted on
+// inference.cancel_send_failed with a bounded reason. A provider whose writer
+// is gone (disconnect race, the historical "expected case") reports
+// writer_stopped through the real DogStatsD client.
+func TestSendProviderCancelMetersDeliveryFailure(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := NewServer(registry.New(logger), store.NewMemory(store.Config{AdminKey: "k"}), ServerConfig{}, logger)
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	// Connected as far as the Server can tell (Conn set) but its writer has
+	// been torn down: EnqueueText fails with the writer-stopped sentinel.
+	p := &registry.Provider{ID: "p-dead", Conn: &websocket.Conn{}}
+	if srv.sendProviderCancel(p, "req-1") {
+		t.Fatal("sendProviderCancel must report failure when the writer is gone")
+	}
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	got := findMetrics(packets, metricCancelSendFailed)
+	if len(got) != 1 || !strings.Contains(got[0], "reason:writer_stopped") {
+		t.Fatalf("cancel_send_failed packets = %v, want one with reason:writer_stopped", got)
+	}
+	for _, pk := range got {
+		if strings.Contains(pk, "req-1") || strings.Contains(pk, "p-dead") {
+			t.Fatalf("metric must not carry request or provider identity: %q", pk)
+		}
+	}
+
+	// No socket at all is a test fixture, not a delivery failure: no metric.
+	if srv.sendProviderCancel(&registry.Provider{ID: "p-nosock"}, "req-2") {
+		t.Fatal("provider without a socket cannot succeed")
+	}
+	_ = dd.Statsd.Flush()
+	if extra := findMetrics(collector.drain(), metricCancelSendFailed); len(extra) != 0 {
+		t.Fatalf("nil Conn must not be metered as a delivery failure: %v", extra)
+	}
+}
+
+// TestCancelDispatchSkipsCancelAfterCompletionIngress pins the hedge-loser
+// edge case: a racer that completed EMPTY on time is parked by handleComplete
+// on the speculative empty-completion decision WITHOUT RemovePending, so its
+// record is still live when cancelDispatch runs — yet the completion ingress
+// proves nothing is running. No cancel, no cancel_sent, no zombie entry. A
+// racer with no terminal at all still gets its cancel recorded; this fixture
+// has no socket, so nothing is handed to a writer and cancel_sent stays at
+// zero (delivery counting is pinned in TestCancelSendCountsOnlyDeliveredFrames).
+func TestCancelDispatchSkipsCancelAfterCompletionIngress(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "k"}), ServerConfig{}, logger)
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+	model := "hedge-empty-model"
+	provider := makeRoutableProvider(t, reg, "p1", model)
+	newPending := func(id string) *registry.PendingRequest {
+		pr := &registry.PendingRequest{
+			RequestID:  id,
+			Model:      model,
+			ChunkCh:    make(chan registry.ProviderChunk, 1),
+			CompleteCh: make(chan protocol.UsageInfo, 1),
+			ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		}
+		provider.AddPending(pr)
+		return pr
+	}
+
+	finished := newPending("req-finished-empty")
+	finished.MarkCompletionIngress(time.Now())
+	srv.cancelDispatch(provider, finished, cancelCauseHedgeLoser)
+	if provider.GetPending(finished.RequestID) != nil {
+		t.Fatal("cancelDispatch must still remove the pending record")
+	}
+	if n := srv.zombieCanceller.size(); n != 0 {
+		t.Fatalf("a racer that already completed must not be tracked as a zombie (size=%d)", n)
+	}
+	_ = dd.Statsd.Flush()
+	if got := findMetrics(collector.drain(), metricCancelSent); len(got) != 0 {
+		t.Fatalf("cancel_sent must not fire for a racer whose completion was ingressed: %v", got)
+	}
+
+	running := newPending("req-still-running")
+	srv.cancelDispatch(provider, running, cancelCauseHedgeLoser)
+	if n := srv.zombieCanceller.size(); n != 1 {
+		t.Fatalf("a still-running racer must be tracked for terminal correlation (size=%d)", n)
+	}
+	_ = dd.Statsd.Flush()
+	if got := findMetrics(collector.drain(), metricCancelSent); len(got) != 0 {
+		t.Fatalf("no socket, no frame handed over: cancel_sent must not fire, got %v", got)
+	}
+}
+
+// TestCancelSendCountsOnlyDeliveredFrames pins the delivery semantics of the
+// cancel lifecycle telemetry. A cancel whose enqueue fails (writer stopped /
+// control lane full) is recorded but neither marked nor counted on
+// inference.cancel_sent; a terminal for it is correlated (so the caller does
+// not log it as unknown) but reported as cancelled_terminal{delivered:false}
+// with no cancel_to_terminal_ms sample. The next stray chunk retries; the
+// first cancel that reaches a writer counts cancel_sent exactly once, under
+// the abandon path's cause, and a terminal after it is delivered:true with a
+// latency sample. A live provider whose first send succeeds is counted at once.
+func TestCancelSendCountsOnlyDeliveredFrames(t *testing.T) {
+	srv, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "cancel-delivery-model"
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{{ID: model, ModelType: "chat"}}, "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	ids := reg.ProviderIDs()
+	if len(ids) != 1 {
+		t.Fatalf("registered providers = %v, want exactly one", ids)
+	}
+	live := reg.GetProvider(ids[0])
+	dead := &registry.Provider{ID: "p-dead", Conn: &websocket.Conn{}}
+	entry := func(id string) zombieEntry {
+		srv.zombieCanceller.mu.Lock()
+		defer srv.zombieCanceller.mu.Unlock()
+		e := srv.zombieCanceller.entries[id]
+		if e == nil {
+			t.Fatalf("no zombie entry for %s", id)
+		}
+		return *e
+	}
+	drain := func() []string {
+		_ = dd.Statsd.Flush()
+		return collector.drain()
+	}
+
+	// Enqueue fails: recorded, unsent, not counted.
+	t0 := time.Now()
+	srv.sendAbandonCancel(dead, "req-fail", model, cancelCauseClientGonePost)
+	packets := drain()
+	if got := findMetrics(packets, metricCancelSent); len(got) != 0 {
+		t.Fatalf("a failed enqueue must not count as sent: %v", got)
+	}
+	requireMetricWithTags(t, packets, metricCancelSendFailed, "reason:writer_stopped")
+	if e := entry("req-fail"); e.sent != 0 || e.cause != cancelCauseClientGonePost {
+		t.Fatalf("entry after failed send = %+v, want sent=0 with the abandon cause", e)
+	}
+
+	// The provider finishes on its own: correlated, but no cancel was delivered.
+	e, ok := srv.resolveCancelledTerminal("req-fail", cancelTerminalComplete, cancelledOutcomeCompletePartial, t0.Add(time.Second))
+	if !ok || e.sent != 0 {
+		t.Fatalf("terminal correlation = (%+v, %v), want the unsent entry", e, ok)
+	}
+	packets = drain()
+	if got := findMetrics(packets, metricCancelToTerminalMs); len(got) != 0 {
+		t.Fatalf("no cancel reached the provider, so no cancel→terminal latency: %v", got)
+	}
+	requireMetricWithTags(t, packets, metricCancelledTerminal,
+		"outcome:"+cancelledOutcomeCompletePartial, "cause:"+cancelCauseClientGonePost, "delivered:false")
+
+	// Enqueue fails, then a stray chunk retries on a writer that accepts: the
+	// first DELIVERED cancel counts cancel_sent once under the abandon cause.
+	srv.sendAbandonCancel(dead, "req-retry", model, cancelCauseFirstChunkTimeout)
+	packets = drain()
+	if got := findMetrics(packets, metricCancelSent); len(got) != 0 {
+		t.Fatalf("a failed enqueue must not count as sent: %v", got)
+	}
+	srv.noteStrayChunk(live, live.ID, "req-retry", time.Now().Add(zombieResendRetry))
+	packets = drain()
+	requireMetricWithTags(t, packets, metricCancelSent, "cause:"+cancelCauseFirstChunkTimeout, "model:"+model)
+	requireMetricWithTags(t, packets, metricZombieStreamCancel, "resend_index:0")
+	if e := entry("req-retry"); e.sent != 1 {
+		t.Fatalf("entry after the delivered retry = %+v, want sent=1", e)
+	}
+	if _, ok := srv.resolveCancelledTerminal("req-retry", cancelTerminalError, cancelledOutcomeErrorCancelled, time.Now()); !ok {
+		t.Fatal("delivered retry must still correlate its terminal")
+	}
+	packets = drain()
+	requireMetricWithTags(t, packets, metricCancelToTerminalMs, "terminal:"+cancelTerminalError, "cause:"+cancelCauseFirstChunkTimeout)
+	requireMetricWithTags(t, packets, metricCancelledTerminal,
+		"outcome:"+cancelledOutcomeErrorCancelled, "cause:"+cancelCauseFirstChunkTimeout, "delivered:true")
+
+	// A stray chunk can win the initial enqueue while the abandon path is
+	// releasing registry capacity. Its later send is a resend, not another
+	// first cancel for this request.
+	srv.zombieCanceller.record("req-stray-first", model, cancelCauseClientGonePre, time.Now())
+	srv.noteStrayChunk(live, live.ID, "req-stray-first", time.Now())
+	srv.sendRecordedCancel(live, "req-stray-first", model, cancelCauseClientGonePre)
+	packets = drain()
+	if got := sumMetric(t, packets, metricCancelSent, "cause:"+cancelCauseClientGonePre, "model:"+model); got != 1 {
+		t.Fatalf("a stray-first race must count one initial cancel, got %v: %v", got, packets)
+	}
+
+	// A live writer: counted on the first send, exactly once.
+	srv.sendAbandonCancel(live, "req-live", model, cancelCauseHedgeLoser)
+	packets = drain()
+	if got := requireMetricWithTags(t, packets, metricCancelSent, "cause:"+cancelCauseHedgeLoser, "model:"+model); len(got) != 1 {
+		t.Fatalf("cancel_sent for a delivered first send = %v, want exactly one", got)
+	}
+	if e := entry("req-live"); e.sent != 1 {
+		t.Fatalf("entry after a delivered first send = %+v, want sent=1", e)
+	}
+}
+
+// TestUnknownTerminalPathsOnBareServer: the unknown-request branches of the
+// provider frame handlers now consult the zombie tracker. A Server built as a
+// bare literal (no canceller, no Datadog, no settlement holder — the shape
+// many unit tests use) and a canceller literal with nil maps must both take
+// those branches without panicking.
+func TestUnknownTerminalPathsOnBareServer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	reg := registry.New(logger)
+	for name, srv := range map[string]*Server{
+		"nil canceller":     {registry: reg, logger: logger},
+		"literal canceller": {registry: reg, logger: logger, zombieCanceller: &zombieStreamCanceller{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			provider := &registry.Provider{ID: "p-bare"}
+			const unknownID = "never-dispatched"
+			srv.handleChunk("p-bare", provider, &protocol.InferenceResponseChunkMessage{
+				Type: protocol.TypeInferenceResponseChunk, RequestID: unknownID,
+			})
+			srv.handleInferenceError("p-bare", provider, &protocol.InferenceErrorMessage{
+				Type: protocol.TypeInferenceError, RequestID: unknownID,
+				Error: "boom", StatusCode: 500,
+			})
+			srv.handleCompleteAt("p-bare", provider, &protocol.InferenceCompleteMessage{
+				Type: protocol.TypeInferenceComplete, RequestID: unknownID,
+			}, time.Now())
+			// A second chunk for the same id exercises the re-send path too.
+			srv.handleChunk("p-bare", provider, &protocol.InferenceResponseChunkMessage{
+				Type: protocol.TypeInferenceResponseChunk, RequestID: unknownID,
+			})
+		})
+	}
+}
+
+func TestCancelLatencyUsesFirstSuccessfulSend(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv := &Server{dd: dd, zombieCanceller: newZombieStreamCanceller()}
+	t0 := time.Now()
+	for _, terminal := range []string{cancelTerminalComplete, cancelTerminalStrayChunk} {
+		id := "delayed-" + terminal
+		srv.zombieCanceller.record(id, "m", cancelCauseClientGonePost, t0)
+		srv.zombieCanceller.noteSendFailed(id, t0)
+		srv.zombieCanceller.markSent(id, t0.Add(10*time.Second))
+		// A later resend must not move the latency anchor.
+		srv.zombieCanceller.markSent(id, t0.Add(11*time.Second))
+		if terminal == cancelTerminalComplete {
+			srv.resolveCancelledTerminal(id, terminal, cancelledOutcomeCompletePartial, t0.Add(12*time.Second))
+		} else {
+			srv.zombieCanceller.strayChunk(id, t0.Add(12*time.Second))
+			e, _ := srv.zombieCanceller.terminal(id)
+			srv.emitExpiredCancelEntries([]zombieEntry{e})
+		}
+		_ = dd.Statsd.Flush()
+		packets := collector.drain()
+		got := requireMetricWithTags(t, packets, metricCancelToTerminalMs, "terminal:"+terminal)
+		if len(got) != 1 || !strings.Contains(got[0], metricCancelToTerminalMs+":2000|h") {
+			t.Fatalf("latency must exclude the failed-send delay: %v", got)
+		}
+	}
+}
+
+func TestExpiredUndeliveredCancelIsUnresolved(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv := &Server{dd: dd, zombieCanceller: newZombieStreamCanceller()}
+	t0 := time.Now()
+	// The failed retry sees a stray chunk, but still delivers no cancel.
+	srv.zombieCanceller.record("unsent", "m", cancelCauseClientGonePre, t0)
+	srv.zombieCanceller.noteSendFailed("unsent", t0)
+	srv.zombieCanceller.strayChunk("unsent", t0.Add(time.Second))
+	srv.zombieCanceller.noteSendFailed("unsent", t0.Add(time.Second))
+	e, _ := srv.zombieCanceller.terminal("unsent")
+	srv.emitExpiredCancelEntries([]zombieEntry{e})
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if got := findMetrics(packets, metricCancelToTerminalMs); len(got) != 0 {
+		t.Fatalf("undelivered cancel must not contribute latency: %v", got)
+	}
+	requireMetricWithTags(t, packets, metricCancelUnresolved, "cause:"+cancelCauseClientGonePre)
+}

--- a/coordinator/api/cancellation_integration_test.go
+++ b/coordinator/api/cancellation_integration_test.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -517,4 +519,397 @@ func TestIntegration_ProviderDeduplicationPreservesNewest(t *testing.T) {
 	if !gotRequest {
 		t.Error("provider B should have received the inference request")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Cancel lifecycle: cancels are sent only for attempts that may still be
+// running (no terminal seen); a provider that keeps streaming after a cancel
+// is re-cancelled on the escalating zombie schedule; its eventual terminal is
+// correlated with the cancel (inference.cancel_to_terminal_ms) instead of
+// being dropped as "unknown".
+// ---------------------------------------------------------------------------
+
+// providerCancelLog records every Cancel frame a fake provider receives.
+type providerCancelLog struct {
+	mu      sync.Mutex
+	cancels []time.Time
+}
+
+func (l *providerCancelLog) add(at time.Time) {
+	l.mu.Lock()
+	l.cancels = append(l.cancels, at)
+	l.mu.Unlock()
+}
+
+func (l *providerCancelLog) times() []time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]time.Time(nil), l.cancels...)
+}
+
+// runFakeProviderReader drives a fake provider's read loop: answers
+// attestation challenges, records Cancel frames, and hands each inference
+// request to onRequest (which runs on the reader goroutine). The returned
+// channel closes when the socket is closed.
+func runFakeProviderReader(
+	ctx context.Context,
+	conn *websocket.Conn,
+	pubKey string,
+	cancels *providerCancelLog,
+	onRequest func(protocol.InferenceRequestMessage),
+) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			var env struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(data, &env)
+			switch env.Type {
+			case protocol.TypeAttestationChallenge:
+				_ = conn.Write(ctx, websocket.MessageText, makeValidChallengeResponse(data, pubKey))
+			case protocol.TypeInferenceRequest:
+				var inferReq protocol.InferenceRequestMessage
+				_ = json.Unmarshal(data, &inferReq)
+				onRequest(inferReq)
+			case protocol.TypeCancel:
+				cancels.add(time.Now())
+			}
+		}
+	}()
+	return done
+}
+
+func writeProviderFrame(ctx context.Context, conn *websocket.Conn, msg any) {
+	data, _ := json.Marshal(msg)
+	_ = conn.Write(ctx, websocket.MessageText, data)
+}
+
+func cancelTestChunkSSE(text string) string {
+	return `data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"` + text + `"}}]}` + "\n\n"
+}
+
+// attachTestDD wires a real DogStatsD client (UDP collector) into srv.
+func attachTestDD(t *testing.T, srv *Server) (*udpCollector, *datadogFlusher) {
+	t.Helper()
+	collector := newUDPCollector(t)
+	dd := newTestDD(t, collector)
+	srv.SetDatadog(dd)
+	t.Cleanup(func() {
+		dd.Close()
+		collector.Close()
+	})
+	return collector, &datadogFlusher{flush: func() { _ = dd.Statsd.Flush() }}
+}
+
+type datadogFlusher struct{ flush func() }
+
+// packets flushes the client and drains everything the collector received.
+func (f *datadogFlusher) packets(c *udpCollector) []string {
+	f.flush()
+	var out []string
+	for range 3 {
+		out = append(out, c.drain()...)
+	}
+	return out
+}
+
+// metricValue parses the sample value out of a DogStatsD line
+// ("name:VALUE|type|#tags").
+func metricValue(t *testing.T, packet string) float64 {
+	t.Helper()
+	head, _, _ := strings.Cut(packet, "|")
+	v, err := strconv.ParseFloat(head[strings.LastIndex(head, ":")+1:], 64)
+	if err != nil {
+		t.Fatalf("metric value in %q: %v", packet, err)
+	}
+	return v
+}
+
+func requireMetricWithTags(t *testing.T, packets []string, name string, tags ...string) []string {
+	t.Helper()
+	var matched []string
+	for _, p := range findMetrics(packets, name) {
+		ok := true
+		for _, tag := range tags {
+			if !strings.Contains(p, tag) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			matched = append(matched, p)
+		}
+	}
+	if len(matched) == 0 {
+		t.Fatalf("no %s packet carrying %v; packets=%v", name, tags, findMetrics(packets, name))
+	}
+	return matched
+}
+
+// connectRoutableProvider connects a fake provider for model and makes it
+// routable (attestation challenge answered, hardware trust).
+func connectRoutableProvider(t *testing.T, ctx context.Context, tsURL, model, pubKey string, reg *registry.Registry) *websocket.Conn {
+	t.Helper()
+	models := []protocol.ModelInfo{{ID: model, ModelType: "chat", Quantization: "4bit"}}
+	conn := connectProvider(t, ctx, tsURL, models, pubKey)
+	challengeCtx, challengeCancel := context.WithTimeout(ctx, 5*time.Second)
+	waitForChallenge(t, challengeCtx, conn, pubKey)
+	challengeCancel()
+	time.Sleep(200 * time.Millisecond)
+	makeProviderRoutable(reg)
+	return conn
+}
+
+func streamingChatRequest(ctx context.Context, tsURL, model string) (*http.Response, error) {
+	body := `{"model":"` + model + `","messages":[{"role":"user","content":"hello"}],"stream":true}`
+	httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost, tsURL+"/v1/chat/completions", strings.NewReader(body))
+	httpReq.Header.Set("Authorization", "Bearer test-key")
+	return http.DefaultClient.Do(httpReq)
+}
+
+// TestIntegration_NoCancelAfterCleanCompletion: a request that streams and
+// completes cleanly must NOT be followed by a Cancel frame. Before this rule
+// the post-commit defer cancelled after every committed request — one no-op
+// cancel per dispatch fleet-wide.
+func TestIntegration_NoCancelAfterCleanCompletion(t *testing.T) {
+	srv, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	collector, dd := attachTestDD(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pubKey := testPublicKeyB64()
+	model := "clean-complete-model"
+	conn := connectRoutableProvider(t, ctx, ts.URL, model, pubKey, reg)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	cancels := &providerCancelLog{}
+	readerDone := runFakeProviderReader(ctx, conn, pubKey, cancels, func(inferReq protocol.InferenceRequestMessage) {
+		writeProviderFrame(ctx, conn, testEncryptedChunk(t, inferReq, pubKey, cancelTestChunkSSE("Hello")))
+		writeProviderFrame(ctx, conn, protocol.InferenceCompleteMessage{
+			Type:      protocol.TypeInferenceComplete,
+			RequestID: inferReq.RequestID,
+			Usage:     protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 1},
+		})
+	})
+
+	resp, err := streamingChatRequest(ctx, ts.URL, model)
+	if err != nil {
+		t.Fatalf("http request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || !strings.Contains(string(body), "Hello") {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+
+	// Keep the provider listening well past the completion.
+	time.Sleep(time.Second)
+	conn.Close(websocket.StatusNormalClosure, "")
+	<-readerDone
+
+	if n := len(cancels.times()); n != 0 {
+		t.Fatalf("provider received %d Cancel frame(s) after a clean inference_complete, want 0", n)
+	}
+	packets := dd.packets(collector)
+	if got := findMetrics(packets, metricCancelSent); len(got) != 0 {
+		t.Fatalf("cancel_sent must not fire for a clean completion: %v", got)
+	}
+	if got := findMetrics(packets, metricCancelToTerminalMs); len(got) != 0 {
+		t.Fatalf("cancel_to_terminal_ms must not fire for a clean completion: %v", got)
+	}
+}
+
+// TestIntegration_NoCancelAfterProviderErrorTerminal: a provider that fails
+// an attempt with inference_error has nothing running, so the retry path must
+// not send it a Cancel frame.
+func TestIntegration_NoCancelAfterProviderErrorTerminal(t *testing.T) {
+	srv, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	collector, dd := attachTestDD(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pubKey := testPublicKeyB64()
+	model := "provider-error-model"
+	conn := connectRoutableProvider(t, ctx, ts.URL, model, pubKey, reg)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	cancels := &providerCancelLog{}
+	readerDone := runFakeProviderReader(ctx, conn, pubKey, cancels, func(inferReq protocol.InferenceRequestMessage) {
+		writeProviderFrame(ctx, conn, protocol.InferenceErrorMessage{
+			Type:        protocol.TypeInferenceError,
+			RequestID:   inferReq.RequestID,
+			Error:       "generation failed",
+			StatusCode:  http.StatusInternalServerError,
+			FailureCode: protocol.FailureCodeGenerationFailure,
+		})
+	})
+
+	resp, err := streamingChatRequest(ctx, ts.URL, model)
+	if err != nil {
+		t.Fatalf("http request: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("status=%d, want a failure after the only provider errored", resp.StatusCode)
+	}
+
+	time.Sleep(time.Second)
+	conn.Close(websocket.StatusNormalClosure, "")
+	<-readerDone
+
+	if n := len(cancels.times()); n != 0 {
+		t.Fatalf("provider received %d Cancel frame(s) after its own inference_error, want 0", n)
+	}
+	if got := findMetrics(dd.packets(collector), metricCancelSent); len(got) != 0 {
+		t.Fatalf("cancel_sent must not fire after a provider error terminal: %v", got)
+	}
+}
+
+// runZombieStreamScenario streams one chunk, disconnects the consumer (which
+// sends the first cancel), then keeps streaming chunks from the fake provider
+// for zombieFor as if it had not honored the cancel, and finally sends the
+// given terminal ("complete" or "error"). It returns the Cancel frame times
+// the provider observed, the DogStatsD packets, the model, and the request id.
+func runZombieStreamScenario(t *testing.T, terminal string, zombieFor time.Duration) ([]time.Time, []string, string, string) {
+	t.Helper()
+	srv, reg, _, ts := setupTestServer(t)
+	defer ts.Close()
+	collector, dd := attachTestDD(t, srv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	pubKey := testPublicKeyB64()
+	model := "zombie-" + terminal + "-model"
+	conn := connectRoutableProvider(t, ctx, ts.URL, model, pubKey, reg)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	cancels := &providerCancelLog{}
+	reqCh := make(chan protocol.InferenceRequestMessage, 1)
+	readerDone := runFakeProviderReader(ctx, conn, pubKey, cancels, func(inferReq protocol.InferenceRequestMessage) {
+		writeProviderFrame(ctx, conn, testEncryptedChunk(t, inferReq, pubKey, cancelTestChunkSSE("Hello")))
+		reqCh <- inferReq
+	})
+
+	reqCtx, reqCancel := context.WithCancel(ctx)
+	resp, err := streamingChatRequest(reqCtx, ts.URL, model)
+	if err != nil {
+		reqCancel()
+		t.Fatalf("http request: %v", err)
+	}
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	if !strings.Contains(string(buf[:n]), "Hello") {
+		reqCancel()
+		t.Fatalf("expected first chunk to contain 'Hello', got: %s", buf[:n])
+	}
+	// Consumer leaves mid-stream: the coordinator sends the first cancel.
+	reqCancel()
+	resp.Body.Close()
+
+	inferReq := <-reqCh
+	// The provider ignores the cancel and keeps generating.
+	deadline := time.Now().Add(zombieFor)
+	for i := 0; time.Now().Before(deadline); i++ {
+		writeProviderFrame(ctx, conn, testEncryptedChunk(t, inferReq, pubKey, cancelTestChunkSSE(fmt.Sprintf("z%d", i))))
+		time.Sleep(100 * time.Millisecond)
+	}
+	switch terminal {
+	case "complete":
+		writeProviderFrame(ctx, conn, protocol.InferenceCompleteMessage{
+			Type:      protocol.TypeInferenceComplete,
+			RequestID: inferReq.RequestID,
+			Usage:     protocol.UsageInfo{PromptTokens: 5, CompletionTokens: 20},
+		})
+	case "error":
+		writeProviderFrame(ctx, conn, protocol.InferenceErrorMessage{
+			Type:          protocol.TypeInferenceError,
+			RequestID:     inferReq.RequestID,
+			Error:         "request cancelled",
+			StatusCode:    499,
+			FailureCode:   protocol.FailureCodeCancelled,
+			TerminalCause: terminalCauseCancelled,
+		})
+	default:
+		t.Fatalf("unknown terminal %q", terminal)
+	}
+	// Let the terminal settle (handleComplete runs off the read loop).
+	time.Sleep(300 * time.Millisecond)
+	conn.Close(websocket.StatusNormalClosure, "")
+	<-readerDone
+	return cancels.times(), dd.packets(collector), model, inferReq.RequestID
+}
+
+func requireNoIdentityInPackets(t *testing.T, packets []string, requestID string) {
+	t.Helper()
+	for _, p := range packets {
+		if strings.Contains(p, requestID) {
+			t.Fatalf("metric must not carry the request id: %q", p)
+		}
+	}
+}
+
+// TestIntegration_ZombieStreamRecancelScheduleAndCompleteTerminal: a provider
+// that keeps streaming after the consumer-gone cancel is re-cancelled at
+// +1 s and +3 s after the first cancel (escalating schedule), and its late
+// inference_complete is correlated with that cancel: cancel_to_terminal_ms
+// {terminal:complete, model, cause:client_gone_post} fires with the
+// cancel→terminal latency, and the terminal is classified complete_partial
+// instead of "unknown".
+func TestIntegration_ZombieStreamRecancelScheduleAndCompleteTerminal(t *testing.T) {
+	const zombieFor = 3500 * time.Millisecond
+	cancels, packets, model, requestID := runZombieStreamScenario(t, "complete", zombieFor)
+
+	if len(cancels) < 3 || len(cancels) > 4 {
+		t.Fatalf("Cancel frames over %v of zombie chunks = %d (%v), want 3: first, +1 s, +3 s", zombieFor, len(cancels), cancels)
+	}
+	gap1, gap2 := cancels[1].Sub(cancels[0]), cancels[2].Sub(cancels[0])
+	if gap1 < 900*time.Millisecond || gap1 > 2500*time.Millisecond {
+		t.Fatalf("first re-send at +%v after the first cancel, want ~+1 s", gap1)
+	}
+	if gap2 < 2900*time.Millisecond || gap2 > 6*time.Second {
+		t.Fatalf("second re-send at +%v after the first cancel, want ~+3 s", gap2)
+	}
+
+	hist := requireMetricWithTags(t, packets, metricCancelToTerminalMs,
+		"terminal:complete", "model:"+model, "cause:"+cancelCauseClientGonePost)
+	if v := metricValue(t, hist[0]); v < 0.8*float64(zombieFor/time.Millisecond) {
+		t.Fatalf("cancel_to_terminal_ms = %v, want >= ~%v (the zombie phase)", v, zombieFor)
+	}
+	requireMetricWithTags(t, packets, metricCancelSent, "cause:"+cancelCauseClientGonePost, "model:"+model)
+	requireMetricWithTags(t, packets, metricZombieStreamCancel, "resend_index:1")
+	requireMetricWithTags(t, packets, metricZombieStreamCancel, "resend_index:2")
+	requireMetricWithTags(t, packets, metricCancelledTerminal, "outcome:"+cancelledOutcomeCompletePartial, "delivered:true")
+	if got := findMetrics(packets, metricCancelUnresolved); len(got) != 0 {
+		t.Fatalf("a correlated terminal must not also count as unresolved: %v", got)
+	}
+	requireNoIdentityInPackets(t, packets, requestID)
+}
+
+// TestIntegration_CancelToTerminalOnLateErrorTerminal: the provider honors
+// the cancel late with a 499 inference_error; the terminal is correlated
+// (terminal:error) and classified error_cancelled.
+func TestIntegration_CancelToTerminalOnLateErrorTerminal(t *testing.T) {
+	const zombieFor = 1200 * time.Millisecond
+	cancels, packets, model, requestID := runZombieStreamScenario(t, "error", zombieFor)
+
+	if len(cancels) < 2 || len(cancels) > 3 {
+		t.Fatalf("Cancel frames over %v of zombie chunks = %d (%v), want 2: first, +1 s", zombieFor, len(cancels), cancels)
+	}
+	hist := requireMetricWithTags(t, packets, metricCancelToTerminalMs,
+		"terminal:error", "model:"+model, "cause:"+cancelCauseClientGonePost)
+	if v := metricValue(t, hist[0]); v < 0.8*float64(zombieFor/time.Millisecond) {
+		t.Fatalf("cancel_to_terminal_ms = %v, want >= ~%v", v, zombieFor)
+	}
+	requireMetricWithTags(t, packets, metricCancelledTerminal, "outcome:"+cancelledOutcomeErrorCancelled, "delivered:true")
+	requireMetricWithTags(t, packets, metricZombieStreamCancel, "resend_index:1")
+	requireNoIdentityInPackets(t, packets, requestID)
 }

--- a/coordinator/api/chip_family_tags.go
+++ b/coordinator/api/chip_family_tags.go
@@ -1,0 +1,22 @@
+package api
+
+import "strings"
+
+// sanitizeChipFamilyTag maps untrusted hardware labels to a fixed vocabulary.
+// New Apple families need an explicit addition; arbitrary registration strings
+// share one fallback across MLX and client-cancellation telemetry.
+func sanitizeChipFamilyTag(family string) string {
+	family = strings.TrimSpace(family)
+	switch family {
+	case "", "Unknown":
+		return "unknown"
+	case "M1", "M1 Pro", "M1 Max", "M1 Ultra",
+		"M2", "M2 Pro", "M2 Max", "M2 Ultra",
+		"M3", "M3 Pro", "M3 Max", "M3 Ultra",
+		"M4", "M4 Pro", "M4 Max", "M4 Ultra",
+		"M5", "M5 Pro", "M5 Max", "M5 Ultra":
+		return strings.ReplaceAll(family, " ", "_")
+	default:
+		return "other"
+	}
+}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -412,14 +412,11 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	// Typed drain refusal (R2, registry/drain_state.go): the provider is
 	// restarting, not sick and not dishonest about capacity. It feeds NO
 	// breaker and NO gray-box capacity state (no cooldown strike, no rate
-	// derate, no budget clamp) — it marks the provider draining so routing
-	// skips it from the next scan on, which also covers a drain whose event
-	// heartbeat has not landed yet; the provider's next idle/serving
-	// heartbeat clears the mark either way.
+	// derate, no budget clamp). Ingress marks draining before releasing the
+	// pending slot, so its queue drain already skips this provider. Do not
+	// repeat that mutation here: an idle/serving heartbeat may have cleared
+	// the mark while this consumer was waiting to process its error channel.
 	if isDrainingErrorReason(errReason) {
-		if s.registry.MarkDraining(providerID) {
-			s.ddIncr("routing.provider_draining", []string{"model:" + pr.Model})
-		}
 		return
 	}
 	// Typed terminal-cause gate (the deadline-incident fix): the provider told

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -189,24 +189,34 @@ func (s *Server) shedIfModelRejected(w http.ResponseWriter, r *http.Request, par
 
 // sendProviderCancel sends a Cancel message for the given request to the
 // provider with a bounded timeout so a half-dead WebSocket doesn't hang the
-// caller. Errors are logged at debug level because a disconnect race is the
-// expected case — the provider may already be gone.
-func (s *Server) sendProviderCancel(provider *registry.Provider, requestID string) {
+// caller. It reports whether the frame was handed to the writer. Failures are
+// logged at debug level because a disconnect race is the expected case — the
+// provider may already be gone — but every one is metered
+// (inference.cancel_send_failed{reason}) since a dropped cancel is the only
+// silent-loss path on the coordinator side of cancel delivery.
+//
+// This is the raw primitive. Abandon paths that may leave the provider
+// generating go through sendAbandonCancel / cancelDispatch so the cancel is
+// recorded for terminal correlation and zombie re-sends.
+func (s *Server) sendProviderCancel(provider *registry.Provider, requestID string) bool {
 	if provider == nil || provider.Conn == nil {
-		return
+		return false
 	}
 	cancelMsg := protocol.CancelMessage{Type: protocol.TypeCancel, RequestID: requestID}
 	cancelData, err := json.Marshal(cancelMsg)
 	if err != nil {
 		s.logger.Error("failed to marshal cancel message", "request_id", requestID, "error", err)
-		return
+		return false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cancelWriteTimeout)
 	defer cancel()
 	if err := provider.EnqueueText(ctx, cancelData); err != nil {
+		s.ddIncr(metricCancelSendFailed, []string{"reason:" + cancelSendFailureReason(err)})
 		s.logger.Debug("failed to send cancel (provider may have disconnected)",
 			"request_id", requestID, "error", err)
+		return false
 	}
+	return true
 }
 
 func writeProviderInferenceRequestDeferred(
@@ -221,24 +231,61 @@ func writeProviderInferenceRequestDeferred(
 	return provider.WriteTextDeferred(ctx, builder, onHandoff)
 }
 
-// cancelDispatch cleans up a speculative dispatch participant that lost the
-// race (or a failed/timed-out attempt): removes the pending request, marks the
-// provider idle, sends a cancel over WebSocket so the provider stops generating
-// tokens, and refunds this attempt's provider-specific reservation top-up.
+// cancelDispatch abandons a dispatch attempt that may still be generating
+// (hedge loser, client gone before content): removes the pending request,
+// marks the provider idle, sends a cancel over WebSocket so the provider stops,
+// and refunds this attempt's provider-specific reservation top-up. cause is
+// the bounded cancel cause recorded for terminal correlation.
+//
+// The cancel is sent only when THIS call removed a live pending record and no
+// clean terminal has been ingressed for it. A missing record means a provider
+// terminal already claimed the attempt (handleInferenceError removes pending
+// before publishing on ErrorCh); a completion parked on the speculative
+// empty-completion decision leaves the record but marks completion ingress.
+// In both cases nothing is running provider-side, and cancelling would only
+// cost the provider a no-op frame per request. Attempts whose terminal was
+// observed by the caller use cancelDispatchAfterTerminal instead.
 //
 // The top-up refund only runs if THIS call actually removed the pending request
 // (RemovePending returned non-nil). If settlement (handleComplete) already
 // claimed it via its own RemovePending, we must not also refund — that would
 // double-credit the consumer.
-func (s *Server) cancelDispatch(provider *registry.Provider, pr *registry.PendingRequest) {
+func (s *Server) cancelDispatch(provider *registry.Provider, pr *registry.PendingRequest, cause string) {
+	if provider == nil || pr == nil {
+		return
+	}
+	pr.ResolveSpeculativeEmptyCompletion(false)
+	now := time.Now()
+	// Record before RemovePending: a terminal racing this cleanup looks the
+	// id up only after its own RemovePending returns nil, and must find the
+	// entry rather than log the terminal as unknown.
+	created, expired := s.zombieCanceller.record(pr.RequestID, pr.Model, cause, now)
+	s.emitExpiredCancelEntries(expired)
+	removed := provider.RemovePending(pr.RequestID)
+	s.registry.SetProviderIdle(provider.ID)
+	if removed != nil && !pr.HasCompletionIngress() {
+		pr.Profile.Mark(registry.StampCancelSent)
+		s.sendRecordedCancel(provider, pr.RequestID, pr.Model, cause)
+	} else if created {
+		s.zombieCanceller.forget(pr.RequestID)
+	}
+	if removed != nil {
+		s.refundProviderExtra(pr)
+	}
+}
+
+// cancelDispatchAfterTerminal is cancelDispatch for an attempt whose provider
+// terminal the caller has already observed (ErrorCh value / ChunkCh closed).
+// The terminal handler removed the pending record before publishing it, so
+// nothing is running provider-side and no cancel frame is sent — only the
+// speculative arbitration, idle transition and top-up refund remain.
+func (s *Server) cancelDispatchAfterTerminal(provider *registry.Provider, pr *registry.PendingRequest) {
 	if provider == nil || pr == nil {
 		return
 	}
 	pr.ResolveSpeculativeEmptyCompletion(false)
 	removed := provider.RemovePending(pr.RequestID)
 	s.registry.SetProviderIdle(provider.ID)
-	pr.Profile.Mark(registry.StampCancelSent)
-	s.sendProviderCancel(provider, pr.RequestID)
 	if removed != nil {
 		s.refundProviderExtra(pr)
 	}
@@ -254,14 +301,20 @@ func (s *Server) cancelDispatchForFirstContentTimeout(
 	if provider == nil || pr == nil {
 		return false
 	}
+	now := time.Now()
+	created, expired := s.zombieCanceller.record(pr.RequestID, pr.Model, cancelCauseFirstChunkTimeout, now)
+	s.emitExpiredCancelEntries(expired)
 	removed, deferred := provider.RemovePendingForFirstContentTimeout(pr.RequestID)
 	if deferred || removed == nil {
+		if created {
+			s.zombieCanceller.forget(pr.RequestID)
+		}
 		return false
 	}
 	pr.ResolveSpeculativeEmptyCompletion(false)
 	s.registry.SetProviderIdle(provider.ID)
 	pr.Profile.Mark(registry.StampCancelSent)
-	s.sendProviderCancel(provider, pr.RequestID)
+	s.sendRecordedCancel(provider, pr.RequestID, pr.Model, cancelCauseFirstChunkTimeout)
 	s.refundProviderExtra(pr)
 	return true
 }
@@ -356,6 +409,19 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	if isProviderHealthNeutralErrorReason(errReason) {
 		return
 	}
+	// Typed drain refusal (R2, registry/drain_state.go): the provider is
+	// restarting, not sick and not dishonest about capacity. It feeds NO
+	// breaker and NO gray-box capacity state (no cooldown strike, no rate
+	// derate, no budget clamp) — it marks the provider draining so routing
+	// skips it from the next scan on, which also covers a drain whose event
+	// heartbeat has not landed yet; the provider's next idle/serving
+	// heartbeat clears the mark either way.
+	if isDrainingErrorReason(errReason) {
+		if s.registry.MarkDraining(providerID) {
+			s.ddIncr("routing.provider_draining", []string{"model:" + pr.Model})
+		}
+		return
+	}
 	// Typed terminal-cause gate (the deadline-incident fix): the provider told
 	// us WHY the attempt died, so the status/string heuristics below must not
 	// misread a platform-policy terminal as sickness. Neutral causes touch no
@@ -381,6 +447,16 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 		}
 		return
 	}
+	// Late disconnect-flush strike (registry/version_reset.go): the session this
+	// 502 was flushed from was dropped at or before its identity's version-
+	// changed reset, so the reset already accounted for it. The flush is
+	// recorded HERE, by the request goroutine, not by Disconnect — and
+	// registration evicts a same-serial predecessor and stores the new version
+	// on one goroutine, ahead of these consumers — so without the check the
+	// new binary would be quarantined for the old one's death.
+	if s.registry.IsSupersededDisconnectFlush(providerID, statusCode) {
+		return
+	}
 	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
 		s.ddIncr("routing.cooldown_entered", []string{"model:" + pr.Model})
 	}
@@ -394,10 +470,8 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	}
 	// Feed the STABLE-IDENTITY ejection breaker too (survives reconnect churn, so a
 	// zombie that fault-loops while constantly disconnecting still accumulates).
-	if sid := s.registry.GetProviderStableIdentity(providerID); sid != "" {
-		if ejected, _ := s.registry.RecordProviderServeOutcome(sid, false, statusCode, errStr); ejected {
-			s.ddIncr("routing.provider_ejected", []string{"model:" + pr.Model})
-		}
+	if ejected, _ := s.registry.RecordProviderSessionServeOutcome(providerID, false, statusCode, errStr); ejected {
+		s.ddIncr("routing.provider_ejected", []string{"model:" + pr.Model})
 	}
 	// Feed the capacity-reject cooldown. Capacity-class rejections are
 	// DELIBERATELY invisible to reputation and to ALL the breakers above (a

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -392,7 +392,7 @@ func (s *Server) writeGenericProviderError(w http.ResponseWriter, errMsg protoco
 // cause (admission_timeout — healthy but busy) feeds only the black-hole
 // capacity cooldown. Absent/engine_error/unknown causes keep the legacy
 // status/string funnels bit-for-bit (see api/terminal_cause.go).
-func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string) {
+func (s *Server) noteInferenceError(providerID string, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, causes ...protocol.CoordinatorInferenceErrorCause) {
 	if providerID == "" || pr == nil {
 		return
 	}
@@ -451,10 +451,10 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	// registration evicts a same-serial predecessor and stores the new version
 	// on one goroutine, ahead of these consumers — so without the check the
 	// new binary would be quarantined for the old one's death.
-	if s.registry.IsSupersededDisconnectFlush(providerID, statusCode) {
+	if s.registry.IsSupersededDisconnectFlush(providerID, statusCode, causes...) {
 		return
 	}
-	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape()) {
+	if s.registry.RecordInferenceError(providerID, pr.Model, statusCode, pr.Traits.CooldownShape(), causes...) {
 		s.ddIncr("routing.cooldown_entered", []string{"model:" + pr.Model})
 	}
 	// Feed EVERY provider terminal into the per-provider node-health breaker (not
@@ -462,12 +462,12 @@ func (s *Server) noteInferenceError(providerID string, pr *registry.PendingReque
 	// fault-503ing ~all of its requests gets quarantined fleet-wide. errStr lets
 	// the breaker tell a capacity-503 (ignored) from a fault-503 (counted). Both
 	// breakers coexist.
-	if opened, _ := s.registry.RecordProviderOutcome(providerID, false, statusCode, errStr); opened {
+	if opened, _ := s.registry.RecordProviderOutcome(providerID, false, statusCode, errStr, causes...); opened {
 		s.ddIncr("routing.provider_breaker_open", []string{"model:" + pr.Model})
 	}
 	// Feed the STABLE-IDENTITY ejection breaker too (survives reconnect churn, so a
 	// zombie that fault-loops while constantly disconnecting still accumulates).
-	if ejected, _ := s.registry.RecordProviderSessionServeOutcome(providerID, false, statusCode, errStr); ejected {
+	if ejected, _ := s.registry.RecordProviderSessionServeOutcome(providerID, false, statusCode, errStr, causes...); ejected {
 		s.ddIncr("routing.provider_ejected", []string{"model:" + pr.Model})
 	}
 	// Feed the capacity-reject cooldown. Capacity-class rejections are
@@ -631,9 +631,9 @@ func (s *Server) noteInferenceSuccess(pr *registry.PendingRequest) {
 // so arms where cancelDispatch did refund are safe, and a failed pre-commit
 // attempt never reaches settlement (its channels are closed and it is neither
 // pending nor parked), so this can never double-credit against a settle.
-func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) (discardedHeld bool) {
+func (s *Server) noteDispatchProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string, causes ...protocol.CoordinatorInferenceErrorCause) (discardedHeld bool) {
 	if provider != nil {
-		s.noteInferenceError(provider.ID, pr, statusCode, errStr, errReason, terminalCause)
+		s.noteInferenceError(provider.ID, pr, statusCode, errStr, errReason, terminalCause, causes...)
 	}
 	s.refundProviderExtra(pr)
 	if held == nil || len(*held) == 0 {
@@ -2657,7 +2657,7 @@ func (s *Server) writeChatStreamProviderError(
 	errMsg protocol.InferenceErrorMessage,
 ) {
 	s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-	s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+	s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, errMsg.CoordinatorCause)
 	s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 	s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 	s.writeChatStreamTerminalError(
@@ -2697,7 +2697,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(
 	}
 	if initialError != nil {
 		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause)
+		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause, initialError.CoordinatorCause)
 		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, *initialError))
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(*initialError))
@@ -2713,7 +2713,7 @@ func (s *Server) handleResponsesStreamingResponseWithFirstChunk(
 	// emitProviderError settles and reports an in-band provider error.
 	emitProviderError := func(errMsg protocol.InferenceErrorMessage) {
 		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, errMsg.CoordinatorCause)
 		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))
@@ -2828,7 +2828,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 	}
 	if initialError != nil {
 		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause)
+		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause, initialError.CoordinatorCause)
 		s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, *initialError))
 		s.writeGenericProviderError(w, *initialError)
 		return
@@ -2842,7 +2842,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 				case errMsg, ok := <-pr.ErrorCh:
 					if ok && errMsg.Error != "" {
 						s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+						s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, errMsg.CoordinatorCause)
 						s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 						s.writeGenericProviderError(w, errMsg)
 						return
@@ -3002,7 +3002,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 				continue
 			}
 			s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+			s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, errMsg.CoordinatorCause)
 			s.updateInferenceRouteOutcomeForPending(pr, preResponseProviderErrorOutcome(pr, errMsg))
 			s.writeGenericProviderError(w, errMsg)
 			return

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1353,13 +1353,13 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			if attempt > 0 {
 				// The legacy loop's exhausted ladder wrote ONE request_rejections
 				// row and ONE OR-uptime outcome for a mid-ladder TTFT storm; keep
-				// both (the attempt-0 path emits neither, unchanged).
+				// the rejection row and legacy dispatched-request metric.
 				retryAfter := s.estimateTTFTRetryAfter(d.model, bestTTFT, d.deadline)
 				s.recordRejection(d.rejectionInfoWithDecision("dispatch", "ttft_too_slow", http.StatusTooManyRequests, retryAfter*1000, decision))
 				d.recordDispatchedRequestOutcome(
 					d.kvBackendAttribution(), classifyOutcomeByCode(http.StatusTooManyRequests))
-				d.recordRequestOutcomeORView(classifyOutcomeByCode(http.StatusTooManyRequests))
 			}
+			d.recordRequestOutcomeORView(classifyOutcomeByCode(http.StatusTooManyRequests))
 			s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, d.deadline)
 			return outcomeResponseWritten
 		}
@@ -1767,8 +1767,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 // provider error and, unless held boilerplate was discarded (which emits its own
 // pre-content failover counter), emits the generic retry counter. This is the
 // exact `if !d.noteProviderError(...) { s.ddIncr(retry) }` pattern.
-func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) {
-	if !d.noteProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held) {
+func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string, causes ...protocol.CoordinatorInferenceErrorCause) {
+	if !d.noteProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held, causes...) {
 		d.s.ddIncr("inference.dispatches", []string{"status:retry"})
 	}
 }
@@ -1797,11 +1797,11 @@ func (d *dispatchState) noteDispatchRetry(provider *registry.Provider, pr *regis
 // (with its retry_precontent counter) run for EVERY reason:
 // noteDispatchProviderError only feeds noteInferenceError for a non-nil
 // provider, while the refund + held handling are unconditional.
-func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string) (discardedHeld bool) {
+func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *registry.PendingRequest, statusCode int, errStr, errReason, terminalCause string, held *[]string, causes ...protocol.CoordinatorInferenceErrorCause) (discardedHeld bool) {
 	if isProviderHealthNeutralErrorReason(errReason) {
 		provider = nil
 	}
-	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held)
+	return d.s.noteDispatchProviderError(provider, pr, statusCode, errStr, errReason, terminalCause, held, causes...)
 }
 
 // rejectionReasonOversized is the rejection-ledger reason_code for a request the
@@ -2129,7 +2129,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2173,7 +2173,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2466,7 +2466,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2489,7 +2489,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -2658,7 +2658,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -2716,7 +2716,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					d.excludeProviders[backupProvider.ID] = struct{}{}
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg)
-					d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld)
+					d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld, errMsg.CoordinatorCause)
 					// Preserve a deterministic-unservable verdict from this loser so the
 					// surviving primary's error can't mask it (see latchDeterministicLoser).
 					d.latchDeterministicLoser(backupProvider, errMsg)
@@ -2792,7 +2792,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatchAfterTerminal(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
-			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving backup's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(provider, errMsg)
@@ -2826,7 +2826,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			s.cancelDispatchAfterTerminal(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
-			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld, errMsg.CoordinatorCause)
 			// Preserve a deterministic-unservable verdict from this loser so the
 			// surviving primary's error can't mask it (see latchDeterministicLoser).
 			d.latchDeterministicLoser(backupProvider, errMsg)
@@ -2968,7 +2968,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks, errMsg2.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					d.requestID = ""
@@ -2994,7 +2994,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks, errMsg2.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -3085,7 +3085,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
-					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld)
+					d.noteDispatchRetry(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld, errMsg2.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -3120,7 +3120,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
-			d.noteProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld)
+			d.noteProviderError(backupProvider, backupPR, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &backupHeld, errMsg2.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry
@@ -3201,7 +3201,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
-					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks, errMsg2.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -3222,7 +3222,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
-			d.noteProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
+			d.noteProviderError(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks, errMsg2.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			d.requestID = ""
@@ -3354,7 +3354,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 					if s.metrics != nil {
 						s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 					}
-					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 					d.provider = nil
 					d.pr = nil
 					return outcomeRetry
@@ -3389,7 +3389,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			if s.metrics != nil {
 				s.metrics.IncCounter("inference_dispatches_total", MetricLabel{"result", "retry"})
 			}
-			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
+			d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks, errMsg.CoordinatorCause)
 			d.provider = nil
 			d.pr = nil
 			return outcomeRetry

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -809,6 +809,10 @@ func (d *dispatchState) resolveDominantExhaustedStatus(
 ) (statusCode int, reason string, timeoutReclassified bool, dominance exhaustedDominance) {
 	statusCode, reason, timeoutReclassified = classifyExhaustedStatus(
 		failure.statusCode, failure.terminalCause)
+	if timeoutReclassified && failure.errText == errQueueDeadlineExpired {
+		// Never dispatched: the synthetic timeout came from the queue wait.
+		reason = rejectionReasonQueueDeadline
+	}
 	switch {
 	case d.terminalClientError:
 		statusCode = d.terminalClientErrorCode
@@ -950,7 +954,7 @@ func (d *dispatchState) providerFailedRoutingOutcomeFor(pr *registry.PendingRequ
 		return out
 	}
 	class := "provider_error"
-	if d.lastErrCoordinatorCause == protocol.CoordinatorCauseProviderDisconnected {
+	if d.lastErrCoordinatorCause.IsProviderDisconnect() {
 		class = "provider_disconnect_pre_commit"
 	}
 	out := d.errorRoutingOutcomeFor(pr, "error", class, d.lastErrCode)
@@ -1025,7 +1029,11 @@ func dispatchErrorClass(errText string) string {
 // routed through updateInferenceRouteOutcomeForPending, which would also fire
 // the cache-selection terminal for a request that never had a provider.
 func (d *dispatchState) queuedExitOutcome(ap *registry.AttemptProfile, status, reason string, code int) {
-	d.updateRoutingOutcome(d.errorRoutingOutcome(status, reason, code))
+	outcome := d.errorRoutingOutcome(status, reason, code)
+	// No provider attempt was dispatched: the funnel counts this exit on
+	// inference.queue_outcome, never on inference.attempt_outcome.
+	outcome.QueueExit = true
+	d.updateRoutingOutcome(outcome)
 	ap.SetOutcome(status, reason, "", "", "")
 }
 
@@ -1201,7 +1209,12 @@ func (d *dispatchState) updateSpeculativeClientGone(pr *registry.PendingRequest)
 // backup bookkeeping (updateSpeculativeClientGone) never double-counts.
 func (d *dispatchState) emitClientGone(phase string) {
 	d.stampClientGone(phase)
-	d.s.emitClientGone(d.model, d.estimatedPromptTokens, providerChipFamily(d.provider), phase)
+	// deadline_bucket: elapsed on the request clock vs the first-content
+	// budget. At/past ~the budget the upstream timed out on us (its 504), so
+	// the OR-view outcome is `timeout`; earlier it is an excluded client abort.
+	bucket := d.clientGoneDeadlineBucket()
+	d.s.emitClientGoneBucketed(d.model, d.estimatedPromptTokens, providerChipFamily(d.provider), phase, bucket)
+	d.recordRequestOutcomeORView(orViewClassForClientGone(bucket))
 }
 
 // dispatchPrimary selects (and, when no idle provider exists on the first
@@ -1345,6 +1358,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				s.recordRejection(d.rejectionInfoWithDecision("dispatch", "ttft_too_slow", http.StatusTooManyRequests, retryAfter*1000, decision))
 				d.recordDispatchedRequestOutcome(
 					d.kvBackendAttribution(), classifyOutcomeByCode(http.StatusTooManyRequests))
+				d.recordRequestOutcomeORView(classifyOutcomeByCode(http.StatusTooManyRequests))
 			}
 			s.writeTTFTTooSlow(w, d.model, d.publicModel, bestTTFT, d.deadline)
 			return outcomeResponseWritten
@@ -1490,10 +1504,17 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			if errors.Is(err, context.DeadlineExceeded) ||
 				errors.Is(err, registry.ErrQueueFirstContentDeadline) {
+				// The first-content clock ran out while the request was still
+				// queued: nothing was dispatched, so this is the queue's own
+				// terminal (queue_deadline), not a provider that went silent
+				// (first_chunk_timeout). Same synthetic 504 → retryable 429
+				// path; the distinct latched text is what
+				// resolveDominantExhaustedStatus keys the reason on. The route
+				// row and the attempt profile carry queue_deadline as well.
 				s.recordWarmPoolQueueState(d.model)
 				d.queuedExitOutcome(queuePR.Profile,
-					"timeout", "first_chunk_timeout", http.StatusGatewayTimeout)
-				d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+					"timeout", rejectionReasonQueueDeadline, http.StatusGatewayTimeout)
+				d.setLastError(errQueueDeadlineExpired, http.StatusGatewayTimeout)
 				return outcomeFailFast
 			}
 			if errors.Is(err, registry.ErrQueueTTFTTooSlow) {
@@ -1790,6 +1811,18 @@ func (d *dispatchState) noteProviderError(provider *registry.Provider, pr *regis
 // "prompt_too_long" and the legacy dispatch-exhausted "unservable_token_budget".
 const rejectionReasonOversized = "oversized_request"
 
+// rejectionReasonQueueDeadline is the rejection-ledger reason_code for a
+// request whose request-absolute first-content clock expired while it was
+// still waiting in the coordinator queue. Nothing was dispatched — it is the
+// queue's own terminal, kept distinct from first_chunk_timeout (a dispatched
+// provider that produced no content in time) so telemetry stops conflating
+// queue expiry with provider silence. Same retryable 429 + Retry-After.
+const rejectionReasonQueueDeadline = "queue_deadline"
+
+// errQueueDeadlineExpired is the latched error text for that terminal; the
+// exhausted ladder keys the queue_deadline reason on it.
+const errQueueDeadlineExpired = "first-content deadline expired while queued for a provider"
+
 // rejectionReasonRoutingSaturated is the rejection-ledger reason_code for a
 // request shed because no provider-selection scan slot freed up within its
 // remaining first-content budget (Server.routingScanSem — the coordinator
@@ -1913,6 +1946,15 @@ func (d *dispatchState) shouldStopFailover() bool {
 		d.lastFailureDeadline = true
 		return false
 	case rejectionTransientCapacity:
+		if isDrainingErrorReason(d.lastErrReason) {
+			// Typed drain refusal (R2): the provider is restarting, not the
+			// fleet full. Keep failing over (the provider is now marked
+			// draining and excluded) WITHOUT charging the request's bounded
+			// transient-capacity allowance — a drain wave must not turn into
+			// 429s for requests the rest of the fleet can serve.
+			d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:draining"})
+			return false
+		}
 		d.s.ddIncr("routing.dispatch_to_capacity_503", []string{"model:" + d.model, "reason:transient"})
 		d.capacityRetries++
 		if d.capacityRetries >= maxCapacityClassRetries {
@@ -2084,7 +2126,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
@@ -2111,7 +2153,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed, retrying",
@@ -2223,7 +2265,7 @@ func (d *dispatchState) waitFirstChunk() (outcome dispatchOutcome) {
 		case <-r.Context().Done():
 			speculativeTimer.Stop()
 			deadlineTimer.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -2421,7 +2463,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
@@ -2441,7 +2483,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			if s.metrics != nil {
@@ -2497,7 +2539,7 @@ func (d *dispatchState) waitNoBackup() dispatchOutcome {
 			return outcomeRetry
 		case <-r.Context().Done():
 			remainingDeadline.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -2519,7 +2561,7 @@ func (d *dispatchState) awaitPrimaryEmptyCompletion(
 	backupPR *registry.PendingRequest,
 ) dispatchOutcome {
 	d.pr.ResolveSpeculativeEmptyCompletion(true)
-	d.s.cancelDispatch(backupProvider, backupPR)
+	d.s.cancelDispatch(backupProvider, backupPR, cancelCauseHedgeLoser)
 	d.markSpeculativeLoser(backupPR)
 	return d.waitAccepted()
 }
@@ -2532,7 +2574,7 @@ func (d *dispatchState) awaitBackupEmptyCompletion(
 	backupHeld []string,
 ) dispatchOutcome {
 	backupPR.ResolveSpeculativeEmptyCompletion(true)
-	d.s.cancelDispatch(primaryProvider, primaryPR)
+	d.s.cancelDispatch(primaryProvider, primaryPR, cancelCauseHedgeLoser)
 	d.s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
 	d.s.registry.RecordWarmPoolSpeculativeWon(d.model)
 	d.markSpeculativeLoser(primaryPR)
@@ -2602,7 +2644,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Primary wins!
 			raceDeadline.Stop()
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR, cancelCauseHedgeLoser)
 			if ok {
 				d.markSpeculativeLoser(backupPR)
 				d.commitFirstContent(pr, chunk.Data)
@@ -2613,7 +2655,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					// Primary failed but we already cancelled backup.
 					d.markSpeculativeLoser(backupPR)
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
@@ -2651,7 +2693,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 			}
 			// Backup wins!
 			raceDeadline.Stop()
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseHedgeLoser)
 			s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
 			s.registry.RecordWarmPoolSpeculativeWon(d.model)
 			if ok {
@@ -2682,7 +2724,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					return d.raceBackupChunkClosedWaitPrimary(provider, pr)
 				default:
 					// Backup channel closed with no error — treat as committed.
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatch(provider, pr, cancelCauseHedgeLoser)
 					d.markSpeculativeLoser(pr)
 					backupPR.BackupWon = true
 					d.provider = backupProvider
@@ -2739,7 +2781,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					return d.awaitBackupEmptyCompletion(
 						provider, pr, backupProvider, backupPR, backupHeld)
 				}
-				s.cancelDispatch(backupProvider, backupPR)
+				s.cancelDispatch(backupProvider, backupPR, cancelCauseHedgeLoser)
 				d.markSpeculativeLoser(backupPR)
 				d.commitFirstContent(pr, chunk.Data)
 				d.committed = true
@@ -2747,7 +2789,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg)
 			d.noteProviderError(provider, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &d.heldChunks)
@@ -2767,7 +2809,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				if emptyCompletionPrecedesChunk(pr, chunk) {
 					return d.awaitPrimaryEmptyCompletion(backupProvider, backupPR)
 				}
-				s.cancelDispatch(provider, pr)
+				s.cancelDispatch(provider, pr, cancelCauseHedgeLoser)
 				d.markSpeculativeLoser(pr)
 				backupPR.BackupWon = true
 				d.provider = backupProvider
@@ -2781,7 +2823,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				return outcomeCommitted
 			}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAfterTerminal(backupProvider, backupPR)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg)
 			d.noteProviderError(backupProvider, backupPR, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, &backupHeld)
@@ -2800,7 +2842,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 					return d.awaitBackupEmptyCompletion(
 						provider, pr, backupProvider, backupPR, backupHeld)
 				}
-				s.cancelDispatch(backupProvider, backupPR)
+				s.cancelDispatch(backupProvider, backupPR, cancelCauseHedgeLoser)
 				d.markSpeculativeLoser(backupPR)
 				d.commitFirstContent(pr, chunk.Data)
 				d.committed = true
@@ -2810,7 +2852,7 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 				if emptyCompletionPrecedesChunk(pr, chunk) {
 					return d.awaitPrimaryEmptyCompletion(backupProvider, backupPR)
 				}
-				s.cancelDispatch(provider, pr)
+				s.cancelDispatch(provider, pr, cancelCauseHedgeLoser)
 				s.ddIncr("inference.speculative_win", []string{"model:" + d.model})
 				s.registry.RecordWarmPoolSpeculativeWon(d.model)
 				d.markSpeculativeLoser(pr)
@@ -2892,8 +2934,8 @@ func (d *dispatchState) runRace(backupProvider *registry.Provider, backupPR *reg
 		case <-r.Context().Done():
 			raceDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatch(provider, pr)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
+			s.cancelDispatch(backupProvider, backupPR, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -2922,7 +2964,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.updateSpeculativeFailure(pr, errMsg2)
@@ -2948,7 +2990,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -2996,7 +3038,7 @@ func (d *dispatchState) raceBackupChunkClosedWaitPrimary(provider *registry.Prov
 		case <-r.Context().Done():
 			remainingPrimary.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -3039,7 +3081,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				select {
 				case errMsg2 := <-backupPR.ErrorCh:
 					d.excludeProviders[backupProvider.ID] = struct{}{}
-					s.cancelDispatch(backupProvider, backupPR)
+					s.cancelDispatchAfterTerminal(backupProvider, backupPR)
 					d.setLastInferenceError(backupProvider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(backupProvider)
 					d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -3074,7 +3116,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 				return outcomeCommitted
 			}
 			d.excludeProviders[backupProvider.ID] = struct{}{}
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatchAfterTerminal(backupProvider, backupPR)
 			d.setLastInferenceError(backupProvider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(backupProvider)
 			d.updateSpeculativeFailure(backupPR, errMsg2)
@@ -3128,7 +3170,7 @@ func (d *dispatchState) racePrimaryFailedWaitBackup(backupProvider *registry.Pro
 		case <-r.Context().Done():
 			backupDeadline.Stop()
 			d.updateSpeculativeClientGone(backupPR)
-			s.cancelDispatch(backupProvider, backupPR)
+			s.cancelDispatch(backupProvider, backupPR, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -3156,7 +3198,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				select {
 				case errMsg2 := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg2)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					d.noteDispatchRetry(provider, pr, errMsg2.StatusCode, errMsg2.Error, errMsg2.ErrorReason, errMsg2.TerminalCause, &d.heldChunks)
@@ -3176,7 +3218,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.setLastInferenceError(provider, errMsg2)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			d.updateSpeculativeFailure(pr, errMsg2)
@@ -3221,7 +3263,7 @@ func (d *dispatchState) raceBackupErrWaitPrimary(provider *registry.Provider, pr
 		case <-r.Context().Done():
 			primaryDeadline.Stop()
 			d.updateSpeculativeClientGone(pr)
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -3292,7 +3334,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 				select {
 				case errMsg := <-pr.ErrorCh:
 					d.excludeProviders[provider.ID] = struct{}{}
-					s.cancelDispatch(provider, pr)
+					s.cancelDispatchAfterTerminal(provider, pr)
 					d.setLastInferenceError(provider, errMsg)
 					d.lastFailedVersion = failedProviderVersion(provider)
 					s.logger.Warn("provider failed after accepting request, retrying",
@@ -3327,7 +3369,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 				return outcomeCommitted
 			}
 			d.excludeProviders[provider.ID] = struct{}{}
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatchAfterTerminal(provider, pr)
 			d.setLastInferenceError(provider, errMsg)
 			d.lastFailedVersion = failedProviderVersion(provider)
 			s.logger.Warn("provider failed after accepting request, retrying",
@@ -3399,7 +3441,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 			d.pr = nil
 			return outcomeRetry
 		case <-r.Context().Done():
-			s.cancelDispatch(provider, pr)
+			s.cancelDispatch(provider, pr, cancelCauseClientGonePre)
 			d.refundReservation()
 			return outcomeClientGone
 		}
@@ -3425,7 +3467,14 @@ func (d *dispatchState) run() {
 		// in practice the loop ends at exhaustion or success; maxDispatchAttempts
 		// is only a hot-loop ceiling and this is the wall-clock bound.
 		if attempt > 0 && r.Context().Err() != nil {
-			goto exhausted
+			// The client left between attempts (D2). There is no in-flight
+			// provider (the previous attempt already cleaned up and wrote its
+			// own route outcome) and nobody to write a 429/5xx to, so record it
+			// as client_gone like every other pre-content cancel arm — not as
+			// the exhausted ladder's rate_limited / provider_5xx outcome.
+			d.refundReservation()
+			d.emitClientGone(phaseBeforeFirstToken)
+			return
 		}
 		if attempt > 0 && d.firstTokenExpired() {
 			// The request-absolute first-token budget is gone: the client must
@@ -3455,6 +3504,7 @@ func (d *dispatchState) run() {
 		if d.timing.RoutedAt.IsZero() {
 			d.timing.RoutedAt = time.Now()
 		}
+		d.emitRouteLatency()
 
 		s.ddIncr("routing.decisions", []string{"model:" + d.model, "outcome:selected"})
 		s.ddIncr("routing.provider_selected", []string{"provider_id:" + d.provider.ID, "model:" + d.model})
@@ -3528,7 +3578,7 @@ exhausted:
 		statusCode, reason, timeoutReclassified, dominance :=
 			d.resolveDominantExhaustedStatus(failure, stickyFault)
 		if timeoutReclassified {
-			s.ddIncr("routing.first_chunk_timeout_reclassified", []string{"model:" + d.model})
+			s.ddIncr("routing.first_chunk_timeout_reclassified", []string{"model:" + d.model, "reason:" + reason})
 		}
 		switch dominance {
 		case exhaustedClientError:
@@ -3598,6 +3648,7 @@ exhausted:
 		// OR-uptime outcome for a dispatched-but-failed request (exactly once;
 		// pre-dispatch rejections emit from recordRejection instead).
 		d.recordDispatchedRequestOutcome(kvBackend, classifyOutcomeByCode(statusCode))
+		d.recordRequestOutcomeORView(classifyOutcomeByCode(statusCode))
 		if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
 			retryAfter := s.estimateRetryAfter(d.model)
 			if d.lastErrFeasibleAfterMS > 0 {
@@ -3766,20 +3817,32 @@ func (d *dispatchState) writeCommittedResponse() {
 	snapshotChatCompletionMetadata(pr, info)
 
 	// On return (disconnect/timeout/completion): free the slot, tell the
-	// provider to stop, and preserve billing for a mid-stream disconnect.
+	// provider to stop if it may still be generating, and preserve billing for
+	// a mid-stream disconnect.
 	// Park BEFORE RemovePending so a racing provider terminal always finds the
 	// record in pending or the holder — never neither (which would drop it and
 	// mis-refund). GetPending is nil if a terminal already settled it (normal
 	// completion), so nothing is parked then. Both settle paths are
 	// FinalizeReservation-guarded, so the park-then-remove overlap can't double-bill.
+	//
+	// The cancel is sent only when a pending record still existed — no terminal
+	// seen, so the provider may still be running (consumer gone mid-stream, idle
+	// stream timeout). After a clean completion or a provider error terminal the
+	// record is already gone and a cancel would only cost the provider a no-op
+	// frame per request (~one per dispatch fleet-wide before this rule).
 	defer func() {
-		terminalSettled := true
+		abandoned := false
+		cause := cancelCauseStreamTimeout
+		if r.Context().Err() != nil {
+			cause = cancelCauseClientGonePost
+		}
 		if stale := provider.GetPending(requestID); stale != nil {
-			// The provider is still generating for a client that is gone: this
-			// cancel is the one that stops real work, so stamp it.
-			terminalSettled = false
-			stale.Profile.Mark(registry.StampCancelSent)
+			// Record the abandon BEFORE parking so a terminal racing this
+			// defer is correlated with the cancel rather than logged as unknown.
+			_, expired := s.zombieCanceller.record(requestID, pr.Model, cause, time.Now())
+			s.emitExpiredCancelEntries(expired)
 			s.holdForSettlement(stale)
+			abandoned = true
 		} else {
 			// A terminal already claimed the pending. In every normal path the
 			// reservation is finalized by now (completion billed it, the relay
@@ -3794,16 +3857,22 @@ func (d *dispatchState) writeCommittedResponse() {
 				s.refundReservedBalance(refundPr, "post_terminal_sweep:"+requestID)
 			})
 		}
-		provider.RemovePending(requestID) // then remove so SetProviderIdle frees the slot
+		removed := provider.RemovePending(requestID) // then remove so SetProviderIdle frees the slot
 		s.registry.SetProviderIdle(provider.ID)
-		// A settled terminal means the provider already sent its completion or
-		// error (or disconnected): there is no generation left to stop, so the
-		// cancel frame — one marshal and one writer-lane WebSocket write per
-		// completed request — is skipped. Only a still-pending request (the
-		// client-gone / mid-stream exits above) gets the cancel.
-		if !terminalSettled {
-			s.sendProviderCancel(provider, requestID)
+		if !abandoned {
+			return
 		}
+		if removed == nil {
+			// A terminal claimed the record between GetPending and
+			// RemovePending: it settles via the parked copy and nothing is
+			// running provider-side.
+			s.zombieCanceller.forget(requestID)
+			return
+		}
+		// The provider is still generating for a client that is gone: this
+		// cancel is the one that stops real work, so stamp it.
+		pr.Profile.Mark(registry.StampCancelSent)
+		s.sendRecordedCancel(provider, requestID, pr.Model, cause)
 	}()
 
 	// The committed provider's held preamble chunks stream out first, in

--- a/coordinator/api/dispatch_nonfault_breaker_test.go
+++ b/coordinator/api/dispatch_nonfault_breaker_test.go
@@ -41,6 +41,7 @@ func newBreakerExemptionHarness(t *testing.T, name string) (*Server, *registry.R
 	provider.Mu().Lock()
 	provider.AccountID = "acct-" + name
 	provider.Mu().Unlock()
+	provider.RebindStableFaultKey()
 	pr := &registry.PendingRequest{
 		RequestID: "req-" + name,
 		Model:     "test-model",

--- a/coordinator/api/dispatch_ttft_terminal_test.go
+++ b/coordinator/api/dispatch_ttft_terminal_test.go
@@ -242,6 +242,10 @@ func TestDispatch_TTFTRejectAttempt0_SingleReservationAnd429(t *testing.T) {
 	if w.Header().Get("Retry-After") == "" {
 		t.Error("Retry-After header missing")
 	}
+	if got := srv.metrics.Snapshot().Counters[counterKey(metricRequestOutcomeORViewCounter,
+		MetricLabel{"model", model}, MetricLabel{"class", orClassRateLimited})]; got != 1 {
+		t.Errorf("attempt-zero OR-view rate_limited count = %d, want exactly 1", got)
+	}
 	if d.attempt != 0 {
 		t.Errorf("dispatch attempts = %d, want the loop to stop at attempt 0", d.attempt+1)
 	}

--- a/coordinator/api/drain_ingress_test.go
+++ b/coordinator/api/drain_ingress_test.go
@@ -62,7 +62,7 @@ func TestDrainingIngressFencesQueuedDemandBeforeRelease(t *testing.T) {
 				// A delayed classification must not mark the provider draining again.
 				srv.registry.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle"})
 				em := <-pr.ErrorCh
-				srv.noteInferenceError(p.ID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause)
+				srv.noteInferenceError(p.ID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause, em.CoordinatorCause)
 				if srv.registry.ProviderDraining(p.ID) {
 					t.Fatal("delayed consumer classification overwrote the recovery heartbeat")
 				}

--- a/coordinator/api/drain_ingress_test.go
+++ b/coordinator/api/drain_ingress_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// A typed drain rejection must fence the provider before releasing its slot.
+// No consumer reads ErrorCh here: the ingress-triggered queue drain must make
+// the right decision without waiting for consumer-side error classification.
+func TestDrainingIngressFencesQueuedDemandBeforeRelease(t *testing.T) {
+	for _, reason := range []string{errorReasonDraining, errorReasonCapacityBusy} {
+		t.Run(reason, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			srv, _ := testServer(t)
+			ts := httptest.NewServer(srv.Handler())
+			t.Cleanup(ts.Close)
+			const model = "drain-ingress-model"
+			fp := startFailoverProvider(t, ctx, ts, srv.registry, failoverProviderConfig{
+				Name: "drain-ingress", Version: "0.9.0", DecodeTPS: 100,
+				Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+			})
+			p := srv.registry.GetProvider(fp.registryID)
+			pr := &registry.PendingRequest{
+				RequestID: "rejected", ProviderID: p.ID, Model: model,
+				ErrorCh: make(chan protocol.InferenceErrorMessage, 1),
+				ChunkCh: make(chan registry.ProviderChunk, 1), CompleteCh: make(chan protocol.UsageInfo, 1),
+			}
+			p.AddPending(pr)
+			waiting := &registry.QueuedRequest{
+				RequestID: "waiting", Model: model, ResponseCh: make(chan *registry.Provider, 1),
+				Pending: &registry.PendingRequest{
+					RequestID: "waiting", Model: model, RequestedMaxTokens: 32, EstimatedPromptTokens: 32,
+					ErrorCh: make(chan protocol.InferenceErrorMessage, 1),
+					ChunkCh: make(chan registry.ProviderChunk, 1), CompleteCh: make(chan protocol.UsageInfo, 1),
+				},
+			}
+			if err := srv.registry.Queue().Enqueue(waiting); err != nil {
+				t.Fatal(err)
+			}
+			srv.handleInferenceError(p.ID, p, &protocol.InferenceErrorMessage{
+				RequestID: pr.RequestID, FailureCode: protocol.FailureCodeCapacity,
+				StatusCode: http.StatusServiceUnavailable, ErrorReason: reason,
+			})
+			if reason == errorReasonDraining {
+				if !srv.registry.ProviderDraining(p.ID) {
+					t.Error("drain state was deferred to the consumer")
+				}
+				select {
+				case <-waiting.ResponseCh:
+					t.Fatal("queued demand was reassigned during the drain rejection")
+				default:
+				}
+				// Recovery can arrive before the consumer processes this terminal.
+				// A delayed classification must not mark the provider draining again.
+				srv.registry.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle"})
+				em := <-pr.ErrorCh
+				srv.noteInferenceError(p.ID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause)
+				if srv.registry.ProviderDraining(p.ID) {
+					t.Fatal("delayed consumer classification overwrote the recovery heartbeat")
+				}
+			} else {
+				select {
+				case assigned := <-waiting.ResponseCh:
+					if assigned != p {
+						t.Fatal("control did not exercise the released-slot queue drain")
+					}
+				default:
+					t.Fatal("control did not exercise the released-slot queue drain")
+				}
+			}
+		})
+	}
+}

--- a/coordinator/api/drain_integration_test.go
+++ b/coordinator/api/drain_integration_test.go
@@ -1,0 +1,259 @@
+package api
+
+// R2 (coordinator half) integration tests: drain awareness through the real
+// HTTP + WebSocket path. A provider that reports heartbeat status "draining",
+// or that refuses a dispatch with the typed error_reason "draining", is
+// skipped by routing and counted as TRANSIENT capacity; the typed refusal
+// consumes none of the request's transient-capacity retries and derates no
+// gray-box capacity state for the pair. Legacy providers (untyped 503 →
+// capacity_busy) keep today's bounded path — used here as the control.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// sendHeartbeatStatus emits a heartbeat with the given status from the fake
+// provider's socket (the same frame a Swift provider sends every ~30s).
+func (fp *failoverProvider) sendHeartbeatStatus(t *testing.T, ctx context.Context, status string) {
+	t.Helper()
+	writeProviderJSON(t, ctx, fp.conn, protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: status, Stats: protocol.HeartbeatStats{},
+	})
+}
+
+// typedRejectScript refuses every dispatch pre-content with the typed
+// capacity reason (draining or capacity_busy) as a 503 — the Swift drain
+// admission rejection shape.
+func typedRejectScript(reason string) inferenceScript {
+	return func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		fp.sendTypedInferenceError(ctx, req, protocol.FailureCodeCapacity, reason, http.StatusServiceUnavailable)
+	}
+}
+
+// TestDrain_HeartbeatStatusSkipsProvider: the fast provider A reports
+// "draining"; the admission preflight counts it as transient capacity, the
+// request is served by B without ever touching A, and an "idle" heartbeat
+// restores A.
+func TestDrain_HeartbeatStatusSkipsProvider(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "drain-heartbeat-model"
+
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.9.0", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+
+	pA.sendHeartbeatStatus(t, ctx, protocol.HeartbeatStatusDraining)
+	awaitCondition(t, 5*time.Second, func() bool { return reg.ProviderDraining(pA.registryID) }, "provider-a marked draining by its heartbeat")
+
+	candidates, capacityRejections, tooLarge := reg.QuickCapacityCheck(model, 500, 64, registry.RequestTraits{})
+	if candidates != 1 || capacityRejections != 1 || tooLarge != 0 {
+		t.Errorf("QuickCapacityCheck = (%d, %d, %d), want (1, 1, 0): B routable, A transient", candidates, capacityRejections, tooLarge)
+	}
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("provider-b"))
+	if got := pA.dispatchCount(); got != 0 {
+		t.Errorf("draining provider-a received %d dispatch(es), want 0", got)
+	}
+
+	pA.sendHeartbeatStatus(t, ctx, "idle")
+	awaitCondition(t, 5*time.Second, func() bool { return !reg.ProviderDraining(pA.registryID) }, "provider-a drain cleared by an idle heartbeat")
+	status, body, err = postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request after drain cleared: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("provider-a"))
+	if got := pB.dispatchCount(); got != 1 {
+		t.Errorf("provider-b dispatches = %d, want 1", got)
+	}
+}
+
+// TestDrain_TypedRejection_NoRetryChargeNoDerate: four draining providers
+// outrank the one serving box. Each refuses once with the typed "draining"
+// reason and is marked draining (never re-dispatched); the request keeps
+// failing over WITHOUT spending its 3 transient-capacity retries and lands on
+// the serving box on attempt 5. No draining pair is capacity-cooled or
+// budget-clamped. The capacity_busy control below shows the bounded path
+// this deliberately does not take.
+func TestDrain_TypedRejection_NoRetryChargeNoDerate(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "drain-typed-model"
+
+	draining := make([]*failoverProvider, 0, 4)
+	for i, tps := range []float64{200, 150, 100, 50} {
+		draining = append(draining, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name: "draining-" + strings.Repeat("x", i+1), Version: "0.9.0", DecodeTPS: tps,
+			Models: []failoverModelSpec{{ID: model}}, Script: typedRejectScript(errorReasonDraining),
+		}))
+	}
+	serving := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "serving", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("serving"))
+	if got := serving.dispatchCount(); got != 1 {
+		t.Errorf("serving dispatches = %d, want 1", got)
+	}
+	total := 0
+	for _, fp := range draining {
+		n := fp.dispatchCount()
+		total += n
+		if n != 1 {
+			t.Errorf("%s dispatches = %d, want exactly 1 (skipped after its typed draining refusal)", fp.name, n)
+		}
+		if !reg.ProviderDraining(fp.registryID) {
+			t.Errorf("%s not marked draining after its typed refusal", fp.name)
+		}
+		if reg.CapacityCooldownActive(fp.registryID, model) {
+			t.Errorf("%s: capacity-reject cooldown active — a drain refusal must not feed the black-hole cooldown", fp.name)
+		}
+		if reg.BudgetClampActive(fp.registryID, model) {
+			t.Errorf("%s: budget clamp armed — a drain refusal must not derate the pair", fp.name)
+		}
+	}
+	if total != 4 {
+		t.Errorf("draining dispatches = %d, want 4 (one per provider; more than 3 proves no capacity retry was charged)", total)
+	}
+
+	// The marked providers stay excluded for the next request too — no
+	// heartbeat status needed.
+	status, body, err = postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("second chat request: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("serving"))
+	for _, fp := range draining {
+		if n := fp.dispatchCount(); n != 1 {
+			t.Errorf("%s dispatches after second request = %d, want 1", fp.name, n)
+		}
+	}
+}
+
+// TestDrain_LegacyCapacityBusyControl_StillBounded: the same topology with
+// the legacy typed reason capacity_busy: each refusal charges a transient-
+// capacity retry, so the ladder stops after maxCapacityClassRetries with an
+// uptime-neutral 429 and never reaches the serving box — the behavior the
+// draining reason is exempted from.
+func TestDrain_LegacyCapacityBusyControl_StillBounded(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "drain-control-model"
+
+	busy := make([]*failoverProvider, 0, 4)
+	for i, tps := range []float64{200, 150, 100, 50} {
+		busy = append(busy, startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+			Name: "busy-" + strings.Repeat("x", i+1), Version: "0.9.0", DecodeTPS: tps,
+			Models: []failoverModelSpec{{ID: model}}, Script: typedRejectScript(errorReasonCapacityBusy),
+		}))
+	}
+	serving := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "serving", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	if status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429 after %d capacity_busy refusals; body = %s", status, maxCapacityClassRetries, body)
+	}
+	if got := serving.dispatchCount(); got != 0 {
+		t.Errorf("serving dispatches = %d, want 0 (the bounded ladder stopped first)", got)
+	}
+	total := 0
+	for _, fp := range busy {
+		total += fp.dispatchCount()
+		if reg.ProviderDraining(fp.registryID) {
+			t.Errorf("%s marked draining by a capacity_busy refusal", fp.name)
+		}
+	}
+	if total != maxCapacityClassRetries {
+		t.Errorf("busy dispatches = %d, want %d (one per charged capacity retry)", total, maxCapacityClassRetries)
+	}
+}
+
+// TestDrain_TypedRejectionClearedByIdleHeartbeat: a provider whose drain the
+// coordinator learned from the typed rejection alone (its "draining" event
+// heartbeat never landed) reports idle once the drain aborts — the mark
+// clears on that heartbeat and the provider is routable again, rather than
+// staying excluded until the 150 s TTL.
+func TestDrain_TypedRejectionClearedByIdleHeartbeat(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "drain-idle-heartbeat-model"
+
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.9.0", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: typedRejectScript(errorReasonDraining),
+	})
+	startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("chat request: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("provider-b"))
+	if !reg.ProviderDraining(pA.registryID) {
+		t.Fatalf("provider-a not marked draining after its typed refusal")
+	}
+
+	before := reg.GetProvider(pA.registryID)
+	before.Mu().Lock()
+	lastHB := before.LastHeartbeat
+	before.Mu().Unlock()
+	pA.sendHeartbeatStatus(t, ctx, "idle")
+	awaitCondition(t, 5*time.Second, func() bool {
+		p := reg.GetProvider(pA.registryID)
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.LastHeartbeat.After(lastHB)
+	}, "idle heartbeat processed")
+	if reg.ProviderDraining(pA.registryID) {
+		t.Fatalf("rejection-set drain mark survived the provider's idle heartbeat")
+	}
+
+	// Routable again: the fast box is selected first and (still scripted to
+	// refuse) types the reason once more, re-marking itself for exactly one
+	// bounce before B serves.
+	status, body, err = postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil {
+		t.Fatalf("second chat request: %v", err)
+	}
+	assertCleanFailoverStream(t, status, body, markerFor("provider-b"))
+	if got := pA.dispatchCount(); got != 2 {
+		t.Errorf("provider-a dispatches = %d, want 2 (routable again after the idle heartbeat)", got)
+	}
+	if !reg.ProviderDraining(pA.registryID) {
+		t.Fatalf("second typed refusal did not re-mark provider-a draining")
+	}
+}

--- a/coordinator/api/first_token_clock_test.go
+++ b/coordinator/api/first_token_clock_test.go
@@ -276,7 +276,7 @@ func TestAbandonInflightDefersToPublishedIngress(t *testing.T) {
 	}
 
 	pr.FinishProviderChunkIngress(receivedAt, true)
-	d.s.cancelDispatch(provider, pr)
+	d.s.cancelDispatch(provider, pr, cancelCauseFirstChunkTimeout)
 }
 
 func TestWriteFirstTokenTimeoutUsesOpenRouter429Contract(t *testing.T) {

--- a/coordinator/api/fleet_gauges.go
+++ b/coordinator/api/fleet_gauges.go
@@ -1,0 +1,43 @@
+package api
+
+// Per-model queue gauges, pushed from StartDDGaugeLoop.
+//
+// request_queue.depth is a single fleet-wide number and queue_wait_ms is
+// sampled only at request terminals, so a model whose queue is backing up is
+// invisible until its requests time out. These gauges close that gap.
+const (
+	// metricQueueDepthByModel is a distinct name (not request_queue.depth with a
+	// model tag): the untagged fleet-wide gauge already exists under that name
+	// and a mixed tag set would double-count in sum:/avg: queries.
+	metricQueueDepthByModel = "request_queue.depth_by_model"
+	metricQueueOldestAgeMs  = "request_queue.oldest_age_ms"
+)
+
+// emitPerModelQueueGauges pushes request_queue.depth_by_model{model} and
+// request_queue.oldest_age_ms{model}. servedModels is the live per-model
+// provider snapshot the gauge loop already computed; every served model gets a
+// point (0 when nothing is queued) so the series does not go blank between
+// queueing episodes, and models that are queued without a live provider are
+// still reported.
+func (s *Server) emitPerModelQueueGauges(servedModels map[string]int64) {
+	if s == nil || s.dd == nil || s.registry == nil {
+		return
+	}
+	q := s.registry.Queue()
+	if q == nil {
+		return
+	}
+	models := make(map[string]struct{}, len(servedModels)+4)
+	for model := range servedModels {
+		models[model] = struct{}{}
+	}
+	for _, model := range q.QueuedModels() {
+		models[model] = struct{}{}
+	}
+	for model := range models {
+		depth, oldestAge := q.QueueStats(model)
+		tags := []string{"model:" + model}
+		s.ddGauge(metricQueueDepthByModel, float64(depth), tags)
+		s.ddGauge(metricQueueOldestAgeMs, float64(oldestAge.Milliseconds()), tags)
+	}
+}

--- a/coordinator/api/fleet_gauges.go
+++ b/coordinator/api/fleet_gauges.go
@@ -1,5 +1,27 @@
 package api
 
+import "sync"
+
+// Only the immediately preceding set is retained. A departing model gets one
+// zero sample, then leaves the tracker rather than accumulating forever.
+type queueGaugeState struct {
+	mu     sync.Mutex
+	models map[string]struct{}
+}
+
+func (state *queueGaugeState) reconcile(current map[string]struct{}) []string {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	var retired []string
+	for model := range state.models {
+		if _, present := current[model]; !present {
+			retired = append(retired, model)
+		}
+	}
+	state.models = current
+	return retired
+}
+
 // Per-model queue gauges, pushed from StartDDGaugeLoop.
 //
 // request_queue.depth is a single fleet-wide number and queue_wait_ms is
@@ -34,10 +56,16 @@ func (s *Server) emitPerModelQueueGauges(servedModels map[string]int64) {
 	for _, model := range q.QueuedModels() {
 		models[model] = struct{}{}
 	}
+	retired := s.queueGauges.reconcile(models)
 	for model := range models {
 		depth, oldestAge := q.QueueStats(model)
 		tags := []string{"model:" + model}
 		s.ddGauge(metricQueueDepthByModel, float64(depth), tags)
 		s.ddGauge(metricQueueOldestAgeMs, float64(oldestAge.Milliseconds()), tags)
+	}
+	for _, model := range retired {
+		tags := []string{"model:" + model}
+		s.ddGauge(metricQueueDepthByModel, 0, tags)
+		s.ddGauge(metricQueueOldestAgeMs, 0, tags)
 	}
 }

--- a/coordinator/api/fleet_gauges_test.go
+++ b/coordinator/api/fleet_gauges_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestQueueGaugesEmitFinalZeroWhenModelDisappears(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+	const model = "departing-queue-model"
+	q := srv.registry.Queue()
+	if err := q.Enqueue(&registry.QueuedRequest{RequestID: "waiting", Model: model}); err != nil {
+		t.Fatal(err)
+	}
+	srv.emitPerModelQueueGauges(map[string]int64{model: 1})
+	_ = dd.Statsd.Flush()
+	if packets := collector.drain(); sumMetric(t, packets, metricQueueDepthByModel, "model:"+model) != 1 {
+		t.Fatal("missing initial nonzero queue depth")
+	}
+	q.Remove("waiting", model)
+	srv.emitPerModelQueueGauges(nil)
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	for _, metric := range []string{metricQueueDepthByModel, metricQueueOldestAgeMs} {
+		found := findMetrics(packets, metric)
+		if !hasMetric(found, "model:"+model) || sumMetric(t, found, metric, "model:"+model) != 0 {
+			t.Errorf("%s did not publish the departing model's zero: %v", metric, found)
+		}
+	}
+	// After the final zero, the model is forgotten instead of being retained
+	// and emitted forever as more distinct queued models pass through.
+	srv.emitPerModelQueueGauges(nil)
+	_ = dd.Statsd.Flush()
+	if packets := collector.drain(); len(findMetrics(packets, metricQueueDepthByModel))+len(findMetrics(packets, metricQueueOldestAgeMs)) != 0 {
+		t.Fatal("departed model remained in the gauge tracker")
+	}
+}

--- a/coordinator/api/gate_wait_metric_test.go
+++ b/coordinator/api/gate_wait_metric_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// awaitMetric polls the collector until a packet for metric arrives or the
+// timeout lapses (the DogStatsD client may buffer briefly). Matched as a
+// substring: the client prefixes every name with the configured namespace.
+func awaitMetric(t *testing.T, c *udpCollector, metric string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, p := range c.drain() {
+			if strings.Contains(p, metric+":") {
+				return p
+			}
+		}
+	}
+	t.Fatalf("no %s packet within %v", metric, timeout)
+	return ""
+}
+
+// TestRegistryGateWaitHistogramTaggedBySite: NewServer wires the registry's
+// gate-wait observer to the registry.gate.wait_ms histogram, tagged with the
+// recorder site, so the per-identity locks that replaced the request-path
+// registry write lock stay observable.
+func TestRegistryGateWaitHistogramTaggedBySite(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "test-key"}), ServerConfig{}, logger)
+	defer srv.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+
+	const model = "gate-wait-metric-model"
+	p := makeRoutableProvider(t, reg, "gate-wait-metric-provider", model)
+
+	// Block the recorder behind its identity's held gate so the wait is
+	// measurable (well above the 1 ms reporting threshold).
+	release := reg.HoldGateForTest(p.ID)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		release()
+	}()
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+
+	packet := awaitMetric(t, collector, "registry.gate.wait_ms", 5*time.Second)
+	if !strings.Contains(packet, "site:breaker") {
+		t.Fatalf("gate-wait histogram missing the site tag: %s", packet)
+	}
+	if !strings.Contains(packet, "|h|") {
+		t.Fatalf("gate-wait metric is not a histogram: %s", packet)
+	}
+}

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -48,7 +48,7 @@ func (s *Server) handleGenericEndpointStreamingResponseWithError(
 	}
 	if initialError != nil {
 		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause)
+		s.noteInferenceError(pr.ProviderID, pr, initialError.StatusCode, initialError.Error, initialError.ErrorReason, initialError.TerminalCause, initialError.CoordinatorCause)
 		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, *initialError))
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(*initialError))
@@ -64,7 +64,7 @@ func (s *Server) handleGenericEndpointStreamingResponseWithError(
 	// emitProviderError settles and reports an in-band provider error.
 	emitProviderError := func(errMsg protocol.InferenceErrorMessage) {
 		s.refundReservedBalance(pr, "provider_error:"+pr.RequestID)
-		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause)
+		s.noteInferenceError(pr.ProviderID, pr, errMsg.StatusCode, errMsg.Error, errMsg.ErrorReason, errMsg.TerminalCause, errMsg.CoordinatorCause)
 		s.ddIncr("inference.in_band_error", []string{"model:" + pr.Model, "reason:provider_error"})
 		s.updateInferenceRouteOutcomeForPending(pr, postCommitProviderErrorOutcome(pr, errMsg))
 		emitter.emitError("provider_error", clientSafeInferenceErrorMessage(errMsg))

--- a/coordinator/api/inference_error_sanitize.go
+++ b/coordinator/api/inference_error_sanitize.go
@@ -126,7 +126,8 @@ func legacyInferenceFailureCode(status int, reason, terminalCause string) protoc
 		errorReasonRequestExceedsNodeBudget,
 		errorReasonRequestExceedsBatchBudget,
 		errorReasonCapacityBusy,
-		errorReasonDeadlineUnreachable:
+		errorReasonDeadlineUnreachable,
+		errorReasonDraining:
 		return protocol.FailureCodeCapacity
 	case errorReasonCancelled:
 		return protocol.FailureCodeCancelled
@@ -279,7 +280,8 @@ func safeInferenceErrorReason(code protocol.InferenceFailureCode, supplied strin
 			errorReasonRequestExceedsNodeBudget,
 			errorReasonRequestExceedsBatchBudget,
 			errorReasonCapacityBusy,
-			errorReasonDeadlineUnreachable:
+			errorReasonDeadlineUnreachable,
+			errorReasonDraining:
 			return reason
 		default:
 			return errorReasonCapacityTimeout
@@ -305,7 +307,7 @@ func safeInferenceErrorReason(code protocol.InferenceFailureCode, supplied strin
 // coordinator-synthetic or directly-constructed messages that did not traverse
 // the provider read-loop sanitizer.
 func clientSafeInferenceErrorMessage(msg protocol.InferenceErrorMessage) string {
-	if msg.CoordinatorCause == protocol.CoordinatorCauseProviderDisconnected {
+	if msg.CoordinatorCause.IsProviderDisconnect() {
 		return "provider disconnected"
 	}
 	if msg.FailureCode.Valid() {
@@ -319,14 +321,21 @@ func clientSafeInferenceErrorMessage(msg protocol.InferenceErrorMessage) string 
 // delivery. It preserves the one non-wire coordinator cause and otherwise
 // applies the same provider ingress boundary.
 func normalizeInferenceErrorForInternalUse(msg protocol.InferenceErrorMessage) protocol.InferenceErrorMessage {
-	if msg.CoordinatorCause == protocol.CoordinatorCauseProviderDisconnected {
+	if msg.CoordinatorCause.IsProviderDisconnect() {
+		// The abrupt flush carries no reason and stays provider_error; the
+		// graceful restart flush keeps its coordinator-internal
+		// provider_restart marker (health-neutral through the reason funnel).
+		reason := errorReasonProviderError
+		if msg.CoordinatorCause == protocol.CoordinatorCauseProviderRestart {
+			reason = errorReasonProviderRestart
+		}
 		return protocol.InferenceErrorMessage{
 			Type:             protocol.TypeInferenceError,
 			RequestID:        msg.RequestID,
 			Error:            "provider disconnected",
 			StatusCode:       http.StatusBadGateway,
-			ErrorReason:      errorReasonProviderError,
-			CoordinatorCause: protocol.CoordinatorCauseProviderDisconnected,
+			ErrorReason:      reason,
+			CoordinatorCause: msg.CoordinatorCause,
 			AttemptUsage:     msg.AttemptUsage,
 		}
 	}

--- a/coordinator/api/inference_failure_class.go
+++ b/coordinator/api/inference_failure_class.go
@@ -175,6 +175,11 @@ func classifyRejection(reason, errStr string, providerBudget int64, modelContext
 		return rejectionDeterministicUnservable
 	case "request_exceeds_node", "request_exceeds_node_budget", "capacity_busy":
 		return rejectionTransientCapacity
+	case errorReasonDraining:
+		// Typed drain refusal (R2): this node is restarting; another serves.
+		// Transient for failover, but shouldStopFailover does not charge it
+		// against maxCapacityClassRetries (isDrainingErrorReason).
+		return rejectionTransientCapacity
 	case errorReasonDeadlineUnreachable:
 		return rejectionDeadlineUnreachable
 	case "request_exceeds_batch_token_budget":

--- a/coordinator/api/lock_wait_metrics_test.go
+++ b/coordinator/api/lock_wait_metrics_test.go
@@ -33,6 +33,7 @@ func waitForMetric(t *testing.T, collector *udpCollector, substr string) string 
 // lock-wait observer to the registry.mu.write_wait_ms histogram, tagged with
 // the call site.
 func TestRegistryLockWaitHistogramTaggedBySite(t *testing.T) {
+	t.Setenv("EIGENINFERENCE_RESERVE_COMMIT_MODE", "global")
 	collector := newUDPCollector(t)
 	defer collector.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -46,16 +47,15 @@ func TestRegistryLockWaitHistogramTaggedBySite(t *testing.T) {
 	const model = "lock-wait-metric-model"
 	p := makeRoutableProvider(t, reg, "lock-wait-metric-provider", model)
 
-	// Block the recorder behind a held write lock so the wait is measurable.
-	release := reg.HoldWriteLockForTest()
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		release()
-	}()
-	reg.ClearDispatchLoadCooldown(p.ID, model)
+	// The global compatibility commit still emits the write-lock metric.
+	reserved, _, _ := reg.ReserveProviderWithPlan(model, &registry.PendingRequest{RequestID: "global-metric", Model: model, EstimatedPromptTokens: 1})
+	if reserved == nil {
+		t.Fatal("global reservation failed")
+	}
+	defer p.RemovePending("global-metric")
 
 	packet := waitForMetric(t, collector, "registry.mu.write_wait_ms")
-	if !strings.Contains(packet, "site:dispatch_load_cooldown") {
+	if !strings.Contains(packet, "site:commit") {
 		t.Fatalf("lock-wait histogram missing the site tag: %s", packet)
 	}
 	if !strings.Contains(packet, "|h|") {

--- a/coordinator/api/profiler_test.go
+++ b/coordinator/api/profiler_test.go
@@ -653,7 +653,9 @@ func TestQueuedAttemptExitsCarryRouteOutcome(t *testing.T) {
 	}{
 		{"queue_full", 0, 10 * time.Second, nil, outcomeResponseWritten, "rejected", "queue_full"},
 		{"client_gone", 4, 10 * time.Second, func(_ *testing.T, _ *Server, cancel context.CancelFunc) { cancel() }, outcomeClientGone, "cancelled", "client_gone"},
-		{"first_chunk_timeout", 4, 200 * time.Millisecond, nil, outcomeFailFast, "timeout", "first_chunk_timeout"},
+		// The queue-wait first-content expiry is the queue's own terminal
+		// (queue_deadline), kept distinct from a dispatched provider's silence.
+		{"queue_deadline", 4, 200 * time.Millisecond, nil, outcomeFailFast, "timeout", rejectionReasonQueueDeadline},
 		{"ttft_too_slow", 4, 10 * time.Second, failQueued(registry.ErrQueueTTFTTooSlow), outcomeResponseWritten, "error", "ttft_too_slow"},
 		{"model_capability_unsupported", 4, 10 * time.Second, failQueued(registry.ErrQueueToolConstraintUnavailable), outcomeResponseWritten, "error", "model_capability_unsupported"},
 		{"queue_timeout", 4, 10 * time.Second, failQueued(nil), outcomeResponseWritten, "timeout", "queue_timeout"},

--- a/coordinator/api/prompt_buckets.go
+++ b/coordinator/api/prompt_buckets.go
@@ -59,13 +59,25 @@ func providerChipFamily(p *registry.Provider) string {
 // request was cancelled in the queue before a provider was chosen) so the tag is
 // always present for dashboard grouping.
 func (s *Server) emitClientGone(model string, promptTokens int, chipFamily, phase string) {
-	if chipFamily == "" {
-		chipFamily = "unknown"
+	// After-commit callers (provider terminals, settlement grace) have no
+	// first-content clock to bucket against: the budget was met before commit.
+	s.emitClientGoneBucketed(model, promptTokens, chipFamily, phase, deadlineBucketNotApplicable)
+}
+
+// emitClientGoneBucketed is emitClientGone with the deadline_bucket tag: for a
+// pre-content cancel, how far into the first-content budget the client left
+// (see deadlineBucket), which separates "the upstream timed out on us" from an
+// early application abort. deadlineBucket is normalized to "unknown" when empty.
+func (s *Server) emitClientGoneBucketed(model string, promptTokens int, chipFamily, phase, deadlineBucket string) {
+	chipFamily = sanitizeChipFamilyTag(chipFamily)
+	if deadlineBucket == "" {
+		deadlineBucket = deadlineBucketUnknown
 	}
 	s.ddIncr("routing.client_gone", []string{
 		"model:" + model,
 		"prompt_bucket:" + promptBucket(promptTokens),
 		"chip_family:" + chipFamily,
 		"phase:" + phase,
+		"deadline_bucket:" + deadlineBucket,
 	})
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -162,20 +162,50 @@ const maxProviderVersionLength = 128
 //   - "ws_close_<code>" — the peer sent a WebSocket close frame (1000 = normal
 //     shutdown, 1001 = going away, 1006/close codes from intermediaries, ...);
 //   - "read_error"      — the socket died without a close frame (TCP reset,
-//     NAT/LB teardown, machine went to sleep mid-write).
+//     NAT/LB teardown, machine went to sleep mid-write);
+//   - "read_error_control_frame" — nhooyr failed while handling a peer
+//     control frame (see readErrorDisconnectReason).
+//
+// readReason is the frame-less classification from readErrorDisconnectReason
+// and is used only when neither stronger signal applies.
 //
 // The registry's own generic "disconnect" remains the reason for closes the
 // read loop did NOT observe first — in practice the stale-eviction sweep —
 // so post-fix, lingering "disconnect" rows ≈ silent drops reaped by eviction.
-func sessionDisconnectReason(closeStatus websocket.StatusCode, oomSuspected bool) string {
+func sessionDisconnectReason(closeStatus websocket.StatusCode, oomSuspected bool, readReason string) string {
 	switch {
 	case oomSuspected:
 		return string(registry.DisconnectReasonOOMSuspected)
 	case closeStatus != -1:
 		return "ws_close_" + strconv.Itoa(int(closeStatus))
 	default:
-		return "read_error"
+		return readReason
 	}
+}
+
+const (
+	readErrorReasonGeneric      = "read_error"
+	readErrorReasonControlFrame = "read_error_control_frame"
+)
+
+// readErrorDisconnectReason classifies a frame-less provider Read failure
+// into a fixed two-value vocabulary shared by the ws_disconnects metric, the
+// telemetry event, and the provider_sessions disconnect_reason column.
+//
+// nhooyr answers peer pings on its READ goroutine, with a 5s budget to take
+// the connection's per-frame write lock and put the pong on the wire. When
+// that fails, the library fails the Read with "failed to handle control frame
+// opPing: failed to write control frame opPong: failed to acquire lock: ..."
+// — the peer was alive (it just pinged us), so this is a
+// coordinator-side write stall, not a network drop, and must not be counted
+// with real drops. The same prefix covers any other control-frame handling
+// failure (e.g. a malformed control frame); close frames are never wrapped
+// this way (they surface as a CloseError on the peer_close branch).
+func readErrorDisconnectReason(err error) string {
+	if err != nil && strings.Contains(err.Error(), "failed to handle control frame") {
+		return readErrorReasonControlFrame
+	}
+	return readErrorReasonGeneric
 }
 
 // closeSessionWithReason closes this connection's provider_sessions row with a
@@ -207,6 +237,12 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 	var schedulerSEKey string
 	var schedulerGeneration uint64
 
+	// peerCloseStatus is the close code the peer sent, captured by the read
+	// loop so the deferred teardown can flush pending requests with the
+	// health-neutral restart cause on a graceful 1000/1001 close and the
+	// striking abrupt cause otherwise (registry.ClassifyPeerClose). -1 = no
+	// close frame observed.
+	peerCloseStatus := websocket.StatusCode(-1)
 	// Cancel context for cleanup of the challenge loop goroutine.
 	loopCtx, loopCancel := context.WithCancel(ctx)
 	defer func() {
@@ -222,7 +258,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		// provider down), so the measured reconnect gap starts here rather
 		// than at the last periodic coverage pass.
 		s.stopTrustCoverageForProvider(providerID)
-		s.registry.Disconnect(providerID)
+		s.registry.DisconnectWithReason(providerID, registry.ClassifyPeerClose(peerCloseStatus, false))
 		conn.Close(websocket.StatusNormalClosure, "goodbye")
 	}()
 
@@ -231,7 +267,9 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 		if err != nil {
 			closeStatus := websocket.CloseStatus(err)
 			oomSuspected := false
+			readReason := readErrorReasonGeneric
 			if closeStatus != -1 {
+				peerCloseStatus = closeStatus
 				s.logger.Info("provider websocket closed",
 					"provider_id", providerID, "close_code", int(closeStatus))
 				// Peer-initiated closes were previously unmetered — only
@@ -247,20 +285,23 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					"code:" + strconv.Itoa(int(closeStatus)),
 				})
 			} else {
-				s.logger.Error("provider websocket read error", "provider_id", providerID, "error", err)
+				readReason = readErrorDisconnectReason(err)
+				s.logger.Error("provider websocket read error",
+					"provider_id", providerID, "error", err, "reason", readReason)
 				s.emit(context.Background(), protocol.SeverityWarn, protocol.KindConnectivity,
 					"provider websocket read error",
 					map[string]any{
 						"provider_id": providerID,
 						"ws_state":    "read_error",
+						"reason":      readReason,
 						"last_error":  err.Error(),
 					})
 				if s.metrics != nil {
 					s.metrics.IncCounter("ws_disconnects_total",
-						MetricLabel{"reason", "read_error"},
+						MetricLabel{"reason", readReason},
 					)
 				}
-				s.ddIncr("ws.disconnects", []string{"reason:read_error"})
+				s.ddIncr("ws.disconnects", []string{"reason:" + readReason})
 
 				// An abrupt read_error under high last-known memory pressure with
 				// active inference is very likely a jetsam OOM (the kill leaves no
@@ -317,17 +358,15 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					provider.Status = registry.StatusOffline
 				}
 				provider.Mu().Unlock()
-				s.closeSessionWithReason(providerID, sessionDisconnectReason(closeStatus, oomSuspected))
+				s.closeSessionWithReason(providerID, sessionDisconnectReason(closeStatus, oomSuspected, readReason))
 			}
 			return
 		}
 
 		var msg protocol.ProviderMessage
-		// Call the typed decoder directly: json.Unmarshal would first validate
-		// the whole frame (a full scan) and then invoke this same method, which
-		// decodes the frame again. The typed decode still rejects malformed
-		// input, an unknown type, and a type-mismatched payload.
-		if err := msg.UnmarshalJSON(data); err != nil {
+		// DecodeProviderMessage is json.Unmarshal minus its redundant outer
+		// validation pass; per-token chunk frames take a hand-written decoder.
+		if err := protocol.DecodeProviderMessage(data, &msg); err != nil {
 			// Decoder errors may quote provider-controlled fields (notably an
 			// unknown message type). Never reflect the detail into logs.
 			s.logger.Warn("invalid provider message", "provider_id", providerID)
@@ -407,11 +446,12 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 				}
 			}
 
-			// Store provider version.
+			// Store provider version. SetVersion also runs the version-changed
+			// reconnect reset for the session's stable identity, which the
+			// attestation bind above could not (the version was not stored
+			// yet) — see registry/version_reset.go.
 			if regMsg.Version != "" {
-				provider.Mu().Lock()
-				provider.Version = regMsg.Version
-				provider.Mu().Unlock()
+				provider.SetVersion(regMsg.Version)
 			}
 
 			// Verify runtime integrity against the known-good manifest. Swift
@@ -591,13 +631,17 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					s.ddIncr("routing.cache_telemetry_rejected", []string{"source:heartbeat"})
 				}
 			}
+			// The pre-heartbeat snapshot is the baseline for the MLX reclaimer
+			// counter deltas (recordMLXCacheTelemetry); nil on the session's
+			// first heartbeat.
+			prevCapacity := provider.BackendCapacitySnapshot()
 			s.registry.Heartbeat(providerID, hbMsg)
 			// Emit only from the accepted registry snapshot: malformed values
 			// have been clamped and slot model IDs constrained to this
 			// connection's coordinator-known inventory.
 			capacity := provider.BackendCapacitySnapshot()
 			s.recordBackendWedgeTelemetry(capacity)
-			s.recordMLXCacheTelemetry(providerID, capacity)
+			s.recordMLXCacheTelemetry(provider, prevCapacity, capacity)
 			// W5 Fix 2 (2a): a late/changed APNs token carried in the heartbeat
 			// re-arms a code-identity challenge WITHOUT a reconnect.
 			s.maybeRearmCodeAttest(loopCtx, providerID, provider, hbMsg)
@@ -1783,19 +1827,14 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 	}
 	pr, receivedAt := provider.BeginPendingChunkIngress(msg.RequestID)
 	if pr == nil {
-		// Until it matches pending state, request_id is provider-controlled and
-		// therefore an arbitrary log-exfiltration channel.
-		s.logger.Warn("chunk for unknown request", "provider_id", providerID)
 		s.ddIncr("inference.unknown_request_frames", []string{"kind:chunk"})
 		s.unknownRequestFrames.Add(1)
-		// The provider is still generating into a stream we abandoned (consumer
-		// gone / already settled), burning its GPU and token-budget admission.
-		// Nudge it to stop — throttled so a chunk-per-token zombie doesn't flood
-		// the provider with cancels.
-		if s.zombieCanceller.shouldCancel(msg.RequestID, time.Now()) {
-			s.sendProviderCancel(provider, msg.RequestID)
-			s.ddIncr("inference.zombie_stream_cancel", []string{})
-		}
+		// The provider is generating into a stream the coordinator abandoned
+		// (cancelled, consumer gone, already settled) — or sent an id it never
+		// owned. noteStrayChunk re-sends the cancel on the escalating zombie
+		// schedule and rate-limits the log line per provider; request_id stays
+		// out of the log until it matches coordinator state.
+		s.noteStrayChunk(provider, providerID, msg.RequestID, receivedAt)
 		return
 	}
 	ingressClassified := false
@@ -1849,7 +1888,7 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		// either late first content or an on-time chunk that finished
 		// classification as boilerplate only after the deadline.
 		s.ddIncr("inference.first_content_after_deadline", []string{})
-		s.sendProviderCancel(provider, pr.RequestID)
+		s.sendAbandonCancel(provider, pr.RequestID, pr.Model, cancelCauseLateContent)
 		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
 			Type:        protocol.TypeInferenceError,
 			RequestID:   pr.RequestID,
@@ -1880,7 +1919,7 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 			"request_id", msg.RequestID,
 		)
 		s.ddIncr("inference.chunk_overflow_abort", []string{})
-		s.sendProviderCancel(provider, msg.RequestID)
+		s.sendAbandonCancel(provider, pr.RequestID, pr.Model, cancelCauseOverflow)
 		// 499 + "request cancelled" classifies as a consumer-side terminal in
 		// handleInferenceError: no provider reputation hit for our backpressure.
 		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
@@ -2105,13 +2144,32 @@ func (s *Server) handleCompleteAt(
 	// Clear any parked settlement record (consumer disconnected mid-stream):
 	// settles the disconnect case and stops the grace timer from no-op-refunding.
 	parked := s.claimSettlement(msg.RequestID)
+	// No live pending record means the attempt was abandoned (or is unknown):
+	// correlate the terminal with the cancel the coordinator sent. Metric-only
+	// — a parked post-commit record still settles billing below, and a
+	// pre-commit attempt was refunded when it was abandoned. Only a terminal
+	// that finds no live record is matched, so the coordinator's own
+	// synthesized errors (raised while the record is live) never resolve one.
+	var cancelled zombieEntry
+	wasCancelled := false
 	if pr == nil {
+		cancelled, wasCancelled = s.resolveCancelledTerminal(
+			msg.RequestID, cancelTerminalComplete, cancelledOutcomeCompletePartial, receivedAt)
 		pr = parked
 	}
 	if pr == nil {
-		// Until it matches pending state, request_id is provider-controlled and
-		// therefore an arbitrary log-exfiltration channel.
-		s.logger.Warn("complete for unknown request", "provider_id", providerID)
+		if wasCancelled && cancelled.cause != cancelCauseStrayChunk {
+			// The id matched a cancel the coordinator recorded, so it is
+			// coordinator-minted and safe to log: the provider honored the
+			// cancel with a partial completion.
+			s.logger.Debug("complete for cancelled request",
+				"request_id", msg.RequestID, "provider_id", providerID, "cause", cancelled.cause)
+		} else {
+			// Until it matches pending state, request_id is provider-controlled and
+			// therefore an arbitrary log-exfiltration channel.
+			s.logger.Warn("complete for unknown request", "provider_id", providerID)
+			s.emitUnknownFrame(unknownFrameKindComplete, provider)
+		}
 		s.ddIncr("inference.unknown_request_frames", []string{"kind:complete"})
 		s.unknownRequestFrames.Add(1)
 		// A claimed terminal whose pending request a consumer-side cleanup
@@ -2749,14 +2807,29 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 	// Clear any parked settlement record (consumer disconnected mid-stream).
 	// Same object as a non-nil pr when the terminal raced the disconnect defer.
 	parked := s.claimSettlement(msg.RequestID)
+	// See handleCompleteAt: a terminal with no live pending record is matched
+	// against the cancel the coordinator sent for it (metric-only).
+	var cancelled zombieEntry
+	wasCancelled := false
 	if pr == nil {
+		cancelled, wasCancelled = s.resolveCancelledTerminal(
+			msg.RequestID, cancelTerminalError, cancelledErrorOutcome(msg), time.Now())
 		pr = parked
 	}
 	if pr == nil {
-		// request_id is provider-controlled until it matches coordinator-owned
-		// pending state. Do not log it: an attacker could use unknown IDs as an
-		// arbitrary log exfiltration channel.
-		s.logger.Warn("error for unknown request", "provider_id", providerID)
+		if wasCancelled && cancelled.cause != cancelCauseStrayChunk {
+			// Coordinator-minted id (it matched a recorded cancel): the
+			// provider honored the cancel before producing output.
+			s.logger.Debug("error for cancelled request",
+				"request_id", msg.RequestID, "provider_id", providerID,
+				"cause", cancelled.cause, "status_code", msg.StatusCode)
+		} else {
+			// request_id is provider-controlled until it matches coordinator-owned
+			// pending state. Do not log it: an attacker could use unknown IDs as an
+			// arbitrary log exfiltration channel.
+			s.logger.Warn("error for unknown request", "provider_id", providerID)
+			s.emitUnknownFrame(unknownFrameKindError, provider)
+		}
 		s.ddIncr("inference.unknown_request_frames", []string{"kind:error"})
 		s.unknownRequestFrames.Add(1)
 		// A terminal claimed here whose pending request a consumer-side cleanup

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -631,17 +631,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 					s.ddIncr("routing.cache_telemetry_rejected", []string{"source:heartbeat"})
 				}
 			}
-			// The pre-heartbeat snapshot is the baseline for the MLX reclaimer
-			// counter deltas (recordMLXCacheTelemetry); nil on the session's
-			// first heartbeat.
-			prevCapacity := provider.BackendCapacitySnapshot()
-			s.registry.Heartbeat(providerID, hbMsg)
-			// Emit only from the accepted registry snapshot: malformed values
-			// have been clamped and slot model IDs constrained to this
-			// connection's coordinator-known inventory.
-			capacity := provider.BackendCapacitySnapshot()
-			s.recordBackendWedgeTelemetry(capacity)
-			s.recordMLXCacheTelemetry(provider, prevCapacity, capacity)
+			s.applyProviderHeartbeat(providerID, provider, hbMsg)
 			// W5 Fix 2 (2a): a late/changed APNs token carried in the heartbeat
 			// re-arms a code-identity challenge WITHOUT a reconnect.
 			s.maybeRearmCodeAttest(loopCtx, providerID, provider, hbMsg)

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -2788,7 +2788,8 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 	// would otherwise never finalize (neither the funnel nor the fallback
 	// completes a claimed terminal).
 	var claimedHere *registry.AttemptProfile
-	if pending := provider.GetPending(msg.RequestID); pending != nil && pending.Profile != nil && !owned {
+	pending := provider.GetPending(msg.RequestID)
+	if pending != nil && pending.Profile != nil && !owned {
 		if !pending.Profile.ClaimTerminal() {
 			s.logger.Warn("duplicate error for in-flight request", "provider_id", providerID)
 			s.ddIncr("inference.unknown_request_frames", []string{"kind:duplicate_error"})
@@ -2802,6 +2803,9 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 		// consumer-side cleanup removes it before RemovePending.
 		s.retainProviderProfile(pending.Profile, msg.Profile)
 		msg.Profile = nil
+	}
+	if pending != nil && isDrainingErrorReason(msg.ErrorReason) {
+		s.noteProviderDraining(providerID, pending.Model)
 	}
 	pr := provider.RemovePending(msg.RequestID)
 	// Clear any parked settlement record (consumer disconnected mid-stream).
@@ -2843,6 +2847,11 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 	}
 	// From this point onward use only the coordinator-owned identifier.
 	msg.RequestID = pr.RequestID
+	if pending == nil && isDrainingErrorReason(msg.ErrorReason) {
+		// A consumer-gone request may already be parked outside the pending
+		// map. Fence its provider before SetProviderIdle drains queued work.
+		s.noteProviderDraining(providerID, pr.Model)
+	}
 	if ap := pr.Profile; ap != nil {
 		ap.Mark(registry.StampCompleteIngress)
 		// A pending entry was claimed at the peek above; a PARKED record (no

--- a/coordinator/api/provider_disconnect_reason_test.go
+++ b/coordinator/api/provider_disconnect_reason_test.go
@@ -9,7 +9,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
@@ -28,23 +32,63 @@ func TestSessionDisconnectReason(t *testing.T) {
 		name         string
 		closeStatus  websocket.StatusCode
 		oomSuspected bool
+		readReason   string
 		want         string
 	}{
-		{"normal close frame", websocket.StatusNormalClosure, false, "ws_close_1000"},
-		{"going away close frame", websocket.StatusGoingAway, false, "ws_close_1001"},
-		{"policy violation (challenge force-reconnect)", websocket.StatusPolicyViolation, false, "ws_close_1008"},
-		{"abrupt drop", -1, false, "read_error"},
-		{"abrupt drop under memory pressure", -1, true, "oom_suspected"},
+		{"normal close frame", websocket.StatusNormalClosure, false, readErrorReasonGeneric, "ws_close_1000"},
+		{"going away close frame", websocket.StatusGoingAway, false, readErrorReasonGeneric, "ws_close_1001"},
+		{"policy violation (challenge force-reconnect)", websocket.StatusPolicyViolation, false, readErrorReasonGeneric, "ws_close_1008"},
+		{"abrupt drop", -1, false, readErrorReasonGeneric, "read_error"},
+		{"control-frame handling failure", -1, false, readErrorReasonControlFrame, "read_error_control_frame"},
+		{"abrupt drop under memory pressure", -1, true, readErrorReasonGeneric, "oom_suspected"},
 		// A close frame never coexists with the OOM classification in the read
 		// loop (classification only runs on the abrupt branch), but the mapping
 		// must still prioritize the stronger signal if both are ever set.
-		{"oom wins over close frame", websocket.StatusNormalClosure, true, "oom_suspected"},
+		{"oom wins over close frame", websocket.StatusNormalClosure, true, readErrorReasonGeneric, "oom_suspected"},
+		// Likewise the read-error classification only exists on the frame-less
+		// branch; a close code must win if both are ever set.
+		{"close code wins over control-frame reason", websocket.StatusNormalClosure, false, readErrorReasonControlFrame, "ws_close_1000"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := sessionDisconnectReason(tt.closeStatus, tt.oomSuspected); got != tt.want {
-				t.Errorf("sessionDisconnectReason(%d, %v) = %q, want %q",
-					tt.closeStatus, tt.oomSuspected, got, tt.want)
+			if got := sessionDisconnectReason(tt.closeStatus, tt.oomSuspected, tt.readReason); got != tt.want {
+				t.Errorf("sessionDisconnectReason(%d, %v, %q) = %q, want %q",
+					tt.closeStatus, tt.oomSuspected, tt.readReason, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadErrorDisconnectReason pins the frame-less read-error classification.
+// The first case is the exact chain nhooyr produces when a pong cannot take
+// the write lock while a data frame is in flight (observed live in
+// registry.TestUnfragmentedConnWriteStallsPeerPing); anything not about a
+// control frame stays the generic "read_error".
+func TestReadErrorDisconnectReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"pong blocked behind an in-flight data frame",
+			errors.New("failed to get reader: failed to handle control frame opPing: failed to write control frame opPong: failed to acquire lock: context deadline exceeded"),
+			readErrorReasonControlFrame},
+		{"pong write stalled on a full socket",
+			errors.New("failed to get reader: failed to handle control frame opPing: failed to write control frame opPong: failed to write frame: context deadline exceeded"),
+			readErrorReasonControlFrame},
+		{"malformed control frame",
+			errors.New("failed to get reader: failed to handle control frame opPing: received fragmented control frame"),
+			readErrorReasonControlFrame},
+		{"tcp reset",
+			errors.New("failed to get reader: failed to read frame header: read tcp 127.0.0.1:1->127.0.0.1:2: read: connection reset by peer"),
+			readErrorReasonGeneric},
+		{"eof", io.EOF, readErrorReasonGeneric},
+		{"nil", nil, readErrorReasonGeneric},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readErrorDisconnectReason(tt.err); got != tt.want {
+				t.Errorf("readErrorDisconnectReason(%v) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
 	}
@@ -66,6 +110,12 @@ func newSessionReasonHarness(t *testing.T, ctx context.Context) *sessionReasonHa
 // is handed to the server (and, via NewServer, the registry). The harness
 // itself keeps reading session rows from the raw store.
 func newSessionReasonHarnessWith(t *testing.T, ctx context.Context, wrap func(*registry.Registry, *store.MemoryStore) store.Store) *sessionReasonHarness {
+	return newSessionReasonHarnessDial(t, ctx, wrap, nil)
+}
+
+// newSessionReasonHarnessDial additionally lets the test control how the
+// provider WebSocket is dialed (e.g. to capture the underlying net.Conn).
+func newSessionReasonHarnessDial(t *testing.T, ctx context.Context, wrap func(*registry.Registry, *store.MemoryStore) store.Store, dialOpts *websocket.DialOptions) *sessionReasonHarness {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	st := store.NewMemory(store.Config{AdminKey: "test-key"})
@@ -80,7 +130,7 @@ func newSessionReasonHarnessWith(t *testing.T, ctx context.Context, wrap func(*r
 	t.Cleanup(ts.Close)
 
 	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") + "/ws/provider"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, _, err := websocket.Dial(ctx, wsURL, dialOpts)
 	if err != nil {
 		t.Fatalf("websocket dial: %v", err)
 	}
@@ -187,6 +237,51 @@ func TestProviderSessionReasonAbruptClose(t *testing.T) {
 
 	if reason := h.closedReason(t); reason != "read_error" {
 		t.Errorf("disconnect_reason = %q, want %q", reason, "read_error")
+	}
+}
+
+// A read-loop exit caused by a control-frame handling failure must be stamped
+// "read_error_control_frame" through the real HTTP path, not the generic
+// "read_error". The trigger here is a protocol violation (a FIN=0 ping) rather
+// than the production write stall — that stall is reproduced live in
+// registry.TestUnfragmentedConnWriteStallsPeerPing — because it
+// deterministically yields the same "failed to handle control frame" read
+// error the classifier keys on, without a multi-second socket stall.
+func TestProviderSessionReasonControlFrameReadError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rawConnCh := make(chan net.Conn, 1)
+	h := newSessionReasonHarnessDial(t, ctx, nil, &websocket.DialOptions{
+		HTTPClient: &http.Client{Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				c, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				rawConnCh <- c
+				return c, nil
+			},
+		}},
+	})
+	var rawConn net.Conn
+	select {
+	case rawConn = <-rawConnCh:
+	default:
+		t.Fatal("dial did not capture the underlying net.Conn")
+	}
+	defer h.conn.CloseNow()
+
+	// A masked, zero-length ping with FIN clear, written underneath the idle
+	// nhooyr client. nhooyr's handleControl rejects it ("received fragmented
+	// control frame") and readLoop wraps it as "failed to handle control frame
+	// opPing: ..." — a frame-less Read failure on the coordinator side.
+	if _, err := rawConn.Write([]byte{0x09, 0x80, 0x11, 0x22, 0x33, 0x44}); err != nil {
+		t.Fatalf("write fragmented ping: %v", err)
+	}
+
+	if reason := h.closedReason(t); reason != "read_error_control_frame" {
+		t.Errorf("disconnect_reason = %q, want %q", reason, "read_error_control_frame")
 	}
 }
 

--- a/coordinator/api/provider_drain.go
+++ b/coordinator/api/provider_drain.go
@@ -1,0 +1,10 @@
+package api
+
+// A validated provider terminal announces draining before its pending slot is
+// released. Consumer-side classification remains read-only so a delayed error
+// cannot overwrite a newer heartbeat that announces recovery.
+func (s *Server) noteProviderDraining(providerID, model string) {
+	if s.registry.MarkDraining(providerID) {
+		s.ddIncr("routing.provider_draining", []string{"model:" + model})
+	}
+}

--- a/coordinator/api/provider_heartbeat.go
+++ b/coordinator/api/provider_heartbeat.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Reordered sequence-stamped heartbeats still prove liveness, but must not
+// contribute repeated samples from the unchanged allocator snapshot.
+func (s *Server) applyProviderHeartbeat(id string, provider *registry.Provider, msg *protocol.HeartbeatMessage) bool {
+	previous := provider.BackendCapacitySnapshot()
+	if !s.registry.Heartbeat(id, msg) {
+		return false
+	}
+	capacity := provider.BackendCapacitySnapshot()
+	s.recordBackendWedgeTelemetry(capacity)
+	s.recordMLXCacheTelemetry(provider, previous, capacity)
+	return true
+}

--- a/coordinator/api/provider_heartbeat_bench_test.go
+++ b/coordinator/api/provider_heartbeat_bench_test.go
@@ -137,16 +137,18 @@ func benchLocalStatsd(tb testing.TB) *datadog.Client {
 // providerReadLoop for a baseline heartbeat (no prefix-cache fields, so
 // UpdatePrefixCacheSnapshot is skipped exactly as in production).
 func runHeartbeatBranch(ctx context.Context, s *Server, providerID string, provider *registry.Provider, hb *protocol.HeartbeatMessage) {
+	prev := provider.BackendCapacitySnapshot()
 	s.registry.Heartbeat(providerID, hb)
-	runHeartbeatTail(ctx, s, providerID, provider, hb)
+	runHeartbeatTail(ctx, s, providerID, provider, prev, hb)
 }
 
 // runHeartbeatTail is the API-side tail after registry ingest, exactly as the
-// branch runs it today.
-func runHeartbeatTail(ctx context.Context, s *Server, providerID string, provider *registry.Provider, hb *protocol.HeartbeatMessage) {
+// branch runs it today. prev is the pre-ingest capacity snapshot the MLX
+// telemetry diffs its reclaimer counters against.
+func runHeartbeatTail(ctx context.Context, s *Server, providerID string, provider *registry.Provider, prev *protocol.BackendCapacity, hb *protocol.HeartbeatMessage) {
 	capacity := provider.BackendCapacitySnapshot()
 	s.recordBackendWedgeTelemetry(capacity)
-	s.recordMLXCacheTelemetry(providerID, capacity)
+	s.recordMLXCacheTelemetry(provider, prev, capacity)
 	s.maybeRearmCodeAttest(ctx, providerID, provider, hb)
 }
 
@@ -186,8 +188,11 @@ func BenchmarkHeartbeatBranchTelemetryOnly(b *testing.B) {
 	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
+	// Steady state: the previous snapshot equals the current one, so the MLX
+	// reclaimer deltas are zero — the realistic per-heartbeat tail cost.
+	prev := p.BackendCapacitySnapshot()
 	for i := 0; i < b.N; i++ {
-		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, hb)
+		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, prev, hb)
 	}
 }
 
@@ -200,7 +205,10 @@ func BenchmarkHeartbeatBranchTelemetryOnlyStatsd(b *testing.B) {
 	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
+	// Steady state: the previous snapshot equals the current one, so the MLX
+	// reclaimer deltas are zero — the realistic per-heartbeat tail cost.
+	prev := p.BackendCapacitySnapshot()
 	for i := 0; i < b.N; i++ {
-		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, hb)
+		runHeartbeatTail(ctx, s, benchHeartbeatProviderID, p, prev, hb)
 	}
 }

--- a/coordinator/api/provider_heartbeat_bench_test.go
+++ b/coordinator/api/provider_heartbeat_bench_test.go
@@ -137,9 +137,8 @@ func benchLocalStatsd(tb testing.TB) *datadog.Client {
 // providerReadLoop for a baseline heartbeat (no prefix-cache fields, so
 // UpdatePrefixCacheSnapshot is skipped exactly as in production).
 func runHeartbeatBranch(ctx context.Context, s *Server, providerID string, provider *registry.Provider, hb *protocol.HeartbeatMessage) {
-	prev := provider.BackendCapacitySnapshot()
-	s.registry.Heartbeat(providerID, hb)
-	runHeartbeatTail(ctx, s, providerID, provider, prev, hb)
+	s.applyProviderHeartbeat(providerID, provider, hb)
+	s.maybeRearmCodeAttest(ctx, providerID, provider, hb)
 }
 
 // runHeartbeatTail is the API-side tail after registry ingest, exactly as the

--- a/coordinator/api/provider_heartbeat_telemetry_test.go
+++ b/coordinator/api/provider_heartbeat_telemetry_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestRejectedHeartbeatDoesNotEmitAllocatorSamples(t *testing.T) {
+	srv, _ := testServer(t)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+	p := newMLXTelemetryProvider(t, srv.registry, "sequence-telemetry", "M3", "0.8.20")
+	apply := func(seq uint64) bool {
+		capacity := mlxCapacity(5, 2, 4096)
+		capacity.CapacitySeq = seq
+		return srv.applyProviderHeartbeat(p.ID, p, &protocol.HeartbeatMessage{BackendCapacity: capacity})
+	}
+	if !apply(2) {
+		t.Fatal("first stamped heartbeat was rejected")
+	}
+	_ = dd.Statsd.Flush()
+	if !hasMetric(collector.drain(), "provider.mlx_memory.active_gb") {
+		t.Fatal("accepted heartbeat did not emit allocator telemetry")
+	}
+	for _, seq := range []uint64{2, 1} {
+		if apply(seq) {
+			t.Errorf("reordered sequence %d was accepted", seq)
+		}
+	}
+	_ = dd.Statsd.Flush()
+	if packets := collector.drain(); len(findMetrics(packets, "provider.mlx_")) != 0 {
+		t.Fatalf("rejected heartbeats emitted repeated allocator samples: %v", packets)
+	}
+	if !apply(0) {
+		t.Fatal("legacy unsequenced heartbeat was rejected")
+	}
+	_ = dd.Statsd.Flush()
+	if !hasMetric(collector.drain(), "provider.mlx_memory.active_gb") {
+		t.Fatal("legacy accepted heartbeat stopped reporting telemetry")
+	}
+}

--- a/coordinator/api/provider_mlx_cache_telemetry.go
+++ b/coordinator/api/provider_mlx_cache_telemetry.go
@@ -1,33 +1,89 @@
 package api
 
-import "github.com/eigeninference/d-inference/coordinator/protocol"
+import (
+	"math"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
 
 // recordMLXCacheTelemetry turns the provider heartbeat's allocator snapshot
-// into live Datadog gauges. Heartbeats are the durable operational path for
+// into Datadog metrics. Heartbeats are the durable operational path for
 // provider diagnostics; unlike the retired free-form telemetry client, they
 // carry no prompt or response data and continue flowing during normal serving.
 //
-// Cumulative reclaimer values are gauges rather than coordinator-side counters:
-// they reset when the provider process restarts, and Datadog can derive rates
-// without the coordinator maintaining per-provider delta state.
-func (s *Server) recordMLXCacheTelemetry(providerID string, capacity *protocol.BackendCapacity) {
-	if capacity == nil {
+// Cardinality: tags are bounded — chip_family and provider_version — never a
+// provider id. The previous per-provider gauges were tagged by the connection
+// UUID, so every reconnect minted a fresh series (~9 gauges × fleet, churning).
+// Point-in-time values are emitted as histograms with DogStatsD (agent-side
+// avg/max/p95/count across the fleet per tag set), or as latest-value gauges
+// per bounded tag set when the HTTPS series API is configured. HTTP gauges
+// preserve visibility without claiming fleet percentiles. Reclaimer counters
+// are converted to per-heartbeat deltas against prev (the capacity snapshot
+// taken before this heartbeat was applied) and emitted as counts, so a
+// fleet-wide reclaim rate survives aggregation. prev is nil on a session's
+// first observation: no baseline, no deltas. A counter that went backwards
+// (provider-side reset) contributes nothing for that heartbeat.
+func (s *Server) recordMLXCacheTelemetry(provider *registry.Provider, prev, capacity *protocol.BackendCapacity) {
+	if s.dd == nil || capacity == nil {
 		return
 	}
-
-	tags := []string{"provider_id:" + providerID}
-	s.ddGauge("provider.mlx_memory.active_gb", capacity.GPUMemoryActiveGB, tags)
-	s.ddGauge("provider.mlx_memory.peak_gb", capacity.GPUMemoryPeakGB, tags)
-	s.ddGauge("provider.mlx_memory.cache_gb", capacity.GPUMemoryCacheGB, tags)
+	tags := mlxTelemetryTags(provider)
+	s.dd.HistogramOrGauge("provider.mlx_memory.active_gb", capacity.GPUMemoryActiveGB, tags)
+	s.dd.HistogramOrGauge("provider.mlx_memory.peak_gb", capacity.GPUMemoryPeakGB, tags)
+	s.dd.HistogramOrGauge("provider.mlx_memory.cache_gb", capacity.GPUMemoryCacheGB, tags)
 
 	reclaimer := capacity.MLXCacheReclaimer
 	if reclaimer == nil {
 		return
 	}
-	s.ddGauge("provider.mlx_cache.limit_bytes", float64(reclaimer.CacheLimitBytes), tags)
-	s.ddGauge("provider.mlx_cache.sweep_signals_total", float64(reclaimer.SweepSignals), tags)
-	s.ddGauge("provider.mlx_cache.reclaims_total", float64(reclaimer.Reclaims), tags)
-	s.ddGauge("provider.mlx_cache.reclaimed_bytes_total", float64(reclaimer.ReclaimedBytes), tags)
-	s.ddGauge("provider.mlx_cache.last_reclaimed_bytes", float64(reclaimer.LastReclaimedBytes), tags)
-	s.ddGauge("provider.mlx_cache.last_reclaim_duration_ms", float64(reclaimer.LastReclaimDurationMS), tags)
+	s.dd.HistogramOrGauge("provider.mlx_cache.limit_bytes", float64(reclaimer.CacheLimitBytes), tags)
+
+	if prev == nil || prev.MLXCacheReclaimer == nil {
+		return
+	}
+	last := prev.MLXCacheReclaimer
+	s.ddCountDelta("provider.mlx_cache.sweep_signals", last.SweepSignals, reclaimer.SweepSignals, tags)
+	reclaims := s.ddCountDelta("provider.mlx_cache.reclaims", last.Reclaims, reclaimer.Reclaims, tags)
+	s.ddCountDelta("provider.mlx_cache.reclaimed_bytes", last.ReclaimedBytes, reclaimer.ReclaimedBytes, tags)
+	if reclaims > 0 {
+		// The last_* fields describe the most recent reclaim; sample them
+		// only when a reclaim happened since the previous heartbeat so the
+		// distribution is of reclaims, not of heartbeats.
+		s.dd.HistogramOrGauge("provider.mlx_cache.last_reclaimed_bytes", float64(reclaimer.LastReclaimedBytes), tags)
+		s.dd.HistogramOrGauge("provider.mlx_cache.last_reclaim_duration_ms", float64(reclaimer.LastReclaimDurationMS), tags)
+	}
+}
+
+// ddCountDelta emits cur-prev for a provider-side cumulative counter and
+// returns the delta. Nothing is emitted for a zero or negative delta.
+func (s *Server) ddCountDelta(name string, prev, cur uint64, tags []string) int64 {
+	delta := counterDelta(prev, cur)
+	if delta > 0 {
+		s.ddCount(name, delta, tags)
+	}
+	return delta
+}
+
+// counterDelta is cur-prev clamped to [0, MaxInt64]; a counter that went
+// backwards (provider restart or reset) yields 0.
+func counterDelta(prev, cur uint64) int64 {
+	if cur <= prev {
+		return 0
+	}
+	if d := cur - prev; d <= math.MaxInt64 {
+		return int64(d)
+	}
+	return math.MaxInt64
+}
+
+// mlxTelemetryTags builds the bounded tag set for the MLX telemetry: the chip
+// family reported at registration and the provider version, both read under
+// the provider's lock and fenced to tag-safe values (provider-controlled
+// strings must never mint cardinality).
+func mlxTelemetryTags(provider *registry.Provider) []string {
+	return []string{
+		"chip_family:" + sanitizeChipFamilyTag(providerChipFamily(provider)),
+		"provider_version:" + providerVersionTag(provider),
+	}
 }

--- a/coordinator/api/provider_mlx_cache_telemetry_test.go
+++ b/coordinator/api/provider_mlx_cache_telemetry_test.go
@@ -1,63 +1,265 @@
 package api
 
 import (
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
 )
 
-func TestRecordMLXCacheTelemetryEmitsHeartbeatGauges(t *testing.T) {
-	collector := newUDPCollector(t)
-	defer collector.Close()
-	ddClient := newTestDD(t, collector)
-	defer ddClient.Close()
+var uuidShaped = regexp.MustCompile(`(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 
-	s := &Server{}
-	s.SetDatadog(ddClient)
-	s.recordMLXCacheTelemetry("provider-1", &protocol.BackendCapacity{
-		GPUMemoryActiveGB: 21,
-		GPUMemoryPeakGB:   31,
-		GPUMemoryCacheGB:  6,
-		MLXCacheReclaimer: &protocol.MLXCacheReclaimerTelemetry{
-			CacheLimitBytes:       8 << 30,
-			SweepSignals:          12,
-			Reclaims:              4,
-			ReclaimedBytes:        24 << 30,
-			LastReclaimedBytes:    6 << 30,
-			LastReclaimDurationMS: 17,
-		},
-	})
-	_ = ddClient.Statsd.Flush()
-	payload := strings.Join(collector.drain(), "\n")
+// packetTags returns the DogStatsD tags of one wire line (after "|#").
+func packetTags(line string) []string {
+	i := strings.Index(line, "|#")
+	if i < 0 {
+		return nil
+	}
+	return strings.Split(line[i+2:], ",")
+}
 
-	for _, metric := range []string{
-		"provider.mlx_memory.active_gb",
-		"provider.mlx_memory.peak_gb",
-		"provider.mlx_memory.cache_gb",
-		"provider.mlx_cache.limit_bytes",
-		"provider.mlx_cache.sweep_signals_total",
-		"provider.mlx_cache.reclaims_total",
-		"provider.mlx_cache.reclaimed_bytes_total",
-		"provider.mlx_cache.last_reclaimed_bytes",
-		"provider.mlx_cache.last_reclaim_duration_ms",
-	} {
-		if !strings.Contains(payload, metric) {
-			t.Errorf("missing %s in DogStatsD payload: %s", metric, payload)
+func containsTag(line, tag string) bool {
+	for _, t := range packetTags(line) {
+		if t == tag {
+			return true
 		}
 	}
-	if !strings.Contains(payload, "provider_id:provider-1") {
-		t.Fatalf("allocator gauges must identify the provider: %s", payload)
+	return false
+}
+
+// assertBoundedTags fails if any emitted line carries a provider id or a
+// UUID-shaped tag value, or lacks the two bounded tags.
+func assertBoundedTags(t *testing.T, packets []string) {
+	t.Helper()
+	for _, p := range packets {
+		for _, tag := range packetTags(p) {
+			if strings.HasPrefix(tag, "provider_id:") {
+				t.Fatalf("provider_id tag emitted: %s", p)
+			}
+			if uuidShaped.MatchString(tag) {
+				t.Fatalf("UUID-shaped tag value emitted: %s", p)
+			}
+		}
+		if !containsTag(p, "chip_family:M3") || !containsTag(p, "provider_version:0.8.x") {
+			t.Fatalf("bounded tags missing: %s", p)
+		}
 	}
 }
 
-func TestRecordMLXCacheTelemetryLegacyAndNilSafe(t *testing.T) {
-	s := &Server{}
-	// No Datadog client and no reclaimer block are both valid during rollout.
-	s.recordMLXCacheTelemetry("legacy", nil)
-	s.recordMLXCacheTelemetry("legacy", &protocol.BackendCapacity{
-		GPUMemoryActiveGB: 1,
-		GPUMemoryPeakGB:   2,
-		GPUMemoryCacheGB:  0.5,
-	})
+func newMLXTelemetryProvider(t *testing.T, reg *registry.Registry, id, chipFamily, version string) *registry.Provider {
+	t.Helper()
+	p := makeRoutableProvider(t, reg, id, "test-model")
+	p.Mu().Lock()
+	p.Hardware.ChipFamily = chipFamily
+	p.Version = version
+	p.Mu().Unlock()
+	return p
+}
+
+func mlxCapacity(sweeps, reclaims, reclaimedBytes uint64) *protocol.BackendCapacity {
+	return &protocol.BackendCapacity{
+		GPUMemoryActiveGB: 8,
+		GPUMemoryPeakGB:   12,
+		GPUMemoryCacheGB:  2,
+		MLXCacheReclaimer: &protocol.MLXCacheReclaimerTelemetry{
+			CacheLimitBytes:       1 << 30,
+			SweepSignals:          sweeps,
+			Reclaims:              reclaims,
+			ReclaimedBytes:        reclaimedBytes,
+			LastReclaimedBytes:    2048,
+			LastReclaimDurationMS: 3,
+		},
+	}
+}
+
+// TestMLXCacheTelemetryBoundedTagsAndDeltas walks the heartbeat sequence a
+// provider session produces — first observation, a reclaim, no change, a
+// counter reset — and checks that every emitted line (histograms and counts)
+// carries only the bounded tags, never the session UUID, and that the
+// cumulative reclaimer counters surface as per-heartbeat deltas.
+func TestMLXCacheTelemetryBoundedTagsAndDeltas(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "test-key"}), ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+	// Counts are aggregated client-side by datadog-go; force them onto the
+	// wire before reading the collector.
+	flushAndDrain := func() []string {
+		_ = ddClient.Statsd.Flush()
+		return collector.drain()
+	}
+
+	provider := newMLXTelemetryProvider(t, reg, uuid.New().String(), "M3", "0.8.20")
+
+	// 1. First heartbeat of the session: no baseline → point-in-time
+	// histograms only, no deltas, no last_* samples.
+	first := mlxCapacity(5, 2, 4096)
+	srv.recordMLXCacheTelemetry(provider, nil, first)
+	packets := flushAndDrain()
+	assertBoundedTags(t, packets)
+	for _, want := range []string{
+		"provider.mlx_memory.active_gb:8|h", "provider.mlx_memory.peak_gb:12|h",
+		"provider.mlx_memory.cache_gb:2|h", "provider.mlx_cache.limit_bytes:1073741824|h",
+	} {
+		if !hasMetric(packets, want) {
+			t.Fatalf("first heartbeat: missing %q in %v", want, packets)
+		}
+	}
+	for _, absent := range []string{"mlx_cache.reclaims", "mlx_cache.sweep_signals", "mlx_cache.reclaimed_bytes", "mlx_cache.last_"} {
+		if hasMetric(packets, absent) {
+			t.Fatalf("first heartbeat: %q emitted without a baseline: %v", absent, packets)
+		}
+	}
+
+	// 2. A reclaim happened: deltas as counts + last_* samples.
+	second := mlxCapacity(7, 3, 8192)
+	srv.recordMLXCacheTelemetry(provider, first, second)
+	packets = flushAndDrain()
+	assertBoundedTags(t, packets)
+	for _, want := range []string{
+		"provider.mlx_cache.sweep_signals:2|c", "provider.mlx_cache.reclaims:1|c",
+		"provider.mlx_cache.reclaimed_bytes:4096|c",
+		"provider.mlx_cache.last_reclaimed_bytes:2048|h", "provider.mlx_cache.last_reclaim_duration_ms:3|h",
+	} {
+		if !hasMetric(packets, want) {
+			t.Fatalf("reclaim heartbeat: missing %q in %v", want, packets)
+		}
+	}
+
+	// 3. Nothing changed: memory histograms still flow, no counts, no last_*.
+	srv.recordMLXCacheTelemetry(provider, second, second)
+	packets = flushAndDrain()
+	assertBoundedTags(t, packets)
+	if !hasMetric(packets, "provider.mlx_memory.active_gb:8|h") {
+		t.Fatalf("steady heartbeat: memory histogram missing: %v", packets)
+	}
+	for _, absent := range []string{"|c|", "mlx_cache.last_"} {
+		if hasMetric(packets, absent) {
+			t.Fatalf("steady heartbeat: unexpected %q in %v", absent, packets)
+		}
+	}
+
+	// 4. Counters went backwards (provider-side reset): no counts.
+	srv.recordMLXCacheTelemetry(provider, second, first)
+	packets = flushAndDrain()
+	assertBoundedTags(t, packets)
+	if hasMetric(packets, "|c|") {
+		t.Fatalf("reset heartbeat: a negative delta was emitted as a count: %v", packets)
+	}
+
+	// 5. No reclaimer block: memory histograms only.
+	srv.recordMLXCacheTelemetry(provider, second, &protocol.BackendCapacity{GPUMemoryActiveGB: 8})
+	packets = flushAndDrain()
+	assertBoundedTags(t, packets)
+	if hasMetric(packets, "mlx_cache") {
+		t.Fatalf("reclaimer-less heartbeat emitted cache metrics: %v", packets)
+	}
+}
+
+// TestMLXCacheTelemetryFleetCardinalityIsBounded reconnects many sessions
+// (fresh UUIDs) across a few chip families and versions: the number of
+// distinct tag sets must be the product of the bounded dimensions, not the
+// number of sessions.
+func TestMLXCacheTelemetryFleetCardinalityIsBounded(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "test-key"}), ServerConfig{}, logger)
+	ddClient := newTestDD(t, collector)
+	defer ddClient.Close()
+	srv.SetDatadog(ddClient)
+	// Counts are aggregated client-side by datadog-go; force them onto the
+	// wire before reading the collector.
+	flushAndDrain := func() []string {
+		_ = ddClient.Statsd.Flush()
+		return collector.drain()
+	}
+
+	families := []string{"M3", "M4"}
+	versions := []string{"0.8.20", "0.9.1"}
+	const sessions = 40
+	for i := 0; i < sessions; i++ {
+		p := newMLXTelemetryProvider(t, reg, uuid.New().String(), families[i%2], versions[(i/2)%2])
+		srv.recordMLXCacheTelemetry(p, mlxCapacity(1, 1, 1), mlxCapacity(2, 2, 2))
+	}
+	packets := flushAndDrain()
+	if len(packets) < sessions {
+		t.Fatalf("expected at least one line per session, got %d", len(packets))
+	}
+	tagSets := map[string]struct{}{}
+	for _, p := range packets {
+		tags := packetTags(p)
+		for _, tag := range tags {
+			if strings.HasPrefix(tag, "provider_id:") || uuidShaped.MatchString(tag) {
+				t.Fatalf("session-scoped tag emitted: %s", p)
+			}
+		}
+		sort.Strings(tags)
+		tagSets[strings.Join(tags, ",")] = struct{}{}
+	}
+	if want := len(families) * len(versions); len(tagSets) != want {
+		t.Fatalf("distinct tag sets = %d, want %d (bounded by chip_family × provider_version): %v", len(tagSets), want, tagSets)
+	}
+}
+
+func TestMLXCacheTelemetryNoDatadogIsNoop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := registry.New(logger)
+	srv := NewServer(reg, store.NewMemory(store.Config{AdminKey: "test-key"}), ServerConfig{}, logger)
+	// No panic and no work without a Datadog client, including a nil provider.
+	srv.recordMLXCacheTelemetry(nil, nil, mlxCapacity(1, 1, 1))
+	// A bare Server (tests that never run NewServer) and a nil capacity are
+	// both valid during rollout.
+	bare := &Server{}
+	bare.recordMLXCacheTelemetry(nil, nil, nil)
+	bare.recordMLXCacheTelemetry(nil, nil, &protocol.BackendCapacity{GPUMemoryActiveGB: 1})
+}
+
+func TestSanitizeChipFamilyTag(t *testing.T) {
+	cases := map[string]string{
+		"":                                      "unknown",
+		"  ":                                    "unknown",
+		"Unknown":                               "unknown",
+		"M3":                                    "M3",
+		" M4 Pro ":                              "M4_Pro",
+		"m5":                                    "other",
+		"M3;drop":                               "other",
+		"M3,env:prod":                           "other",
+		"Apple-M3":                              "other",
+		"family-that-is-way-too-long-for-a-tag": "other",
+		fmt.Sprintf("%017d", 0):                 "other",
+	}
+	for in, want := range cases {
+		if got := sanitizeChipFamilyTag(in); got != want {
+			t.Errorf("sanitizeChipFamilyTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCounterDelta(t *testing.T) {
+	if got := counterDelta(5, 7); got != 2 {
+		t.Fatalf("delta = %d, want 2", got)
+	}
+	if got := counterDelta(7, 5); got != 0 {
+		t.Fatalf("backwards delta = %d, want 0", got)
+	}
+	if got := counterDelta(0, ^uint64(0)); got <= 0 {
+		t.Fatalf("saturated delta = %d, want positive", got)
+	}
 }

--- a/coordinator/api/queue_deadline_test.go
+++ b/coordinator/api/queue_deadline_test.go
@@ -1,0 +1,204 @@
+package api
+
+// queue_deadline (routing-v2 P4): a request whose request-absolute
+// first-content clock expires while it is still waiting in the coordinator
+// queue was reported as first_chunk_timeout — indistinguishable in the
+// rejection ledger from a dispatched provider that went silent. It now carries
+// its own reason code, with the same retryable 429 + Retry-After.
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"nhooyr.io/websocket"
+)
+
+// TestQueuedRequestExpiresAsQueueDeadlineLive drives the REAL HTTP path: the
+// single slot is saturated, the request queues, nothing drains it, and the
+// 400ms first-content deadline fires inside the queue wait.
+func TestQueuedRequestExpiresAsQueueDeadlineLive(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	const model = "queue-deadline-live-model"
+	_, st, reg, ts := queuedFleetHarness(t, ctx, ServerConfig{FirstContentDeadlineBase: 400 * time.Millisecond}, model)
+
+	start := time.Now()
+	res := chatRequestWithID(ctx, ts.URL, model, "queue-deadline-live")
+	elapsed := time.Since(start)
+	if res.err != nil {
+		t.Fatalf("chat request: %v", res.err)
+	}
+	if res.status != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", res.status, res.body)
+	}
+	if res.retryAfter == "" {
+		t.Fatal("queue_deadline 429 missing Retry-After")
+	}
+	if !strings.Contains(res.body, "rate_limit_exceeded") || !strings.Contains(res.body, errQueueDeadlineExpired) {
+		t.Fatalf("body is not the queue-deadline rejection: %s", res.body)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("request resolved after %v, want the ~400ms first-content deadline, not the queue max wait", elapsed)
+	}
+	if depth := reg.Queue().QueueSize(model); depth != 0 {
+		t.Fatalf("queue depth = %d after the deadline terminal, want 0", depth)
+	}
+
+	// The rejection ledger (written asynchronously) must carry the queue's own
+	// reason, never first_chunk_timeout.
+	var rec *store.RejectionRecord
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && rec == nil {
+		for _, r := range st.RejectionRecordsSince(time.Time{}) {
+			if r.Stage == "dispatch" {
+				r := r
+				rec = &r
+				break
+			}
+		}
+		if rec == nil {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if rec == nil {
+		t.Fatalf("no dispatch-stage rejection recorded; records=%+v", st.RejectionRecordsSince(time.Time{}))
+	}
+	if rec.ReasonCode != rejectionReasonQueueDeadline {
+		t.Fatalf("rejection ReasonCode = %q, want %q", rec.ReasonCode, rejectionReasonQueueDeadline)
+	}
+	if rec.HTTPStatus != http.StatusTooManyRequests || rec.RetryAfterMs <= 0 {
+		t.Fatalf("rejection record = status %d retry_after_ms %d, want 429 with a positive Retry-After", rec.HTTPStatus, rec.RetryAfterMs)
+	}
+	if rec.ResolvedModel != model {
+		t.Fatalf("rejection ResolvedModel = %q, want %q", rec.ResolvedModel, model)
+	}
+}
+
+// TestResolveDominantExhaustedStatus_QueueDeadline pins the classification at
+// the unit level: the queue-wait synthetic 504 reclassifies to a 429 with
+// reason queue_deadline; the dispatched-provider synthetic 504 keeps
+// first_chunk_timeout; a sticky genuine provider fault is never overridden.
+func TestResolveDominantExhaustedStatus_QueueDeadline(t *testing.T) {
+	srv, _ := testServer(t)
+	newState := func() *dispatchState {
+		return &dispatchState{s: srv, model: "m", excludeProviders: map[string]struct{}{}}
+	}
+
+	d := newState()
+	d.setLastError(errQueueDeadlineExpired, http.StatusGatewayTimeout)
+	failure, sticky := d.terminalFailureForExhaustion()
+	code, reason, reclassified, dominance := d.resolveDominantExhaustedStatus(failure, sticky)
+	if code != http.StatusTooManyRequests || reason != rejectionReasonQueueDeadline || !reclassified || dominance != exhaustedUndecided {
+		t.Fatalf("queue deadline = (%d, %q, %v, %d), want (429, queue_deadline, true, undecided)", code, reason, reclassified, dominance)
+	}
+
+	d = newState()
+	d.setLastError("timeout waiting for first response", http.StatusGatewayTimeout)
+	failure, sticky = d.terminalFailureForExhaustion()
+	code, reason, reclassified, _ = d.resolveDominantExhaustedStatus(failure, sticky)
+	if code != http.StatusTooManyRequests || reason != "first_chunk_timeout" || !reclassified {
+		t.Fatalf("dispatched timeout = (%d, %q, %v), want (429, first_chunk_timeout, true)", code, reason, reclassified)
+	}
+
+	// A sticky genuine fault from an earlier attempt outranks the queue's
+	// terminal: its own text, its own status.
+	d = newState()
+	fault := dispatchTerminalFailure{errText: "boom", statusCode: http.StatusBadGateway}
+	d.genuineFault = &fault
+	d.setLastError(errQueueDeadlineExpired, http.StatusGatewayTimeout)
+	failure, sticky = d.terminalFailureForExhaustion()
+	code, reason, reclassified, dominance = d.resolveDominantExhaustedStatus(failure, sticky)
+	if !sticky || code != http.StatusBadGateway || reason != "dispatch_exhausted" || reclassified || dominance != exhaustedGenuineFault {
+		t.Fatalf("sticky fault = (%d, %q, %v, %d), want (502, dispatch_exhausted, false, genuine fault)", code, reason, reclassified, dominance)
+	}
+}
+
+// queuedFleetHarness boots a coordinator with one REAL WebSocket provider whose
+// heartbeat reports a saturated token budget, so every request for model
+// capacity-spills to the coordinator queue (queue-before-shed on, cold dispatch
+// off). Returns the server, store, registry and test server.
+func queuedFleetHarness(t *testing.T, ctx context.Context, cfg ServerConfig, model string) (*Server, *store.MemoryStore, *registry.Registry, *httptest.Server) {
+	t.Helper()
+	return queuedFleetHarnessConfigured(t, ctx, cfg, model, nil)
+}
+
+// queuedFleetHarnessConfigured is queuedFleetHarness with a hook that runs on
+// the server BEFORE the HTTP listener starts and any provider connects. Wiring
+// that provider goroutines read (the Datadog client, emitters) must go through
+// it: setting those fields after connectProvider races the heartbeat path.
+func queuedFleetHarnessConfigured(t *testing.T, ctx context.Context, cfg ServerConfig, model string, configure func(*Server)) (*Server, *store.MemoryStore, *registry.Registry, *httptest.Server) {
+	t.Helper()
+	t.Setenv(envQueueBeforeShed, "true")
+	t.Setenv(envColdDispatch, "false")
+	t.Setenv("EIGENINFERENCE_SERVABILITY_GATE", "false")
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, cfg, logger)
+	srv.challengeInterval = time.Hour
+	if configure != nil {
+		configure(srv)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	conn := connectProvider(t, ctx, ts.URL, []protocol.ModelInfo{
+		{ID: model, ModelType: "chat", Quantization: "4bit"},
+	}, testPublicKeyB64())
+	t.Cleanup(func() { conn.Close(websocket.StatusNormalClosure, "done") })
+	p := markOnlyProviderRoutable(t, reg)
+	writeAdaptiveHeartbeat(t, ctx, conn, model, &protocol.BackendCapacity{
+		TotalMemoryGB: 64,
+		Slots: []protocol.BackendSlotCapacity{{
+			Model:                 model,
+			State:                 "running",
+			MaxConcurrency:        1,
+			ActiveTokenBudgetUsed: 950,
+			ActiveTokenBudgetMax:  1_000,
+		}},
+	})
+	waitForAdaptiveCondition(t, time.Second, func() bool {
+		p.Mu().Lock()
+		defer p.Mu().Unlock()
+		return p.BackendCapacity != nil && p.BackendCapacity.Slots[0].ActiveTokenBudgetUsed == 950
+	})
+	return srv, st, reg, ts
+}
+
+type chatResult struct {
+	status     int
+	body       string
+	retryAfter string
+	err        error
+}
+
+func chatRequestWithID(ctx context.Context, baseURL, model, requestID string) chatResult {
+	body := `{"model":"` + model + `","messages":[{"role":"user","content":"hello"}],"stream":true,"max_tokens":64}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", strings.NewReader(body))
+	if err != nil {
+		return chatResult{err: err}
+	}
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	if requestID != "" {
+		req.Header.Set("X-Request-ID", requestID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return chatResult{err: err}
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	return chatResult{status: resp.StatusCode, body: string(data), retryAfter: resp.Header.Get("Retry-After")}
+}

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -121,6 +121,10 @@ func (s *Server) recordRejection(info rejectionInfo) {
 			model = info.requestedModel
 		}
 		s.recordRequestOutcome(model, newUnknownKVBackendAttribution(), orUptimeClassForRejection(info.httpStatus))
+		// OR-view mirror of the pre-dispatch arm (the dispatch-stage exhausted
+		// rejection is counted by run()'s tail). Resolved model only: the raw
+		// requested name is client-controlled and must not mint tag values.
+		s.recordRequestOutcomeORView(info.resolvedModel, orUptimeClassForRejection(info.httpStatus))
 	}
 
 	// Seed the counterfactual from whatever the caller already computed.

--- a/coordinator/api/relay_bench_test.go
+++ b/coordinator/api/relay_bench_test.go
@@ -1,0 +1,126 @@
+package api
+
+// Benchmarks for the provider-side half of the streaming relay: one WebSocket
+// frame (one token) from the read loop's decode through handleChunk (pending
+// lookup, decrypt, boilerplate classification, channel hand-off). The fixture
+// encrypts a Swift-shaped content delta with real X25519/NaCl keys and renders
+// the frame in the Swift provider's sorted-key wire order.
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// relayBenchContentChunk is a content delta as the Swift provider emits it
+// (JSONEncoder .sortedKeys; nil optionals omitted, never null).
+const relayBenchContentChunk = `data: {"choices":[{"delta":{"content":" the"},"index":0}],"created":1756800000,"id":"chatcmpl-7f3a2b1c","model":"mlx-community/gemma-4-26B-A4B-it-qat-4bit","object":"chat.completion.chunk"}`
+
+type relayBenchFixture struct {
+	srv      *Server
+	provider *registry.Provider
+	pr       *registry.PendingRequest
+	frame    []byte // Swift-shaped WS frame
+}
+
+func newRelayBenchFixture(b *testing.B) *relayBenchFixture {
+	b.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	st := store.NewMemory(store.Config{AdminKey: "test-key"})
+	reg := registry.New(logger)
+	srv := NewServer(reg, st, ServerConfig{}, logger)
+
+	providerPublicKey := testPublicKeyB64()
+	provider := reg.Register("provider-bench", nil, &protocol.RegisterMessage{
+		Type:                    protocol.TypeRegister,
+		Hardware:                protocol.Hardware{ChipName: "Apple M3 Max", ChipFamily: "M3", MemoryGB: 64},
+		Models:                  []protocol.ModelInfo{{ID: "test-model", ModelType: "chat", Quantization: "4bit"}},
+		Backend:                 "mlx-swift",
+		PublicKey:               providerPublicKey,
+		EncryptedResponseChunks: true,
+		PrivacyCapabilities:     testPrivacyCaps(),
+	})
+	sessionKeys, err := e2e.GenerateSessionKeys()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pr := &registry.PendingRequest{
+		RequestID:      "0f3a9c1e-6b7d-4a2e-9c5f-1d2e3f4a5b6c",
+		Model:          "test-model",
+		PublicModel:    "gemma-4-26b",
+		ChunkCh:        make(chan registry.ProviderChunk, chunkBufferSize),
+		CompleteCh:     make(chan protocol.UsageInfo, 1),
+		ErrorCh:        make(chan protocol.InferenceErrorMessage, 1),
+		SessionPrivKey: &sessionKeys.PrivateKey,
+	}
+	provider.AddPending(pr)
+
+	value, _ := testProviderKeys.Load(providerPublicKey)
+	kp := value.(testProviderKeyPair)
+	payload, err := e2e.Encrypt([]byte(relayBenchContentChunk), sessionKeys.PublicKey,
+		&e2e.SessionKeys{PublicKey: kp.public, PrivateKey: kp.private})
+	if err != nil {
+		b.Fatal(err)
+	}
+	frame := `{"encrypted_data":{"ciphertext":"` + payload.Ciphertext +
+		`","ephemeral_public_key":"` + payload.EphemeralPublicKey +
+		`"},"request_id":"` + pr.RequestID +
+		`","type":"` + protocol.TypeInferenceResponseChunk + `"}`
+	return &relayBenchFixture{srv: srv, provider: provider, pr: pr, frame: []byte(frame)}
+}
+
+// handleChunk alone (lookup + decrypt + classify + channel send).
+func BenchmarkRelay_HandleChunk(b *testing.B) {
+	f := newRelayBenchFixture(b)
+	var pm protocol.ProviderMessage
+	if err := protocol.DecodeProviderMessage(f.frame, &pm); err != nil {
+		b.Fatal(err)
+	}
+	msg := pm.Payload.(*protocol.InferenceResponseChunkMessage)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f.srv.handleChunk(f.provider.ID, f.provider, msg)
+		<-f.pr.ChunkCh
+	}
+}
+
+// The read loop's per-frame work as it stands now: DecodeProviderMessage
+// (chunk fast path) + handleChunk.
+func BenchmarkRelay_ReadLoopPerFrame(b *testing.B) {
+	f := newRelayBenchFixture(b)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(f.frame)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var pm protocol.ProviderMessage
+		if err := protocol.DecodeProviderMessage(f.frame, &pm); err != nil {
+			b.Fatal(err)
+		}
+		f.srv.handleChunk(f.provider.ID, f.provider, pm.Payload.(*protocol.InferenceResponseChunkMessage))
+		<-f.pr.ChunkCh
+	}
+}
+
+// Permanent baseline: the same per-frame work with encoding/json decoding the
+// frame (what the read loop paid before the hand-written chunk decoder).
+func BenchmarkRelay_ReadLoopPerFrame_GenericDecode(b *testing.B) {
+	f := newRelayBenchFixture(b)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(f.frame)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var msg protocol.InferenceResponseChunkMessage
+		if err := json.Unmarshal(f.frame, &msg); err != nil {
+			b.Fatal(err)
+		}
+		f.srv.handleChunk(f.provider.ID, f.provider, &msg)
+		<-f.pr.ChunkCh
+	}
+}

--- a/coordinator/api/restart_disconnect_integration_test.go
+++ b/coordinator/api/restart_disconnect_integration_test.go
@@ -1,0 +1,396 @@
+package api
+
+// R1 integration tests: a provider that closes its socket GRACEFULLY
+// (WebSocket 1000/1001 — stop / restart / update) with requests in flight must
+// not be booked as sick. The requests still fail over invisibly (pre-content)
+// or surface an in-band error (post-commit), exactly like an abrupt drop, but
+// the flushed 502s strike none of the stable-identity health trackers. An
+// abrupt drop (CloseNow) keeps striking — that is the reconnecting-zombie
+// discriminator. A reconnect on a NEWER binary version then clears the
+// disconnect-flush strikes an abrupt death left behind; the same version does
+// not (registry/version_reset.go).
+//
+// Same live harness as failover_integration_test.go: real coordinator
+// (httptest + in-memory store + real registry), fake providers speaking the
+// full encrypted WS protocol.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// closeGoingAway sends a graceful 1001 going-away close — what
+// CoordinatorClient.shutdown() emits on the provider's run() shutdown path.
+func (fp *failoverProvider) closeGoingAway() {
+	fp.closeOnce.Do(func() {
+		_ = fp.conn.Close(websocket.StatusGoingAway, "restarting")
+	})
+}
+
+// bindRestartTestIdentity binds a fake provider's live session to a serial
+// identity so the flushed 502s land on (and can be queried through) the
+// stable fault key rather than the session UUID.
+func bindRestartTestIdentity(t *testing.T, reg *registry.Registry, fp *failoverProvider, serial string) string {
+	t.Helper()
+	p := reg.GetProvider(fp.registryID)
+	if p == nil {
+		t.Fatalf("provider %s not registered", fp.name)
+	}
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: serial})
+	return "serial:" + serial
+}
+
+// awaitCondition polls cond until it holds or timeout elapses.
+func awaitCondition(t *testing.T, timeout time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// holdThenCloseScript sends the boilerplate role chunk for every dispatch and
+// holds the request open; when the closeAt-th dispatch arrives it closes the
+// socket — gracefully (1001) or abruptly (CloseNow) — with every held request
+// still pre-content.
+func holdThenCloseScript(model string, closeAt int, graceful bool) inferenceScript {
+	return func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		fp.sendRoleChunk(ctx, req, model)
+		if fp.dispatchCount() < closeAt {
+			return
+		}
+		time.Sleep(40 * time.Millisecond)
+		if graceful {
+			fp.closeGoingAway()
+		} else {
+			fp.closeNow()
+		}
+	}
+}
+
+// runRestartDisconnectScenario dispatches inFlight streaming requests to the
+// fast provider A (one at a time, waiting for each dispatch to land so the
+// cost scheduler cannot spill one onto B), lets A's script close the socket on
+// the last one, and returns the consumer results plus A's stable identity.
+func runRestartDisconnectScenario(t *testing.T, ctx context.Context, model string, inFlight int, graceful bool, serial string) (reg *registry.Registry, srv *httptest.Server, pA, pB *failoverProvider, stableID string, statuses []int, bodies []string) {
+	t.Helper()
+	reg, _, srv = setupFailoverServer(t)
+	pA = startFailoverProvider(t, ctx, srv, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.9.0", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: holdThenCloseScript(model, inFlight, graceful),
+	})
+	pB = startFailoverProvider(t, ctx, srv, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+	stableID = bindRestartTestIdentity(t, reg, pA, serial)
+
+	statuses = make([]int, inFlight)
+	bodies = make([]string, inFlight)
+	var wg sync.WaitGroup
+	for i := 0; i < inFlight; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			status, body, err := postChat(ctx, srv.URL, "test-key", buildChatBody(t, model, true, nil))
+			if err != nil {
+				t.Errorf("request %d: %v", i, err)
+				return
+			}
+			statuses[i], bodies[i] = status, body
+		}(i)
+		want := i + 1
+		awaitCondition(t, 5*time.Second, func() bool { return pA.dispatchCount() >= want }, "dispatch to provider-a")
+	}
+	wg.Wait()
+	return reg, srv, pA, pB, stableID, statuses, bodies
+}
+
+// TestRestartDisconnect_GracefulCloseIsHealthNeutral: three pre-content
+// requests in flight on A when it closes with 1001. All three fail over to B
+// invisibly, and A's identity carries NO inference-error cooldown and NO open
+// node breaker afterwards (three 502 flush strikes would have tripped the
+// 2-strike cooldown — see the abrupt sibling below).
+func TestRestartDisconnect_GracefulCloseIsHealthNeutral(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "restart-graceful-model"
+
+	reg, _, pA, pB, stableID, statuses, bodies := runRestartDisconnectScenario(t, ctx, model, 3, true, "SER-GRACEFUL")
+
+	for i := range statuses {
+		assertCleanFailoverStream(t, statuses[i], bodies[i], markerFor("provider-b"))
+	}
+	if got := pB.dispatchCount(); got != 3 {
+		t.Errorf("provider-b dispatches = %d, want 3 (every held request retried on B)", got)
+	}
+	if got := pA.dispatchCount(); got != 3 {
+		t.Errorf("provider-a dispatches = %d, want 3", got)
+	}
+	if reg.InferenceErrorCooldownActive(stableID, model, "base") {
+		t.Errorf("graceful close: inference-error cooldown ACTIVE for %s — the restart flush struck the identity", stableID)
+	}
+	if reg.ProviderBreakerOpen(stableID) {
+		t.Errorf("graceful close: node breaker OPEN for %s", stableID)
+	}
+	if reg.HealthEjectionOpen(stableID) {
+		t.Errorf("graceful close: identity %s ejected", stableID)
+	}
+}
+
+// TestRestartDisconnect_AbruptCloseStillStrikes: the same three in-flight
+// requests, but A drops the socket without a close frame. The requests still
+// fail over to B, and the flush DOES strike: the (identity, model, shape)
+// inference-error cooldown is active — the zombie discriminator is intact.
+func TestRestartDisconnect_AbruptCloseStillStrikes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "restart-abrupt-model"
+
+	reg, _, _, pB, stableID, statuses, bodies := runRestartDisconnectScenario(t, ctx, model, 3, false, "SER-ABRUPT")
+
+	for i := range statuses {
+		assertCleanFailoverStream(t, statuses[i], bodies[i], markerFor("provider-b"))
+	}
+	if got := pB.dispatchCount(); got != 3 {
+		t.Errorf("provider-b dispatches = %d, want 3", got)
+	}
+	awaitCondition(t, 5*time.Second, func() bool {
+		return reg.InferenceErrorCooldownActive(stableID, model, "base")
+	}, "inference-error cooldown after an abrupt drop with in-flight work")
+}
+
+// TestRestartDisconnect_PostCommitStreamStillGetsInBandError: content has
+// already flowed to two consumers when A closes gracefully. Both streams must
+// surface the in-band "provider disconnected" error (no silent retry — B gets
+// nothing), and the two post-commit flush terminals still strike nothing.
+func TestRestartDisconnect_PostCommitStreamStillGetsInBandError(t *testing.T) {
+	reg, _, ts := setupFailoverServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	model := "restart-post-commit-model"
+	const partial = "partial-before-restart"
+
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, body []byte) {
+		fp.sendRoleChunk(ctx, req, model)
+		fp.sendContentChunk(ctx, req, model, partial)
+		if fp.dispatchCount() < 2 {
+			return
+		}
+		time.Sleep(60 * time.Millisecond)
+		fp.closeGoingAway()
+	}
+	pA := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-a", Version: "0.9.0", DecodeTPS: 200,
+		Models: []failoverModelSpec{{ID: model}}, Script: script,
+	})
+	pB := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider-b", Version: "0.9.0", DecodeTPS: 1,
+		Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+	})
+	stableID := bindRestartTestIdentity(t, reg, pA, "SER-POST-COMMIT")
+
+	statuses := make([]int, 2)
+	bodies := make([]string, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+			if err != nil {
+				t.Errorf("request %d: %v", i, err)
+				return
+			}
+			statuses[i], bodies[i] = status, body
+		}(i)
+		want := i + 1
+		awaitCondition(t, 5*time.Second, func() bool { return pA.dispatchCount() >= want }, "dispatch to provider-a")
+	}
+	wg.Wait()
+
+	for i := range statuses {
+		if statuses[i] != http.StatusOK {
+			t.Errorf("request %d: status = %d, want 200 (committed by content); body = %s", i, statuses[i], bodies[i])
+		}
+		if !strings.Contains(bodies[i], partial) {
+			t.Errorf("request %d: stream missing the pre-restart content; body = %s", i, bodies[i])
+		}
+		if !strings.Contains(bodies[i], `"provider_error"`) || !strings.Contains(bodies[i], "provider disconnected") {
+			t.Errorf("request %d: post-commit restart did not surface the in-band provider-disconnected error; body = %s", i, bodies[i])
+		}
+		if strings.Contains(bodies[i], markerFor("provider-b")) {
+			t.Errorf("request %d: coordinator retried on provider-b AFTER content had flowed; body = %s", i, bodies[i])
+		}
+	}
+	if got := pB.dispatchCount(); got != 0 {
+		t.Errorf("provider-b dispatches = %d, want 0", got)
+	}
+	if reg.InferenceErrorCooldownActive(stableID, model, "base") {
+		t.Errorf("post-commit graceful close struck the identity's inference-error cooldown")
+	}
+	if reg.ProviderBreakerOpen(stableID) {
+		t.Errorf("post-commit graceful close opened the node breaker")
+	}
+}
+
+// TestVersionChangedReconnect_ClearsAbruptFlushStrikes: A dies abruptly with
+// three in-flight requests (cooldown trips on its serial), then a session
+// with the SAME serial registers on a NEWER version — the cooldown is gone.
+// The sibling with the SAME version keeps it.
+func TestVersionChangedReconnect_ClearsAbruptFlushStrikes(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		reconnectVer string
+		wantCooldown bool
+	}{
+		{"newer version clears", "0.9.1", false},
+		{"same version retains", "0.9.0", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			model := "restart-version-model"
+			serial := "SER-VERSION-" + strings.ReplaceAll(tc.reconnectVer, ".", "-")
+
+			reg, srv, _, _, stableID, statuses, bodies := runRestartDisconnectScenario(t, ctx, model, 3, false, serial)
+			for i := range statuses {
+				assertCleanFailoverStream(t, statuses[i], bodies[i], markerFor("provider-b"))
+			}
+			awaitCondition(t, 5*time.Second, func() bool {
+				return reg.InferenceErrorCooldownActive(stableID, model, "base")
+			}, "cooldown after the abrupt drop")
+
+			// The upgraded box comes back: a fresh session on the same
+			// coordinator, same serial. The registration path stores the
+			// version BEFORE the test binds the identity, so
+			// bindStableFaultKey is the seam exercised here.
+			pA2 := startFailoverProvider(t, ctx, srv, reg, failoverProviderConfig{
+				Name: "provider-a2", Version: tc.reconnectVer, DecodeTPS: 200,
+				Models: []failoverModelSpec{{ID: model}}, Script: fullServeScript(model),
+			})
+			bindRestartTestIdentity(t, reg, pA2, serial)
+
+			if got := reg.InferenceErrorCooldownActive(pA2.registryID, model, "base"); got != tc.wantCooldown {
+				t.Errorf("cooldown via the new session = %v, want %v", got, tc.wantCooldown)
+			}
+			if got := reg.InferenceErrorCooldownActive(stableID, model, "base"); got != tc.wantCooldown {
+				t.Errorf("cooldown via the stable id = %v, want %v", got, tc.wantCooldown)
+			}
+		})
+	}
+}
+
+// TestVersionChangedReconnect_LateFlushStrikesAreSuperseded: the flush 502s of
+// an abruptly dropped session are recorded by the request goroutines that
+// drain its ErrorCh, so they can reach noteInferenceError AFTER the identity's
+// version-changed reset — registration evicts a same-serial predecessor
+// (DisconnectDuplicatesBySerial) and stores the new version on the same
+// goroutine, ahead of those consumers. The reset then ran against empty
+// windows and consumed its interval; without the discard the late strikes
+// would quarantine the NEW binary for the old one's death. Every tracker must
+// stay closed for the new session, while the strikes of a session that died
+// under an unchanged version, or after the reset (a throttled third version
+// stamps no new reset), still land.
+func TestVersionChangedReconnect_LateFlushStrikesAreSuperseded(t *testing.T) {
+	const (
+		serial = "SER-LATE-FLUSH"
+		stable = "serial:" + serial
+		model  = "late-flush-model"
+	)
+	bind := func(t *testing.T, reg *registry.Registry, id, version string) {
+		t.Helper()
+		p := makeRoutableProvider(t, reg, id, model)
+		// Registration order: attestation binds the identity, then the api
+		// stores the version (the seam that runs the reset).
+		p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: serial})
+		p.SetVersion(version)
+	}
+	// dropAbruptly parks work on the session and drops it without a close
+	// frame: the flush is now in the consumer's ErrorCh, not yet recorded.
+	dropAbruptly := func(t *testing.T, reg *registry.Registry, id string) {
+		t.Helper()
+		p := reg.GetProvider(id)
+		if p == nil {
+			t.Fatalf("provider %s not registered", id)
+		}
+		p.AddPending(&registry.PendingRequest{
+			RequestID:  id + "-req",
+			Model:      model,
+			ProviderID: id,
+			ErrorCh:    make(chan protocol.InferenceErrorMessage, 1),
+		})
+		reg.DisconnectWithReason(id, registry.DisconnectReasonReadError)
+	}
+	// feedFlush plays the consumers' recording of the flushed 502s through
+	// the breaker chokepoint: enough for the inference-error cooldown (2), the
+	// node breaker (5) and the identity ejection (8).
+	feedFlush := func(srv *Server, id string) {
+		pr := &registry.PendingRequest{RequestID: id + "-req", Model: model, ProviderID: id}
+		for i := 0; i < 8; i++ {
+			srv.noteInferenceError(id, pr, 502, "provider disconnected", "", "")
+		}
+	}
+	quarantined := func(t *testing.T, reg *registry.Registry, liveID string, want bool) {
+		t.Helper()
+		if got := reg.InferenceErrorCooldownActive(liveID, model, "base"); got != want {
+			t.Errorf("InferenceErrorCooldownActive(%s) = %v, want %v", liveID, got, want)
+		}
+		if got := reg.ProviderBreakerOpen(liveID); got != want {
+			t.Errorf("ProviderBreakerOpen(%s) = %v, want %v", liveID, got, want)
+		}
+		if got := reg.HealthEjectionOpen(stable); got != want {
+			t.Errorf("HealthEjectionOpen(%s) = %v, want %v", stable, got, want)
+		}
+	}
+
+	t.Run("flush recorded after the version reset is discarded", func(t *testing.T) {
+		srv, reg, _, ts := setupTestServer(t)
+		defer ts.Close()
+		bind(t, reg, "s1", "0.9.0")
+		dropAbruptly(t, reg, "s1")
+		bind(t, reg, "s2", "0.9.1") // reset runs here, against empty windows
+		feedFlush(srv, "s1")        // the consumers catch up afterwards
+		quarantined(t, reg, "s2", false)
+	})
+
+	t.Run("same version keeps striking", func(t *testing.T) {
+		srv, reg, _, ts := setupTestServer(t)
+		defer ts.Close()
+		bind(t, reg, "s1", "0.9.0")
+		dropAbruptly(t, reg, "s1")
+		bind(t, reg, "s2", "0.9.0") // the zombie signature: no reset
+		feedFlush(srv, "s1")
+		quarantined(t, reg, "s2", true)
+	})
+
+	t.Run("a drop after the reset still strikes even when the next version change is throttled", func(t *testing.T) {
+		srv, reg, _, ts := setupTestServer(t)
+		defer ts.Close()
+		bind(t, reg, "s1", "0.9.0")
+		dropAbruptly(t, reg, "s1")
+		bind(t, reg, "s2", "0.9.1")
+		feedFlush(srv, "s1")
+		quarantined(t, reg, "s2", false)
+
+		dropAbruptly(t, reg, "s2")
+		bind(t, reg, "s3", "0.9.2") // inside the interval: throttled, no new reset
+		feedFlush(srv, "s2")
+		quarantined(t, reg, "s3", true)
+	})
+}

--- a/coordinator/api/restart_disconnect_integration_test.go
+++ b/coordinator/api/restart_disconnect_integration_test.go
@@ -343,7 +343,7 @@ func TestVersionChangedReconnect_LateFlushStrikesAreSuperseded(t *testing.T) {
 	feedFlush := func(srv *Server, id string) {
 		pr := &registry.PendingRequest{RequestID: id + "-req", Model: model, ProviderID: id}
 		for i := 0; i < 8; i++ {
-			srv.noteInferenceError(id, pr, 502, "provider disconnected", "", "")
+			srv.noteInferenceError(id, pr, 502, "provider disconnected", "", "", protocol.CoordinatorCauseProviderDisconnected)
 		}
 	}
 	quarantined := func(t *testing.T, reg *registry.Registry, liveID string, want bool) {

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -36,7 +36,19 @@ const (
 	// on the normal bounded-failover path, NEVER in the terminal client-error
 	// stop set (see isTerminalClientErrorCode).
 	errorReasonToolNoncompliance = "tool_noncompliance"
-	errorReasonUnknown           = "unknown"
+	// errorReasonDraining (R2): the provider's typed refusal because it is
+	// draining ahead of a restart/update. Transient capacity for failover
+	// (another provider serves) that consumes NO transient-capacity retry,
+	// derates NO gray-box state, and marks the provider draining
+	// (registry.MarkDraining) so the next scan skips it.
+	errorReasonDraining = protocol.InferenceErrorReasonDraining
+	// errorReasonProviderRestart (R1): coordinator-internal marker stamped by
+	// the registry on the pending-request flush of a GRACEFUL peer close
+	// (restart/stop/update). Health-neutral through
+	// isProviderHealthNeutralErrorReason; never accepted from the wire
+	// (safeInferenceErrorReason does not emit it).
+	errorReasonProviderRestart = protocol.InferenceErrorReasonProviderRestart
+	errorReasonUnknown         = "unknown"
 )
 
 // errorClassClientError is the route-outcome error_class for a DETERMINISTIC
@@ -100,7 +112,25 @@ func isDeadlineUnreachableErrorReason(reason string) bool {
 // supplied remaining SLA, not provider sickness or capacity dishonesty.
 func isProviderHealthNeutralErrorReason(reason string) bool {
 	return isNonProviderFaultErrorReason(reason) ||
-		isDeadlineUnreachableErrorReason(reason)
+		isDeadlineUnreachableErrorReason(reason) ||
+		isProviderRestartErrorReason(reason)
+}
+
+// isProviderRestartErrorReason reports whether reason is the coordinator-
+// internal provider_restart marker the registry stamps on the flushed
+// terminals of a GRACEFUL peer close (registry.DisconnectWithReason). The
+// requests fail over like any disconnect, but the terminal is health-neutral:
+// no breaker/cooldown/ejection strike, no clear. An abrupt drop's flush
+// carries no reason and keeps striking (the zombie discriminator).
+func isProviderRestartErrorReason(reason string) bool {
+	return normalizeInferenceErrorReason(reason) == errorReasonProviderRestart
+}
+
+// isDrainingErrorReason reports whether reason is the provider's typed
+// draining refusal (R2): transient capacity that consumes no capacity retry
+// and derates nothing; the provider is marked draining instead.
+func isDrainingErrorReason(reason string) bool {
+	return normalizeInferenceErrorReason(reason) == errorReasonDraining
 }
 
 // Final-status values persisted on inference_routes (store.InferenceRouteOutcome
@@ -132,6 +162,8 @@ var validInferenceErrorReasons = map[string]struct{}{
 	errorReasonProviderError:             {},
 	errorReasonClientError:               {},
 	errorReasonToolNoncompliance:         {},
+	errorReasonDraining:                  {},
+	errorReasonProviderRestart:           {},
 	errorReasonUnknown:                   {},
 }
 
@@ -150,6 +182,8 @@ func (s *Server) updateInferenceRouteOutcomeWithModel(requestID string, attempt 
 		return
 	}
 	s.emitInferenceErrorMetric(model, outcome)
+	s.emitAttemptOutcomeMetric(model, outcome)
+	s.emitCommittedRequestOutcomeORView(model, outcome)
 	s.emitTimingDecompositionMetric(model, outcome.FinalStatus, outcome)
 	// Off the request path: the batching sink pipelines this update with its
 	// neighbours after the group's route inserts (route_telemetry_submit.go).
@@ -280,7 +314,7 @@ func dispatchFailedPendingRouteOutcome(pr *registry.PendingRequest, class string
 }
 
 func providerDisconnectedError(msg protocol.InferenceErrorMessage) bool {
-	return msg.CoordinatorCause == protocol.CoordinatorCauseProviderDisconnected
+	return msg.CoordinatorCause.IsProviderDisconnect()
 }
 
 // applyAttemptUsage copies a typed error terminal's provider-reported partial

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -439,7 +439,8 @@ type Server struct {
 
 	// dd is the Datadog integration client for DogStatsD metrics and
 	// Logs API event forwarding. Nil when DD is not configured.
-	dd *datadog.Client
+	dd          *datadog.Client
+	queueGauges queueGaugeState
 
 	// apiKeyCache memoizes ValidateKeyFull results so repeated requests
 	// with the same API key skip the DB round trip. Entries expire after

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -3043,9 +3043,12 @@ func (s *Server) StartDDGaugeLoop(ctx context.Context) {
 				enforced = 1.0
 			}
 			s.ddGauge("attestation.code_enforced", enforced, nil)
-			for model, count := range s.registry.ModelProviderSnapshot() {
+			perModel := s.registry.ModelProviderSnapshot()
+			for model, count := range perModel {
 				s.ddGauge("providers.per_model", float64(count), []string{"model:" + model})
 			}
+			// Per-model queue depth/age (fleet_gauges.go).
+			s.emitPerModelQueueGauges(perModel)
 			for ver, count := range s.registry.ProviderCountByVersion() {
 				s.ddGauge("providers.per_version", float64(count), []string{"version:" + ver})
 			}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -870,6 +870,12 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		s.trustReplayInFlight = make(map[string]struct{})
 	}
 	reg.SetRuntimeCapabilitiesPromotedHook(s.handleRuntimeCapabilitiesPromoted)
+	// The per-identity gate locks that replaced the request-path registry
+	// write lock (registry/gate_state.go) report any acquisition wait above
+	// 1 ms here, tagged by recorder site, so the new locks stay observable.
+	reg.SetGateWaitObserver(func(site string, wait time.Duration) {
+		s.ddHistogram("registry.gate.wait_ms", float64(wait.Microseconds())/1000, []string{"site:" + site})
+	})
 	s.profiler = newProfilerFromEnv(s)
 	s.registerDefaultGauges()
 	s.routes()

--- a/coordinator/api/telemetry_tag_cardinality_test.go
+++ b/coordinator/api/telemetry_tag_cardinality_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTelemetryTagsCollapseRotatingRegistrationValues(t *testing.T) {
+	versions := map[string]bool{}
+	chips := map[string]bool{}
+	for i := range 10000 {
+		for _, version := range []string{fmt.Sprintf("0.8.%d", i), fmt.Sprintf("0.8.16-rc.%d", i), fmt.Sprintf("%d.1.1", i)} {
+			versions[sanitizeVersionTag(version)] = true
+		}
+		chips[sanitizeChipFamilyTag(fmt.Sprintf("build%d", i))] = true
+	}
+	if len(versions) != 3 || !versions["0.8.x"] || !versions["prerelease"] || !versions["other_release"] {
+		t.Fatalf("rotating semver values escaped fixed buckets: %v", versions)
+	}
+	if len(chips) != 1 || !chips["other"] {
+		t.Fatalf("rotating chip labels escaped the fallback: %v", chips)
+	}
+}
+
+func TestClientGoneChipTagsUseSameVocabularyAsMLX(t *testing.T) {
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv := &Server{dd: dd}
+	for _, chip := range []string{"build1", "build2", "M4 Pro", ""} {
+		srv.emitClientGoneBucketed("m", 100, chip, phaseBeforeFirstToken, deadlineBucketUnknown)
+	}
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	for _, tag := range []string{"chip_family:other", "chip_family:M4_Pro", "chip_family:unknown"} {
+		requireMetricWithTags(t, packets, "routing.client_gone", tag)
+	}
+	for _, line := range findMetrics(packets, "routing.client_gone") {
+		if containsTag(line, "chip_family:build1") || containsTag(line, "chip_family:build2") {
+			t.Fatalf("provider-controlled chip label escaped: %s", line)
+		}
+	}
+}

--- a/coordinator/api/terminal_cause_test.go
+++ b/coordinator/api/terminal_cause_test.go
@@ -44,7 +44,7 @@ func deliverTypedError(t *testing.T, srv *Server, provider *registry.Provider, m
 	if !ok {
 		t.Fatalf("ErrorCh closed without a terminal for %s", requestID)
 	}
-	srv.noteInferenceError(pr.ProviderID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause)
+	srv.noteInferenceError(pr.ProviderID, pr, em.StatusCode, em.Error, em.ErrorReason, em.TerminalCause, em.CoordinatorCause)
 	return pr
 }
 

--- a/coordinator/api/unknown_frame_metrics.go
+++ b/coordinator/api/unknown_frame_metrics.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Unknown-frame instrumentation (zombie-stream amplifier visibility).
+//
+// A provider that keeps generating into a request the coordinator already
+// abandoned (consumer gone, first-chunk timeout, settled) sends chunk /
+// complete / error frames whose request_id matches no pending state. The
+// coordinator logs each one and (throttled) re-sends a cancel, but during the
+// 2026-08-31 cascade ~65K such frames in 10 minutes were invisible on any
+// panel: inference.zombie_stream_cancel is throttled and untagged. This
+// counter is the raw, unthrottled count, tagged by the FRAME KIND and the
+// provider's binary version — bounded vocabularies — so a zombie wave can be
+// pinned to a release. It never carries the provider id or the request id.
+const (
+	metricUnknownFrames        = "inference.unknown_frames"
+	metricUnknownFramesCounter = "inference_unknown_frames_total"
+
+	unknownFrameKindChunk    = "chunk"
+	unknownFrameKindComplete = "complete"
+	unknownFrameKindError    = "error"
+)
+
+// maxVersionTagLen bounds the provider_version tag before parsing: a release
+// version is short, and anything longer is untrusted input.
+const maxVersionTagLen = 32
+
+// versionTagPrereleaseKinds are the prerelease identifiers a release version
+// can carry ("0.8.16-rc.1"). Any other prerelease shape is not a release.
+var versionTagPrereleaseKinds = map[string]bool{"alpha": true, "beta": true, "rc": true}
+
+// emitUnknownFrame counts one provider frame for an unknown request id.
+func (s *Server) emitUnknownFrame(kind string, provider *registry.Provider) {
+	if s == nil {
+		return
+	}
+	version := providerVersionTag(provider)
+	if s.metrics != nil {
+		s.metrics.IncCounter(metricUnknownFramesCounter,
+			MetricLabel{"kind", kind}, MetricLabel{"provider_version", version})
+	}
+	if s.dd == nil {
+		return
+	}
+	s.ddIncr(metricUnknownFrames, []string{"kind:" + kind, "provider_version:" + version})
+}
+
+// providerVersionTag reads the provider's reported binary version under its
+// lock and fences it to a bounded, tag-safe value.
+func providerVersionTag(p *registry.Provider) string {
+	if p == nil {
+		return "unknown"
+	}
+	p.Mu().Lock()
+	version := p.Version
+	p.Mu().Unlock()
+	return sanitizeVersionTag(version)
+}
+
+// sanitizeVersionTag maps strict semver to a fixed release-family vocabulary.
+// Patch versions and arbitrary numeric prereleases cannot mint new series.
+// Exact binary versions remain available in provider metadata and logs.
+func sanitizeVersionTag(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "unknown"
+	}
+	if len(version) > maxVersionTagLen {
+		return "other"
+	}
+	version = strings.TrimPrefix(version, "v")
+	core, pre, hasPre := strings.Cut(version, "-")
+	segs := strings.Split(core, ".")
+	if len(segs) != 3 {
+		return "other"
+	}
+	for _, seg := range segs {
+		if !versionTagNumeric(seg) {
+			return "other"
+		}
+	}
+	if hasPre {
+		kind, n, ok := strings.Cut(pre, ".")
+		if !ok || !versionTagPrereleaseKinds[kind] || !versionTagNumeric(n) {
+			return "other"
+		}
+		return "prerelease"
+	}
+	switch segs[0] + "." + segs[1] {
+	case "0.6":
+		return "0.6.x"
+	case "0.7":
+		return "0.7.x"
+	case "0.8":
+		return "0.8.x"
+	case "0.9":
+		return "0.9.x"
+	default:
+		return "other_release"
+	}
+}
+
+// versionTagNumeric reports whether s is a semver numeric identifier: one or
+// more ASCII digits with no leading zero (or exactly "0").
+func versionTagNumeric(s string) bool {
+	if s == "" || (len(s) > 1 && s[0] == '0') {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/coordinator/api/version_reset_fault_test.go
+++ b/coordinator/api/version_reset_fault_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestProviderEncryption502SurvivesVersionReset(t *testing.T) {
+	srv, reg, provider, pr := newBreakerExemptionHarness(t, "genuine-502")
+	provider.SetVersion("0.9.0")
+	for i := range breakerStrikeRounds {
+		deliverTypedError(t, srv, provider, pr.Model, fmt.Sprintf("encryption-%d", i), protocol.InferenceErrorMessage{
+			FailureCode: protocol.FailureCodeEncryptionFailure, StatusCode: 502,
+		})
+	}
+	assertBreakerStates(t, reg, provider, pr, true)
+	provider.SetVersion("0.9.1")
+	assertBreakerStates(t, reg, provider, pr, true)
+	// A genuine fault delivered late after an actual disconnect also must not
+	// be discarded by the early API-side superseded-flush optimization.
+	reg.Disconnect(provider.ID)
+	provider2 := makeRoutableProvider(t, reg, "new-encryption-session", pr.Model)
+	provider2.Mu().Lock()
+	provider2.AccountID = "acct-genuine-502"
+	provider2.Mu().Unlock()
+	provider2.RebindStableFaultKey()
+	provider2.SetVersion("0.9.1")
+	reg.RecordInferenceSuccess(provider2.ID, pr.Model, "base")
+	reg.RecordProviderOutcome(provider2.ID, true, 200, "")
+	reg.RecordProviderSessionServeOutcome(provider2.ID, true, 200, "")
+	for range breakerStrikeRounds {
+		srv.noteInferenceError(provider.ID, &registry.PendingRequest{Model: pr.Model}, 502, "encryption failure", "", "")
+	}
+	assertBreakerStates(t, reg, provider2, pr, true)
+}

--- a/coordinator/api/zombie_eviction.go
+++ b/coordinator/api/zombie_eviction.go
@@ -1,0 +1,37 @@
+package api
+
+import "container/list"
+
+// Recency operations are constant-time under z.mu. The list stores only IDs;
+// expired snapshots never retain links into the rest of the tracker.
+func (z *zombieStreamCanceller) touchLocked(id string) {
+	if z.positions == nil {
+		z.positions = make(map[string]*list.Element)
+	}
+	if node := z.positions[id]; node != nil {
+		z.recency.MoveToBack(node)
+	} else {
+		z.positions[id] = z.recency.PushBack(id)
+	}
+}
+
+func (z *zombieStreamCanceller) removeLocked(id string) {
+	delete(z.entries, id)
+	if node := z.positions[id]; node != nil {
+		z.recency.Remove(node)
+		delete(z.positions, id)
+	}
+}
+
+// Capped insertion evicts one least-recently-active entry without scanning.
+// record/strayChunk already run the rate-limited TTL sweep; reaching the cap
+// must not force an extra map walk on every unseen request or stray token.
+func (z *zombieStreamCanceller) makeRoomLocked() []zombieEntry {
+	if len(z.entries) < zombieCancelMaxEntries {
+		return nil
+	}
+	id := z.recency.Front().Value.(string)
+	expired := *z.entries[id]
+	z.removeLocked(id)
+	return []zombieEntry{expired}
+}

--- a/coordinator/api/zombie_eviction_test.go
+++ b/coordinator/api/zombie_eviction_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestZombieCappedInsertionKeepsRecentlyActiveEntries(t *testing.T) {
+	z := newZombieStreamCanceller()
+	now := time.Now()
+	for i := range zombieCancelMaxEntries {
+		z.record(fmt.Sprint(i), "m", cancelCauseHedgeLoser, now)
+	}
+	z.markSent("0", now)
+	z.strayChunk("1", now)
+	_, expired := z.record("new", "m", cancelCauseHedgeLoser, now)
+	if len(expired) != 1 || z.entries["2"] != nil || z.entries["0"] == nil || z.entries["1"] == nil {
+		t.Fatal("capped insertion did not evict the least recently active entry")
+	}
+	z.forget("0")
+	z.terminal("1")
+	z.record("expire-trigger", "m", cancelCauseHedgeLoser, now.Add(zombieEntryTTL+time.Second))
+	if z.size() != 1 || z.recency.Len() != 1 || len(z.positions) != 1 {
+		t.Fatal("forget, terminal or TTL expiry leaked eviction metadata")
+	}
+}
+
+func TestZombieCappedInsertionDoesNotForceExpirySweep(t *testing.T) {
+	z := newZombieStreamCanceller()
+	now := time.Now()
+	for i := range zombieCancelMaxEntries {
+		z.record(fmt.Sprint(i), "m", cancelCauseHedgeLoser, now)
+	}
+	// A regular sweep at the exact TTL boundary retains all entries. They
+	// expire a nanosecond later, but a capped insertion must not bypass the
+	// one-second sweep cadence and walk all of them on the token hot path.
+	z.record("0", "m", cancelCauseHedgeLoser, now.Add(zombieEntryTTL))
+	_, expired := z.record("new", "m", cancelCauseHedgeLoser, now.Add(zombieEntryTTL+time.Nanosecond))
+	if len(expired) != 1 || z.size() != zombieCancelMaxEntries {
+		t.Fatalf("capped insertion forced a sweep: expired=%d retained=%d", len(expired), z.size())
+	}
+}
+
+// Run with a fixed clock so every operation measures capped insertion, not
+// the separately rate-limited expiry sweep. IDs revisit evicted streams like
+// a restart wave exceeding the tracker cap.
+func BenchmarkZombieCappedStrayChurn(b *testing.B) {
+	z := newZombieStreamCanceller()
+	now := time.Now()
+	ids := make([]string, zombieCancelMaxEntries*2)
+	for i := range ids {
+		ids[i] = fmt.Sprint(i)
+	}
+	for _, id := range ids[:zombieCancelMaxEntries] {
+		z.strayChunk(id, now)
+	}
+	b.ResetTimer()
+	for i := range b.N {
+		z.strayChunk(ids[(i+zombieCancelMaxEntries)%len(ids)], now)
+	}
+}

--- a/coordinator/api/zombie_stream.go
+++ b/coordinator/api/zombie_stream.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"container/list"
 	"sync"
 	"time"
 )
@@ -130,6 +131,8 @@ type zombieStreamCanceller struct {
 	entries   map[string]*zombieEntry
 	warn      map[string]*strayChunkWarnState
 	lastSweep time.Time
+	recency   list.List
+	positions map[string]*list.Element
 }
 
 func newZombieStreamCanceller() *zombieStreamCanceller {
@@ -173,12 +176,13 @@ func (z *zombieStreamCanceller) record(requestID, model, cause string, now time.
 	z.mu.Lock()
 	z.ensureMapsLocked()
 	defer z.mu.Unlock()
-	expired = z.sweepLocked(now, false)
+	expired = z.sweepLocked(now)
 	if _, ok := z.entries[requestID]; ok {
 		return false, expired
 	}
-	expired = append(expired, z.makeRoomLocked(now)...)
+	expired = append(expired, z.makeRoomLocked()...)
 	z.entries[requestID] = &zombieEntry{model: model, cause: cause, firstCancelAt: now}
+	z.touchLocked(requestID)
 	return true, expired
 }
 
@@ -196,6 +200,7 @@ func (z *zombieStreamCanceller) markSent(requestID string, now time.Time) (resen
 	if e == nil {
 		return -1
 	}
+	z.touchLocked(requestID)
 	return e.markSent(now)
 }
 
@@ -221,6 +226,7 @@ func (z *zombieStreamCanceller) send(requestID string, enqueue func() bool) (res
 		e.nextResendAt = time.Now().Add(zombieResendRetry)
 		return -1, false
 	}
+	z.touchLocked(requestID)
 	return e.markSent(time.Now()), true
 }
 
@@ -231,7 +237,7 @@ func (z *zombieStreamCanceller) forget(requestID string) {
 		return
 	}
 	z.mu.Lock()
-	delete(z.entries, requestID)
+	z.removeLocked(requestID)
 	z.mu.Unlock()
 }
 
@@ -262,15 +268,16 @@ func (z *zombieStreamCanceller) strayChunk(requestID string, now time.Time) stra
 	z.mu.Lock()
 	z.ensureMapsLocked()
 	defer z.mu.Unlock()
-	res := strayChunkResult{expired: z.sweepLocked(now, false)}
+	res := strayChunkResult{expired: z.sweepLocked(now)}
 	e := z.entries[requestID]
 	if e == nil {
-		res.expired = append(res.expired, z.makeRoomLocked(now)...)
+		res.expired = append(res.expired, z.makeRoomLocked()...)
 		e = &zombieEntry{cause: cancelCauseStrayChunk, firstCancelAt: now}
 		z.entries[requestID] = e
 	}
 	e.strayChunks++
 	e.lastStrayAt = now
+	z.touchLocked(requestID)
 	res.cause = e.cause
 	res.model = e.model
 	if e.resendDue(now) {
@@ -293,7 +300,7 @@ func (z *zombieStreamCanceller) terminal(requestID string) (zombieEntry, bool) {
 	if !ok {
 		return zombieEntry{}, false
 	}
-	delete(z.entries, requestID)
+	z.removeLocked(requestID)
 	return *e, true
 }
 
@@ -332,10 +339,10 @@ func (z *zombieStreamCanceller) size() int {
 }
 
 // sweepLocked expires entries idle past zombieEntryTTL (and stale warn state),
-// at most once per zombieSweepEvery unless forced. Expired entries are
+// at most once per zombieSweepEvery. Expired entries are
 // returned so the caller can report them outside the lock.
-func (z *zombieStreamCanceller) sweepLocked(now time.Time, force bool) []zombieEntry {
-	if !force && now.Sub(z.lastSweep) < zombieSweepEvery {
+func (z *zombieStreamCanceller) sweepLocked(now time.Time) []zombieEntry {
+	if now.Sub(z.lastSweep) < zombieSweepEvery {
 		return nil
 	}
 	z.lastSweep = now
@@ -343,37 +350,13 @@ func (z *zombieStreamCanceller) sweepLocked(now time.Time, force bool) []zombieE
 	for id, e := range z.entries {
 		if now.Sub(e.lastActivity()) > zombieEntryTTL {
 			expired = append(expired, *e)
-			delete(z.entries, id)
+			z.removeLocked(id)
 		}
 	}
 	for id, st := range z.warn {
 		if now.Sub(st.lastWarnAt) > strayChunkWarnStateTTL {
 			delete(z.warn, id)
 		}
-	}
-	return expired
-}
-
-// makeRoomLocked keeps the map under its cap ahead of an insert: expire first,
-// then evict the least recently active entry.
-func (z *zombieStreamCanceller) makeRoomLocked(now time.Time) []zombieEntry {
-	if len(z.entries) < zombieCancelMaxEntries {
-		return nil
-	}
-	expired := z.sweepLocked(now, true)
-	if len(z.entries) < zombieCancelMaxEntries {
-		return expired
-	}
-	var oldestID string
-	var oldest time.Time
-	for id, e := range z.entries {
-		if la := e.lastActivity(); oldestID == "" || la.Before(oldest) {
-			oldestID, oldest = id, la
-		}
-	}
-	if oldestID != "" {
-		expired = append(expired, *z.entries[oldestID])
-		delete(z.entries, oldestID)
 	}
 	return expired
 }

--- a/coordinator/api/zombie_stream.go
+++ b/coordinator/api/zombie_stream.go
@@ -5,59 +5,375 @@ import (
 	"time"
 )
 
-// zombieCancelThrottle bounds how often the coordinator re-sends a cancel for
-// the same abandoned (unknown) request. A zombie stream emits ~1 chunk per
-// token, so cancelling on every chunk would flood the provider with WS writes;
-// one cancel per request per this interval is enough to stop a provider that's
-// actually listening, and harmless against one that isn't.
-const zombieCancelThrottle = 10 * time.Second
-const zombieCancelMaxEntries = 4096
+// Zombie-stream cancel tracking.
+//
+// Every abandon path that may leave a provider generating records its request
+// here before it sends the cancel (sendAbandonCancel / cancelDispatch) and
+// marks the entry sent only once the frame was handed to the provider writer.
+// The entry lets the coordinator:
+//
+//   - correlate the provider's eventual terminal with the cancel and emit
+//     inference.cancel_to_terminal_ms instead of dropping it as "unknown";
+//   - re-send the cancel on an escalating schedule while stray chunks prove the
+//     provider has not stopped, so a cancel lost to a full control lane or
+//     delayed behind a cold model load is retried within ~1 s, not 10 s;
+//   - attribute every cancel to a bounded cause.
+//
+// The map is bounded (zombieCancelMaxEntries) and swept opportunistically by
+// the calls that touch it — there is no background goroutine, so a
+// terminal-less entry is reported when the map is next used, not exactly at
+// expiry.
 
-// zombieStreamCanceller throttles cancels sent for chunks that arrive for a
-// request the coordinator no longer tracks (consumer gone / already settled).
-// Such a stream burns provider GPU and token-budget admission until max_tokens,
-// so the coordinator nudges the provider to stop — but at most once per
-// throttle window per request.
+const (
+	zombieCancelMaxEntries = 4096
+	// zombieEntryTTL bounds how long an entry waits for its terminal after its
+	// last activity (cancel send or stray chunk). It exceeds the settlement
+	// grace (defaultTerminalSettleGrace) so a post-commit terminal that still
+	// settles billing is correlated, and covers a cold model load that delays
+	// the provider's cancel handling by minutes.
+	zombieEntryTTL = 5 * time.Minute
+	// zombieSweepEvery rate-limits the opportunistic full-map sweep.
+	zombieSweepEvery = time.Second
+	// zombieResendRetry is how soon a stray chunk may re-attempt a cancel whose
+	// send failed (control lane full / writer stopped).
+	zombieResendRetry = 250 * time.Millisecond
+	// zombieResendInterval is the steady re-send cadence once the escalating
+	// schedule is exhausted.
+	zombieResendInterval = 30 * time.Second
+	// zombieResendIndexMax caps the resend_index metric tag: 0 = the first
+	// cancel was triggered by a stray chunk (no abandon path recorded one),
+	// 1..3 = the escalating schedule, 4 = the steady zombieResendInterval regime.
+	zombieResendIndexMax = 4
+	// strayChunkWarnEvery rate-limits the "chunk for unknown request" Warn to
+	// one line per provider per window; chunks suppressed in between are
+	// counted on the next line.
+	strayChunkWarnEvery = 10 * time.Second
+	// strayChunkWarnStateTTL drops a provider's rate-limit state once it has
+	// been silent this long, keeping that map bounded by live providers.
+	strayChunkWarnStateTTL = 10 * strayChunkWarnEvery
+)
+
+// zombieResendSchedule holds the re-send instants relative to the FIRST
+// cancel. Points already in the past when a re-send fires are skipped, so a
+// zombie whose first stray chunk arrives late gets one re-send, not a burst.
+var zombieResendSchedule = []time.Duration{time.Second, 3 * time.Second, 10 * time.Second}
+
+// zombieEntry is one abandoned request awaiting its provider terminal.
+type zombieEntry struct {
+	model string
+	cause string
+	// firstCancelAt anchors tracking expiry and the re-send schedule.
+	firstCancelAt time.Time
+	// firstSentAt anchors latency only after the first successful enqueue.
+	firstSentAt time.Time
+	lastSentAt  time.Time
+	// lastStrayAt is the last chunk seen for the request after it was
+	// abandoned (zero if none): the last evidence of generation.
+	lastStrayAt  time.Time
+	nextResendAt time.Time
+	scheduleIdx  int
+	// sent counts cancels actually handed to the provider writer so far: the
+	// abandon path's first plus re-sends. It stays 0 while every enqueue has
+	// failed (control lane full, writer stopped), so a terminal that arrives
+	// then is the provider finishing on its own, not honoring a cancel.
+	sent        int
+	strayChunks int
+}
+
+func (e *zombieEntry) lastActivity() time.Time {
+	t := e.firstCancelAt
+	if e.lastSentAt.After(t) {
+		t = e.lastSentAt
+	}
+	if e.lastStrayAt.After(t) {
+		t = e.lastStrayAt
+	}
+	return t
+}
+
+// markSent records a cancel send at now, returning its resend index (0 for
+// the very first send), and arms the next re-send instant.
+func (e *zombieEntry) markSent(now time.Time) (resendIndex int) {
+	resendIndex = min(e.sent, zombieResendIndexMax)
+	if e.sent == 0 {
+		e.firstSentAt = now
+	}
+	e.sent++
+	e.lastSentAt = now
+	for e.scheduleIdx < len(zombieResendSchedule) {
+		at := e.firstCancelAt.Add(zombieResendSchedule[e.scheduleIdx])
+		e.scheduleIdx++
+		if at.After(now) {
+			e.nextResendAt = at
+			return resendIndex
+		}
+	}
+	e.nextResendAt = now.Add(zombieResendInterval)
+	return resendIndex
+}
+
+func (e *zombieEntry) resendDue(now time.Time) bool {
+	return !now.Before(e.nextResendAt)
+}
+
+// strayChunkWarnState rate-limits the unknown-chunk Warn for one provider.
+type strayChunkWarnState struct {
+	lastWarnAt time.Time
+	suppressed int
+}
+
+// zombieStreamCanceller is the per-request map behind the tracking above.
+// All methods are nil-receiver safe: a Server built without one (zero-value
+// literals in tests) cancels stray chunks but tracks nothing.
 type zombieStreamCanceller struct {
-	mu   sync.Mutex
-	sent map[string]time.Time
+	mu        sync.Mutex
+	entries   map[string]*zombieEntry
+	warn      map[string]*strayChunkWarnState
+	lastSweep time.Time
 }
 
 func newZombieStreamCanceller() *zombieStreamCanceller {
-	return &zombieStreamCanceller{sent: make(map[string]time.Time)}
+	return &zombieStreamCanceller{
+		entries: make(map[string]*zombieEntry),
+		warn:    make(map[string]*strayChunkWarnState),
+	}
 }
 
-// shouldCancel reports whether to send a cancel for requestID now, recording
-// the send. Returns false within zombieCancelThrottle of the last send for that
-// id. Opportunistically sweeps expired entries so the map stays bounded.
-func (z *zombieStreamCanceller) shouldCancel(requestID string, now time.Time) bool {
+// strayChunkResult is what strayChunk decided for one chunk.
+type strayChunkResult struct {
+	// send reports whether a cancel should be (re-)sent now; resendIndex is
+	// the index that send would carry (0 = no cancel delivered yet).
+	send        bool
+	resendIndex int
+	// cause is the entry's cancel cause; cancelCauseStrayChunk means no abandon
+	// path ever recorded this id — it is genuinely unknown.
+	cause   string
+	model   string
+	expired []zombieEntry
+}
+
+// ensureMapsLocked makes a canceller literal (nil maps) usable. Caller holds mu.
+func (z *zombieStreamCanceller) ensureMapsLocked() {
+	if z.entries == nil {
+		z.entries = make(map[string]*zombieEntry)
+	}
+	if z.warn == nil {
+		z.warn = make(map[string]*strayChunkWarnState)
+	}
+}
+
+// record registers an abandon-path cancel for requestID before it is sent.
+// Idempotent: an existing entry is left untouched. created reports whether
+// this call inserted the entry (so a caller that then decides not to cancel
+// can forget only what it created).
+func (z *zombieStreamCanceller) record(requestID, model, cause string, now time.Time) (created bool, expired []zombieEntry) {
+	if z == nil {
+		return false, nil
+	}
+	z.mu.Lock()
+	z.ensureMapsLocked()
+	defer z.mu.Unlock()
+	expired = z.sweepLocked(now, false)
+	if _, ok := z.entries[requestID]; ok {
+		return false, expired
+	}
+	expired = append(expired, z.makeRoomLocked(now)...)
+	z.entries[requestID] = &zombieEntry{model: model, cause: cause, firstCancelAt: now}
+	return true, expired
+}
+
+// markSent notes that a cancel was just handed to the provider writer for a
+// recorded requestID and returns its resend index (0 for the first cancel
+// delivered for the id, whichever path delivered it; -1 for an untracked id).
+// Callers invoke it only after the enqueue succeeded.
+func (z *zombieStreamCanceller) markSent(requestID string, now time.Time) (resendIndex int) {
+	if z == nil {
+		return -1
+	}
 	z.mu.Lock()
 	defer z.mu.Unlock()
-
-	if t, ok := z.sent[requestID]; ok {
-		if now.Sub(t) < zombieCancelThrottle {
-			return false
-		}
-		delete(z.sent, requestID)
+	e := z.entries[requestID]
+	if e == nil {
+		return -1
 	}
+	return e.markSent(now)
+}
 
-	if len(z.sent) >= zombieCancelMaxEntries {
-		var oldestID string
-		var oldest time.Time
-		for id, t := range z.sent {
-			if now.Sub(t) > zombieCancelThrottle {
-				delete(z.sent, id)
-				continue
-			}
-			if oldestID == "" || t.Before(oldest) {
-				oldestID = id
-				oldest = t
-			}
-		}
-		if len(z.sent) >= zombieCancelMaxEntries && oldestID != "" {
-			delete(z.sent, oldestID)
+// send atomically records a successful enqueue before a terminal or sweep can
+// remove its entry. enqueue must only submit to the nonblocking provider control
+// queue; it must not wait for the frame to reach the network. Provider terminals
+// may arrive as soon as enqueue succeeds, so releasing mu between enqueue and
+// markSent would misclassify a delivered cancel as unsent.
+func (z *zombieStreamCanceller) send(requestID string, enqueue func() bool) (resendIndex int, sent bool) {
+	if z == nil {
+		return -1, enqueue()
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	e := z.entries[requestID]
+	if e == nil {
+		// The bounded tracker may have evicted the entry while the abandon
+		// path released capacity. Preserve its best-effort cancel even when
+		// terminal correlation is no longer available.
+		return -1, enqueue()
+	}
+	if !enqueue() {
+		e.nextResendAt = time.Now().Add(zombieResendRetry)
+		return -1, false
+	}
+	return e.markSent(time.Now()), true
+}
+
+// forget drops requestID: a terminal had already claimed the attempt, so no
+// cancel was sent and there is nothing to correlate.
+func (z *zombieStreamCanceller) forget(requestID string) {
+	if z == nil {
+		return
+	}
+	z.mu.Lock()
+	delete(z.entries, requestID)
+	z.mu.Unlock()
+}
+
+// noteSendFailed lets the next stray chunk re-attempt the cancel almost
+// immediately instead of waiting for the schedule.
+func (z *zombieStreamCanceller) noteSendFailed(requestID string, now time.Time) {
+	if z == nil {
+		return
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	if e := z.entries[requestID]; e != nil {
+		e.nextResendAt = now.Add(zombieResendRetry)
+	}
+}
+
+// strayChunk notes a chunk for a request the coordinator no longer tracks and
+// decides whether to (re-)send the cancel. An id nobody abandoned gets an
+// entry of its own (cause cancelCauseStrayChunk) and an immediate cancel. A
+// send decision holds the entry for zombieResendRetry so a burst of chunks
+// yields one attempt; the caller marks the send (markSent) only after the
+// enqueue succeeded, or leaves the hold as the retry point when it failed.
+func (z *zombieStreamCanceller) strayChunk(requestID string, now time.Time) strayChunkResult {
+	if z == nil {
+		// Untracked (zero-value Server): still cancel, never throttle.
+		return strayChunkResult{send: true, cause: cancelCauseStrayChunk}
+	}
+	z.mu.Lock()
+	z.ensureMapsLocked()
+	defer z.mu.Unlock()
+	res := strayChunkResult{expired: z.sweepLocked(now, false)}
+	e := z.entries[requestID]
+	if e == nil {
+		res.expired = append(res.expired, z.makeRoomLocked(now)...)
+		e = &zombieEntry{cause: cancelCauseStrayChunk, firstCancelAt: now}
+		z.entries[requestID] = e
+	}
+	e.strayChunks++
+	e.lastStrayAt = now
+	res.cause = e.cause
+	res.model = e.model
+	if e.resendDue(now) {
+		res.send = true
+		res.resendIndex = min(e.sent, zombieResendIndexMax)
+		e.nextResendAt = now.Add(zombieResendRetry)
+	}
+	return res
+}
+
+// terminal resolves requestID against a provider terminal: it returns and
+// removes the entry, or reports false when the id was never abandoned.
+func (z *zombieStreamCanceller) terminal(requestID string) (zombieEntry, bool) {
+	if z == nil {
+		return zombieEntry{}, false
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	e, ok := z.entries[requestID]
+	if !ok {
+		return zombieEntry{}, false
+	}
+	delete(z.entries, requestID)
+	return *e, true
+}
+
+// allowStrayWarn reports whether the unknown-chunk Warn may be logged for
+// providerID now, with the number of chunks suppressed since the last line.
+func (z *zombieStreamCanceller) allowStrayWarn(providerID string, now time.Time) (allow bool, suppressed int) {
+	if z == nil {
+		return true, 0
+	}
+	z.mu.Lock()
+	z.ensureMapsLocked()
+	defer z.mu.Unlock()
+	st := z.warn[providerID]
+	if st == nil {
+		z.warn[providerID] = &strayChunkWarnState{lastWarnAt: now}
+		return true, 0
+	}
+	if now.Sub(st.lastWarnAt) < strayChunkWarnEvery {
+		st.suppressed++
+		return false, st.suppressed
+	}
+	suppressed = st.suppressed
+	st.suppressed = 0
+	st.lastWarnAt = now
+	return true, suppressed
+}
+
+// size reports the number of tracked requests (tests).
+func (z *zombieStreamCanceller) size() int {
+	if z == nil {
+		return 0
+	}
+	z.mu.Lock()
+	defer z.mu.Unlock()
+	return len(z.entries)
+}
+
+// sweepLocked expires entries idle past zombieEntryTTL (and stale warn state),
+// at most once per zombieSweepEvery unless forced. Expired entries are
+// returned so the caller can report them outside the lock.
+func (z *zombieStreamCanceller) sweepLocked(now time.Time, force bool) []zombieEntry {
+	if !force && now.Sub(z.lastSweep) < zombieSweepEvery {
+		return nil
+	}
+	z.lastSweep = now
+	var expired []zombieEntry
+	for id, e := range z.entries {
+		if now.Sub(e.lastActivity()) > zombieEntryTTL {
+			expired = append(expired, *e)
+			delete(z.entries, id)
 		}
 	}
-	z.sent[requestID] = now
-	return true
+	for id, st := range z.warn {
+		if now.Sub(st.lastWarnAt) > strayChunkWarnStateTTL {
+			delete(z.warn, id)
+		}
+	}
+	return expired
+}
+
+// makeRoomLocked keeps the map under its cap ahead of an insert: expire first,
+// then evict the least recently active entry.
+func (z *zombieStreamCanceller) makeRoomLocked(now time.Time) []zombieEntry {
+	if len(z.entries) < zombieCancelMaxEntries {
+		return nil
+	}
+	expired := z.sweepLocked(now, true)
+	if len(z.entries) < zombieCancelMaxEntries {
+		return expired
+	}
+	var oldestID string
+	var oldest time.Time
+	for id, e := range z.entries {
+		if la := e.lastActivity(); oldestID == "" || la.Before(oldest) {
+			oldestID, oldest = id, la
+		}
+	}
+	if oldestID != "" {
+		expired = append(expired, *z.entries[oldestID])
+		delete(z.entries, oldestID)
+	}
+	return expired
 }

--- a/coordinator/api/zombie_stream_test.go
+++ b/coordinator/api/zombie_stream_test.go
@@ -1,49 +1,351 @@
 package api
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
 
-func TestZombieStreamCancellerThrottle(t *testing.T) {
+// deliverStrayChunk mirrors noteStrayChunk's success path: a stray chunk that
+// decides to (re-)send is followed by markSent once the enqueue succeeded. The
+// tracker itself only arms the short retry hold on the decision.
+func deliverStrayChunk(z *zombieStreamCanceller, requestID string, at time.Time) strayChunkResult {
+	res := z.strayChunk(requestID, at)
+	if res.send {
+		if idx := z.markSent(requestID, at); idx != res.resendIndex {
+			panic(fmt.Sprintf("markSent index %d != decided index %d", idx, res.resendIndex))
+		}
+	}
+	return res
+}
+
+// TestZombieStreamCancellerEscalatingSchedule pins the re-send schedule for a
+// request an abandon path recorded: stray chunks re-send the cancel at +1 s,
+// +3 s, +10 s after the FIRST cancel, then every 30 s.
+func TestZombieStreamCancellerEscalatingSchedule(t *testing.T) {
 	z := newZombieStreamCanceller()
 	t0 := time.Now()
+	created, _ := z.record("req-1", "model-a", cancelCauseClientGonePost, t0)
+	if !created {
+		t.Fatal("first record should create the entry")
+	}
+	z.markSent("req-1", t0)
 
-	if !z.shouldCancel("req-1", t0) {
-		t.Fatal("first chunk for an unknown request should cancel")
+	steps := []struct {
+		at   time.Duration
+		send bool
+		idx  int
+	}{
+		{100 * time.Millisecond, false, 0},
+		{900 * time.Millisecond, false, 0},
+		{time.Second, true, 1},
+		{1500 * time.Millisecond, false, 0},
+		{3 * time.Second, true, 2},
+		{5 * time.Second, false, 0},
+		{10 * time.Second, true, 3},
+		{20 * time.Second, false, 0},
+		{40 * time.Second, true, 4},
+		{60 * time.Second, false, 0},
+		{70 * time.Second, true, 4}, // steady regime: index capped
 	}
-	if z.shouldCancel("req-1", t0.Add(time.Second)) {
-		t.Fatal("second chunk within the throttle window should NOT re-cancel")
-	}
-	// A different request is independent.
-	if !z.shouldCancel("req-2", t0.Add(time.Second)) {
-		t.Fatal("a different unknown request should cancel")
-	}
-	// After the throttle window, the same request cancels again.
-	if !z.shouldCancel("req-1", t0.Add(zombieCancelThrottle+time.Second)) {
-		t.Fatal("after the throttle window the same request should cancel again")
+	for _, st := range steps {
+		res := deliverStrayChunk(z, "req-1", t0.Add(st.at))
+		if res.send != st.send {
+			t.Fatalf("at +%v: send=%v, want %v", st.at, res.send, st.send)
+		}
+		if res.send && res.resendIndex != st.idx {
+			t.Fatalf("at +%v: resend_index=%d, want %d", st.at, res.resendIndex, st.idx)
+		}
+		if res.cause != cancelCauseClientGonePost {
+			t.Fatalf("at +%v: cause=%q, want recorded cause", st.at, res.cause)
+		}
 	}
 }
 
-func TestZombieStreamCancellerSweepBounded(t *testing.T) {
+// TestZombieStreamCancellerLateFirstStrayChunkDoesNotBurst: a zombie whose
+// chunks only start arriving after several schedule points (provider was
+// blocked behind a cold load) gets ONE re-send, then the next future point.
+func TestZombieStreamCancellerLateFirstStrayChunkDoesNotBurst(t *testing.T) {
 	z := newZombieStreamCanceller()
-	base := time.Now()
-	for i := 0; i < 5000; i++ {
-		z.shouldCancel(string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune(i)), base)
-	}
-	z.mu.Lock()
-	n := len(z.sent)
-	z.mu.Unlock()
-	if n > zombieCancelMaxEntries {
-		t.Fatalf("map not bounded during fresh burst: %d entries", n)
-	}
+	t0 := time.Now()
+	z.record("req-late", "m", cancelCauseHedgeLoser, t0)
+	z.markSent("req-late", t0)
 
-	// All those are expired relative to a far-future call, which triggers the sweep.
-	z.shouldCancel("trigger", base.Add(zombieCancelThrottle+time.Hour))
-	z.mu.Lock()
-	n = len(z.sent)
-	z.mu.Unlock()
-	if n > zombieCancelMaxEntries {
-		t.Fatalf("map not bounded after sweep: %d entries", n)
+	if res := deliverStrayChunk(z, "req-late", t0.Add(5*time.Second)); !res.send || res.resendIndex != 1 {
+		t.Fatalf("late first stray chunk: send=%v idx=%d, want send idx 1", res.send, res.resendIndex)
+	}
+	if res := deliverStrayChunk(z, "req-late", t0.Add(5100*time.Millisecond)); res.send {
+		t.Fatal("+3 s point already passed must be skipped, not fired as a burst")
+	}
+	if res := deliverStrayChunk(z, "req-late", t0.Add(10*time.Second)); !res.send || res.resendIndex != 2 {
+		t.Fatalf("+10 s: send=%v idx=%d, want send idx 2", res.send, res.resendIndex)
+	}
+}
+
+// TestZombieStreamCancellerUnrecordedIdCancelsImmediately: a chunk for an id
+// nobody abandoned is cancelled at once (resend_index 0, cause stray_chunk)
+// and then follows the same schedule.
+func TestZombieStreamCancellerUnrecordedIdCancelsImmediately(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	res := deliverStrayChunk(z, "bogus", t0)
+	if !res.send || res.resendIndex != 0 || res.cause != cancelCauseStrayChunk {
+		t.Fatalf("first stray chunk for unknown id: %+v", res)
+	}
+	if res := deliverStrayChunk(z, "bogus", t0.Add(500*time.Millisecond)); res.send {
+		t.Fatal("second chunk within 1 s must not re-cancel")
+	}
+	if res := deliverStrayChunk(z, "bogus", t0.Add(time.Second)); !res.send || res.resendIndex != 1 {
+		t.Fatalf("+1 s: %+v, want re-send index 1", res)
+	}
+}
+
+// TestZombieStreamCancellerSendFailureRetriesQuickly: a failed send is retried
+// on the next stray chunk after zombieResendRetry, not at the next schedule point.
+func TestZombieStreamCancellerSendFailureRetriesQuickly(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	z.record("req-f", "m", cancelCauseFirstChunkTimeout, t0)
+	z.markSent("req-f", t0)
+	z.noteSendFailed("req-f", t0)
+	if res := z.strayChunk("req-f", t0.Add(zombieResendRetry/2)); res.send {
+		t.Fatal("retry must wait zombieResendRetry")
+	}
+	if res := z.strayChunk("req-f", t0.Add(zombieResendRetry)); !res.send || res.resendIndex != 1 {
+		t.Fatalf("retry after failure: %+v", res)
+	}
+}
+
+// TestZombieStreamCancellerUndeliveredCancelKeepsIndexZero: an abandon path
+// whose enqueue failed never marks the entry sent. The decision to re-send on
+// a stray chunk holds the entry for zombieResendRetry (a chunk burst yields
+// one attempt) without advancing the schedule or the resend index; the first
+// delivery — whenever it happens — is index 0 and only then does the
+// escalating schedule start.
+func TestZombieStreamCancellerUndeliveredCancelKeepsIndexZero(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	z.record("req-u", "m", cancelCauseClientGonePost, t0)
+	z.noteSendFailed("req-u", t0) // abandon path's own send was refused
+
+	if res := z.strayChunk("req-u", t0.Add(zombieResendRetry/2)); res.send {
+		t.Fatal("retry must wait zombieResendRetry")
+	}
+	res := z.strayChunk("req-u", t0.Add(zombieResendRetry))
+	if !res.send || res.resendIndex != 0 || res.cause != cancelCauseClientGonePost {
+		t.Fatalf("first retry decision: %+v, want send idx 0 under the abandon cause", res)
+	}
+	// The decision alone holds the entry (one attempt per burst) ...
+	if res := z.strayChunk("req-u", t0.Add(zombieResendRetry+time.Millisecond)); res.send {
+		t.Fatal("a chunk inside the hold must not decide a second send")
+	}
+	// ... and a failed retry leaves it undelivered: still index 0 next time.
+	z.noteSendFailed("req-u", t0.Add(zombieResendRetry))
+	res = z.strayChunk("req-u", t0.Add(2*zombieResendRetry))
+	if !res.send || res.resendIndex != 0 {
+		t.Fatalf("second retry decision: %+v, want send idx 0 (nothing delivered yet)", res)
+	}
+	e := z.entries["req-u"]
+	if e.sent != 0 {
+		t.Fatalf("sent = %d before any successful enqueue, want 0", e.sent)
+	}
+	// Delivered: index 0, schedule anchored on the FIRST cancel time.
+	if idx := z.markSent("req-u", t0.Add(2*zombieResendRetry)); idx != 0 {
+		t.Fatalf("markSent index = %d, want 0 for the first delivered cancel", idx)
+	}
+	if e.sent != 1 {
+		t.Fatalf("sent = %d after the delivered retry, want 1", e.sent)
+	}
+	if res := deliverStrayChunk(z, "req-u", t0.Add(900*time.Millisecond)); res.send {
+		t.Fatal("+0.9 s: the +1 s schedule point has not arrived")
+	}
+	if res := deliverStrayChunk(z, "req-u", t0.Add(time.Second)); !res.send || res.resendIndex != 1 {
+		t.Fatalf("+1 s: %+v, want re-send index 1", res)
+	}
+	if idx := z.markSent("never-recorded", t0); idx != -1 {
+		t.Fatalf("markSent on an untracked id = %d, want -1", idx)
+	}
+}
+
+// TestZombieStreamCancellerTerminalResolvesEntry: the provider terminal
+// returns the entry (first cancel time, cause, model) exactly once.
+func TestZombieStreamCancellerTerminalResolvesEntry(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	z.record("req-t", "model-x", cancelCauseClientGonePre, t0)
+	z.markSent("req-t", t0)
+	deliverStrayChunk(z, "req-t", t0.Add(200*time.Millisecond))
+
+	e, ok := z.terminal("req-t")
+	if !ok {
+		t.Fatal("terminal should resolve a recorded entry")
+	}
+	if !e.firstCancelAt.Equal(t0) || e.cause != cancelCauseClientGonePre || e.model != "model-x" || e.strayChunks != 1 {
+		t.Fatalf("entry = %+v", e)
+	}
+	if _, ok := z.terminal("req-t"); ok {
+		t.Fatal("entry must be removed on terminal")
+	}
+	if _, ok := z.terminal("never"); ok {
+		t.Fatal("unknown id must not resolve")
+	}
+	if z.size() != 0 {
+		t.Fatalf("size = %d, want 0", z.size())
+	}
+}
+
+// TestZombieStreamCancellerRecordIsIdempotentAndForgetOnlyDropsCreated: a
+// second record for the same id neither resets the schedule nor creates, and
+// forget after a non-creating record leaves the original entry alone.
+func TestZombieStreamCancellerRecordIsIdempotent(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	z.record("req-i", "m", cancelCauseOverflow, t0)
+	z.markSent("req-i", t0)
+	created, _ := z.record("req-i", "m", cancelCauseHedgeLoser, t0.Add(time.Second))
+	if created {
+		t.Fatal("second record must not create")
+	}
+	e, ok := z.terminal("req-i")
+	if !ok || e.cause != cancelCauseOverflow || !e.firstCancelAt.Equal(t0) {
+		t.Fatalf("entry = %+v, want original cause and first cancel time", e)
+	}
+	// forget drops the entry.
+	z.record("req-g", "m", cancelCauseOverflow, t0)
+	z.forget("req-g")
+	if z.size() != 0 {
+		t.Fatal("forget must drop the entry")
+	}
+}
+
+// TestZombieStreamCancellerSweepExpiresIdleEntries: an entry idle past
+// zombieEntryTTL is returned as expired on the next touch, preserving its last
+// stray-chunk time so the caller can report it as the terminal.
+func TestZombieStreamCancellerSweepExpiresIdleEntries(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	z.record("req-a", "m", cancelCauseClientGonePost, t0)
+	z.markSent("req-a", t0)
+	deliverStrayChunk(z, "req-a", t0.Add(2*time.Second))
+	z.record("req-b", "m", cancelCauseHedgeLoser, t0) // never any chunk
+
+	// Still live just under the TTL (activity = last stray chunk at +2 s).
+	if _, expired := z.record("other", "m", cancelCauseHedgeLoser, t0.Add(2*time.Second+zombieEntryTTL)); len(expired) != 1 {
+		t.Fatalf("expected only req-b (idle since t0) expired, got %d", len(expired))
+	}
+	_, expired := z.record("other2", "m", cancelCauseHedgeLoser, t0.Add(3*time.Second+zombieEntryTTL))
+	if len(expired) != 1 {
+		t.Fatalf("expected req-a expired, got %d", len(expired))
+	}
+	if e := expired[0]; e.cause != cancelCauseClientGonePost || !e.lastStrayAt.Equal(t0.Add(2*time.Second)) {
+		t.Fatalf("expired entry = %+v", e)
+	}
+	if _, ok := z.terminal("req-a"); ok {
+		t.Fatal("expired entry must be gone")
+	}
+}
+
+// TestZombieStreamCancellerBounded: the map never exceeds its cap; the
+// least recently active entry is evicted and reported.
+func TestZombieStreamCancellerBounded(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	evicted := 0
+	for i := 0; i < zombieCancelMaxEntries+100; i++ {
+		_, expired := z.record(fmt.Sprintf("req-%d", i), "m", cancelCauseHedgeLoser, t0.Add(time.Duration(i)*time.Millisecond))
+		evicted += len(expired)
+		if z.size() > zombieCancelMaxEntries {
+			t.Fatalf("size %d exceeds cap", z.size())
+		}
+	}
+	if evicted != 100 {
+		t.Fatalf("evicted = %d, want 100", evicted)
+	}
+	// The oldest ids were the ones evicted.
+	if _, ok := z.terminal("req-0"); ok {
+		t.Fatal("req-0 should have been evicted first")
+	}
+	if _, ok := z.terminal(fmt.Sprintf("req-%d", zombieCancelMaxEntries+99)); !ok {
+		t.Fatal("newest entry must survive")
+	}
+}
+
+// TestStrayChunkWarnRateLimit: one Warn per provider per window, with the
+// suppressed count carried onto the next allowed line; providers independent.
+func TestStrayChunkWarnRateLimit(t *testing.T) {
+	z := newZombieStreamCanceller()
+	t0 := time.Now()
+	if allow, n := z.allowStrayWarn("p1", t0); !allow || n != 0 {
+		t.Fatalf("first warn: allow=%v n=%d", allow, n)
+	}
+	for i := 1; i <= 5; i++ {
+		if allow, n := z.allowStrayWarn("p1", t0.Add(time.Duration(i)*time.Second)); allow || n != i {
+			t.Fatalf("within window #%d: allow=%v n=%d", i, allow, n)
+		}
+	}
+	if allow, n := z.allowStrayWarn("p2", t0.Add(time.Second)); !allow || n != 0 {
+		t.Fatalf("other provider: allow=%v n=%d", allow, n)
+	}
+	if allow, n := z.allowStrayWarn("p1", t0.Add(strayChunkWarnEvery)); !allow || n != 5 {
+		t.Fatalf("after window: allow=%v suppressed=%d, want allow with 5", allow, n)
+	}
+	if allow, n := z.allowStrayWarn("p1", t0.Add(strayChunkWarnEvery+time.Second)); allow || n != 1 {
+		t.Fatalf("counter must reset after an allowed line: allow=%v n=%d", allow, n)
+	}
+}
+
+func TestCancelEnqueueIsAtomicWithTerminalResolution(t *testing.T) {
+	z := newZombieStreamCanceller()
+	z.record("immediate-terminal", "m", cancelCauseClientGonePost, time.Now())
+	enqueuing := make(chan struct{})
+	finishEnqueue := make(chan struct{})
+	sendDone := make(chan bool, 1)
+	go func() {
+		index, sent := z.send("immediate-terminal", func() bool {
+			close(enqueuing)
+			<-finishEnqueue
+			return true
+		})
+		sendDone <- sent && index == 0
+	}()
+	<-enqueuing
+	terminalStarted := make(chan struct{})
+	terminalDone := make(chan zombieEntry, 1)
+	go func() {
+		close(terminalStarted)
+		e, _ := z.terminal("immediate-terminal")
+		terminalDone <- e
+	}()
+	<-terminalStarted
+	// The provider may respond before enqueue returns; terminal correlation
+	// must wait until successful acceptance and its timestamp are recorded.
+	select {
+	case <-terminalDone:
+		close(finishEnqueue)
+		<-sendDone
+		t.Fatal("terminal removed the entry before the successful enqueue was marked")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(finishEnqueue)
+	if !<-sendDone {
+		t.Fatal("first successful enqueue was not recorded")
+	}
+	e := <-terminalDone
+	if e.sent != 1 || e.firstSentAt.IsZero() {
+		t.Fatalf("immediate terminal classified delivered enqueue as unsent: %+v", e)
+	}
+}
+
+func TestCancelEvictedEntryStillReceivesBestEffortSend(t *testing.T) {
+	z := newZombieStreamCanceller()
+	z.record("evicted", "m", cancelCauseClientGonePost, time.Now())
+	z.forget("evicted") // a bounded-map eviction before the abandon path resumes
+	called := false
+	index, sent := z.send("evicted", func() bool {
+		called = true
+		return true
+	})
+	if !called || !sent || index != -1 {
+		t.Fatalf("untracked best-effort send = (%d, %v), called=%v", index, sent, called)
 	}
 }

--- a/coordinator/datadog/metrics_snapshot.go
+++ b/coordinator/datadog/metrics_snapshot.go
@@ -1,0 +1,20 @@
+package datadog
+
+// HistogramOrGauge records a snapshot through the configured metric transport.
+// DogStatsD-only deployments retain agent-side histogram aggregation. With an
+// API key, the HTTPS series API is authoritative and receives the latest value
+// for each tag set as a gauge; it does not provide histogram percentiles.
+//
+// This is opt-in: Histogram remains DogStatsD-only for existing callers. The
+// presence of a Statsd client cannot select the transport because opening a UDP
+// socket succeeds even when no agent is listening.
+func (c *Client) HistogramOrGauge(name string, value float64, tags []string) {
+	if c == nil {
+		return
+	}
+	if c.httpMetrics() {
+		c.Gauge(name, value, tags)
+		return
+	}
+	c.Histogram(name, value, tags)
+}

--- a/coordinator/datadog/metrics_snapshot_test.go
+++ b/coordinator/datadog/metrics_snapshot_test.go
@@ -1,0 +1,115 @@
+package datadog
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+func TestHistogramOrGaugeUsesConfiguredTransport(t *testing.T) {
+	for _, apiKey := range []string{"", "test-api-key"} {
+		name := "dogstatsd"
+		if apiKey != "" {
+			name = "http-with-non-nil-statsd"
+		}
+		t.Run(name, func(t *testing.T) {
+			socket, err := net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer socket.Close()
+			sd, err := statsd.New(socket.LocalAddr().String(), statsd.WithNamespace("d_inference."), statsd.WithoutTelemetry())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer sd.Close()
+			type submission struct {
+				body []byte
+				key  string
+			}
+			requests := make(chan submission, 1)
+			intake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				requests <- submission{body: body, key: r.Header.Get("Dd-Api-Key")}
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer intake.Close()
+			c := &Client{
+				Statsd: sd, logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				apiKey: apiKey, httpClient: intake.Client(), seriesURL: intake.URL,
+				series: newSeriesBuffer(), flushIntervalSecs: 5,
+			}
+			tags := []string{"chip_family:M3", "provider_version:0.8.x"}
+			c.HistogramOrGauge("provider.mlx_memory.active_gb", 8, tags)
+			c.HistogramOrGauge("provider.mlx_memory.active_gb", 12, tags)
+			c.flushSeries()
+			if err := sd.Flush(); err != nil {
+				t.Fatal(err)
+			}
+			if apiKey != "" {
+				var request submission
+				select {
+				case request = <-requests:
+				default:
+					t.Fatal("snapshot was not submitted over HTTP")
+				}
+				var body struct {
+					Series []ddMetric `json:"series"`
+				}
+				if err := json.Unmarshal(request.body, &body); err != nil {
+					t.Fatal(err)
+				}
+				if request.key != apiKey || len(body.Series) != 1 {
+					t.Fatalf("unexpected HTTP snapshot: key=%q series=%+v", request.key, body.Series)
+				}
+				metric := body.Series[0]
+				if metric.Metric != "d_inference.provider.mlx_memory.active_gb" || metric.Type != "gauge" || len(metric.Points) != 1 || metric.Points[0][1] != 12 {
+					t.Fatalf("expected latest-value gauge: %+v", metric)
+				}
+				if strings.Join(metric.Tags, ",") != strings.Join(tags, ",") {
+					t.Fatalf("snapshot tags changed: %v", metric.Tags)
+				}
+			} else {
+				select {
+				case request := <-requests:
+					t.Fatalf("DogStatsD-only snapshot unexpectedly used HTTP: %s", request.body)
+				default:
+				}
+			}
+			if err := socket.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+				t.Fatal(err)
+			}
+			buf := make([]byte, 4096)
+			var packets strings.Builder
+			for {
+				n, _, err := socket.ReadFrom(buf)
+				if err != nil {
+					if timeout, ok := err.(net.Error); ok && timeout.Timeout() {
+						break
+					}
+					t.Fatal(err)
+				}
+				packets.Write(buf[:n])
+			}
+			if apiKey != "" {
+				if packets.Len() != 0 {
+					t.Fatalf("HTTP snapshots were duplicated over UDP: %s", packets.String())
+				}
+			} else {
+				for _, value := range []string{"8", "12"} {
+					if !strings.Contains(packets.String(), "d_inference.provider.mlx_memory.active_gb:"+value+"|h|#"+strings.Join(tags, ",")) {
+						t.Fatalf("missing histogram value %s: %s", value, packets.String())
+					}
+				}
+			}
+		})
+	}
+}

--- a/coordinator/protocol/chunk_decode_bench_test.go
+++ b/coordinator/protocol/chunk_decode_bench_test.go
@@ -1,0 +1,97 @@
+package protocol
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// Benchmarks for the per-token inference_response_chunk frame decode — the
+// single hottest decode in the coordinator (one WebSocket frame per streamed
+// token, ~117K/s at peak). The fixture mirrors the Swift provider's wire shape:
+// JSONEncoder with .sortedKeys, so "type" is the LAST top-level key and the
+// nested payload keys are alphabetical too.
+
+// benchSwiftChunkFrame returns a Swift-shaped chunk frame of roughly the
+// production size (~620 B): a UUID request id, a 32-byte X25519 key and a
+// ~340-byte NaCl box (nonce || ciphertext), both base64.
+func benchSwiftChunkFrame() []byte {
+	eph := make([]byte, 32)
+	ct := make([]byte, 340)
+	if _, err := rand.Read(eph); err != nil {
+		panic(err)
+	}
+	if _, err := rand.Read(ct); err != nil {
+		panic(err)
+	}
+	return []byte(swiftShapedChunkFrame(
+		"0f3a9c1e-6b7d-4a2e-9c5f-1d2e3f4a5b6c",
+		base64.StdEncoding.EncodeToString(eph),
+		base64.StdEncoding.EncodeToString(ct),
+	))
+}
+
+// swiftShapedChunkFrame renders the exact key order the Swift provider emits
+// (JSONEncoder .sortedKeys, .withoutEscapingSlashes; empty data omitted).
+func swiftShapedChunkFrame(requestID, ephemeralPublicKey, ciphertext string) string {
+	return `{"encrypted_data":{"ciphertext":"` + ciphertext +
+		`","ephemeral_public_key":"` + ephemeralPublicKey +
+		`"},"request_id":"` + requestID +
+		`","type":"` + TypeInferenceResponseChunk + `"}`
+}
+
+// The read loop's decode as it stood before the hand-written scanner:
+// json.Unmarshal into ProviderMessage (outer validation pass + UnmarshalJSON).
+// Comparable to A6's BenchmarkChunk_1_FrameUnmarshal.
+func BenchmarkChunkFrame_ProviderMessage_Unmarshal(b *testing.B) {
+	frame := benchSwiftChunkFrame()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(frame)))
+	for i := 0; i < b.N; i++ {
+		var pm ProviderMessage
+		if err := json.Unmarshal(frame, &pm); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Permanent generic baseline: encoding/json straight into the concrete struct
+// (what the fallback path costs).
+func BenchmarkChunkFrame_Concrete_Unmarshal(b *testing.B) {
+	frame := benchSwiftChunkFrame()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(frame)))
+	for i := 0; i < b.N; i++ {
+		var msg InferenceResponseChunkMessage
+		if err := json.Unmarshal(frame, &msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The read loop's decode as it stands now: DecodeProviderMessage, which skips
+// encoding/json's outer validation pass and takes the chunk fast path.
+func BenchmarkChunkFrame_DecodeProviderMessage(b *testing.B) {
+	frame := benchSwiftChunkFrame()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(frame)))
+	for i := 0; i < b.N; i++ {
+		var pm ProviderMessage
+		if err := DecodeProviderMessage(frame, &pm); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The scanner alone.
+func BenchmarkChunkFrame_Scan(b *testing.B) {
+	frame := benchSwiftChunkFrame()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(frame)))
+	for i := 0; i < b.N; i++ {
+		if _, ok := scanChunkFrame(frame); !ok {
+			b.Fatal("fast path not taken")
+		}
+	}
+}

--- a/coordinator/protocol/chunk_scan.go
+++ b/coordinator/protocol/chunk_scan.go
@@ -1,0 +1,250 @@
+package protocol
+
+import "strings"
+
+// Hand-written decoder for the inference_response_chunk frame — the one
+// provider→coordinator message that arrives once per streamed token (~117K/s
+// at fleet peak). encoding/json spent ~65% of the per-chunk relay CPU on this
+// frame; the scanner below decodes the production wire shape with one byte
+// walk and two allocations.
+//
+// It follows type_scan.go's rule: never complete, only never wrong. The fast
+// path accepts exactly the shapes it can decode identically to encoding/json —
+// the four known top-level keys (type, request_id, data, encrypted_data), the
+// two known payload keys, plain printable-ASCII strings with no escapes, and
+// null/object for the payload. Anything else (unknown or case-variant keys,
+// duplicates, escapes, non-ASCII bytes, numbers, trailing bytes, malformed
+// input) reports ok=false and the caller falls back to the generic decode.
+// The Swift provider emits keys sorted (JSONEncoder .sortedKeys), so "type" is
+// the LAST top-level key on the wire; the scanner reads every key in one pass
+// rather than looking for "type" first.
+//
+// TestScanChunkFrameStructShapeGuard pins the field sets the scanner knows
+// about: adding a JSON field to InferenceResponseChunkMessage or
+// EncryptedPayload without teaching the scanner would otherwise silently push
+// every chunk back onto the slow path.
+
+// chunkFrame co-allocates the message with its payload so a decoded frame is
+// one struct allocation plus one string allocation (see buildChunkFrame).
+type chunkFrame struct {
+	msg InferenceResponseChunkMessage
+	enc EncryptedPayload
+}
+
+// scanChunkFrame decodes data as an inference_response_chunk frame. ok is
+// false when the frame is not a chunk or is any shape the scanner is not
+// certain about; callers must then use the generic decode. When ok is true
+// the result equals what json.Unmarshal into InferenceResponseChunkMessage
+// would produce (FuzzChunkFrameDecode holds this against encoding/json).
+func scanChunkFrame(data []byte) (*InferenceResponseChunkMessage, bool) {
+	var (
+		requestID, chunkData, ephemeral, ciphertext []byte
+		seenType, seenRequestID, seenData, seenEnc  bool
+		encObject                                   bool // encrypted_data was an object (non-nil payload)
+	)
+	i := skipJSONWhitespace(data, 0)
+	if i >= len(data) || data[i] != '{' {
+		return nil, false
+	}
+	i = skipJSONWhitespace(data, i+1)
+	if i < len(data) && data[i] == '}' {
+		return nil, false // no "type": not a chunk frame
+	}
+	for {
+		key, next, ok := scanASCIIJSONString(data, i)
+		if !ok {
+			return nil, false
+		}
+		i = skipJSONWhitespace(data, next)
+		if i >= len(data) || data[i] != ':' {
+			return nil, false
+		}
+		i = skipJSONWhitespace(data, i+1)
+		switch string(key) {
+		case "type":
+			if seenType {
+				return nil, false
+			}
+			seenType = true
+			v, vNext, vOK := scanASCIIJSONString(data, i)
+			if !vOK || string(v) != TypeInferenceResponseChunk {
+				return nil, false
+			}
+			i = vNext
+		case "request_id":
+			if seenRequestID {
+				return nil, false
+			}
+			seenRequestID = true
+			requestID, i, ok = scanASCIIJSONString(data, i)
+			if !ok {
+				return nil, false
+			}
+		case "data":
+			if seenData {
+				return nil, false
+			}
+			seenData = true
+			chunkData, i, ok = scanASCIIJSONString(data, i)
+			if !ok {
+				return nil, false
+			}
+		case "encrypted_data":
+			if seenEnc {
+				return nil, false
+			}
+			seenEnc = true
+			if i < len(data) && data[i] == '{' {
+				ephemeral, ciphertext, i, ok = scanChunkEncryptedPayload(data, i)
+				encObject = true
+			} else {
+				i, ok = scanJSONNull(data, i)
+			}
+			if !ok {
+				return nil, false
+			}
+		default:
+			// Unknown key, or a case variant of a known one that encoding/json
+			// would still match: defer to the generic decode.
+			return nil, false
+		}
+		i = skipJSONWhitespace(data, i)
+		if i >= len(data) {
+			return nil, false
+		}
+		switch data[i] {
+		case ',':
+			i = skipJSONWhitespace(data, i+1)
+		case '}':
+			if skipJSONWhitespace(data, i+1) != len(data) {
+				return nil, false // trailing bytes: encoding/json rejects the document
+			}
+			if !seenType {
+				return nil, false
+			}
+			return buildChunkFrame(requestID, chunkData, ephemeral, ciphertext, encObject), true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// scanChunkEncryptedPayload scans the encrypted_data object starting at the
+// '{' at data[i]. It accepts exactly the two known keys as plain ASCII strings.
+func scanChunkEncryptedPayload(data []byte, i int) (ephemeral, ciphertext []byte, next int, ok bool) {
+	i = skipJSONWhitespace(data, i+1)
+	if i < len(data) && data[i] == '}' {
+		return nil, nil, i + 1, true // {} decodes to a zero, non-nil payload
+	}
+	var seenEphemeral, seenCiphertext bool
+	for {
+		key, keyNext, keyOK := scanASCIIJSONString(data, i)
+		if !keyOK {
+			return nil, nil, 0, false
+		}
+		i = skipJSONWhitespace(data, keyNext)
+		if i >= len(data) || data[i] != ':' {
+			return nil, nil, 0, false
+		}
+		i = skipJSONWhitespace(data, i+1)
+		switch string(key) {
+		case "ephemeral_public_key":
+			if seenEphemeral {
+				return nil, nil, 0, false
+			}
+			seenEphemeral = true
+			ephemeral, i, keyOK = scanASCIIJSONString(data, i)
+		case "ciphertext":
+			if seenCiphertext {
+				return nil, nil, 0, false
+			}
+			seenCiphertext = true
+			ciphertext, i, keyOK = scanASCIIJSONString(data, i)
+		default:
+			return nil, nil, 0, false
+		}
+		if !keyOK {
+			return nil, nil, 0, false
+		}
+		i = skipJSONWhitespace(data, i)
+		if i >= len(data) {
+			return nil, nil, 0, false
+		}
+		switch data[i] {
+		case ',':
+			i = skipJSONWhitespace(data, i+1)
+		case '}':
+			return ephemeral, ciphertext, i + 1, true
+		default:
+			return nil, nil, 0, false
+		}
+	}
+}
+
+// scanJSONNull accepts exactly the literal null at data[i] followed by a
+// structural byte or whitespace, returning the index after it.
+func scanJSONNull(data []byte, i int) (next int, ok bool) {
+	if len(data)-i < 4 || string(data[i:i+4]) != "null" {
+		return 0, false
+	}
+	next = i + 4
+	if next < len(data) {
+		switch data[next] {
+		case ',', '}', ' ', '\t', '\n', '\r':
+		default:
+			return 0, false
+		}
+	}
+	return next, true
+}
+
+// scanASCIIJSONString scans a JSON string at data[i] whose content is plain
+// printable ASCII (0x20..0x7E) with no escape sequences, so its raw bytes ARE
+// its decoded value. Anything else (escapes, control bytes, non-ASCII — which
+// encoding/json would unescape or coerce) bails.
+func scanASCIIJSONString(data []byte, i int) (s []byte, next int, ok bool) {
+	if i >= len(data) || data[i] != '"' {
+		return nil, 0, false
+	}
+	i++
+	start := i
+	for i < len(data) {
+		c := data[i]
+		if c == '"' {
+			return data[start:i], i + 1, true
+		}
+		if c == '\\' || c < 0x20 || c >= 0x7f {
+			return nil, 0, false
+		}
+		i++
+	}
+	return nil, 0, false
+}
+
+// buildChunkFrame copies the scanned fields out of the frame buffer into one
+// shared string allocation (the four values live and die together with the
+// chunk) and one struct allocation for message + payload.
+func buildChunkFrame(requestID, chunkData, ephemeral, ciphertext []byte, encObject bool) *InferenceResponseChunkMessage {
+	var sb strings.Builder
+	sb.Grow(len(requestID) + len(chunkData) + len(ephemeral) + len(ciphertext))
+	sb.Write(requestID)
+	sb.Write(chunkData)
+	sb.Write(ephemeral)
+	sb.Write(ciphertext)
+	s := sb.String()
+
+	f := &chunkFrame{}
+	f.msg.Type = TypeInferenceResponseChunk
+	off := 0
+	f.msg.RequestID = s[off : off+len(requestID)]
+	off += len(requestID)
+	f.msg.Data = s[off : off+len(chunkData)]
+	off += len(chunkData)
+	if encObject {
+		f.enc.EphemeralPublicKey = s[off : off+len(ephemeral)]
+		off += len(ephemeral)
+		f.enc.Ciphertext = s[off : off+len(ciphertext)]
+		f.msg.EncryptedData = &f.enc
+	}
+	return &f.msg
+}

--- a/coordinator/protocol/chunk_scan_test.go
+++ b/coordinator/protocol/chunk_scan_test.go
@@ -1,0 +1,230 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// chunkFrameCorpus is the golden corpus for the chunk-frame fast path: real
+// wire shapes (Swift provider, Go encoder), the edge shapes encoding/json
+// tolerates that the scanner deliberately hands back to it, and malformed
+// input. fast pins which shapes the scanner is expected to decode itself; a
+// shape the scanner does not take must still decode identically through the
+// generic path, and a shape it takes must equal encoding/json's result.
+var chunkFrameCorpus = []struct {
+	name  string
+	frame string
+	fast  bool
+}{
+	// --- production shapes: fast path ---
+	{
+		name:  "swift sorted keys",
+		frame: swiftShapedChunkFrame("0f3a9c1e-6b7d-4a2e-9c5f-1d2e3f4a5b6c", "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=", "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0A="),
+		fast:  true,
+	},
+	{
+		name:  "go struct key order",
+		frame: `{"type":"inference_response_chunk","request_id":"req-1","encrypted_data":{"ephemeral_public_key":"a+b/c=","ciphertext":"d+e/f=="}}`,
+		fast:  true,
+	},
+	{
+		name:  "whitespace between tokens",
+		frame: " \n{ \"request_id\" : \"req-1\" ,\n\t\"encrypted_data\" : { \"ciphertext\" : \"Zm9v\" , \"ephemeral_public_key\" : \"YmFy\" } ,\r\n\"type\" : \"inference_response_chunk\" }\n",
+		fast:  true,
+	},
+	{name: "plaintext data without escapes", frame: `{"type":"inference_response_chunk","request_id":"req-1","data":"data: [DONE]"}`, fast: true},
+	{name: "encrypted_data null", frame: `{"type":"inference_response_chunk","request_id":"req-1","encrypted_data":null}`, fast: true},
+	{name: "encrypted_data empty object", frame: `{"type":"inference_response_chunk","request_id":"req-1","encrypted_data":{}}`, fast: true},
+	{name: "type only", frame: `{"type":"inference_response_chunk"}`, fast: true},
+	{name: "empty strings", frame: `{"type":"inference_response_chunk","request_id":"","data":"","encrypted_data":{"ephemeral_public_key":"","ciphertext":""}}`, fast: true},
+	{name: "printable ascii edge bytes", frame: `{"type":"inference_response_chunk","request_id":" !#$%&'()*+,-./:;<=>?@[]^_` + "`" + `{|}~"}`, fast: true},
+
+	// --- shapes encoding/json accepts that the scanner defers: fallback ---
+	{name: "data with escapes", frame: `{"type":"inference_response_chunk","request_id":"req-1","data":"data: {\"id\":\"x\"}\n\n"}`, fast: false},
+	{name: "unicode request_id raw utf8", frame: `{"type":"inference_response_chunk","request_id":"réq-ü-☃"}`, fast: false},
+	{name: "unicode escape in request_id", frame: `{"type":"inference_response_chunk","request_id":"r\u00e9q"}`, fast: false},
+	{name: "escaped slash", frame: `{"type":"inference_response_chunk","request_id":"a\/b"}`, fast: false},
+	{name: "openai-shaped nulls", frame: `{"type":"inference_response_chunk","request_id":"req-1","data":null,"encrypted_data":null}`, fast: false},
+	{name: "extra unknown top-level field", frame: `{"type":"inference_response_chunk","request_id":"req-1","sequence":7,"encrypted_data":{"ephemeral_public_key":"a","ciphertext":"b"}}`, fast: false},
+	{name: "extra unknown nested field", frame: `{"type":"inference_response_chunk","request_id":"req-1","encrypted_data":{"ephemeral_public_key":"a","ciphertext":"b","nonce":"c"}}`, fast: false},
+	{name: "case-variant key", frame: `{"Type":"inference_response_chunk","request_id":"req-1"}`, fast: false},
+	{name: "case-variant nested key", frame: `{"type":"inference_response_chunk","encrypted_data":{"Ciphertext":"b","ephemeral_public_key":"a"}}`, fast: false},
+	{name: "duplicate request_id", frame: `{"type":"inference_response_chunk","request_id":"first","request_id":"second"}`, fast: false},
+	{name: "duplicate type", frame: `{"type":"inference_response_chunk","type":"inference_response_chunk"}`, fast: false},
+	{name: "duplicate nested ciphertext", frame: `{"type":"inference_response_chunk","encrypted_data":{"ciphertext":"a","ciphertext":"b"}}`, fast: false},
+	{name: "request_id null", frame: `{"type":"inference_response_chunk","request_id":null}`, fast: false},
+	{name: "del byte in string", frame: "{\"type\":\"inference_response_chunk\",\"request_id\":\"a\x7fb\"}", fast: false},
+	{name: "not a chunk (heartbeat)", frame: `{"type":"heartbeat","status":"idle"}`, fast: false},
+	{name: "not a chunk (accepted, known keys only)", frame: `{"request_id":"req-1","type":"inference_accepted"}`, fast: false},
+	{name: "empty object", frame: `{}`, fast: false},
+
+	// --- malformed: fallback (generic decode reports the error) ---
+	{name: "truncated", frame: `{"type":"inference_response_chunk","request_id":"req-`, fast: false},
+	{name: "truncated after key", frame: `{"type":"inference_response_chunk","request_id"`, fast: false},
+	{name: "trailing garbage", frame: `{"type":"inference_response_chunk","request_id":"req-1"} x`, fast: false},
+	{name: "two documents", frame: `{"type":"inference_response_chunk"}{"type":"inference_response_chunk"}`, fast: false},
+	{name: "trailing comma", frame: `{"type":"inference_response_chunk","request_id":"req-1",}`, fast: false},
+	{name: "missing colon", frame: `{"type" "inference_response_chunk"}`, fast: false},
+	{name: "missing comma", frame: `{"type":"inference_response_chunk" "request_id":"req-1"}`, fast: false},
+	{name: "number request_id", frame: `{"type":"inference_response_chunk","request_id":42}`, fast: false},
+	{name: "encrypted_data string", frame: `{"type":"inference_response_chunk","encrypted_data":"nope"}`, fast: false},
+	{name: "encrypted_data bad literal", frame: `{"type":"inference_response_chunk","encrypted_data":nullx}`, fast: false},
+	{name: "encrypted_data truncated object", frame: `{"type":"inference_response_chunk","encrypted_data":{"ciphertext":"a"`, fast: false},
+	{name: "nested trailing comma", frame: `{"type":"inference_response_chunk","encrypted_data":{"ciphertext":"a",}}`, fast: false},
+	{name: "control byte in string", frame: "{\"type\":\"inference_response_chunk\",\"request_id\":\"a\tb\"}", fast: false},
+	{name: "array document", frame: `[{"type":"inference_response_chunk"}]`, fast: false},
+	{name: "bare string", frame: `"inference_response_chunk"`, fast: false},
+	{name: "null document", frame: `null`, fast: false},
+	{name: "empty input", frame: ``, fast: false},
+	{name: "whitespace only", frame: " \n", fast: false},
+	{name: "unterminated object", frame: `{"type":"inference_response_chunk"`, fast: false},
+}
+
+// TestScanChunkFrameGolden checks every corpus frame two ways: the scanner's
+// own result against encoding/json into the concrete struct, and the read
+// loop's DecodeProviderMessage against json.Unmarshal into ProviderMessage.
+func TestScanChunkFrameGolden(t *testing.T) {
+	for _, tc := range chunkFrameCorpus {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(tc.frame)
+			got, ok := scanChunkFrame(data)
+			if ok != tc.fast {
+				t.Fatalf("scanChunkFrame ok = %v, want %v", ok, tc.fast)
+			}
+			var want InferenceResponseChunkMessage
+			wantErr := json.Unmarshal(data, &want)
+			if ok {
+				if wantErr != nil {
+					t.Fatalf("scanner accepted a frame encoding/json rejects: %v", wantErr)
+				}
+				if !reflect.DeepEqual(*got, want) {
+					t.Fatalf("scanner result differs from encoding/json:\n got  %+v\n want %+v", *got, want)
+				}
+			}
+			assertDecodeProviderMessageEquivalent(t, data)
+		})
+	}
+}
+
+// assertDecodeProviderMessageEquivalent holds the read-loop contract:
+// DecodeProviderMessage fails exactly when json.Unmarshal fails and decodes to
+// the same message when both succeed.
+func assertDecodeProviderMessageEquivalent(t testing.TB, data []byte) {
+	t.Helper()
+	var generic, direct ProviderMessage
+	genericErr := json.Unmarshal(data, &generic)
+	directErr := DecodeProviderMessage(data, &direct)
+	if (genericErr == nil) != (directErr == nil) {
+		t.Fatalf("DecodeProviderMessage err = %v, json.Unmarshal err = %v", directErr, genericErr)
+	}
+	if genericErr == nil && !reflect.DeepEqual(generic, direct) {
+		t.Fatalf("DecodeProviderMessage result differs from json.Unmarshal:\n got  %+v\n want %+v", direct, generic)
+	}
+}
+
+// TestScanChunkFrameSwiftShapeTakesFastPath is the wire-shape regression
+// guard: the exact frame the Swift provider emits (sorted keys, empty data
+// omitted, no escapes in base64/UUID) must decode without encoding/json.
+func TestScanChunkFrameSwiftShapeTakesFastPath(t *testing.T) {
+	frame := swiftShapedChunkFrame(
+		"0f3a9c1e-6b7d-4a2e-9c5f-1d2e3f4a5b6c",
+		"fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=",
+		"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0A=",
+	)
+	msg, ok := scanChunkFrame([]byte(frame))
+	if !ok {
+		t.Fatal("Swift-shaped chunk frame did not take the fast path")
+	}
+	if msg.RequestID != "0f3a9c1e-6b7d-4a2e-9c5f-1d2e3f4a5b6c" || msg.Data != "" ||
+		msg.EncryptedData == nil ||
+		msg.EncryptedData.EphemeralPublicKey != "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw=" ||
+		!strings.HasPrefix(msg.EncryptedData.Ciphertext, "AAECAwQF") {
+		t.Fatalf("decoded fields wrong: %+v / %+v", msg, msg.EncryptedData)
+	}
+	// The Go encoder's key order (type first) is the other shape in the wild
+	// (tests, any Go-side tooling); it must be fast too.
+	goFrame, err := json.Marshal(InferenceResponseChunkMessage{
+		Type:          TypeInferenceResponseChunk,
+		RequestID:     "req-1",
+		EncryptedData: &EncryptedPayload{EphemeralPublicKey: "a", Ciphertext: "b"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := scanChunkFrame(goFrame); !ok {
+		t.Fatal("Go-encoded chunk frame did not take the fast path")
+	}
+}
+
+// TestScanChunkFrameStructShapeGuard pins the JSON field sets the scanner
+// knows about. Adding a field to either struct must come with a scanner
+// update — otherwise the new field silently pushes every chunk onto the slow
+// path (the scanner bails on unknown keys by design).
+func TestScanChunkFrameStructShapeGuard(t *testing.T) {
+	assertJSONFields(t, reflect.TypeOf(InferenceResponseChunkMessage{}),
+		[]string{"type", "request_id", "data", "encrypted_data"})
+	assertJSONFields(t, reflect.TypeOf(EncryptedPayload{}),
+		[]string{"ephemeral_public_key", "ciphertext"})
+}
+
+func assertJSONFields(t *testing.T, typ reflect.Type, want []string) {
+	t.Helper()
+	var got []string
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("json")
+		name := strings.Split(tag, ",")[0]
+		if name == "" || name == "-" {
+			t.Fatalf("%s.%s: scanner requires an explicit json name", typ.Name(), typ.Field(i).Name)
+		}
+		got = append(got, name)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s json fields = %v, want %v — update scanChunkFrame for the new field", typ.Name(), got, want)
+	}
+}
+
+// TestDecodeProviderMessageChunkAllocs pins the fast path's allocation
+// budget: one struct (message + payload) and one shared string.
+func TestDecodeProviderMessageChunkAllocs(t *testing.T) {
+	frame := benchSwiftChunkFrame()
+	allocs := testing.AllocsPerRun(200, func() {
+		var pm ProviderMessage
+		if err := DecodeProviderMessage(frame, &pm); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs > 2 {
+		t.Fatalf("chunk fast path allocates %.0f times per frame, want <= 2", allocs)
+	}
+}
+
+// FuzzChunkFrameDecode holds the scanner to encoding/json: it must never
+// panic, whenever it accepts a frame the generic decoder must accept it and
+// produce the same message, and the read loop's DecodeProviderMessage must
+// succeed exactly when json.Unmarshal does with an identical result.
+func FuzzChunkFrameDecode(f *testing.F) {
+	for _, tc := range chunkFrameCorpus {
+		f.Add([]byte(tc.frame))
+	}
+	f.Add(benchSwiftChunkFrame())
+	f.Add([]byte(`{"type":"heartbeat","status":"idle","note":"say \"hi\""}`))
+	f.Add([]byte(`{"type":"inference_complete","request_id":"r","usage":{"prompt_tokens":1,"completion_tokens":2}}`))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 8192 {
+			t.Skip()
+		}
+		got, ok := scanChunkFrame(data)
+		if ok {
+			var want InferenceResponseChunkMessage
+			if err := json.Unmarshal(data, &want); err != nil {
+				t.Fatalf("scanner accepted a frame encoding/json rejects (%v): %q", err, data)
+			}
+			if !reflect.DeepEqual(*got, want) {
+				t.Fatalf("scanner result differs from encoding/json for %q:\n got  %+v\n want %+v", data, *got, want)
+			}
+		}
+		assertDecodeProviderMessageEquivalent(t, data)
+	})
+}

--- a/coordinator/protocol/inference_failure.go
+++ b/coordinator/protocol/inference_failure.go
@@ -12,7 +12,36 @@ type InferenceFailureCode string
 // cannot claim these control-plane-only conditions.
 type CoordinatorInferenceErrorCause string
 
-const CoordinatorCauseProviderDisconnected CoordinatorInferenceErrorCause = "provider_disconnected"
+const (
+	// CoordinatorCauseProviderDisconnected marks the pending-request flush of
+	// an ABRUPT socket loss (read error, OOM-suspected drop, stale eviction,
+	// duplicate-serial kick): the provider vanished with work in flight, so
+	// the flushed 502s strike the provider's stable-identity health trackers
+	// (the reconnecting-zombie discriminator).
+	CoordinatorCauseProviderDisconnected CoordinatorInferenceErrorCause = "provider_disconnected"
+	// CoordinatorCauseProviderRestart marks the same flush when the provider
+	// sent a peer-initiated graceful close (WebSocket 1000 normal / 1001
+	// going-away — a stop, restart, or update). The requests still fail over
+	// exactly like a disconnect, but the terminal is HEALTH-NEUTRAL: it
+	// strikes no breaker, cooldown, or ejection window and clears none.
+	CoordinatorCauseProviderRestart CoordinatorInferenceErrorCause = "provider_restart"
+)
+
+// InferenceErrorReasonProviderRestart is the coordinator-internal error_reason
+// stamped on the flushed terminals of a graceful (peer-close) disconnect. It
+// rides the existing error_reason funnel so every health tracker that already
+// honors the health-neutral reason vocabulary treats the terminal as neutral
+// without new plumbing. It is NEVER accepted from the provider wire: the
+// ingress sanitizer maps every provider-supplied error_reason through a closed
+// per-failure-code allowlist that does not include it.
+const InferenceErrorReasonProviderRestart = "provider_restart"
+
+// IsProviderDisconnect reports whether the cause marks a coordinator-synthetic
+// disconnect flush of either flavor (abrupt or graceful restart) — the
+// classification every "provider disconnected" presentation path keys on.
+func (c CoordinatorInferenceErrorCause) IsProviderDisconnect() bool {
+	return c == CoordinatorCauseProviderDisconnected || c == CoordinatorCauseProviderRestart
+}
 
 const (
 	FailureCodeInvalidRequest    InferenceFailureCode = "invalid_request"

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -87,6 +87,24 @@ const (
 // provider-swift/Sources/ProviderCore/Protocol/Types.swift.
 const ProviderDrainingForUpdate = "provider draining for update"
 
+// HeartbeatStatusDraining is the HeartbeatMessage.Status a provider reports
+// while it refuses new work ahead of a restart/update (the update drain, a
+// shutdown drain). The coordinator skips a draining provider in routing and
+// counts it as transient capacity (429 / queue material, never "no
+// providers"). Additive: older coordinators ignore unknown status strings and
+// older providers never send it. Mirrored in
+// provider-swift/Sources/ProviderCore/Protocol/ (ProviderStatus).
+const HeartbeatStatusDraining = "draining"
+
+// InferenceErrorReasonDraining is the InferenceErrorMessage.ErrorReason a
+// provider attaches (with failure_code "capacity", status 503) to an inference
+// request it refuses BECAUSE it is draining. The coordinator fails the request
+// over without consuming its transient-capacity retry allowance, derates no
+// gray-box capacity state for the pair, and marks the provider draining so
+// the next scan skips it even when the heartbeat status has not caught up.
+// Mirrored in provider-swift/Sources/ProviderCore/Protocol/ (InferenceErrorReason).
+const InferenceErrorReasonDraining = "draining"
+
 // PrefetchModelStatus is the lifecycle state reported by a provider in
 // response to a PrefetchModelMessage. Unlike a load, a prefetch only
 // downloads + verifies the model on disk; it does NOT load weights into
@@ -921,6 +939,18 @@ type ProviderMessage struct {
 	Payload any // one of: *RegisterMessage, *HeartbeatMessage, etc.
 }
 
+// DecodeProviderMessage decodes one provider→coordinator frame into pm. It is
+// the provider read loop's entry point and accepts exactly the inputs
+// json.Unmarshal(data, pm) accepts, producing the same values — minus the
+// whole-document validation pass encoding/json runs before invoking
+// UnmarshalJSON. That pass is redundant here: every branch of UnmarshalJSON
+// either validates the bytes it consumes itself (the chunk fast path) or hands
+// the complete frame to encoding/json, which validates it.
+// FuzzChunkFrameDecode holds the equivalence against json.Unmarshal.
+func DecodeProviderMessage(data []byte, pm *ProviderMessage) error {
+	return pm.UnmarshalJSON(data)
+}
+
 // UnmarshalJSON reads the "type" field first, then unmarshals the full object
 // into the appropriate concrete struct.
 //
@@ -931,6 +961,16 @@ type ProviderMessage struct {
 // non-string value, malformed input, missing key) it falls back to the
 // envelope decode, preserving the original error behavior.
 func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
+	// Fast path for the per-token chunk frame: a hand-written single-pass
+	// decoder (chunk_scan.go) that never calls encoding/json. It bails on any
+	// shape it is not certain about, in which case the frame takes the
+	// generic path below exactly as before.
+	if msg, ok := scanChunkFrame(data); ok {
+		pm.Type = TypeInferenceResponseChunk
+		pm.Payload = msg
+		return nil
+	}
+
 	msgType, ok := scanTopLevelString(data, "type")
 	if !ok {
 		var envelope struct {

--- a/coordinator/registry/alias_test.go
+++ b/coordinator/registry/alias_test.go
@@ -2,9 +2,11 @@ package registry
 
 import (
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
@@ -554,5 +556,79 @@ func TestMergeProviderModelsRejectsNonCatalogBuild(t *testing.T) {
 	makeProviderRoutable(registerProviderWithModel(devReg, "p1", aliasFP8))
 	if m, _ := devReg.MergeProviderModels("p1", []protocol.ModelInfo{{ID: "anything/goes"}}); len(m) != 1 {
 		t.Fatalf("nil catalog should keep permissive merge, got %v", m)
+	}
+}
+
+// The alias resolver decides Desired vs Previous from providerCanRouteBuildLocked,
+// whose dispatch-load cooldown read is the session's cached gate. A session
+// rebinding away from an identity it SHARES with a sibling moves its cooldown
+// to the new gate and resets the shared source, so a read that loaded the
+// source just before the move would say "not cooled" and resolve the alias to
+// a Desired build whose only provider is cooled; dispatch then observes the
+// real cooldown and queues or rejects instead of taking the routable Previous
+// build. The read runs under p.mu and the bind holds p.mu, so the resolver
+// sees one consistent gate: while the Desired-only session flaps between the
+// shared identity and its own serial carrying a cooldown that travels with it,
+// every resolution must pick Previous.
+func TestResolveModelReadsTheSessionsCurrentGateAcrossRebinds(t *testing.T) {
+	reg := New(testLogger())
+	desired := makeSchedulerProvider(t, reg, "alias-desired", aliasQAT, 100)
+	// The sibling keeps the shared gate live (so a rebind resets it instead of
+	// orphaning it) and serves neither build, so its clean gate cannot make
+	// Desired routable.
+	sibling := makeSchedulerProvider(t, reg, "alias-sibling", "other-model", 100)
+	previous := makeSchedulerProvider(t, reg, "alias-previous", aliasFP8, 100)
+	shared := &attestation.VerificationResult{Valid: true, PublicKey: "PK-ALIAS"}
+	enriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-ALIAS", SerialNumber: "SER-ALIAS"}
+	desired.SetAttestationResult(shared)
+	sibling.SetAttestationResult(shared)
+	previous.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-PREVIOUS"})
+	reg.SetModelAliases(map[string]AliasTarget{
+		"gemma-4-26b": {Desired: aliasQAT, Previous: aliasFP8},
+	})
+	if build, _, _ := reg.ResolveModel("gemma-4-26b"); build != aliasQAT {
+		t.Fatalf("precondition: with a clean Desired provider the alias must resolve to it, got %q", build)
+	}
+	// The Desired provider's pair is cooled for longer than the test runs; the
+	// cooldown follows the session through every rebind (mergeLocked keeps the
+	// later expiry both ways).
+	withGateForSession(reg, desired.ID, func(g *gateState) {
+		g.dispatchLoadCooldowns[aliasQAT] = time.Now().Add(time.Hour)
+	})
+	if build, _, _ := reg.ResolveModel("gemma-4-26b"); build != aliasFP8 {
+		t.Fatalf("precondition: with Desired cooled the alias must fall back to Previous, got %q", build)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var wrong []string
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if build, _, ok := reg.ResolveModel("gemma-4-26b"); !ok || build != aliasFP8 {
+				wrong = append(wrong, build)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 3000; i++ {
+			desired.SetAttestationResult(enriched)
+			desired.SetAttestationResult(shared)
+		}
+		close(stop)
+	}()
+	wg.Wait()
+	if len(wrong) > 0 {
+		t.Fatalf("%d resolutions picked %q while its only provider was cooled (first: %q)", len(wrong), aliasQAT, wrong[0])
+	}
+	if !reg.dispatchLoadCooled(desired.ID, aliasQAT, time.Now()) || sibling.gate.Load() != desired.gate.Load() {
+		t.Fatal("postcondition: the cooldown must still follow the Desired session, back on the shared gate")
 	}
 }

--- a/coordinator/registry/budget_clamp.go
+++ b/coordinator/registry/budget_clamp.go
@@ -59,12 +59,12 @@ import (
 // telemetry keep the existing protections (pair cooldown at threshold 5,
 // node-level streaks) and are never clamped, so a single 503 cannot gate them.
 //
-// Keyed by the STABLE fault identity (faultKeyLocked: serial → SE-key →
+// Lives on the STABLE fault identity's gate (gate_state.go: serial → SE-key →
 // account → session fallback) like every sibling breaker, so a reconnect
-// cannot shed the clamp; migrated on identity rebind (migrateFaultStateLocked)
-// and deliberately NOT cleared by Disconnect. Map is bounded by the same
-// opportunistic >1024 sweep as the sibling cooldown maps. All state is guarded
-// by r.mu; the routing-path reads happen under r.mu held in either mode.
+// cannot shed the clamp; migrated on identity rebind (mergeLocked) and
+// deliberately NOT cleared by Disconnect. TTL-expired entries are dropped by
+// the periodic gate sweep. All state is guarded by gate.mu; the routing-path
+// read is one lock-free flag load for the common no-clamp case.
 const (
 	// envBudgetClamp is the kill switch. Default ON; set to false/0 to restore
 	// pre-clamp behavior (stale-heartbeat admission).
@@ -109,9 +109,9 @@ func loadBudgetClampConfig() budgetClampConfig {
 }
 
 // budgetClampEntry is one pair's active (or released/expired-awaiting-sweep)
-// clamp. Written ONLY under the r.mu write lock (armed/re-armed in
-// RecordCapacityReject, accept flag in RecordCapacityAccept); routing paths
-// read it under r.mu in either mode.
+// clamp. Written and read ONLY under the identity's gate.mu (armed/re-armed
+// in RecordCapacityReject, accept flag in RecordCapacityAccept, routing reads
+// in budgetClampActive).
 type budgetClampEntry struct {
 	// clampedAt is when the capacity-503 landed — the freshness reference for
 	// release condition (a) and the TTL anchor.
@@ -137,21 +137,11 @@ type budgetClampEntry struct {
 // currently reports a token budget; it is STICKY across re-arms of a LIVE
 // clamp (a re-reject during a reconnect's budgetless window must not downgrade
 // the identity's demonstrated budget reporting) but is NOT inherited from a
-// TTL-expired entry — see the in-body comment. Caller holds the r.mu write
-// lock (called from RecordCapacityReject).
-func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported bool, now time.Time) {
-	if !r.budgetClampCfg.Enabled {
+// TTL-expired entry — see the in-body comment. Caller holds g.mu (called from
+// recordCapacityReject).
+func (g *gateState) recordBudgetClampLocked(cfg budgetClampConfig, model string, budgetReported bool, now time.Time) {
+	if !cfg.Enabled {
 		return
-	}
-	// Opportunistic sweep (mirrors the sibling cooldown maps): session-keyed
-	// entries for churned identities are never re-keyed, so bound the map by
-	// dropping TTL-expired clamps once it grows.
-	if len(r.budgetClamps) > 1024 {
-		for k, e := range r.budgetClamps {
-			if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
-				delete(r.budgetClamps, k)
-			}
-		}
 	}
 	// Sticky-or the demonstrated budget reporting from the PREVIOUS entry —
 	// but only while that entry is still inside its TTL. The sticky-or exists
@@ -161,21 +151,20 @@ func (r *Registry) recordBudgetClampLocked(key capacityRejectKey, budgetReported
 	// would let a later benign budgetless reject (cold "not loaded" miss,
 	// pre-heartbeat window) re-arm as stale-budget dishonesty and gate the pair
 	// for another TTL — exactly what the budgetless-armed exemption forbids.
-	if prev, ok := r.budgetClamps[key]; ok && now.Before(prev.clampedAt.Add(r.budgetClampCfg.TTL)) {
+	if prev, ok := g.budgetClamps[model]; ok && now.Before(prev.clampedAt.Add(cfg.TTL)) {
 		budgetReported = budgetReported || prev.budgetReported
 	}
-	r.budgetClamps[key] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
+	g.budgetClamps[model] = &budgetClampEntry{clampedAt: now, budgetReported: budgetReported}
 }
 
-// providerReportsTokenBudgetLocked reports whether the provider's CURRENT
-// backend snapshot carries a token budget for the model (the arming-time input
-// to budgetClampEntry.budgetReported). A missing provider (the reject often
-// races the disconnect that caused it) or a missing/budgetless slot reads
-// false — the sticky-or in recordBudgetClampLocked keeps an identity's
-// demonstrated reporting from being downgraded by such a race. Caller holds
-// r.mu (either mode); takes p.mu internally (r.mu → p.mu lock order).
-func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) bool {
-	p := r.providers[providerID]
+// providerReportsTokenBudget reports whether the provider's CURRENT backend
+// snapshot carries a token budget for the model (the arming-time input to
+// budgetClampEntry.budgetReported). A missing provider (the reject often races
+// the disconnect that caused it) or a missing/budgetless slot reads false —
+// the sticky-or in recordBudgetClampLocked keeps an identity's demonstrated
+// reporting from being downgraded by such a race. Takes p.mu; the caller must
+// not hold a gate.mu (lock order p.mu → gate.mu).
+func providerReportsTokenBudget(p *Provider, modelID string) bool {
 	if p == nil {
 		return false
 	}
@@ -192,20 +181,9 @@ func (r *Registry) providerReportsTokenBudgetLocked(providerID, modelID string) 
 	return false
 }
 
-// noteBudgetClampAcceptLocked records release condition (b): the pair accepted
-// work after the clamp. The entry is kept (not deleted) — release also needs a
-// strictly-fresher heartbeat with meaningful headroom, which the routing-path
-// read evaluates against the provider's live budget fields. Caller holds the
-// r.mu write lock (called from RecordCapacityAccept).
-func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
-	if e, ok := r.budgetClamps[key]; ok {
-		e.acceptedSince = true
-	}
-}
-
-// budgetClampActiveLocked reports whether admission must treat the pair's slot
-// as FULL right now. READ-ONLY (no lazy delete) — routing paths call it under
-// r.mu held in either mode, mirroring capacityCooldownActiveLocked.
+// budgetClampActive reports whether admission must treat the pair's slot as
+// FULL right now. READ-ONLY (no lazy delete): lock-free "no clamp on any
+// model" fast path, otherwise one short gate.mu section. nil-safe.
 //
 // heartbeatAt is when the provider's CURRENT BackendCapacity was delivered
 // (p.LastHeartbeat — Heartbeat overwrites BackendCapacity and stamps
@@ -227,15 +205,17 @@ func (r *Registry) noteBudgetClampAcceptLocked(key capacityRejectKey) {
 // not even once a later heartbeat starts reporting a budget, since no dispatch
 // could get through the clamp to produce the accept proof (the reject was
 // never a stale-budget lie to begin with).
-func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
-	if !r.budgetClampCfg.Enabled {
+func (g *gateState) budgetClampActive(cfg budgetClampConfig, model string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	if !cfg.Enabled || !g.hasPairState(gateFlagBudgetClamp) {
 		return false
 	}
-	e, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+	g = g.lockResolved()
+	defer g.mu.Unlock()
+	e, ok := g.budgetClamps[model]
 	if !ok {
 		return false
 	}
-	if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+	if !now.Before(e.clampedAt.Add(cfg.TTL)) {
 		return false // TTL lapsed: fail open (a re-reject re-arms)
 	}
 	if !e.budgetReported {
@@ -266,14 +246,31 @@ func (r *Registry) budgetClampActiveLocked(providerID, modelID string, heartbeat
 	return !released
 }
 
-// providerBudgetSnapshotLocked reads the pair's live budget snapshot — the
-// heartbeat freshness anchor, the raw headroom (max - used - queued,
-// unclamped), and whether the current capacity report carries a budget for the
-// model at all. A missing provider or a missing/budgetless slot reads
-// zero/false. Caller holds r.mu (either mode); takes p.mu internally
-// (r.mu → p.mu lock order).
-func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
-	p := r.providers[providerID]
+// budgetClamped resolves the session's gate; the scan uses the cached p.gate
+// through budgetClampedFor.
+func (r *Registry) budgetClamped(providerID, modelID string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	return r.lookupGateForSession(providerID).budgetClampActive(r.budgetClampCfg, modelID, heartbeatAt, rawBudgetRemaining, budgetReported, now)
+}
+
+// budgetClampedFor is budgetClampActive on the connected provider's cached
+// gate, confirmed against p.gate (gateView) — the routing snapshot's admission
+// input (snapshotProviderIntoPLockedEx and the preflight), read under p.mu.
+func (r *Registry) budgetClampedFor(p *Provider, model string, heartbeatAt time.Time, rawBudgetRemaining int64, budgetReported bool, now time.Time) bool {
+	view := r.gateViewOf(p)
+	for {
+		clamped := view.g.budgetClampActive(r.budgetClampCfg, model, heartbeatAt, rawBudgetRemaining, budgetReported, now)
+		if !view.moved() {
+			return clamped
+		}
+	}
+}
+
+// providerBudgetSnapshot reads the pair's live budget snapshot — the heartbeat
+// freshness anchor, the raw headroom (max - used - queued, unclamped), and
+// whether the current capacity report carries a budget for the model at all.
+// A missing provider or a missing/budgetless slot reads zero/false. Takes
+// p.mu; the caller must not hold a gate.mu (lock order p.mu → gate.mu).
+func providerBudgetSnapshot(p *Provider, modelID string) (heartbeatAt time.Time, rawRemaining int64, budgetReported bool) {
 	if p == nil {
 		return time.Time{}, 0, false
 	}
@@ -295,41 +292,28 @@ func (r *Registry) providerBudgetSnapshotLocked(providerID, modelID string) (hea
 // dropInactiveBudgetClampLocked deletes the pair's clamp entry when it can no
 // longer gate admission, so the entry's lifecycle matches its effect:
 //   - armed budgetless (entry.budgetReported == false: the exemption means it
-//     NEVER gates, so keeping it only costs the accept fast path);
+//     NEVER gates, so keeping it only costs a lock section per scan);
 //   - TTL lapsed (fail-open — a re-reject re-arms fresh anyway);
 //   - fully released (accept proof AND a strictly-fresher heartbeat with
-//     meaningful headroom, evaluated against the provider's live snapshot).
+//     meaningful headroom, evaluated against the supplied live snapshot).
 //
-// Deleting on release matters twice over: a lingering released entry (a) keeps
-// pulling every subsequent RecordCapacityAccept for the pair onto the r.mu
-// write lock (the fast-path gate keys on map presence), and (b) revives as a
-// block on the identity's next reconnect — the budgetless pre-heartbeat hold
-// branch treats an unreleased-looking entry as an active clamp, re-blocking a
-// pair that already proved recovery. A deleted entry re-arms from scratch on
-// the next reject, with budgetReported re-read at arm time. Called from the
-// accept path (RecordCapacityAcceptOutcome); the heartbeat release sweep uses
-// the snapshot variant below. Caller holds the r.mu WRITE lock.
-func (r *Registry) dropInactiveBudgetClampLocked(providerID, modelID string, now time.Time) {
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	r.dropInactiveBudgetClampSnapshotLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, now)
-}
-
-// dropInactiveBudgetClampSnapshotLocked is dropInactiveBudgetClampLocked with
-// the budget snapshot supplied by the caller instead of re-read from
-// r.providers. The heartbeat release sweep passes the just-delivered
-// heartbeat's OWN stamped time and slot values, so the release proof cannot be
-// voided by a disconnect racing in between the heartbeat stamping the provider
-// and the sweep running — a re-read would find no provider, skip the delete,
-// and let the released entry re-block the identity's next reconnect. Caller
-// holds the r.mu WRITE lock.
-func (r *Registry) dropInactiveBudgetClampSnapshotLocked(providerID, modelID string, heartbeatAt time.Time, rawRemaining int64, budgetReported bool, now time.Time) {
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	e, ok := r.budgetClamps[key]
+// Deleting on release matters: a lingering released entry revives as a block
+// on the identity's next reconnect — the budgetless pre-heartbeat hold branch
+// treats an unreleased-looking entry as an active clamp, re-blocking a pair
+// that already proved recovery. A deleted entry re-arms from scratch on the
+// next reject, with budgetReported re-read at arm time. The snapshot is
+// supplied by the caller (read under p.mu before the gate was taken): the
+// heartbeat release sweep passes the just-delivered heartbeat's OWN stamped
+// time and slot values, so the release proof cannot be voided by a disconnect
+// racing in between the heartbeat stamping the provider and the sweep running.
+// Caller holds g.mu.
+func (g *gateState) dropInactiveBudgetClampLocked(cfg budgetClampConfig, model string, heartbeatAt time.Time, rawRemaining int64, budgetReported bool, now time.Time) {
+	e, ok := g.budgetClamps[model]
 	if !ok {
 		return
 	}
-	if !e.budgetReported || !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
-		delete(r.budgetClamps, key)
+	if !e.budgetReported || !now.Before(e.clampedAt.Add(cfg.TTL)) {
+		delete(g.budgetClamps, model)
 		return
 	}
 	if !e.acceptedSince {
@@ -338,58 +322,54 @@ func (r *Registry) dropInactiveBudgetClampSnapshotLocked(providerID, modelID str
 	if budgetReported &&
 		heartbeatAt.After(e.clampedAt) &&
 		rawRemaining >= budgetClampReleaseMinHeadroomTokens {
-		delete(r.budgetClamps, key)
+		delete(g.budgetClamps, model)
 	}
 }
 
 // releaseBudgetClampsOnHeartbeat drops any clamp entries for the provider's
 // heartbeat-reported models that the just-stamped capacity snapshot proves
 // inactive (released / TTL-expired / budgetless-armed). Called from Heartbeat
-// AFTER BackendCapacity and LastHeartbeat are written, so the
-// accept-then-heartbeat release order cleans up even when the pair gets no
-// further traffic — otherwise the released entry would linger and re-block the
-// identity's next reconnect before its first heartbeat.
+// AFTER BackendCapacity and LastHeartbeat are written (and after p.mu is
+// released), so the accept-then-heartbeat release order cleans up even when
+// the pair gets no further traffic — otherwise the released entry would linger
+// and re-block the identity's next reconnect before its first heartbeat.
 //
 // heartbeatAt and capacity are the heartbeat's OWN stamped time and (clamped)
-// report, evaluated directly rather than re-read from r.providers, so a
+// report, evaluated directly rather than re-read from the provider, so a
 // disconnect racing in after the heartbeat cannot void this heartbeat's
-// release proof. The common case (no clamp state for the provider) is a
-// read-locked probe with one map lookup per reported slot; the write lock is
-// taken only when an entry actually exists.
+// release proof. The common case (no clamp state for the identity) is one
+// lock-free flag load; the gate is locked only when an entry exists.
 func (r *Registry) releaseBudgetClampsOnHeartbeat(providerID string, heartbeatAt time.Time, capacity *protocol.BackendCapacity) {
 	if !r.budgetClampCfg.Enabled || capacity == nil || len(capacity.Slots) == 0 {
 		return
 	}
-	r.mu.RLock()
-	faultKey := r.faultKeyLocked(providerID)
-	var found []protocol.BackendSlotCapacity
-	for _, slot := range capacity.Slots {
-		if _, ok := r.budgetClamps[capacityRejectKey{ProviderID: faultKey, ModelID: slot.Model}]; ok {
-			found = append(found, slot)
-		}
-	}
-	r.mu.RUnlock()
-	if len(found) == 0 {
+	ref, has := r.refHasPairState(r.lookupSessionGateRef(providerID), gateFlagBudgetClamp)
+	if !has {
 		return
 	}
-	r.mu.Lock()
-	now := time.Now()
-	for _, slot := range found {
-		rawRemaining := slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
-		r.dropInactiveBudgetClampSnapshotLocked(providerID, slot.Model, heartbeatAt, rawRemaining, slot.ActiveTokenBudgetMax > 0, now)
+	hold := r.lockGate(ref, "clamp_heartbeat")
+	defer hold.unlock()
+	g := hold.g
+	if g == nil {
+		return
 	}
-	r.mu.Unlock()
+
+	now := time.Now()
+	for _, slot := range capacity.Slots {
+		rawRemaining := slot.ActiveTokenBudgetMax - slot.ActiveTokenBudgetUsed - slot.QueuedTokenBudget
+		g.dropInactiveBudgetClampLocked(r.budgetClampCfg, slot.Model, heartbeatAt, rawRemaining, slot.ActiveTokenBudgetMax > 0, now)
+	}
+	g.publishLocked()
 }
 
 // BudgetClampActive reports whether the (provider, model) pair's token budget
 // is currently clamped for admission. Exposed for tests and observability; the
-// routing hot path uses budgetClampActiveLocked under the already-held r.mu.
+// routing hot path reads the cached p.gate directly.
 func (r *Registry) BudgetClampActive(providerID, modelID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.providers[providerID] == nil {
+	p := r.sessionProvider(providerID)
+	if p == nil {
 		return false
 	}
-	heartbeatAt, rawRemaining, budgetReported := r.providerBudgetSnapshotLocked(providerID, modelID)
-	return r.budgetClampActiveLocked(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
+	heartbeatAt, rawRemaining, budgetReported := providerBudgetSnapshot(p, modelID)
+	return r.budgetClamped(providerID, modelID, heartbeatAt, rawRemaining, budgetReported, time.Now())
 }

--- a/coordinator/registry/budget_clamp_test.go
+++ b/coordinator/registry/budget_clamp_test.go
@@ -71,12 +71,23 @@ func reserveOnce(r *Registry, model, requestID string) (*Provider, RoutingDecisi
 // ageBudgetClamp rewinds the pair's clamp time by d (simulating TTL passage
 // without sleeping), keyed by the pair's CURRENT fault key.
 func ageBudgetClamp(r *Registry, providerID, model string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
-	if e, ok := r.budgetClamps[key]; ok {
-		e.clampedAt = e.clampedAt.Add(-d)
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.budgetClamps[model]; ok {
+			e.clampedAt = e.clampedAt.Add(-d)
+		}
+	})
+}
+
+// clampEntryUnderKey reports whether the identity filed under key holds a
+// clamp entry for model (the old budgetClamps[key] presence check).
+func clampEntryUnderKey(r *Registry, key, model string) bool {
+	found := false
+	readGateForKey(r, key, func(g *gateState) {
+		if g != nil {
+			_, found = g.budgetClamps[model]
+		}
+	})
+	return found
 }
 
 // One capacity-503 must IMMEDIATELY stop admission for a request that fit
@@ -337,15 +348,26 @@ func TestBudgetClampAndRateStateMigrateOnFirstBind(t *testing.T) {
 	// Attestation binds session → serial; state must migrate.
 	setAttestationAndBind(t, r, p, "SER-MIG-CLAMP")
 
-	r.mu.RLock()
-	sessKey := capacityRejectKey{ProviderID: "migrate-sess", ModelID: model}
-	serialKey := capacityRejectKey{ProviderID: "serial:SER-MIG-CLAMP", ModelID: model}
-	_, sessClamp := r.budgetClamps[sessKey]
-	_, serialClamp := r.budgetClamps[serialKey]
-	sessRejects := len(r.capacityRateRejects[sessKey])
-	serialRejects := len(r.capacityRateRejects[serialKey])
-	serialAccepts := len(r.capacityRateAccepts[serialKey])
-	r.mu.RUnlock()
+	// The session-keyed gate is gone after the bind (its state moved); read
+	// the raw index so a forwarded pointer cannot mask leftover residue.
+	var sessClamp bool
+	var sessRejects int
+	if g := rawGateForKey(r, "migrate-sess"); g != nil {
+		g.mu.Lock()
+		_, sessClamp = g.budgetClamps[model]
+		sessRejects = len(g.capacityRateRejects[model])
+		g.mu.Unlock()
+	}
+	var serialClamp bool
+	var serialRejects, serialAccepts int
+	readGateForKey(r, "serial:SER-MIG-CLAMP", func(g *gateState) {
+		if g == nil {
+			return
+		}
+		_, serialClamp = g.budgetClamps[model]
+		serialRejects = len(g.capacityRateRejects[model])
+		serialAccepts = len(g.capacityRateAccepts[model])
+	})
 
 	if sessClamp || sessRejects > 0 {
 		t.Fatal("session-keyed gray-box state orphaned after the identity bind")
@@ -437,10 +459,7 @@ func TestBudgetClampReleasedEntryDoesNotReviveOnReconnect(t *testing.T) {
 		if r.BudgetClampActive(p1.ID, model) {
 			t.Fatal("setup: clamp must have released")
 		}
-		r.mu.RLock()
-		_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
-		r.mu.RUnlock()
-		if lingering {
+		if clampEntryUnderKey(r, "serial:"+serial, model) {
 			t.Fatal("released clamp entry must be deleted, not linger in budgetClamps")
 		}
 
@@ -513,10 +532,7 @@ func TestBudgetClampHeartbeatReleaseSurvivesDisconnectRace(t *testing.T) {
 	r.Disconnect("rel-race-1")
 	r.releaseBudgetClampsOnHeartbeat("rel-race-1", heartbeatAt, capacity)
 
-	r.mu.RLock()
-	_, lingering := r.budgetClamps[capacityRejectKey{ProviderID: "serial:" + serial, ModelID: model}]
-	r.mu.RUnlock()
-	if lingering {
+	if clampEntryUnderKey(r, "serial:"+serial, model) {
 		t.Fatal("release proof voided by the disconnect race — the sweep must evaluate the heartbeat's own snapshot")
 	}
 
@@ -540,10 +556,7 @@ func TestBudgetClampInactiveEntriesAreDeleted(t *testing.T) {
 	const model = "gemma-4-26b-qat-4bit"
 
 	clampEntryExists := func(r *Registry, providerID string) bool {
-		r.mu.RLock()
-		defer r.mu.RUnlock()
-		_, ok := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}]
-		return ok
+		return clampEntryUnderKey(r, r.faultKeyForSession(providerID), model)
 	}
 
 	t.Run("TTL-expired entry dropped on the next accept", func(t *testing.T) {
@@ -648,10 +661,7 @@ func TestBudgetClampLifecycleMissWithStaleBudgetSnapshotDoesNotClamp(t *testing.
 	if r.BudgetClampActive(p.ID, model) {
 		t.Fatal("a lifecycle cold-404 must not arm a gating clamp from the stale budget snapshot")
 	}
-	r.mu.RLock()
-	_, armed := r.budgetClamps[capacityRejectKey{ProviderID: r.faultKeyLocked(p.ID), ModelID: model}]
-	r.mu.RUnlock()
-	if armed {
+	if clampEntryUnderKey(r, r.faultKeyForSession(p.ID), model) {
 		t.Fatal("a lifecycle cold-404 must not touch the clamp map at all")
 	}
 	if sel, _ := reserveOnce(r, model, "rewarm"); sel == nil {

--- a/coordinator/registry/cache_routing_hints.go
+++ b/coordinator/registry/cache_routing_hints.go
@@ -100,6 +100,16 @@ func (hint cacheRoutingHint) currentForProvider(provider *Provider, model string
 	}
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
+	return hint.currentForProviderLocked(provider, model)
+}
+
+// currentForProviderLocked is currentForProvider for a caller that already
+// holds provider.mu (the reservation commit evaluates the discount inside its
+// p.mu section).
+func (hint cacheRoutingHint) currentForProviderLocked(provider *Provider, model string) bool {
+	if provider == nil || hint.Provider != provider {
+		return false
+	}
 	capability, ok := provider.PrefixCacheV2Models[model]
 	return ok &&
 		provider.PrefixCacheProtocol >= 2 &&

--- a/coordinator/registry/capacity_accept_ordering_test.go
+++ b/coordinator/registry/capacity_accept_ordering_test.go
@@ -7,28 +7,29 @@ import (
 )
 
 // capacityStrikesOf returns the pair's recorded reject strikes (chronological).
-func capacityStrikesOf(r *Registry, providerID, modelID string) []time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	strikes := r.capacityRejectStrikes[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	return append([]time.Time(nil), strikes...)
+func capacityStrikesOf(r *Registry, providerID, modelID string) (out []time.Time) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			out = append([]time.Time(nil), g.capacityRejectStrikes[modelID]...)
+		}
+	})
+	return
 }
 
 // TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation: the
 // commit-time accept is observed at the first content chunk but applied when
-// its goroutine finally holds the registry write lock (~190 ms behind queued
-// writers in production). A capacity reject for the same pair recorded in that
+// its goroutine finally holds the identity gate lock. A capacity reject for the same pair recorded in that
 // gap happened AFTER the accept and must survive it; a strike recorded before
-// the observation is still cleared. The test holds the write lock, starts the
+// the observation is still cleared. The test holds the gate lock, starts the
 // accept, records one older and one newer strike while the accept is blocked,
 // then releases the lock.
 func TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation(t *testing.T) {
 	r := New(nil)
 	const provider, model = "prov-late-accept", "gemma-4-26b-8bit"
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
+	g := r.gateForSession(provider).g
 
 	observedAt := time.Now()
-	r.mu.Lock()
+	g.mu.Lock()
 	applied := make(chan struct{})
 	go func() {
 		defer close(applied)
@@ -39,8 +40,9 @@ func TestCapacityAcceptAppliedLateKeepsStrikeRecordedAfterObservation(t *testing
 	older := observedAt.Add(-time.Second)
 	time.Sleep(2 * time.Millisecond)
 	newer := time.Now()
-	r.capacityRejectStrikes[key] = []time.Time{older, newer}
-	r.mu.Unlock()
+	g.capacityRejectStrikes[model] = []time.Time{older, newer}
+	g.publishLocked()
+	g.mu.Unlock()
 	<-applied
 
 	got := capacityStrikesOf(r, provider, model)
@@ -113,10 +115,13 @@ func TestCapacityAcceptObservedBeforeClampDoesNotProveRelease(t *testing.T) {
 
 // capacityTripsOf returns the pair's cooldown trip count (0 = never tripped or
 // accept-cleared).
-func capacityTripsOf(r *Registry, providerID, modelID string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+func capacityTripsOf(r *Registry, providerID, modelID string) (out int) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			out = g.capacityCooldownTrips[modelID]
+		}
+	})
+	return
 }
 
 // TestCapacityAcceptAppliedLateKeepsCooldownArmedByNewerStrikes: while the
@@ -234,25 +239,26 @@ func TestCapacityAcceptRebuildsNewCooldownWithFreshBackoff(t *testing.T) {
 		t.Run(fmt.Sprintf("old_active_%v", active), func(t *testing.T) {
 			r := New(nil)
 			const provider, model = "old-backoff", "model"
-			key := capacityRejectKey{ProviderID: provider, ModelID: model}
+			g := r.gateForSession(provider).g
 			observed := time.Now().Add(-time.Second)
 			oldExpiry := time.Now().Add(-time.Second)
 			if active {
 				oldExpiry = time.Now().Add(5 * time.Minute)
 			}
-			r.mu.Lock()
-			r.capacityCooldownTrips[key] = 4
-			r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: oldExpiry}
-			r.mu.Unlock()
+			g.mu.Lock()
+			g.capacityCooldownTrips[model] = 4
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: oldExpiry}
+			g.publishLocked()
+			g.mu.Unlock()
 			for range r.capacityCooldownCfg.Threshold {
 				r.RecordCapacityReject(provider, model)
 			}
 			strikes := capacityStrikesOf(r, provider, model)
 			wantExpiry := strikes[r.capacityCooldownCfg.Threshold-1].Add(r.capacityCooldownCfg.BaseTTL)
 			r.RecordCapacityAcceptObserved(provider, model, observed, true)
-			r.mu.RLock()
-			got, trips := *r.capacityCooldowns[key], r.capacityCooldownTrips[key]
-			r.mu.RUnlock()
+			g.mu.Lock()
+			got, trips := *g.capacityCooldowns[model], g.capacityCooldownTrips[model]
+			g.mu.Unlock()
 			if trips != 1 || !got.expiry.Equal(wantExpiry) {
 				t.Fatalf("rebuilt cooldown: trips=%d expiry=%v, want 1/%v", trips, got.expiry, wantExpiry)
 			}
@@ -262,18 +268,19 @@ func TestCapacityAcceptRebuildsNewCooldownWithFreshBackoff(t *testing.T) {
 
 func TestCapacityAcceptRebuildPreservesNewProbe(t *testing.T) {
 	r := New(nil)
-	key := capacityRejectKey{ProviderID: "probe", ModelID: "model"}
+	const provider, model = "probe", "model"
+	g := r.gateForSession(provider).g
 	now := time.Now()
 	r.capacityCooldownCfg = capacityCooldownConfig{Threshold: 2, Window: time.Minute, BaseTTL: time.Second, MaxTTL: time.Minute}
-	r.capacityRejectStrikes[key] = []time.Time{now.Add(-4 * time.Second), now.Add(-3 * time.Second)}
+	g.capacityRejectStrikes[model] = []time.Time{now.Add(-4 * time.Second), now.Add(-3 * time.Second)}
 	probeAt := now.Add(-time.Second)
-	r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: now.Add(-2 * time.Second), probeAt: probeAt}
-	r.capacityCooldownTrips[key] = 4
-	r.RecordCapacityAcceptObserved(key.ProviderID, key.ModelID, now.Add(-5*time.Second), false)
-	if entry := r.capacityCooldowns[key]; entry == nil || !entry.probeAt.Equal(probeAt) {
+	g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: now.Add(-2 * time.Second), probeAt: probeAt}
+	g.capacityCooldownTrips[model] = 4
+	r.RecordCapacityAcceptObserved(provider, model, now.Add(-5*time.Second), false)
+	if entry := g.capacityCooldowns[model]; entry == nil || !entry.probeAt.Equal(probeAt) {
 		t.Fatalf("lost current probe: %+v", entry)
 	}
-	if !r.CapacityCooldownActive(key.ProviderID, key.ModelID) {
+	if !r.CapacityCooldownActive(provider, model) {
 		t.Fatal("rebuild allowed a second probe while the first is pending")
 	}
 }

--- a/coordinator/registry/capacity_cooldown.go
+++ b/coordinator/registry/capacity_cooldown.go
@@ -35,10 +35,10 @@ import (
 //
 // RE-PROBE + BACKOFF — TRUE HALF-OPEN. A trip quarantines the pair for
 // BaseTTL (default 120s). After expiry EXACTLY ONE request passes as the
-// probe: the routing gate opens only while no probe claim is fresh, and
-// ReserveProviderEx claims the probe (claimCapacityProbeLocked, under the
-// r.mu write lock held for the whole reservation, so concurrent reservations
-// serialize) the moment it reserves the pair — every other request keeps
+// probe: the routing gate opens only while no probe claim is fresh, and the
+// reservation commit claims the probe (tryClaimCapacityProbe — check and claim
+// in one gate.mu section, so concurrent reservations for the identity
+// serialize there) the moment it reserves the pair — every other request keeps
 // seeing the cooldown until the probe's outcome lands. Accept → all state
 // cleared, the pair is fully re-admitted (a genuinely-full box that recovered
 // gets traffic back). Reject → immediate re-arm with an exponentially doubled
@@ -54,12 +54,11 @@ import (
 // truthful outcome is the queue/429 path, not a guaranteed-reject dispatch.
 // TTLs stagger, so re-probes trickle back on their own.
 //
-// State is keyed by the provider's STABLE fault identity (faultKeyLocked:
+// State lives on the provider's STABLE fault identity gate (gate_state.go:
 // serial → SE-key → account → session fallback), so a reconnect cannot reset
 // a black hole's streak, cooldown, or backoff trip count — the same
-// reconnect-proofing as error_cooldown.go and provider_breaker.go. Maps are
-// bounded by the same opportunistic >1024 sweep. r.mu discipline and the
-// transition-bool return also mirror error_cooldown.go.
+// reconnect-proofing as error_cooldown.go and provider_breaker.go. Guarded by
+// gate.mu; the transition-bool return mirrors error_cooldown.go.
 
 // Env tunables — read ONCE at Registry construction (coordinator restart
 // applies changes). All values have safe defaults; setting the threshold to 0
@@ -91,9 +90,8 @@ const (
 const capacityProbeOutcomeWindow = 30 * time.Second
 
 // capacityCooldownEntry is one pair's active (or expired-awaiting-probe)
-// cooldown. Fields are written ONLY under the r.mu write lock (arm/re-arm in
-// RecordCapacityReject, probe claim in claimCapacityProbeLocked); the routing
-// gate reads them under either lock mode.
+// cooldown. Fields are written and read ONLY under the identity's gate.mu
+// (arm/re-arm in RecordCapacityReject, probe claim in tryClaimCapacityProbe).
 type capacityCooldownEntry struct {
 	// expiry is when the quarantine TTL lapses and the pair becomes eligible
 	// for a single half-open probe.
@@ -138,13 +136,6 @@ func loadCapacityCooldownConfig() capacityCooldownConfig {
 		cfg.MaxTTL = cfg.BaseTTL
 	}
 	return cfg
-}
-
-// capacityRejectKey identifies a capacity-cooldown bucket. A struct key (vs a
-// delimiter-joined string) cannot alias across ids containing the delimiter.
-type capacityRejectKey struct {
-	ProviderID string
-	ModelID    string
 }
 
 // RecordCapacityReject records one capacity-class rejection (token budget /
@@ -241,13 +232,24 @@ func (r *Registry) RecordCapacityRejectBusy(providerID, modelID string) (tripped
 // armClamp gates the budget clamp (false only for request-deterministic
 // rejects, which indict the request rather than the provider). The cooldown
 // strike is fed on all paths.
+//
+// The pair's budget snapshot (does the provider currently report a token
+// budget for the model?) is read under p.mu BEFORE the gate is taken — the
+// lock order is p.mu → gate.mu, never the reverse. Only gate.mu is then held;
+// never r.mu.
 func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, armClamp bool) (tripped bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
-	hold := r.lockWrite("capacity_reject")
+	budgetReported := false
+	if armClamp {
+		budgetReported = providerReportsTokenBudget(r.sessionProvider(providerID), modelID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "capacity_reject")
 	defer hold.unlock()
+	g := hold.g
 	now := time.Now()
+	defer g.updatedLocked(now)
 
 	// Gray-box trackers ride the SAME classified entry point but have their own
 	// kill switches, independent of the cooldown threshold: the budget clamp
@@ -260,12 +262,11 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 	// never reset off. The clamp is armed only when the reject indicts the
 	// PROVIDER (armClamp=false for request-deterministic rejects — an oversized
 	// prompt says nothing about the pair's budget honesty).
-	clampKey := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
 	if armClamp {
-		r.recordBudgetClampLocked(clampKey, r.providerReportsTokenBudgetLocked(providerID, modelID), now)
+		g.recordBudgetClampLocked(r.budgetClampCfg, modelID, budgetReported, now)
 	}
 	if deratePair {
-		r.recordCapacityRateRejectLocked(clampKey, now)
+		g.recordCapacityRateRejectLocked(r.capacityRateCfg, modelID, now)
 	}
 
 	cfg := r.capacityCooldownCfg
@@ -273,36 +274,8 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 		return false // disabled via EIGENINFERENCE_CAPACITY_COOLDOWN_THRESHOLD=0
 	}
 
-	// Opportunistic sweep (mirrors error_cooldown.go): session provider ids are
-	// per-connection UUIDs that never get re-keyed — bound the maps by dropping
-	// expired/idle entries once they grow.
-	if len(r.capacityCooldowns) > 1024 {
-		for key, e := range r.capacityCooldowns {
-			// Half-open entries live PAST their expiry by design: the fresh
-			// probe claim (probeAt) is the only thing keeping the gate closed
-			// while the single probe's outcome is pending. Sweeping such an
-			// entry would reopen the gate mid-probe and leak a thundering herd
-			// through the post-expiry window — keep entries whose claim is
-			// still fresh; they self-resolve within capacityProbeOutcomeWindow.
-			if !now.Before(e.expiry) &&
-				(e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))) {
-				delete(r.capacityCooldowns, key)
-				delete(r.capacityCooldownTrips, key)
-			}
-		}
-	}
-	if len(r.capacityRejectStrikes) > 1024 {
-		for key, strikes := range r.capacityRejectStrikes {
-			if len(strikes) == 0 || !strikes[len(strikes)-1].Add(cfg.Window).After(now) {
-				delete(r.capacityRejectStrikes, key)
-			}
-		}
-	}
-
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-
 	// Slide the window: keep only strikes still inside it, then add this one.
-	strikes := r.capacityRejectStrikes[key]
+	strikes := g.capacityRejectStrikes[modelID]
 	kept := strikes[:0]
 	for _, ts := range strikes {
 		if now.Sub(ts) < cfg.Window {
@@ -310,14 +283,14 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 		}
 	}
 	kept = append(kept, now)
-	r.capacityRejectStrikes[key] = kept
+	g.capacityRejectStrikes[modelID] = kept
 
 	// Active cooldown: record only — never extend or re-arm (see doc above).
-	if e, ok := r.capacityCooldowns[key]; ok && now.Before(e.expiry) {
+	if e, ok := g.capacityCooldowns[modelID]; ok && now.Before(e.expiry) {
 		return false
 	}
 
-	trips := r.capacityCooldownTrips[key]
+	trips := g.capacityCooldownTrips[modelID]
 	// A fresh pair (trips == 0) needs the full threshold inside the window. A
 	// half-open pair (trips > 0: tripped before, no accept since, cooldown
 	// expired → this reject IS the failed re-probe) re-arms immediately.
@@ -326,28 +299,85 @@ func (r *Registry) recordCapacityReject(providerID, modelID string, deratePair, 
 	}
 
 	// Arm/re-arm: fresh entry with an unclaimed probe slot for the NEXT expiry.
-	r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: now.Add(capacityCooldownBackoff(cfg, trips))}
-	r.capacityCooldownTrips[key] = trips + 1
+	g.capacityCooldowns[modelID] = &capacityCooldownEntry{expiry: now.Add(capacityCooldownBackoff(cfg, trips))}
+	g.capacityCooldownTrips[modelID] = trips + 1
 	return true
 }
 
-// claimCapacityProbeLocked claims the single half-open probe for an EXPIRED
-// cooldown entry, called by ReserveProviderEx at reservation commit — the
-// moment a request is actually bound to the pair. Caller MUST hold the r.mu
-// WRITE lock (ReserveProviderEx does, for the whole selection+reservation), so
-// concurrent reservations serialize: the first to reserve the pair claims the
-// probe, and the gate (capacityCooldownActiveLocked) closes for everyone else
-// until the probe's outcome lands or the claim goes stale. A no-op for pairs
-// with no cooldown entry (the overwhelmingly common case — one map lookup) or
-// one still inside its TTL (unreachable via routing, but harmless).
-func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time.Time) {
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
-	if !ok || now.Before(e.expiry) {
-		return
+// tryClaimCapacityProbe claims the single half-open probe for an EXPIRED
+// cooldown entry, called by the reservation commit (under p.mu, in both
+// commit modes) at the moment a request is actually bound to the pair. The
+// check and the claim are ONE gate.mu section, so concurrent commits for the
+// same identity serialize here even though the commit itself no longer holds
+// the registry write lock: the first to reserve the pair claims the probe and
+// every later one sees the fresh claim.
+//
+// Returns false when the pair's gate is CLOSED right now — inside its TTL, or
+// expired with another request's probe claim still fresh — so the caller
+// rejects the reservation instead of leaking a second probe through the
+// post-expiry window. Returns true (a no-op) for a pair with no cooldown entry
+// — the overwhelmingly common case, one lock-free flag load — and true after
+// claiming an unclaimed or stale slot. nil-safe (a bare Provider has no gate).
+//
+// The claim is a mutation, so it goes through lockGate like the recorders: a
+// rebind that lands between loading p.gate and taking the lock moves the
+// cooldown entry to the session's new gate, and a claim made on the old
+// (emptied) gate would find no entry and admit — a leaked probe through a
+// cooled pair. lockGate sees p.gate moved and re-resolves. Lock order: the
+// caller holds p.mu; gatesMu (on a re-resolve) and gate.mu nest under it.
+func (r *Registry) tryClaimCapacityProbe(p *Provider, model string, now time.Time) bool {
+	return r.claimCapacityProbeRef(r.probeGateRef(p), model, now)
+}
+
+// probeGateRef resolves the gate the commit's probe claim targets: the
+// connected Provider's cached p.gate (no lock), remembering p so lockGate can
+// tell when the session rebound between this load and the lock. A Provider
+// that was never registered (bare test objects) falls back to the session
+// lookup; nil resolves to no gate.
+func (r *Registry) probeGateRef(p *Provider) gateRef {
+	if p == nil {
+		return gateRef{}
+	}
+	if g := p.gate.Load(); g != nil {
+		return gateRef{g: g.resolve(), p: p, session: p.ID}
+	}
+	return r.lookupSessionGateRef(p.ID)
+}
+
+// claimCapacityProbeRef is tryClaimCapacityProbe on an already-resolved ref
+// (split out so a test can interpose a rebind between resolution and claim).
+func (r *Registry) claimCapacityProbeRef(ref gateRef, model string, now time.Time) bool {
+	ref, has := r.refHasPairState(ref, gateFlagCapacityCooldown)
+	if !has {
+		return true
+	}
+	hold := r.lockGate(ref, "capacity_probe")
+	if hold.g == nil {
+		return true
+	}
+	// Release directly, not via hold.unlock(): the caller holds p.mu (and
+	// r.mu in global commit mode), and the observer's DogStatsD emit must
+	// never run inside those sections. The probe's gate wait is therefore not
+	// reported; the recorders' waits on the same gates are.
+	defer hold.g.mu.Unlock()
+	return hold.g.tryClaimCapacityProbeLocked(model, now)
+}
+
+// tryClaimCapacityProbeLocked is the check-and-claim itself. Caller holds
+// g.mu (lockGate has validated the gate is the session's current one).
+func (g *gateState) tryClaimCapacityProbeLocked(model string, now time.Time) bool {
+	e, ok := g.capacityCooldowns[model]
+	if !ok {
+		return true
+	}
+	if now.Before(e.expiry) {
+		return false
 	}
 	if e.probeAt.IsZero() || !now.Before(e.probeAt.Add(capacityProbeOutcomeWindow)) {
 		e.probeAt = now
+		return true
 	}
+	return false
 }
 
 // RecordCapacityAccept records that the (provider, model) pair ACCEPTED work —
@@ -372,9 +402,9 @@ func (r *Registry) claimCapacityProbeLocked(providerID, modelID string, now time
 // first content says nothing about fault behavior, and wiping the exponential
 // backoff on any served chunk would let a flapping node reset it forever;
 // RecordProviderServeOutcome(ok=true) at clean completion is the fault-recovery
-// signal. An ACTIVE ejection window (healthEjectionUntil still in the future)
-// is also left untouched: ejection doesn't cancel in-flight work, so content
-// can flow from an ejected node, and lifting the quarantine early on it would
+// signal. An ACTIVE ejection window (ejectionUntil still in the future) is
+// also left untouched: ejection doesn't cancel in-flight work, so content can
+// flow from an ejected node, and lifting the quarantine early on it would
 // defeat the cooldown — recovery goes through the half-open success probe.
 // It returns whether a capacity-503 RATE outcome was recorded for this accept
 // (see RecordCapacityAcceptOutcome) so commit-time callers can stamp the request
@@ -396,134 +426,128 @@ func (r *Registry) RecordCapacityAccept(providerID, modelID string) (rateOutcome
 // that never commit content without double-counting streamed requests. The
 // cooldown/streak/clamp accept semantics below are identical for both values
 // (belt-and-braces accepts stay harmless there).
+//
+// This takes ONLY the identity's gate.mu
+// — never r.mu. The one provider read it may need (the live budget snapshot
+// that decides whether an accept RELEASES a clamp) happens under p.mu before
+// the gate is taken, and only when the gate's flag word says a clamp exists.
 func (r *Registry) RecordCapacityAcceptOutcome(providerID, modelID string, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	return r.RecordCapacityAcceptObserved(providerID, modelID, time.Now(), countRateOutcome)
 }
 
-// RecordCapacityAcceptObserved is RecordCapacityAcceptOutcome for an accept
-// that was OBSERVED at observedAt but is being applied now — the commit-time
-// accept runs off the dispatch goroutine so the first client byte never waits
-// for the registry write lock, and even a synchronous caller waits behind
-// every queued writer (~190 ms at the production median) before its accept
-// lands. In that gap a capacity reject for the SAME pair can be recorded. It
-// happened AFTER the accept, so it is not "a reject with no accept after it"
-// erased by the accept; it is the first strike of a possible new streak and
-// must survive. Concretely:
-//
-//   - reject STRIKES stamped after observedAt are kept (their timestamps are
-//     the existing per-strike window stamps); older ones are cleared;
-//   - the budget clamp's accept proof (release condition b) is granted only
-//     when the clamp was armed at or before observedAt — a clamp re-armed by
-//     a later reject keeps waiting for an accept that follows it;
-//   - cooldown history is rebuilt from the surviving strikes with fresh
-//     backoff: an observed accept resets every earlier trip. Retaining the
-//     previous trip count would incorrectly lengthen a newly justified trip;
-//   - the node-level capacity streak is always cleared: it is a bare count
-//     that cannot be split by time; keeping it would over-count toward
-//     ejection of a node that has just served content, and completion
-//     (RecordProviderServeOutcome ok=true) clears it anyway;
-//   - the capacity-503 RATE outcome is stamped with the apply time: the rate
-//     window is order-independent by design and its histories must stay
-//     chronological.
-//
-// A zero or future observedAt means "observed now".
+// RecordCapacityAcceptObserved applies a first-content accept at its original
+// observation time. A delayed recorder retains newer strikes, rebuilds their
+// cooldown with fresh backoff, and proves clamp release only if observed after
+// the clamp was armed. The rate window records apply time to stay ordered.
+// All fault-state mutations remain under gate.mu, never the global registry
+// lock. A zero or future observation is treated as now.
 func (r *Registry) RecordCapacityAcceptObserved(providerID, modelID string, observedAt time.Time, countRateOutcome bool) (rateOutcomeRecorded bool) {
 	if providerID == "" || modelID == "" {
 		return false
 	}
-	// The rate config is immutable after Registry construction. An enabled
-	// offered outcome is the common path and already requires the write lock, so
-	// skip a redundant read-lock probe. Completion calls that already counted
-	// their rate outcome retain the old healthy fast path: use the read lock to
-	// avoid write acquisition when there is no cooldown/clamp state to clear.
-	shouldRecordRate := countRateOutcome && r.capacityRateCfg.PenaltyMs > 0
-	if !shouldRecordRate {
-		r.mu.RLock()
-		key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-		_, hasStrikes := r.capacityRejectStrikes[key]
-		_, hasCooldown := r.capacityCooldowns[key]
-		_, hasTrips := r.capacityCooldownTrips[key]
-		_, hasClamp := r.budgetClamps[key]
-		_, hasNodeStreak := r.healthEjectionCapacityStreaks[key.ProviderID]
-		capacityTripped := r.healthEjectionLastTripCapacity[key.ProviderID]
-		r.mu.RUnlock()
-		if !hasStrikes && !hasCooldown && !hasTrips && !hasClamp && !hasNodeStreak && !capacityTripped {
+	// An identity with no gate has nothing to clear; create one only when
+	// there is a rate outcome to record, so a straggling accept for a dead
+	// session does not file a gate under its id.
+	ref := r.lookupSessionGateRef(providerID)
+	if ref.g == nil {
+		if !countRateOutcome || r.capacityRateCfg.PenaltyMs <= 0 {
 			return false
 		}
+		ref = r.gateForSession(providerID)
 	}
-	hold := r.lockWrite("capacity_accept")
+	var heartbeatAt time.Time
+	var rawRemaining int64
+	var budgetReported bool
+	ref, hasClamp := r.refHasPairState(ref, gateFlagBudgetClamp)
+	if hasClamp {
+		heartbeatAt, rawRemaining, budgetReported = providerBudgetSnapshot(r.sessionProvider(providerID), modelID)
+	}
+	hold := r.lockGate(ref, "capacity_accept")
+	defer hold.unlock()
+	g := hold.g
+	if g == nil {
+		return false
+	}
+
 	now := time.Now()
 	if observedAt.IsZero() || observedAt.After(now) {
 		observedAt = now
 	}
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	// Clear the strikes this accept answers — those recorded up to the instant
-	// it was observed. Strikes are chronological, so the survivors are a suffix.
-	if strikes := r.capacityRejectStrikes[key]; len(strikes) > 0 {
+	if strikes := g.capacityRejectStrikes[modelID]; len(strikes) > 0 {
 		kept := strikes[:0]
-		for _, ts := range strikes {
-			if ts.After(observedAt) {
-				kept = append(kept, ts)
+		for _, stamp := range strikes {
+			if stamp.After(observedAt) {
+				kept = append(kept, stamp)
 			}
 		}
 		if len(kept) == 0 {
-			delete(r.capacityRejectStrikes, key)
+			delete(g.capacityRejectStrikes, modelID)
 		} else {
-			r.capacityRejectStrikes[key] = kept
+			g.capacityRejectStrikes[modelID] = kept
 		}
 	}
-	r.rebuildCapacityCooldownLocked(key)
+	g.rebuildCapacityCooldownLocked(r.capacityCooldownCfg, modelID)
 	// Gray-box trackers: the accept is PROOF for the clamp's release condition
 	// (b) — never an instant release, which still needs a strictly-fresher
 	// heartbeat with meaningful headroom — and ONE served outcome for the rate
 	// window (which deliberately has NO reset semantics: the accept/reject mix
 	// IS the signal). Then drop the entry if it is now inactive (this accept
 	// completed the release proof, the TTL lapsed, or it was armed budgetless):
-	// a lingering inactive entry would keep every later accept for the pair off
-	// the read-lock fast path above and would re-block the identity's next
-	// budgetless reconnect window.
-	if e, hasClamp := r.budgetClamps[key]; hasClamp {
-		// An accept observed BEFORE the clamp armed is not proof the clamp
-		// has released; only a clamp armed at or before the observation is.
+	// a lingering inactive entry would keep re-blocking the identity's next
+	// budgetless reconnect window. The snapshot was read before the gate was
+	// taken (lock order p.mu → gate.mu), so two benign races exist: a clamp
+	// armed in between sees a zero snapshot and keeps holding, and a heartbeat
+	// delivered in between already ran its own release pass before
+	// acceptedSince was set, so the release lands on the NEXT heartbeat or
+	// accept. Neither can release early.
+	if e, hasClamp := g.budgetClamps[modelID]; hasClamp {
 		if !e.clampedAt.After(observedAt) {
-			r.noteBudgetClampAcceptLocked(key)
+			e.acceptedSince = true
 		}
-		r.dropInactiveBudgetClampLocked(providerID, modelID, now)
+		g.dropInactiveBudgetClampLocked(r.budgetClampCfg, modelID, heartbeatAt, rawRemaining, budgetReported, now)
 	}
 	if countRateOutcome {
-		rateOutcomeRecorded = r.recordCapacityRateAcceptLocked(key, now)
+		rateOutcomeRecorded = g.recordCapacityRateAcceptLocked(r.capacityRateCfg, modelID, now)
 	}
-	delete(r.healthEjectionCapacityStreaks, key.ProviderID)
-	if r.healthEjectionLastTripCapacity[key.ProviderID] {
-		delete(r.healthEjectionTrips, key.ProviderID)
-		delete(r.healthEjectionLastTripCapacity, key.ProviderID)
+	g.ejectionCapacityStreak = capacityStreak{}
+	if g.ejectionLastTripCapacity {
+		g.ejectionTrips = 0
+		g.ejectionLastTripCapacity = false
 	}
-	hold.unlock()
+	g.updatedLocked(now)
 	return rateOutcomeRecorded
 }
 
 // CapacityCooldownActive reports whether the (provider, model) pair is
 // currently quarantined by the capacity-reject cooldown. Exposed for tests and
-// observability; the routing hot path uses capacityCooldownActiveLocked under
-// the already-held r.mu.
+// observability.
 func (r *Registry) CapacityCooldownActive(providerID, modelID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownActiveLocked(providerID, modelID, time.Now())
+	return r.capacityCooled(providerID, modelID, time.Now())
 }
 
-// capacityCooldownActiveLocked reports whether routing should skip the pair.
-// READ-ONLY (no lazy delete, no claim) — some callers hold only r.mu.RLock.
-// Caller holds r.mu in either mode (mirrors inferenceErrorCooldownActiveLocked).
+// capacityCooled resolves the session's gate; the scan uses the cached p.gate
+// directly.
+func (r *Registry) capacityCooled(providerID, modelID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).capacityCooled(modelID, now)
+}
+
+// capacityCooled reports whether routing should skip the pair. READ-ONLY (no
+// lazy delete, no claim): lock-free "no cooldown entry on any model" fast
+// path, otherwise one short gate.mu section. nil-safe.
 //
 // Half-open semantics: inside the TTL the gate is closed. Once now reaches the
 // expiry it opens ONLY while no probe claim is fresh — the first reservation
-// through claims the probe (claimCapacityProbeLocked, write lock), which
-// closes the gate again for everyone else until the probe's outcome lands
-// (accept deletes the entry; reject re-arms it) or the claim goes stale after
+// through claims the probe (tryClaimCapacityProbe, at commit), which closes
+// the gate again for everyone else until the probe's outcome lands (accept
+// deletes the entry; reject re-arms it) or the claim goes stale after
 // capacityProbeOutcomeWindow (a lost probe must not wedge the pair).
-func (r *Registry) capacityCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}]
+func (g *gateState) capacityCooled(modelID string, now time.Time) bool {
+	if !g.hasPairState(gateFlagCapacityCooldown) {
+		return false
+	}
+	g = g.lockResolved()
+	defer g.mu.Unlock()
+	e, ok := g.capacityCooldowns[modelID]
 	if !ok {
 		return false
 	}
@@ -552,12 +576,11 @@ func capacityCooldownBackoff(cfg capacityCooldownConfig, trips int) time.Duratio
 
 // rebuildCapacityCooldownLocked applies the post-accept strike history from a
 // fresh breaker. The caller has removed every strike answered by the accept.
-func (r *Registry) rebuildCapacityCooldownLocked(key capacityRejectKey) {
-	previous := r.capacityCooldowns[key]
-	delete(r.capacityCooldowns, key)
-	delete(r.capacityCooldownTrips, key)
-	cfg := r.capacityCooldownCfg
-	strikes := r.capacityRejectStrikes[key]
+func (g *gateState) rebuildCapacityCooldownLocked(cfg capacityCooldownConfig, modelID string) {
+	previous := g.capacityCooldowns[modelID]
+	delete(g.capacityCooldowns, modelID)
+	delete(g.capacityCooldownTrips, modelID)
+	strikes := g.capacityRejectStrikes[modelID]
 	if cfg.Threshold <= 0 || len(strikes) < cfg.Threshold {
 		return
 	}
@@ -574,6 +597,6 @@ func (r *Registry) rebuildCapacityCooldownLocked(key capacityRejectKey) {
 	if previous != nil && !previous.probeAt.IsZero() && !previous.probeAt.Before(expiry) {
 		entry.probeAt = previous.probeAt
 	}
-	r.capacityCooldowns[key] = entry
-	r.capacityCooldownTrips[key] = trips
+	g.capacityCooldowns[modelID] = entry
+	g.capacityCooldownTrips[modelID] = trips
 }

--- a/coordinator/registry/capacity_cooldown_test.go
+++ b/coordinator/registry/capacity_cooldown_test.go
@@ -11,69 +11,84 @@ import (
 // error_cooldown_test.go and provider_breaker_test.go) ---
 
 func capacityCooldownActiveAt(r *Registry, providerID, modelID string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownActiveLocked(providerID, modelID, now)
+	return r.capacityCooled(providerID, modelID, now)
 }
 
-func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (time.Time, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
-	if !ok {
-		return time.Time{}, false
+func capacityCooldownExpiryOf(r *Registry, providerID, modelID string) (expiry time.Time, ok bool) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		if e, has := g.capacityCooldowns[modelID]; has {
+			expiry, ok = e.expiry, true
+		}
+	})
+	return expiry, ok
+}
+
+// claimCapacityProbe claims the pair's half-open probe as the reservation
+// commit would (check-and-claim under gate.mu); returns whether the claim
+// went through (false = the gate was closed to this request).
+func claimCapacityProbe(r *Registry, providerID, modelID string) bool {
+	if p := r.sessionProvider(providerID); p != nil {
+		return r.tryClaimCapacityProbe(p, modelID, time.Now())
 	}
-	return e.expiry, true
-}
-
-// claimCapacityProbe claims the pair's half-open probe as ReserveProviderEx
-// would at reservation commit (under the r.mu write lock).
-func claimCapacityProbe(r *Registry, providerID, modelID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.claimCapacityProbeLocked(providerID, modelID, time.Now())
+	return r.claimCapacityProbeRef(r.gateForSession(providerID), modelID, time.Now())
 }
 
 // ageCapacityProbeClaim rewinds the pair's probe claim by d, simulating a
 // probe whose outcome never landed (stale claim) without sleeping.
 func ageCapacityProbeClaim(r *Registry, providerID, modelID string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok && !e.probeAt.IsZero() {
-		e.probeAt = e.probeAt.Add(-d)
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.capacityCooldowns[modelID]; ok && !e.probeAt.IsZero() {
+			e.probeAt = e.probeAt.Add(-d)
+		}
+	})
 }
 
-func capacityCooldownTripsOf(r *Registry, providerID, modelID string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityCooldownTrips[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]
+func capacityCooldownTripsOf(r *Registry, providerID, modelID string) (trips int) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			trips = g.capacityCooldownTrips[modelID]
+		}
+	})
+	return trips
 }
 
 // expireCapacityCooldown rewinds the pair's cooldown expiry into the past
 // (and clears any probe claim), simulating the TTL elapsing (active ->
 // half-open, probe unclaimed) without sleeping.
 func expireCapacityCooldown(r *Registry, providerID, modelID string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if e, ok := r.capacityCooldowns[capacityRejectKey{ProviderID: providerID, ModelID: modelID}]; ok {
-		e.expiry = time.Now().Add(-time.Second)
-		e.probeAt = time.Time{}
-	}
+	withGateForSession(r, providerID, func(g *gateState) {
+		if e, ok := g.capacityCooldowns[modelID]; ok {
+			e.expiry = time.Now().Add(-time.Second)
+			e.probeAt = time.Time{}
+		}
+	})
 }
 
 // ageCapacityStrikes rewinds every recorded reject strike for the pair by d,
 // simulating the passage of time without sleeping.
 func ageCapacityStrikes(r *Registry, providerID, modelID string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: providerID, ModelID: modelID}
-	strikes := r.capacityRejectStrikes[key]
-	aged := make([]time.Time, len(strikes))
-	for i, ts := range strikes {
-		aged[i] = ts.Add(-d)
-	}
-	r.capacityRejectStrikes[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		strikes := g.capacityRejectStrikes[modelID]
+		aged := make([]time.Time, len(strikes))
+		for i, ts := range strikes {
+			aged[i] = ts.Add(-d)
+		}
+		g.capacityRejectStrikes[modelID] = aged
+	})
+}
+
+// capacityCooldownEntryOf returns the pair's cooldown entry pointer (nil when
+// none), for tests that inspect the probe claim directly.
+func capacityCooldownEntryOf(r *Registry, providerID, modelID string) (entry *capacityCooldownEntry) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g != nil {
+			entry = g.capacityCooldowns[modelID]
+		}
+	})
+	return entry
 }
 
 // Regression for the 2026-07 black-hole incident: 7 providers capacity-rejected
@@ -450,43 +465,43 @@ func TestCapacityCooldownHalfOpenExactlyOneProbe(t *testing.T) {
 	}
 }
 
-// Map-bound sweep: expired cooldowns and idle strike lists are dropped once the
-// maps grow past the bound, so per-session UUID keys cannot leak forever.
+// Gate sweep: identities whose only capacity state is an expired cooldown and
+// aged-out strikes are idle, so once no live session references them and the
+// idle grace has passed the periodic sweep drops their gates — per-session
+// UUID keys cannot leak forever.
 func TestCapacityCooldownMapsBounded(t *testing.T) {
 	r := New(nil)
 	const model = "gemma-4-26b-8bit"
 	cfg := r.capacityCooldownCfg
 
-	// Seed >1024 expired cooldowns and stale strike lists directly.
-	r.mu.Lock()
+	// Seed >1024 dead identities with expired cooldowns and stale strikes.
 	past := time.Now().Add(-time.Hour)
 	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("dead-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: past}
-		r.capacityCooldownTrips[key] = 1
-		r.capacityRejectStrikes[key] = []time.Time{past.Add(-cfg.Window)}
+		withGateForKey(r, fmt.Sprintf("dead-%d", i), func(g *gateState) {
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: past}
+			g.capacityCooldownTrips[model] = 1
+			g.capacityRejectStrikes[model] = []time.Time{past.Add(-cfg.Window)}
+			g.touched = past
+		})
 	}
-	r.mu.Unlock()
-
-	r.RecordCapacityReject("prov-live", model)
-
-	r.mu.RLock()
-	cooldowns, strikes := len(r.capacityCooldowns), len(r.capacityRejectStrikes)
-	r.mu.RUnlock()
-	if cooldowns > 8 {
-		t.Fatalf("expired cooldowns not swept: %d entries remain", cooldowns)
+	if n := r.gateCount(); n < 1100 {
+		t.Fatalf("setup produced too few gates: %d", n)
 	}
-	if strikes > 8 {
-		t.Fatalf("stale strike lists not swept: %d entries remain", strikes)
+
+	r.sweepGates(time.Now())
+
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("idle identities not swept: %d gates remain", n)
 	}
 }
 
-// Regression (PR #510 Codex P2): the >1024 bound sweep must NOT delete a
-// half-open entry whose probe claim is still fresh. In that state expiry is
-// deliberately in the past and probeAt is the only thing holding the gate
-// closed while the single probe's outcome pends — sweeping it (triggered by a
-// reject on ANY other pair) reopened the gate to a thundering herd mid-probe
-// and dropped the pair's exponential-backoff state.
+// Regression (PR #510 Codex P2): the sweep must NOT delete a half-open entry
+// whose probe claim is still fresh. In that state expiry is deliberately in the
+// past and probeAt is the only thing holding the gate closed while the single
+// probe's outcome pends — sweeping it reopened the gate to a thundering herd
+// mid-probe and dropped the pair's exponential-backoff state. With per-identity
+// gates the same rule holds twice over: a gate with a live session is never
+// dropped, and a fresh claim keeps even a disconnected identity's gate non-idle.
 func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 	r := New(nil)
 	const provider, model = "prov-probed", "gemma-4-26b-8bit"
@@ -497,37 +512,41 @@ func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 		r.RecordCapacityReject(provider, model)
 	}
 	expireCapacityCooldown(r, provider, model)
-	claimCapacityProbe(r, provider, model)
+	if !claimCapacityProbe(r, provider, model) {
+		t.Fatal("setup: the first post-expiry claim must succeed")
+	}
 	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
 		t.Fatal("setup: pending probe should hold the gate closed")
 	}
+	// Age every other tracker the rejects armed (strikes, the gray-box clamp
+	// and rate window) out of their windows and backdate the identity's last
+	// activity, so the fresh probe claim is the ONLY thing keeping the gate.
+	ageCapacityStrikes(r, provider, model, cfg.Window+time.Second)
+	ageBudgetClamp(r, provider, model, r.budgetClampCfg.TTL+time.Second)
+	ageCapacityRateRejects(r, provider, model, capacityRateWindow+time.Second)
+	withGateForSession(r, provider, func(g *gateState) { g.touched = time.Now().Add(-time.Hour) })
 
-	// Grow the map past the sweep bound with long-expired junk entries.
-	r.mu.Lock()
+	// Grow the index past the high-water mark with long-idle junk identities.
 	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
-		r.capacityCooldownTrips[key] = 1
+		withGateForKey(r, fmt.Sprintf("junk-%d", i), func(g *gateState) {
+			g.capacityCooldowns[model] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
+			g.capacityCooldownTrips[model] = 1
+			g.touched = time.Now().Add(-time.Hour)
+		})
 	}
-	r.mu.Unlock()
 
-	// A reject on an unrelated pair triggers the opportunistic sweep.
-	r.RecordCapacityReject("prov-other", model)
+	r.sweepGates(time.Now())
 
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
-	r.mu.RLock()
-	_, probedAlive := r.capacityCooldowns[key]
-	trips := r.capacityCooldownTrips[key]
-	size := len(r.capacityCooldowns)
-	r.mu.RUnlock()
-	if !probedAlive {
+	entry := capacityCooldownEntryOf(r, provider, model)
+	trips := capacityCooldownTripsOf(r, provider, model)
+	if entry == nil {
 		t.Fatal("sweep deleted the half-open entry with a fresh probe claim")
 	}
 	if trips == 0 {
 		t.Fatal("sweep dropped the pair's backoff state mid-probe")
 	}
-	if size > 8 {
-		t.Fatalf("junk entries not bounded by the sweep: %d remain", size)
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("junk identities not bounded by the sweep: %d remain", n)
 	}
 	if !capacityCooldownActiveAt(r, provider, model, time.Now()) {
 		t.Fatal("gate reopened to the herd mid-probe after the sweep")
@@ -536,18 +555,10 @@ func TestCapacityCooldownSweepPreservesFreshProbeClaims(t *testing.T) {
 	// A STALE claim (outcome never landed) must still be sweepable — the
 	// liveness bound, not the claim itself, decides retention.
 	ageCapacityProbeClaim(r, provider, model, capacityProbeOutcomeWindow+time.Second)
-	r.mu.Lock()
-	for i := 0; i < 1100; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("junk2-%d", i), ModelID: model}
-		r.capacityCooldowns[key] = &capacityCooldownEntry{expiry: time.Now().Add(-time.Hour)}
-	}
-	r.mu.Unlock()
-	r.RecordCapacityReject("prov-other-2", model)
-	r.mu.RLock()
-	_, staleAlive := r.capacityCooldowns[key]
-	r.mu.RUnlock()
-	if staleAlive {
-		t.Fatal("sweep retained an entry whose probe claim went stale")
+	withGateForSession(r, provider, func(g *gateState) { g.touched = time.Now().Add(-time.Hour) })
+	r.sweepGates(time.Now())
+	if rawGateForKey(r, provider) != nil {
+		t.Fatal("sweep retained an identity whose probe claim went stale")
 	}
 }
 

--- a/coordinator/registry/capacity_rate.go
+++ b/coordinator/registry/capacity_rate.go
@@ -44,10 +44,11 @@ import (
 // Rejects are recorded once per failed dispatch attempt by
 // RecordCapacityReject.
 //
-// Keyed by the STABLE fault identity like every sibling tracker: reconnects
-// cannot reset the window, entries migrate on identity rebind
-// (migrateFaultStateLocked), Disconnect does NOT clear them, and the maps are
-// bounded by the same opportunistic >1024 sweep. Guarded by r.mu.
+// Keyed by the STABLE fault identity like every sibling tracker: the windows
+// live on the identity's gate (gate_state.go), so reconnects cannot reset
+// them, they migrate on identity rebind (mergeLocked), Disconnect does NOT
+// clear them, and the periodic gate sweep drops fully aged windows. Guarded by
+// gate.mu.
 const (
 	// envCapacityRatePenaltyMs scales the penalty (and is the kill switch: 0
 	// or negative disables the tracker entirely — no recording, no penalty).
@@ -83,28 +84,23 @@ func loadCapacityRateConfig() capacityRateConfig {
 }
 
 // recordCapacityRateRejectLocked appends one capacity-503 outcome for the pair
-// and prunes the window. Caller holds the r.mu write lock (called from
-// RecordCapacityReject).
-func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now time.Time) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// and prunes the window. Caller holds g.mu (called from recordCapacityReject).
+func (g *gateState) recordCapacityRateRejectLocked(cfg capacityRateConfig, model string, now time.Time) {
+	if cfg.PenaltyMs <= 0 {
 		return
 	}
-	_, existed := r.capacityRateRejects[key]
-	r.capacityRateRejects[key] = appendWindowedOutcome(r.capacityRateRejects[key], now)
-	if !existed {
-		sweepCapacityRateMapLocked(r.capacityRateRejects, now)
-	}
+	g.capacityRateRejects[model] = appendWindowedOutcome(g.capacityRateRejects[model], now)
 
 	// A pair may have gone quiet long enough for its accept-only history to
 	// expire before this first/new reject. Prune it now so repeated routing reads
 	// do not keep scanning stale timestamps and the first rate uses only the same
 	// five-minute window as the reject side.
-	if accepts, ok := r.capacityRateAccepts[key]; ok {
+	if accepts, ok := g.capacityRateAccepts[model]; ok {
 		accepts = pruneWindowedOutcomes(accepts, now)
 		if len(accepts) == 0 {
-			delete(r.capacityRateAccepts, key)
+			delete(g.capacityRateAccepts, model)
 		} else {
-			r.capacityRateAccepts[key] = accepts
+			g.capacityRateAccepts[model] = accepts
 		}
 	}
 }
@@ -116,16 +112,12 @@ func (r *Registry) recordCapacityRateRejectLocked(key capacityRejectKey, now tim
 // The rate/penalty read paths still return zero while no reject is in-window, so
 // this healthy history is observationally dormant. Returns whether the accept
 // was stored so the api layer can stamp the request (MarkRateOutcomeCounted)
-// and prevent completion from double-counting it. Caller holds r.mu for write.
-func (r *Registry) recordCapacityRateAcceptLocked(key capacityRejectKey, now time.Time) (recorded bool) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// and prevent completion from double-counting it. Caller holds g.mu.
+func (g *gateState) recordCapacityRateAcceptLocked(cfg capacityRateConfig, model string, now time.Time) (recorded bool) {
+	if cfg.PenaltyMs <= 0 {
 		return false
 	}
-	_, existed := r.capacityRateAccepts[key]
-	r.capacityRateAccepts[key] = appendWindowedOutcome(r.capacityRateAccepts[key], now)
-	if !existed {
-		sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
-	}
+	g.capacityRateAccepts[model] = appendWindowedOutcome(g.capacityRateAccepts[model], now)
 	return true
 }
 
@@ -154,24 +146,8 @@ func appendWindowedOutcome(outcomes []time.Time, now time.Time) []time.Time {
 	return append(pruneWindowedOutcomes(outcomes, now), now)
 }
 
-// sweepCapacityRateMapLocked bounds a rate map by dropping pairs whose newest
-// outcome has aged out of the window, once the map grows (mirrors the sibling
-// cooldown sweeps — churned session-keyed identities are never re-keyed).
-// Histories must remain chronological because this deliberately uses the tail
-// for an O(1) newest check while holding the registry lock.
-func sweepCapacityRateMapLocked(m map[capacityRejectKey][]time.Time, now time.Time) {
-	if len(m) <= 1024 {
-		return
-	}
-	for key, outcomes := range m {
-		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
-			delete(m, key)
-		}
-	}
-}
-
 // countInWindow counts timestamps still inside the window without mutating the
-// chronological slice, so read paths stay safe under r.mu.RLock.
+// chronological slice, so read paths stay safe under a shared lock.
 func countInWindow(outcomes []time.Time, now time.Time) int {
 	cutoff := now.Add(-capacityRateWindow)
 	first := sort.Search(len(outcomes), func(i int) bool {
@@ -180,42 +156,74 @@ func countInWindow(outcomes []time.Time, now time.Time) int {
 	return len(outcomes) - first
 }
 
-// capacityRatePenaltyLocked returns the cost penalty (ms) and the measured
+// capacityRatePenalty returns the cost penalty (ms) and the measured
 // capacity-reject rate for the pair. Penalty is nonzero only when the window
 // holds at least capacityRateMinSample outcomes AND the rate exceeds
 // capacityRateThreshold; the rate is returned whenever computable so callers
-// can expose it for observability. READ-ONLY — callers hold r.mu in either
-// mode (buildCandidateWithReason runs under the selection locks).
-func (r *Registry) capacityRatePenaltyLocked(providerID, modelID string, now time.Time) (penaltyMs, rate float64) {
-	if r.capacityRateCfg.PenaltyMs <= 0 {
+// can expose it for observability.
+//
+// Hot-path fast exit without the lock: the gate publishes its newest rate
+// reject as an atomic, so a healthy pair — no capacity-503 inside the window
+// on ANY model — pays nothing (buildCandidateInto runs this once per
+// candidate per scan). Only a pair with an in-window reject takes the short
+// gate.mu section. nil-safe.
+func (g *gateState) capacityRatePenalty(cfg capacityRateConfig, model string, now time.Time) (penaltyMs, rate float64) {
+	if cfg.PenaltyMs <= 0 || g == nil {
 		return 0, 0
 	}
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	rejects := countInWindow(r.capacityRateRejects[key], now)
-	if rejects == 0 {
-		return 0, 0 // hot-path fast exit: healthy pairs pay nothing
+	newest := g.newestRateRejectNS.Load()
+	if newest == 0 || now.UnixNano()-newest >= int64(capacityRateWindow) {
+		return 0, 0
 	}
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
+	g = g.lockResolved()
+	rejects := countInWindow(g.capacityRateRejects[model], now)
+	accepts := countInWindow(g.capacityRateAccepts[model], now)
+	g.mu.Unlock()
+	if rejects == 0 {
+		return 0, 0
+	}
 	total := rejects + accepts
 	rate = float64(rejects) / float64(total)
 	if total < capacityRateMinSample || rate <= capacityRateThreshold {
 		return 0, rate
 	}
-	return rate * r.capacityRateCfg.PenaltyMs, rate
+	return rate * cfg.PenaltyMs, rate
+}
+
+// capacityRatePenalty resolves the session's gate; the scan uses the cached
+// p.gate through capacityRatePenaltyFor.
+func (r *Registry) capacityRatePenalty(providerID, modelID string, now time.Time) (penaltyMs, rate float64) {
+	return r.lookupGateForSession(providerID).capacityRatePenalty(r.capacityRateCfg, modelID, now)
+}
+
+// capacityRatePenaltyFor is capacityRatePenalty on the connected provider's
+// cached gate, confirmed against p.gate (gateView): the candidate's cost
+// input (buildCandidateInto).
+func (r *Registry) capacityRatePenaltyFor(p *Provider, model string, now time.Time) (penaltyMs, rate float64) {
+	view := r.gateViewOf(p)
+	for {
+		penaltyMs, rate = view.g.capacityRatePenalty(r.capacityRateCfg, model, now)
+		if !view.moved() {
+			return penaltyMs, rate
+		}
+	}
 }
 
 // CapacityRejectRate exposes the pair's windowed capacity-reject rate and
 // sample count for tests and observability.
 func (r *Registry) CapacityRejectRate(providerID, modelID string) (rate float64, samples int) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	g := r.lookupGateForSession(providerID)
+	if g == nil {
+		return 0, 0
+	}
 	now := time.Now()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID}
-	rejects := countInWindow(r.capacityRateRejects[key], now)
+	g = g.lockResolved()
+	rejects := countInWindow(g.capacityRateRejects[modelID], now)
+	accepts := countInWindow(g.capacityRateAccepts[modelID], now)
+	g.mu.Unlock()
 	if rejects == 0 {
 		return 0, 0
 	}
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
 	total := rejects + accepts
 	if total == 0 {
 		return 0, 0

--- a/coordinator/registry/capacity_rate_followup_test.go
+++ b/coordinator/registry/capacity_rate_followup_test.go
@@ -49,18 +49,18 @@ func TestCapacityRateFirstRejectPrunesExpiredAccepts(t *testing.T) {
 	r := New(testLogger())
 	const provider, model = "prov-accept-window", "gemma-4-26b-qat-4bit"
 	now := time.Now()
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
 
-	r.mu.Lock()
-	r.capacityRateAccepts[key] = []time.Time{
-		now.Add(-capacityRateWindow - time.Nanosecond),
-		now.Add(-capacityRateWindow),
-		now.Add(-capacityRateWindow + time.Nanosecond),
-	}
-	r.recordCapacityRateRejectLocked(key, now)
-	rejects := countInWindow(r.capacityRateRejects[key], now)
-	accepts := countInWindow(r.capacityRateAccepts[key], now)
-	r.mu.Unlock()
+	var rejects, accepts int
+	withGateForSession(r, provider, func(g *gateState) {
+		g.capacityRateAccepts[model] = []time.Time{
+			now.Add(-capacityRateWindow - time.Nanosecond),
+			now.Add(-capacityRateWindow),
+			now.Add(-capacityRateWindow + time.Nanosecond),
+		}
+		g.recordCapacityRateRejectLocked(r.capacityRateCfg, model, now)
+		rejects = countInWindow(g.capacityRateRejects[model], now)
+		accepts = countInWindow(g.capacityRateAccepts[model], now)
+	})
 
 	if rejects != 1 || accepts != 1 {
 		t.Fatalf("windowed outcomes = rejects %d accepts %d, want 1/1", rejects, accepts)
@@ -142,9 +142,9 @@ func TestCapacityRateIsIndependentOfOutcomeOrder(t *testing.T) {
 
 // Identity enrichment can merge a stale source history into a destination
 // that already has fresh state from a previous connection. Every timestamp
-// history must remain oldest-to-newest because the bounded-map sweeps use the
-// tail as the newest outcome. This exercises the real sekey -> serial rebind
-// and the >1024 cleanup consequence for both rate maps.
+// history must remain oldest-to-newest because the gate sweep uses the tail as
+// the newest outcome. This exercises the real sekey -> serial rebind and the
+// sweep's consequence for both rate windows.
 func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 	r := New(testLogger())
 	const (
@@ -165,26 +165,27 @@ func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 	now := time.Now()
 	expired := now.Add(-capacityRateWindow - time.Minute)
 	fresh := now.Add(-time.Minute)
-	oldRateKey := capacityRejectKey{ProviderID: oldID, ModelID: model}
-	newRateKey := capacityRejectKey{ProviderID: newID, ModelID: model}
-	oldInferenceKey := inferenceErrorKey{ProviderID: oldID, ModelID: model, Shape: "base"}
-	newInferenceKey := inferenceErrorKey{ProviderID: newID, ModelID: model, Shape: "base"}
+	shapeKey := modelShapeKey{Model: model, Shape: "base"}
 
-	r.mu.Lock()
-	r.inferenceErrorStrikes[oldInferenceKey] = []time.Time{expired}
-	r.inferenceErrorStrikes[newInferenceKey] = []time.Time{fresh}
-	r.capacityRejectStrikes[oldRateKey] = []time.Time{expired}
-	r.capacityRejectStrikes[newRateKey] = []time.Time{fresh}
-	r.capacityRateRejects[oldRateKey] = []time.Time{expired}
-	r.capacityRateRejects[newRateKey] = []time.Time{fresh}
-	r.capacityRateAccepts[oldRateKey] = []time.Time{expired}
-	r.capacityRateAccepts[newRateKey] = []time.Time{fresh}
+	withGateForKey(r, oldID, func(g *gateState) {
+		g.inferenceErrorStrikes[shapeKey] = []time.Time{expired}
+		g.capacityRejectStrikes[model] = []time.Time{expired}
+		g.capacityRateRejects[model] = []time.Time{expired}
+		g.capacityRateAccepts[model] = []time.Time{expired}
+	})
+	withGateForKey(r, newID, func(g *gateState) {
+		g.inferenceErrorStrikes[shapeKey] = []time.Time{fresh}
+		g.capacityRejectStrikes[model] = []time.Time{fresh}
+		g.capacityRateRejects[model] = []time.Time{fresh}
+		g.capacityRateAccepts[model] = []time.Time{fresh}
+	})
 	for i := 0; i < 1024; i++ {
-		key := capacityRejectKey{ProviderID: fmt.Sprintf("expired-rate-%d", i), ModelID: model}
-		r.capacityRateRejects[key] = []time.Time{expired}
-		r.capacityRateAccepts[key] = []time.Time{expired}
+		withGateForKey(r, fmt.Sprintf("expired-rate-%d", i), func(g *gateState) {
+			g.capacityRateRejects[model] = []time.Time{expired}
+			g.capacityRateAccepts[model] = []time.Time{expired}
+			g.touched = now.Add(-gateIdleGrace - time.Minute)
+		})
 	}
-	r.mu.Unlock()
 
 	p.SetAttestationResult(&attestation.VerificationResult{
 		Valid: true, PublicKey: publicKey, SerialNumber: serial,
@@ -193,20 +194,36 @@ func TestFaultTimestampHistoriesStayOrderedAcrossIdentityRebind(t *testing.T) {
 		t.Fatalf("enriched fault key = %q, want %q", got, newID)
 	}
 
-	r.mu.Lock()
-	mergedInference := append([]time.Time(nil), r.inferenceErrorStrikes[newInferenceKey]...)
-	mergedCapacity := append([]time.Time(nil), r.capacityRejectStrikes[newRateKey]...)
-	mergedRejects := append([]time.Time(nil), r.capacityRateRejects[newRateKey]...)
-	mergedAccepts := append([]time.Time(nil), r.capacityRateAccepts[newRateKey]...)
-	_, oldInferenceRemains := r.inferenceErrorStrikes[oldInferenceKey]
-	_, oldCapacityRemains := r.capacityRejectStrikes[oldRateKey]
-	_, oldRejectsRemain := r.capacityRateRejects[oldRateKey]
-	_, oldAcceptsRemain := r.capacityRateAccepts[oldRateKey]
-	sweepCapacityRateMapLocked(r.capacityRateRejects, now)
-	sweepCapacityRateMapLocked(r.capacityRateAccepts, now)
-	freshRejects := countInWindow(r.capacityRateRejects[newRateKey], now)
-	freshAccepts := countInWindow(r.capacityRateAccepts[newRateKey], now)
-	r.mu.Unlock()
+	var mergedInference, mergedCapacity, mergedRejects, mergedAccepts []time.Time
+	readGateForKey(r, newID, func(g *gateState) {
+		mergedInference = append([]time.Time(nil), g.inferenceErrorStrikes[shapeKey]...)
+		mergedCapacity = append([]time.Time(nil), g.capacityRejectStrikes[model]...)
+		mergedRejects = append([]time.Time(nil), g.capacityRateRejects[model]...)
+		mergedAccepts = append([]time.Time(nil), g.capacityRateAccepts[model]...)
+	})
+	// The source identity's gate is orphaned and gone from the index after
+	// the migration; any residue would be filed under its raw key.
+	var oldInferenceRemains, oldCapacityRemains, oldRejectsRemain, oldAcceptsRemain bool
+	if g := rawGateForKey(r, oldID); g != nil {
+		g.mu.Lock()
+		_, oldInferenceRemains = g.inferenceErrorStrikes[shapeKey]
+		_, oldCapacityRemains = g.capacityRejectStrikes[model]
+		_, oldRejectsRemain = g.capacityRateRejects[model]
+		_, oldAcceptsRemain = g.capacityRateAccepts[model]
+		g.mu.Unlock()
+	}
+	r.sweepGates(now)
+	var freshRejects, freshAccepts int
+	readGateForKey(r, newID, func(g *gateState) {
+		if g == nil {
+			t.Fatal("the live identity's gate must survive the sweep")
+		}
+		freshRejects = countInWindow(g.capacityRateRejects[model], now)
+		freshAccepts = countInWindow(g.capacityRateAccepts[model], now)
+	})
+	if n := r.gateCount(); n > 8 {
+		t.Fatalf("expired identities not swept: %d gates remain", n)
+	}
 
 	for name, history := range map[string][]time.Time{
 		"inference strikes": mergedInference,

--- a/coordinator/registry/capacity_rate_test.go
+++ b/coordinator/registry/capacity_rate_test.go
@@ -16,9 +16,19 @@ import (
 // capacityRatePenaltyOf reads the pair's penalty and rate under the lock, as
 // buildCandidateWithReason does.
 func capacityRatePenaltyOf(r *Registry, providerID, model string) (penaltyMs, rate float64) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.capacityRatePenaltyLocked(providerID, model, time.Now())
+	return r.capacityRatePenalty(providerID, model, time.Now())
+}
+
+// rateHistoryOf returns copies of the pair's windowed reject/accept histories.
+func rateHistoryOf(r *Registry, providerID, model string) (rejects, accepts []time.Time) {
+	readGateForSession(r, providerID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		rejects = append([]time.Time(nil), g.capacityRateRejects[model]...)
+		accepts = append([]time.Time(nil), g.capacityRateAccepts[model]...)
+	})
+	return rejects, accepts
 }
 
 // seedRateOutcomes drives the real entry points in reject-first order. Other
@@ -34,15 +44,14 @@ func seedRateOutcomes(r *Registry, providerID, model string, rejects, accepts in
 
 // ageCapacityRateRejects rewinds the pair's reject outcomes by d.
 func ageCapacityRateRejects(r *Registry, providerID, model string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := capacityRejectKey{ProviderID: r.faultKeyLocked(providerID), ModelID: model}
-	outcomes := r.capacityRateRejects[key]
-	aged := make([]time.Time, len(outcomes))
-	for i, ts := range outcomes {
-		aged[i] = ts.Add(-d)
-	}
-	r.capacityRateRejects[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		outcomes := g.capacityRateRejects[model]
+		aged := make([]time.Time, len(outcomes))
+		for i, ts := range outcomes {
+			aged[i] = ts.Add(-d)
+		}
+		g.capacityRateRejects[model] = aged
+	})
 }
 
 // Below the minimum sample no penalty may apply, no matter how bad the rate —
@@ -135,10 +144,8 @@ func TestCapacityRateDecays(t *testing.T) {
 	// observationally inert; accept history must not be deleted just because the
 	// last reject expired.
 	r.RecordCapacityAcceptOutcome(provider, model, true)
-	r.mu.RLock()
-	key := capacityRejectKey{ProviderID: provider, ModelID: model}
-	accepts := countInWindow(r.capacityRateAccepts[key], time.Now())
-	r.mu.RUnlock()
+	_, acceptHistory := rateHistoryOf(r, provider, model)
+	accepts := countInWindow(acceptHistory, time.Now())
 	if accepts != 7 {
 		t.Fatalf("recent accept history = %d, want 7 after the new accept", accepts)
 	}
@@ -161,9 +168,12 @@ func TestCapacityRateAcceptsDoNotResetRejects(t *testing.T) {
 	}
 	// The cooldown strike streak WAS cleared by those accepts (its designed
 	// discriminator) — proving the two trackers are decoupled.
-	r.mu.RLock()
-	strikes := len(r.capacityRejectStrikes[capacityRejectKey{ProviderID: provider, ModelID: model}])
-	r.mu.RUnlock()
+	strikes := -1
+	readGateForSession(r, provider, func(g *gateState) {
+		if g != nil {
+			strikes = len(g.capacityRejectStrikes[model])
+		}
+	})
 	if strikes != 0 {
 		t.Fatalf("cooldown strikes = %d after accepts, want 0 (accept-reset is the cooldown's contract)", strikes)
 	}

--- a/coordinator/registry/disconnect_reason.go
+++ b/coordinator/registry/disconnect_reason.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"nhooyr.io/websocket"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Disconnect-reason plumbing (R1: restart/graceful disconnects are not provider
+// sickness).
+//
+// The provider read loop already classifies how a socket ended — a
+// peer-initiated close frame (1000 normal / 1001 going-away: stop, restart,
+// update) versus a frame-less drop (read error, OOM-suspected kill) — but the
+// generic Disconnect never received it, so the 502 flush of every in-flight
+// request struck the provider's STABLE identity regardless. After a fleet
+// restart wave (2026-08-31: 19,001 in-flight across 316 providers) the
+// upgraded boxes came back quarantined for up to five minutes.
+//
+// DisconnectWithReason keeps the flush itself (the requests still fail over)
+// but stamps a graceful close with CoordinatorCauseProviderRestart and the
+// coordinator-internal error_reason provider_restart, which every health
+// funnel already treats as neutral (api.isProviderHealthNeutralErrorReason).
+// An abrupt drop keeps the legacy CoordinatorCauseProviderDisconnected flush
+// that strikes the identity: that is the reconnecting-zombie discriminator
+// and must stay.
+//
+// NOTE: the Swift provider's auto-update restart (ProcessLifecycle.
+// restartAfterUpdate → launchctl kickstart -k → exit) sends NO close frame
+// today, so it reaches the coordinator as read_error and is NOT covered by
+// this path; the version-changed reconnect reset (version_reset.go) is what
+// covers that wave. Graceful closes come from the run() cancellation shutdown
+// (CoordinatorClient.shutdown → goingAway) and any future SIGTERM trap.
+
+const (
+	// DisconnectReasonPeerClose: the provider sent a graceful WebSocket close
+	// frame (1000 normal / 1001 going-away) — a stop, restart, or update. The
+	// pending flush is health-neutral.
+	DisconnectReasonPeerClose DisconnectReason = "peer_close"
+	// DisconnectReasonReadError: the socket died without a close frame (TCP
+	// reset, NAT/LB teardown, process killed, sleep). Abrupt: the flush
+	// strikes the identity exactly as before.
+	DisconnectReasonReadError DisconnectReason = "read_error"
+)
+
+// ClassifyPeerClose maps the read loop's observed close status to the
+// DisconnectReason that decides the flush cause. closeStatus is
+// websocket.CloseStatus(err): -1 when no close frame was received. Only the
+// two graceful peer codes are restart-neutral; every other code (policy
+// violations, abnormal 1006, intermediary codes, …) and every frame-less drop
+// stays abrupt. oomSuspected wins outright — it is only ever set on a
+// frame-less drop, but the guard keeps the precedence explicit.
+func ClassifyPeerClose(closeStatus websocket.StatusCode, oomSuspected bool) DisconnectReason {
+	switch {
+	case oomSuspected:
+		return DisconnectReasonOOMSuspected
+	case closeStatus == websocket.StatusNormalClosure, closeStatus == websocket.StatusGoingAway:
+		return DisconnectReasonPeerClose
+	case closeStatus == -1:
+		return DisconnectReasonReadError
+	default:
+		return DisconnectReasonNormal
+	}
+}
+
+// DisconnectWithReason is Disconnect with the read loop's classified socket
+// outcome. A DisconnectReasonPeerClose flushes pending requests with the
+// health-neutral restart cause; every other reason takes the abrupt path.
+func (r *Registry) DisconnectWithReason(id string, reason DisconnectReason) {
+	r.disconnectWithCause(id, disconnectFlushCause(reason))
+}
+
+// disconnectFlushCause maps a DisconnectReason to the CoordinatorCause stamped
+// on the flushed pending-request terminals.
+func disconnectFlushCause(reason DisconnectReason) protocol.CoordinatorInferenceErrorCause {
+	if reason == DisconnectReasonPeerClose {
+		return protocol.CoordinatorCauseProviderRestart
+	}
+	return protocol.CoordinatorCauseProviderDisconnected
+}
+
+// disconnectFlushErrorReason is the error_reason stamped on the flushed
+// terminals: the coordinator-internal provider_restart marker for a graceful
+// close (health-neutral through the existing reason funnel), empty for the
+// abrupt flush so its legacy provider_error classification is unchanged.
+func disconnectFlushErrorReason(cause protocol.CoordinatorInferenceErrorCause) string {
+	if cause == protocol.CoordinatorCauseProviderRestart {
+		return protocol.InferenceErrorReasonProviderRestart
+	}
+	return ""
+}

--- a/coordinator/registry/disconnect_reason_test.go
+++ b/coordinator/registry/disconnect_reason_test.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"testing"
+
+	"nhooyr.io/websocket"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestClassifyPeerClose(t *testing.T) {
+	cases := []struct {
+		name   string
+		status websocket.StatusCode
+		oom    bool
+		want   DisconnectReason
+	}{
+		{"normal 1000 is a graceful peer close", websocket.StatusNormalClosure, false, DisconnectReasonPeerClose},
+		{"going-away 1001 is a graceful peer close", websocket.StatusGoingAway, false, DisconnectReasonPeerClose},
+		{"abnormal 1006 stays abrupt", websocket.StatusAbnormalClosure, false, DisconnectReasonNormal},
+		{"policy violation 1008 stays abrupt", websocket.StatusPolicyViolation, false, DisconnectReasonNormal},
+		{"no close frame is a read error", -1, false, DisconnectReasonReadError},
+		{"oom-suspected drop", -1, true, DisconnectReasonOOMSuspected},
+		{"oom wins over a graceful code", websocket.StatusGoingAway, true, DisconnectReasonOOMSuspected},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyPeerClose(tc.status, tc.oom); got != tc.want {
+				t.Fatalf("ClassifyPeerClose(%d, %v) = %q, want %q", tc.status, tc.oom, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDisconnectWithReason_FlushCause: the pending-request flush carries the
+// health-neutral restart cause + provider_restart reason ONLY for a graceful
+// peer close; every abrupt path (read error, OOM, legacy Disconnect) keeps the
+// striking provider_disconnected cause with no reason.
+func TestDisconnectWithReason_FlushCause(t *testing.T) {
+	cases := []struct {
+		name       string
+		disconnect func(r *Registry, id string)
+		wantCause  protocol.CoordinatorInferenceErrorCause
+		wantReason string
+	}{
+		{"graceful peer close", func(r *Registry, id string) { r.DisconnectWithReason(id, DisconnectReasonPeerClose) },
+			protocol.CoordinatorCauseProviderRestart, protocol.InferenceErrorReasonProviderRestart},
+		{"read error", func(r *Registry, id string) { r.DisconnectWithReason(id, DisconnectReasonReadError) },
+			protocol.CoordinatorCauseProviderDisconnected, ""},
+		{"oom suspected", func(r *Registry, id string) { r.DisconnectWithReason(id, DisconnectReasonOOMSuspected) },
+			protocol.CoordinatorCauseProviderDisconnected, ""},
+		{"legacy Disconnect", func(r *Registry, id string) { r.Disconnect(id) },
+			protocol.CoordinatorCauseProviderDisconnected, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(testLogger())
+			msg := testRegisterMessage()
+			msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+			p := r.Register("prov", nil, msg)
+			pr := &PendingRequest{
+				RequestID: "req-1",
+				Model:     "m",
+				ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+			}
+			p.AddPending(pr)
+
+			tc.disconnect(r, "prov")
+
+			if r.GetProvider("prov") != nil {
+				t.Fatalf("provider still registered after disconnect")
+			}
+			got, ok := <-pr.ErrorCh
+			if !ok {
+				t.Fatalf("pending request received no flushed terminal")
+			}
+			if got.CoordinatorCause != tc.wantCause {
+				t.Errorf("CoordinatorCause = %q, want %q", got.CoordinatorCause, tc.wantCause)
+			}
+			if got.ErrorReason != tc.wantReason {
+				t.Errorf("ErrorReason = %q, want %q", got.ErrorReason, tc.wantReason)
+			}
+			if got.StatusCode != 502 || got.Error != "provider disconnected" {
+				t.Errorf("flush = %d %q, want 502 \"provider disconnected\"", got.StatusCode, got.Error)
+			}
+			if !got.CoordinatorCause.IsProviderDisconnect() {
+				t.Errorf("cause %q must classify as a provider disconnect", got.CoordinatorCause)
+			}
+		})
+	}
+}

--- a/coordinator/registry/dispatch_load_cooldown_test.go
+++ b/coordinator/registry/dispatch_load_cooldown_test.go
@@ -6,9 +6,7 @@ import (
 )
 
 func cooldownActive(r *Registry, providerID, modelID string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.dispatchLoadCooldownActiveLocked(providerID, modelID, now)
+	return r.dispatchLoadCooled(providerID, modelID, now)
 }
 
 // Regression for the prod fleet outage: providers wedged on "insufficient
@@ -102,27 +100,24 @@ func TestDispatchLoadCooldownSurvivesRegister(t *testing.T) {
 
 func TestDispatchLoadCooldownSweepBoundsMap(t *testing.T) {
 	r := New(testLogger())
-	// Insert >1024 entries, then force them all past expiry by recording a
-	// fresh failure after the TTL — the opportunistic sweep must drop them.
+	// >1024 identity-less sessions record a load failure and vanish. Once the
+	// cooldowns expire and the idle grace passes, the gate sweep must drop
+	// every one of their gates; a connected provider's gate always survives.
 	for i := 0; i < 1100; i++ {
 		r.RecordDispatchLoadFailure("dead-provider-"+string(rune('a'+i%26))+string(rune('0'+i%10))+string(rune('0'+(i/10)%10))+string(rune('0'+(i/100)%10)), "m")
 	}
-	r.mu.Lock()
-	for k := range r.dispatchLoadCooldowns {
-		r.dispatchLoadCooldowns[k] = time.Now().Add(-time.Second)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
-	size := len(r.dispatchLoadCooldowns)
-	r.mu.Unlock()
-	if size < 1000 {
-		t.Fatalf("setup produced too few distinct entries: %d", size)
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordDispatchLoadFailure(live.ID, "m")
+
+	r.sweepGates(time.Now().Add(gateIdleGrace + dispatchLoadCooldownTTL + time.Second))
+
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
 	}
-
-	r.RecordDispatchLoadFailure("live", "m")
-
-	r.mu.Lock()
-	after := len(r.dispatchLoadCooldowns)
-	r.mu.Unlock()
-	if after != 1 {
-		t.Fatalf("sweep should leave only the live entry, got %d", after)
+	if rawGateForKey(r, live.ID) == nil {
+		t.Fatal("the connected provider's gate must never be swept")
 	}
 }

--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -349,12 +349,14 @@ func (r *Registry) ReserveProviderWithPlan(model string, pr *PendingRequest, exc
 //     valve still protects the all-providers-broken case).
 //
 // Ledger note (why plan reservations cannot double-spend a heartbeat budget):
-// the r.mu WRITE lock is held for the whole loop, exactly like
-// ReserveProviderEx, so reservations serialize fleet-wide; and each entry is
-// re-snapshotted here, so freeMemoryAdmits charges every pending request
-// admitted since the plan was built (fillSnapshotPendingAndPool →
-// coordinatorExtra / pooledBudgetAdmits). See the ledger rationale on
-// reserveProvider's pending-debit path in scheduler.go.
+// each entry is re-snapshotted, re-costed, admit-checked and debited inside
+// ONE p.mu section (exactly like commitProviderReservation), so
+// freeMemoryAdmits charges every pending request admitted since the plan was
+// built (fillSnapshotPendingAndPool → coordinatorExtra / pooledBudgetAdmits)
+// and no concurrent commit can slip between the check and the debit. r.mu is
+// held for reading across the loop (identity checks against r.providers stay
+// valid); the global commit mode takes it for writing instead. See the ledger
+// rationale on reserveProvider's pending-debit path in scheduler.go.
 //
 // Version-diverse retry (SOFT — parity with scanCandidatesLocked's
 // post-candidate AvoidVersion narrowing): when pr.Traits.AvoidVersion is set,
@@ -396,8 +398,9 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	enforceTTFT := pr.MaxTTFTMs > 0 && !pr.RequiresVision
 
 	var skips []PlanSkip
-	hold := r.lockWrite("commit_plan")
-	defer hold.unlock()
+	lock := r.commitLock("commit_plan")
+	lock.lock()
+	defer lock.unlock()
 
 	// tryReserve runs the full CURRENT gate chain against one identity-checked
 	// entry and, on success, commits the reservation. Failure appends the
@@ -422,36 +425,43 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 			return nil, RoutingDecision{}, false
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-		snap, ok := r.snapshotProviderLockedEx(p, model, pr.Traits, relaxTrust, false, now)
-		if !ok {
+
+		// Snapshot, cost, admit and reservation under ONE p.mu hold — the same
+		// commit sequence as commitProviderReservation, so nothing can change
+		// the provider between the admit re-check and the debit.
+		p.mu.Lock()
+		var snap routingSnapshot
+		if ok, _ := r.snapshotProviderIntoPLockedEx(&snap, p, model, pr.Traits, relaxTrust, false, now); !ok {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
 		candidate, _, ok := r.buildCandidateWithReason(snap, pr, now)
 		if !ok {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
 		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
-
-		// Final admit + reservation under p.mu — the same commit sequence as
-		// reserveProvider (snapshotProviderIntoLockedEx released p.mu, so the admit
-		// re-check closes the snapshot→reserve gap, including the vision gate).
-		p.mu.Lock()
 		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false, now) ||
 			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 			p.mu.Unlock()
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
+		// Half-open capacity probe: check-and-claim under gate.mu, identical to
+		// the primary reservation path (p.mu → gate.mu).
+		if !r.tryClaimCapacityProbe(p, model, now) {
+			p.mu.Unlock()
+			skip(PlanSkipGateRejected)
+			return nil, RoutingDecision{}, false
+		}
 		pr.ProviderID = p.ID
 		p.addPendingLocked(pr)
-		// Half-open capacity probe claim: identical to the primary reservation
-		// path (the r.mu write lock held across this loop serializes claims).
-		r.claimCapacityProbeLocked(p.ID, model, now)
 		if p.Status != StatusUntrusted && p.Status != StatusOffline {
 			p.Status = StatusServing
 		}
@@ -522,7 +532,7 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	}
 	// Pass 2: no diverse entry was admissible — fall back to the avoided
 	// version rather than failing closed. The pass-1 identity checks remain
-	// valid: r.providers cannot change while the r.mu write lock is held.
+	// valid: r.providers cannot change while r.mu is held in either mode.
 	for _, entry := range deferred {
 		if p, decision, ok := tryReserve(entry); ok {
 			return p, decision, skips

--- a/coordinator/registry/dispatch_plan_test.go
+++ b/coordinator/registry/dispatch_plan_test.go
@@ -134,10 +134,16 @@ func TestReserveProviderWithPlanPrimarySelectionUnchanged(t *testing.T) {
 	if pA == nil || pB == nil || pA.ID != pB.ID {
 		t.Fatalf("winners differ: ReserveProviderEx=%v ReserveProviderWithPlan=%v", pA, pB)
 	}
-	// The profiler's wall-clock stamps (lock wait, scan, admit, heartbeat age)
-	// legitimately differ between two reservations; everything else must match.
+	// The profiler's wall-clock stamps (lock wait, scan, admit, heartbeat age
+	// — on the decision AND inside the candidate summaries) legitimately differ
+	// between two reservations built a few hundred microseconds apart;
+	// everything else must match.
 	for _, d := range []*RoutingDecision{&decA, &decB} {
 		d.LockWaitUS, d.ScanUS, d.AdmitUS, d.SnapshotAgeMs = 0, 0, 0, 0
+		for i := range d.Top {
+			d.Top[i].HBAgeMs = 0
+		}
+		d.RunnerUp.HBAgeMs, d.BestIdle.HBAgeMs = 0, 0
 	}
 	if decA != decB {
 		t.Fatalf("decisions differ:\n ex:   %+v\n plan: %+v", decA, decB)

--- a/coordinator/registry/drain_state.go
+++ b/coordinator/registry/drain_state.go
@@ -1,0 +1,112 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Drain awareness (R2, coordinator half).
+//
+// A provider that is draining ahead of a restart/update refuses every new
+// dispatch, but until now nothing told routing: its heartbeat kept reporting
+// idle/serving with warm slots, so the cost scheduler kept ranking it as an
+// ideal instant-TTFT target and each bounce cost the request one of its three
+// transient-capacity retries, derated the pair's gray-box capacity-503 rate,
+// and armed its budget clamp — for a healthy box that was about to restart.
+//
+// Wire strings expected from the provider (the Swift half is implemented
+// separately; mirror in provider-swift/Sources/ProviderCore/Protocol/):
+//
+//   - heartbeat `"status": "draining"` (protocol.HeartbeatStatusDraining)
+//     while the provider is refusing new work. Any later heartbeat carrying
+//     "idle" or "serving" clears the state immediately; a heartbeat that
+//     keeps saying "draining" refreshes the TTL.
+//   - inference_error `{"failure_code": "capacity", "status_code": 503,
+//     "error_reason": "draining"}` (protocol.InferenceErrorReasonDraining) on
+//     the drain admission rejection. The api layer marks the provider
+//     draining from that terminal too, so a drain the provider announced
+//     with a rejection before its event heartbeat landed (the announcement
+//     is a detached task and is dropped while the session is not registered)
+//     is skipped from the next scan on.
+//
+// Both markers ship in the same provider binary (released 0.8.16 sends
+// neither), so a provider that typed the reason also reports the status and
+// its own idle/serving heartbeat is authoritative for either mark: an update
+// drain that aborts before its "draining" heartbeat was ever delivered is
+// back in routing on its next heartbeat, not after the TTL. Legacy providers
+// send neither marker and keep today's path (an untyped 503 sanitized to
+// capacity_busy); they never hold a mark. Both markers are additive and
+// ignored by older coordinators.
+//
+// Routing: providerPassesRoutingGatesLockedEx skips a draining provider on
+// the same branch as the capacity-reject cooldown, so the candidate scan and
+// the admission preflight (quickCapacityCheck) count it as a TRANSIENT
+// capacityRejection — an all-draining model surfaces as 429 + Retry-After /
+// queue material, never as a "no providers" 503.
+
+// drainStateTTL bounds how long a draining mark is honored without a
+// refreshing heartbeat: long enough to outlast the 5 s heartbeat cadence and
+// the provider's shutdown path (which restarts the socket anyway), short
+// enough that a provider whose drain was aborted but whose heartbeats stopped
+// arriving is back in routing within minutes. It is the heartbeat-loss
+// fallback; a live provider clears its mark with its next idle/serving.
+const drainStateTTL = 150 * time.Second
+
+// providerDrainingLocked reports whether p has an unexpired draining mark.
+// Caller holds p.mu.
+func providerDrainingLocked(p *Provider, now time.Time) bool {
+	return !p.drainingUntil.IsZero() && now.Before(p.drainingUntil)
+}
+
+// applyHeartbeatDrainStateLocked updates the draining mark from a heartbeat's
+// status string: "draining" (re)arms the TTL, "idle"/"serving" clear the mark
+// whoever set it, and any other value (legacy/unknown) leaves it untouched.
+// The provider's own status report is authoritative over a mark set by its
+// typed rejection: the rejection is only ever emitted by a binary that also
+// reports "draining" while it refuses work, so an idle/serving heartbeat
+// means the drain is over (see the file header). Caller holds p.mu.
+func applyHeartbeatDrainStateLocked(p *Provider, status string, now time.Time) {
+	switch status {
+	case protocol.HeartbeatStatusDraining:
+		p.drainingUntil = now.Add(drainStateTTL)
+	case "idle", "serving":
+		p.drainingUntil = time.Time{}
+	}
+}
+
+// MarkDraining marks a live provider draining for drainStateTTL (the typed
+// draining rejection path). Returns true only on the transition into the
+// draining state so callers can log/meter once. Unknown ids are a no-op.
+func (r *Registry) MarkDraining(id string) (transitioned bool) {
+	r.mu.RLock()
+	p := r.providers[id]
+	r.mu.RUnlock()
+	if p == nil {
+		return false
+	}
+	now := time.Now()
+	p.mu.Lock()
+	was := providerDrainingLocked(p, now)
+	p.drainingUntil = now.Add(drainStateTTL)
+	p.mu.Unlock()
+	if !was {
+		r.logger.Info("provider draining: routing skips it until it reports idle/serving or the drain TTL lapses",
+			"provider_id", id, "ttl", drainStateTTL)
+	}
+	return !was
+}
+
+// ProviderDraining reports whether the provider currently carries an
+// unexpired draining mark (false for unknown ids).
+func (r *Registry) ProviderDraining(id string) bool {
+	r.mu.RLock()
+	p := r.providers[id]
+	r.mu.RUnlock()
+	if p == nil {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return providerDrainingLocked(p, time.Now())
+}

--- a/coordinator/registry/drain_state_test.go
+++ b/coordinator/registry/drain_state_test.go
@@ -1,0 +1,177 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Drain awareness (drain_state.go) on a real Registry with routable
+// providers: the heartbeat "draining" status and the typed-rejection mark
+// both remove a provider from routing while counting it as TRANSIENT
+// capacity (429 / queue material), never as structural absence.
+
+const drainStateTestModel = "drain-model"
+
+// registerDrainStateProvider registers a hardware-trusted, challenge-verified
+// provider serving drainStateTestModel (the routable-provider recipe shared by the
+// scheduler scenario tests).
+func registerDrainStateProvider(t *testing.T, r *Registry, id string, decodeTPS float64) *Provider {
+	t.Helper()
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: drainStateTestModel, ModelType: "chat", Quantization: "4bit"}}
+	msg.DecodeTPS = decodeTPS
+	p := r.Register(id, nil, msg)
+	p.mu.Lock()
+	p.TrustLevel = TrustHardware
+	p.RuntimeVerified = true
+	p.RuntimeManifestChecked = true
+	p.ChallengeVerifiedSIP = true
+	p.LastChallengeVerified = time.Now()
+	p.SystemMetrics = protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"}
+	p.mu.Unlock()
+	return p
+}
+
+func drainStateHeartbeat(status string) *protocol.HeartbeatMessage {
+	return &protocol.HeartbeatMessage{Type: protocol.TypeHeartbeat, Status: status}
+}
+
+func drainStateRequest(id string) *PendingRequest {
+	return &PendingRequest{RequestID: id, Model: drainStateTestModel, EstimatedPromptTokens: 100, RequestedMaxTokens: 64}
+}
+
+func TestHeartbeatDraining_SkipsProviderAndCountsAsCapacity(t *testing.T) {
+	r := New(testLogger())
+	registerDrainStateProvider(t, r, "a", 200)
+	registerDrainStateProvider(t, r, "b", 1)
+
+	// Sanity: the fast box wins while both are routable.
+	if p, _ := r.ReserveProviderEx(drainStateTestModel, drainStateRequest("warm")); p == nil || p.ID != "a" {
+		t.Fatalf("baseline reservation = %v, want provider a", p)
+	}
+	r.GetProvider("a").RemovePending("warm")
+
+	r.Heartbeat("a", drainStateHeartbeat(protocol.HeartbeatStatusDraining))
+	if !r.ProviderDraining("a") {
+		t.Fatalf("provider a not marked draining after a draining heartbeat")
+	}
+	p, decision := r.ReserveProviderEx(drainStateTestModel, drainStateRequest("r1"))
+	if p == nil || p.ID != "b" {
+		t.Fatalf("reservation with a draining = %v, want provider b (decision %+v)", p, decision)
+	}
+	r.GetProvider("b").RemovePending("r1")
+
+	// Only the draining box left: the scan and the admission preflight both
+	// report transient capacity, not "no providers".
+	r.Disconnect("b")
+	p, decision = r.ReserveProviderEx(drainStateTestModel, drainStateRequest("r2"))
+	if p != nil {
+		t.Fatalf("reserved %s while it was draining", p.ID)
+	}
+	if decision.CapacityRejections != 1 {
+		t.Errorf("scan CapacityRejections = %d, want 1 (draining counts as transient capacity); decision %+v", decision.CapacityRejections, decision)
+	}
+	candidates, capacityRejections, tooLarge := r.QuickCapacityCheck(drainStateTestModel, 500, 64, RequestTraits{})
+	if candidates != 0 || capacityRejections != 1 || tooLarge != 0 {
+		t.Errorf("QuickCapacityCheck = (%d, %d, %d), want (0, 1, 0)", candidates, capacityRejections, tooLarge)
+	}
+
+	// A later idle heartbeat clears a heartbeat-owned mark.
+	r.Heartbeat("a", drainStateHeartbeat("idle"))
+	if r.ProviderDraining("a") {
+		t.Fatalf("provider a still draining after an idle heartbeat")
+	}
+	if p, _ := r.ReserveProviderEx(drainStateTestModel, drainStateRequest("r3")); p == nil || p.ID != "a" {
+		t.Fatalf("reservation after the drain cleared = %v, want provider a", p)
+	}
+}
+
+// A mark set by the typed draining REJECTION is cleared by the provider's
+// own idle/serving heartbeat like a heartbeat-set one: the rejection is only
+// emitted by a binary that also reports "draining", so an update drain that
+// aborted before its draining heartbeat was delivered is back in routing on
+// the next heartbeat. The TTL remains the heartbeat-loss fallback.
+func TestMarkDraining_ClearedByIdleHeartbeat_OrTTL(t *testing.T) {
+	r := New(testLogger())
+	p := registerDrainStateProvider(t, r, "a", 200)
+
+	if !r.MarkDraining("a") {
+		t.Fatalf("first MarkDraining did not report a transition")
+	}
+	if r.MarkDraining("a") {
+		t.Fatalf("second MarkDraining reported a transition")
+	}
+	if candidates, rejections, _ := r.QuickCapacityCheck(drainStateTestModel, 500, 64, RequestTraits{}); candidates != 0 || rejections != 1 {
+		t.Errorf("QuickCapacityCheck while marked = (%d, %d), want (0, 1)", candidates, rejections)
+	}
+	// A legacy/unknown status leaves the mark alone.
+	r.Heartbeat("a", drainStateHeartbeat(""))
+	if !r.ProviderDraining("a") {
+		t.Fatalf("rejection-set drain mark cleared by a heartbeat without a status")
+	}
+	// The aborted-drain case: the provider never reported "draining" and now
+	// reports idle. Routing must see it again immediately.
+	r.Heartbeat("a", drainStateHeartbeat("idle"))
+	if r.ProviderDraining("a") {
+		t.Fatalf("rejection-set drain mark survived the provider's idle heartbeat")
+	}
+	if candidates, rejections, _ := r.QuickCapacityCheck(drainStateTestModel, 500, 64, RequestTraits{}); candidates != 1 || rejections != 0 {
+		t.Errorf("QuickCapacityCheck after the idle heartbeat = (%d, %d), want (1, 0)", candidates, rejections)
+	}
+
+	// TTL expiry restores eligibility without any heartbeat.
+	if !r.MarkDraining("a") {
+		t.Fatalf("re-mark after the clear did not report a transition")
+	}
+	p.mu.Lock()
+	p.drainingUntil = time.Now().Add(-time.Second)
+	p.mu.Unlock()
+	if r.ProviderDraining("a") {
+		t.Fatalf("drain mark still honored past its TTL")
+	}
+
+	// Rejection then "draining" then "serving": the provider's own report
+	// clears it in this order too.
+	r.MarkDraining("a")
+	r.Heartbeat("a", drainStateHeartbeat(protocol.HeartbeatStatusDraining))
+	if !r.ProviderDraining("a") {
+		t.Fatalf("draining heartbeat did not keep the mark")
+	}
+	r.Heartbeat("a", drainStateHeartbeat("serving"))
+	if r.ProviderDraining("a") {
+		t.Fatalf("drain mark not cleared by a serving heartbeat")
+	}
+}
+
+func TestDrainState_UnknownProviderIsNoop(t *testing.T) {
+	r := New(testLogger())
+	if r.MarkDraining("nope") {
+		t.Fatalf("MarkDraining on an unknown id reported a transition")
+	}
+	if r.ProviderDraining("nope") {
+		t.Fatalf("ProviderDraining on an unknown id reported true")
+	}
+}
+
+// A heartbeat-owned mark must stay heartbeat-owned when a typed rejection
+// lands on top of it (a dispatch already on the wire when the drain began),
+// so an aborted update that resumes serving clears it with its own
+// idle/serving heartbeat instead of blacking the box out until the TTL.
+func TestMarkDraining_DoesNotTakeOwnershipFromHeartbeat(t *testing.T) {
+	r := New(testLogger())
+	registerDrainStateProvider(t, r, "a", 200)
+
+	r.Heartbeat("a", drainStateHeartbeat(protocol.HeartbeatStatusDraining))
+	if r.MarkDraining("a") {
+		t.Fatalf("MarkDraining on a heartbeat-marked provider reported a transition")
+	}
+	r.Heartbeat("a", drainStateHeartbeat("idle"))
+	if r.ProviderDraining("a") {
+		t.Fatalf("idle heartbeat did not clear a heartbeat-owned mark after a typed rejection landed on it")
+	}
+	if candidates, rejections, _ := r.QuickCapacityCheck(drainStateTestModel, 500, 64, RequestTraits{}); candidates != 1 || rejections != 0 {
+		t.Errorf("QuickCapacityCheck after un-drain = (%d, %d), want (1, 0)", candidates, rejections)
+	}
+}

--- a/coordinator/registry/error_cooldown.go
+++ b/coordinator/registry/error_cooldown.go
@@ -1,6 +1,10 @@
 package registry
 
-import "time"
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // Inference-error circuit breaker.
 //
@@ -53,7 +57,7 @@ const (
 // SICKNESS count as strikes:
 //
 //	500 — provider bug / crash-adjacent backend failure
-//	502 — disconnect flush (registry.Disconnect fails pending requests as 502)
+//	502 — provider failure or an explicitly marked coordinator disconnect flush
 //	504 — accepted the request, then went silent
 //
 // Everything else records nothing and returns false. In particular 503 is a
@@ -70,7 +74,9 @@ const (
 //
 // State lives on the identity's gate (gate_state.go), keyed inside it by
 // (model, shape); only gate.mu is taken, never r.mu.
-func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode int, shape string) (enteredCooldown bool) {
+// The optional coordinator cause tags only synthetic disconnect flushes for
+// version-reset cleanup; an omitted cause preserves the fault on version change.
+func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode int, shape string, causes ...protocol.CoordinatorInferenceErrorCause) (enteredCooldown bool) {
 	switch statusCode {
 	case 500, 502, 504:
 		// Provider-sickness shapes: count the strike.
@@ -78,14 +84,15 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 		return false
 	}
 
+	flush := isDisconnectFlush(statusCode, causes)
 	var source disconnectSource
-	if statusCode == disconnectFlushStatusCode {
+	if flush {
 		source = r.captureDisconnectSource(providerID)
 	}
 	hold := r.lockGate(r.gateForSession(providerID), "inference_error")
 	defer hold.unlock()
 	g := hold.g
-	if statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
+	if flush && source.supersededBy(g) {
 		return false
 	}
 
@@ -105,7 +112,7 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 	kept = append(kept, now)
 	g.inferenceErrorStrikes[key] = kept
 	g.pruneInferenceFlushStrikesLocked(key, now)
-	if statusCode == disconnectFlushStatusCode {
+	if flush {
 		g.noteInferenceFlushStrikeLocked(key, now)
 	}
 

--- a/coordinator/registry/error_cooldown.go
+++ b/coordinator/registry/error_cooldown.go
@@ -12,10 +12,10 @@ import "time"
 // provider-side (5xx) errors so routing falls to other providers — and, paired
 // with version-diverse retry, to other binary versions.
 //
-// SHAPE-KEYED. The breaker is keyed by (provider, model, shape) rather than a
-// "providerID:modelID" string — where "provider" is the STABLE fault key
-// (faultKeyLocked: serial/SE-key when bound, session id otherwise), so strikes
-// and cooldowns survive reconnect churn. Shape ("tools" / "base", from
+// SHAPE-KEYED. The breaker is keyed by (provider, model, shape) — the
+// provider's gate is its STABLE fault key (faultKeyForSession: serial/SE-key
+// when bound, session id otherwise), so strikes and cooldowns survive
+// reconnect churn, and inside the gate a modelShapeKey names the bucket. Shape ("tools" / "base", from
 // RequestTraits.CooldownShape) closes the root bug behind the prod incident: a
 // deterministic tool/template failure that fails EVERY tool request can be
 // interleaved with clean non-tool text successes for the same pair. With a
@@ -24,11 +24,11 @@ import "time"
 // was never quarantined for tools. Per-shape buckets make tool failures
 // accumulate in the "tools" bucket independent of "base" successes, and a
 // success clears ONLY its own shape bucket. The struct key also closes the
-// threat-model colon-collision note (a provider/model id containing ':' could
-// alias a different pair under the old concat key).
+// threat-model colon-collision note (a model id containing ':' could alias a
+// different pair under the old concat key).
 //
-// Modeled on dispatchLoadCooldowns (registry.go): same r.mu discipline, same
-// opportunistic map bounding, window-rebuild-on-write. Only sickness-shaped
+// Modeled on the dispatch-load cooldown (registry.go): per-identity gate
+// state (gate_state.go), window-rebuild-on-write. Only sickness-shaped
 // status codes (500/502/504) count toward quarantine: 4xx are client-shape
 // failures (bad request, context too long) and 503 is the provider's
 // capacity/lifecycle signal (token budget, request rejected, update drain) —
@@ -47,19 +47,6 @@ const (
 	// own even without a served request.
 	inferenceErrorCooldownTTL = 5 * time.Minute
 )
-
-// inferenceErrorKey identifies a circuit-breaker bucket. ProviderID holds the
-// provider's STABLE fault key (faultKeyLocked: serial/SE-key when bound, the
-// session id otherwise) so buckets survive reconnect churn. Shape is the
-// request dimension from RequestTraits.CooldownShape ("tools" / "base"), so a
-// failure that only affects one shape quarantines only that shape. A struct
-// key (vs a delimiter-joined string) cannot alias across ids that contain the
-// delimiter.
-type inferenceErrorKey struct {
-	ProviderID string
-	ModelID    string
-	Shape      string
-}
 
 // RecordInferenceError records a provider-side inference failure for the
 // (provider, model, shape) triple. Only statusCodes that indicate provider
@@ -80,6 +67,9 @@ type inferenceErrorKey struct {
 // inferenceErrorCooldownTTL; further strikes while cooling extend the expiry.
 // Returns true ONLY on the transition into cool-down so callers can emit
 // metrics without double-counting (mirrors RecordDispatchLoadFailure).
+//
+// State lives on the identity's gate (gate_state.go), keyed inside it by
+// (model, shape); only gate.mu is taken, never r.mu.
 func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode int, shape string) (enteredCooldown bool) {
 	switch statusCode {
 	case 500, 502, 504:
@@ -88,39 +78,24 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 		return false
 	}
 
-	hold := r.lockWrite("inference_error")
+	var source disconnectSource
+	if statusCode == disconnectFlushStatusCode {
+		source = r.captureDisconnectSource(providerID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "inference_error")
 	defer hold.unlock()
-	// Recheck under the mutation lock: a version reset can race any API-side check.
-	if statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+	g := hold.g
+	if statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
 		return false
 	}
+
 	now := time.Now()
-	// Key by the stable fault key (serial/SE-key when bound, session id
-	// otherwise) so strikes and cooldowns survive reconnect churn.
-	providerID = r.faultKeyLocked(providerID)
+	defer g.updatedLocked(now)
 
-	// Opportunistic sweep, mirroring dispatchLoadCooldowns: churned identities
-	// are never re-keyed — bound both maps by dropping expired ones once they
-	// grow.
-	if len(r.inferenceErrorCooldowns) > 1024 {
-		for key, expiry := range r.inferenceErrorCooldowns {
-			if !now.Before(expiry) {
-				delete(r.inferenceErrorCooldowns, key)
-			}
-		}
-	}
-	if len(r.inferenceErrorStrikes) > 1024 {
-		for key, strikes := range r.inferenceErrorStrikes {
-			if len(strikes) == 0 || !strikes[len(strikes)-1].Add(inferenceErrorWindow).After(now) {
-				delete(r.inferenceErrorStrikes, key)
-			}
-		}
-	}
-
-	key := inferenceErrorKey{ProviderID: providerID, ModelID: modelID, Shape: shape}
+	key := modelShapeKey{Model: modelID, Shape: shape}
 
 	// Slide the window: keep only strikes still inside it, then add this one.
-	strikes := r.inferenceErrorStrikes[key]
+	strikes := g.inferenceErrorStrikes[key]
 	kept := strikes[:0]
 	for _, ts := range strikes {
 		if now.Sub(ts) < inferenceErrorWindow {
@@ -128,27 +103,21 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 		}
 	}
 	kept = append(kept, now)
-	r.inferenceErrorStrikes[key] = kept
-	// The disconnect-flush tags (version_reset.go) must stay a subset of the
-	// live strikes: slide their window with the strikes, or an identity that
-	// churns on the SAME version for weeks — the reset never fires for it —
-	// keeps every flushed request's timestamp forever.
-	r.pruneInferenceFlushStrikesLocked(key, now)
-	// Tag the disconnect-flush strike so a version-changed reconnect can
-	// remove exactly it (version_reset.go).
+	g.inferenceErrorStrikes[key] = kept
+	g.pruneInferenceFlushStrikesLocked(key, now)
 	if statusCode == disconnectFlushStatusCode {
-		r.noteInferenceFlushStrikeLocked(key, now)
+		g.noteInferenceFlushStrikeLocked(key, now)
 	}
 
 	if len(kept) < inferenceErrorThreshold {
 		return false
 	}
 
-	expiry, active := r.inferenceErrorCooldowns[key]
+	expiry, active := g.inferenceErrorCooldowns[key]
 	active = active && now.Before(expiry)
 	// Threshold met: (re-)arm the cool-down. Repeated failures extend an
 	// active cool-down, but only the transition reports true.
-	r.inferenceErrorCooldowns[key] = now.Add(inferenceErrorCooldownTTL)
+	g.inferenceErrorCooldowns[key] = now.Add(inferenceErrorCooldownTTL)
 	return !active
 }
 
@@ -160,28 +129,41 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 // deterministic tool failure interleaved with text traffic could never trip
 // the breaker (the original incident).
 func (r *Registry) RecordInferenceSuccess(providerID, modelID, shape string) {
-	hold := r.lockWrite("inference_success")
+	hold := r.lockGate(r.lookupSessionGateRef(providerID), "inference_success")
 	defer hold.unlock()
-	key := inferenceErrorKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID, Shape: shape}
-	delete(r.inferenceErrorStrikes, key)
-	delete(r.inferenceErrorCooldowns, key)
-	// The flush tags mark strikes that no longer exist.
-	delete(r.inferenceErrorFlushStrikes, key)
+	g := hold.g
+	if g == nil {
+		return
+	}
+
+	key := modelShapeKey{Model: modelID, Shape: shape}
+	delete(g.inferenceErrorStrikes, key)
+	delete(g.inferenceErrorCooldowns, key)
+	delete(g.inferenceErrorFlushStrikes, key)
+	g.updatedLocked(time.Now())
 }
 
 // InferenceErrorCooldownActive reports whether the (provider, model, shape)
 // triple is currently quarantined by the inference-error circuit breaker.
 func (r *Registry) InferenceErrorCooldownActive(providerID, modelID, shape string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.inferenceErrorCooldownActiveLocked(providerID, modelID, shape, time.Now())
+	return r.inferenceErrorCooled(providerID, modelID, shape, time.Now())
 }
 
-// inferenceErrorCooldownActiveLocked reports whether routing should skip the
-// triple. READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock.
-// Caller holds r.mu in either mode (mirrors dispatchLoadCooldownActiveLocked).
-func (r *Registry) inferenceErrorCooldownActiveLocked(providerID, modelID, shape string, now time.Time) bool {
-	key := inferenceErrorKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID, Shape: shape}
-	expiry, ok := r.inferenceErrorCooldowns[key]
+// inferenceErrorCooled reports whether routing should skip the triple.
+// Resolves the session's gate; the scan uses the cached p.gate directly.
+func (r *Registry) inferenceErrorCooled(providerID, modelID, shape string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).inferenceErrorCooled(modelID, shape, now)
+}
+
+// inferenceErrorCooled is the gate-level check: lock-free "no cooldown on any
+// shape" fast path, otherwise one short gate.mu section. READ-ONLY (no lazy
+// delete). nil-safe.
+func (g *gateState) inferenceErrorCooled(modelID, shape string, now time.Time) bool {
+	if !g.hasPairState(gateFlagErrorCooldown) {
+		return false
+	}
+	g = g.lockResolved()
+	expiry, ok := g.inferenceErrorCooldowns[modelShapeKey{Model: modelID, Shape: shape}]
+	g.mu.Unlock()
 	return ok && now.Before(expiry)
 }

--- a/coordinator/registry/error_cooldown.go
+++ b/coordinator/registry/error_cooldown.go
@@ -90,6 +90,10 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 
 	hold := r.lockWrite("inference_error")
 	defer hold.unlock()
+	// Recheck under the mutation lock: a version reset can race any API-side check.
+	if statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+		return false
+	}
 	now := time.Now()
 	// Key by the stable fault key (serial/SE-key when bound, session id
 	// otherwise) so strikes and cooldowns survive reconnect churn.
@@ -125,6 +129,16 @@ func (r *Registry) RecordInferenceError(providerID, modelID string, statusCode i
 	}
 	kept = append(kept, now)
 	r.inferenceErrorStrikes[key] = kept
+	// The disconnect-flush tags (version_reset.go) must stay a subset of the
+	// live strikes: slide their window with the strikes, or an identity that
+	// churns on the SAME version for weeks — the reset never fires for it —
+	// keeps every flushed request's timestamp forever.
+	r.pruneInferenceFlushStrikesLocked(key, now)
+	// Tag the disconnect-flush strike so a version-changed reconnect can
+	// remove exactly it (version_reset.go).
+	if statusCode == disconnectFlushStatusCode {
+		r.noteInferenceFlushStrikeLocked(key, now)
+	}
 
 	if len(kept) < inferenceErrorThreshold {
 		return false
@@ -151,6 +165,8 @@ func (r *Registry) RecordInferenceSuccess(providerID, modelID, shape string) {
 	key := inferenceErrorKey{ProviderID: r.faultKeyLocked(providerID), ModelID: modelID, Shape: shape}
 	delete(r.inferenceErrorStrikes, key)
 	delete(r.inferenceErrorCooldowns, key)
+	// The flush tags mark strikes that no longer exist.
+	delete(r.inferenceErrorFlushStrikes, key)
 }
 
 // InferenceErrorCooldownActive reports whether the (provider, model, shape)

--- a/coordinator/registry/error_cooldown_test.go
+++ b/coordinator/registry/error_cooldown_test.go
@@ -7,24 +7,22 @@ import (
 )
 
 func inferenceCooldownActiveAt(r *Registry, providerID, modelID, shape string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.inferenceErrorCooldownActiveLocked(providerID, modelID, shape, now)
+	return r.inferenceErrorCooled(providerID, modelID, shape, now)
 }
 
 // ageInferenceStrikes rewinds every recorded strike for the (provider, model,
 // shape) triple by d, simulating the passage of time without sleeping in the
 // test.
 func ageInferenceStrikes(r *Registry, providerID, modelID, shape string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	key := inferenceErrorKey{ProviderID: providerID, ModelID: modelID, Shape: shape}
-	strikes := r.inferenceErrorStrikes[key]
-	aged := make([]time.Time, len(strikes))
-	for i, ts := range strikes {
-		aged[i] = ts.Add(-d)
-	}
-	r.inferenceErrorStrikes[key] = aged
+	withGateForSession(r, providerID, func(g *gateState) {
+		key := modelShapeKey{Model: modelID, Shape: shape}
+		strikes := g.inferenceErrorStrikes[key]
+		aged := make([]time.Time, len(strikes))
+		for i, ts := range strikes {
+			aged[i] = ts.Add(-d)
+		}
+		g.inferenceErrorStrikes[key] = aged
+	})
 }
 
 // Regression for the prod incident: a deterministic provider-side failure
@@ -269,41 +267,35 @@ func TestInferenceErrorShapeKeyedBucketsIndependent(t *testing.T) {
 
 func TestInferenceErrorMapsBounded(t *testing.T) {
 	r := New(testLogger())
-	// Trip the breaker for >1024 distinct dead pairs so both maps grow, then
-	// force everything past expiry — the opportunistic sweep must drop them.
+	// Trip the breaker for >1024 distinct dead identities, then let everything
+	// expire — the gate sweep must drop every idle gate, while a connected
+	// provider's gate keeps its (pruned) state.
 	for i := 0; i < 1100; i++ {
 		id := fmt.Sprintf("dead-provider-%d", i)
 		r.RecordInferenceError(id, "m", 500, "base")
 		r.RecordInferenceError(id, "m", 500, "base")
 	}
-	r.mu.Lock()
-	for k := range r.inferenceErrorCooldowns {
-		r.inferenceErrorCooldowns[k] = time.Now().Add(-time.Second)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
-	for k, strikes := range r.inferenceErrorStrikes {
-		aged := make([]time.Time, len(strikes))
-		for i, ts := range strikes {
-			aged[i] = ts.Add(-(inferenceErrorWindow + time.Second))
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordInferenceError(live.ID, "m", 500, "base")
+
+	future := time.Now().Add(gateIdleGrace + inferenceErrorCooldownTTL + time.Second)
+	r.sweepGates(future)
+
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
+	}
+	readGateForSession(r, live.ID, func(g *gateState) {
+		if g == nil {
+			t.Fatal("the connected provider's gate must never be swept")
 		}
-		r.inferenceErrorStrikes[k] = aged
-	}
-	cooldowns, strikes := len(r.inferenceErrorCooldowns), len(r.inferenceErrorStrikes)
-	r.mu.Unlock()
-	if cooldowns < 1000 || strikes < 1000 {
-		t.Fatalf("setup produced too few distinct entries: cooldowns=%d strikes=%d", cooldowns, strikes)
-	}
-
-	r.RecordInferenceError("live", "m", 500, "base")
-
-	r.mu.Lock()
-	cooldownsAfter, strikesAfter := len(r.inferenceErrorCooldowns), len(r.inferenceErrorStrikes)
-	r.mu.Unlock()
-	if cooldownsAfter != 0 {
-		t.Fatalf("cooldown sweep should drop every expired entry (live pair has no cooldown yet), got %d", cooldownsAfter)
-	}
-	if strikesAfter != 1 {
-		t.Fatalf("strike sweep should leave only the live entry, got %d", strikesAfter)
-	}
+		if len(g.inferenceErrorStrikes) != 0 || len(g.inferenceErrorCooldowns) != 0 {
+			t.Fatalf("expired strikes/cooldowns must be pruned from a live gate: strikes=%d cooldowns=%d",
+				len(g.inferenceErrorStrikes), len(g.inferenceErrorCooldowns))
+		}
+	})
 }
 
 // End-to-end through the production dispatch hot path (ReserveProviderEx): a

--- a/coordinator/registry/fleet_sample.go
+++ b/coordinator/registry/fleet_sample.go
@@ -230,8 +230,10 @@ func (r *Registry) appendProviderSample(rows []store.FleetSnapshotRow, p *Provid
 		// registry-side state is gone or belongs to a new session — drop it.
 		return rows[:start]
 	}
-	breakerOpen := r.providerBreakerOpenLocked(p.ID, now)
-	ejected := stableID != "" && r.healthEjectionOpenLocked(stableID, now)
+	gate := r.gateOf(p)
+	nowNS := now.UnixNano()
+	breakerOpen := gate.breakerOpenAt(nowNS)
+	ejected := r.ejectionOpenFor(gate, stableID, nowNS)
 	if scratch == nil {
 		row := &rows[start]
 		row.BreakerOpen = breakerOpen
@@ -254,10 +256,10 @@ func (r *Registry) appendProviderSample(rows []store.FleetSnapshotRow, p *Provid
 		row.BreakerOpen = breakerOpen
 		row.Ejected = ejected
 		row.EffectiveCap = r.effectiveMaxConcurrencyForModelResolvedLocked(p, raw)
-		row.CooldownActive = r.dispatchLoadCooldownActiveLocked(p.ID, raw, now) ||
-			r.inferenceErrorCooldownActiveLocked(p.ID, raw, shape, now) ||
-			r.capacityCooldownActiveLocked(p.ID, raw, now)
-		row.ClampActive = r.budgetClampActiveLocked(p.ID, raw, heartbeatAt, scratch[i].rawRemaining, scratch[i].budgetReported, now)
+		row.CooldownActive = gate.dispatchLoadCooled(raw, now) ||
+			gate.inferenceErrorCooled(raw, shape, now) ||
+			gate.capacityCooled(raw, now)
+		row.ClampActive = gate.budgetClampActive(r.budgetClampCfg, raw, heartbeatAt, scratch[i].rawRemaining, scratch[i].budgetReported, now)
 	}
 	p.mu.Unlock()
 	// Eligibility via the real routing gates (the snapshot helper takes p.mu
@@ -311,11 +313,13 @@ func (r *Registry) slotEligibilityReasonLocked(p *Provider, model string, probe 
 // a provider with no resident slot to evaluate a model against. Caller holds
 // r.mu (read) and p.mu.
 func (r *Registry) providerLevelGateReasonLocked(p *Provider, now time.Time) (bool, GateReason) {
-	if r.providerBreakerOpenLocked(p.ID, now) {
+	g := r.gateOf(p)
+	nowNS := now.UnixNano()
+	if g.breakerOpenAt(nowNS) {
 		return false, GateBreaker
 	}
 	if healthEjectionEnabled() {
-		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, now) {
+		if r.ejectionOpenFor(g, stableProviderIdentityLocked(p), nowNS) {
 			return false, GateEjection
 		}
 	}

--- a/coordinator/registry/gate_commit_mode.go
+++ b/coordinator/registry/gate_commit_mode.go
@@ -1,0 +1,95 @@
+package registry
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// gate_commit_mode.go — the EIGENINFERENCE_RESERVE_COMMIT_MODE kill switch:
+// how the reservation commit holds the registry lock (shared RLock, or the
+// fleet-wide write lock it replaced). Design and file map: gate_state.go.
+
+// --- reservation commit lock mode ---
+
+// reserveCommitMode selects how commitProviderReservation and
+// ReserveNextFromPlan hold the registry lock while they debit a provider.
+type reserveCommitMode uint8
+
+const (
+	// reserveCommitShared (default) commits under r.mu.RLock + p.mu: the
+	// double-booking guard is the admit re-check under p.mu, the herd guard
+	// is the "winner unchanged since scan" compare under the same p.mu, and
+	// the probe claim is atomic under gate.mu. Commits no longer drain the
+	// fleet-scan reader batch.
+	reserveCommitShared reserveCommitMode = iota
+	// reserveCommitGlobal is the kill switch: commits take r.mu.Lock() and
+	// serialize fleet-wide exactly as before. The recorders stay on their
+	// per-identity gates in both modes — that half is safe on its own.
+	reserveCommitGlobal
+)
+
+// envReserveCommitMode selects the mode: "global" restores the fleet-wide
+// commit serialization; anything else (including unset) is "shared". Read
+// once at Registry construction.
+const envReserveCommitMode = "EIGENINFERENCE_RESERVE_COMMIT_MODE"
+
+func loadReserveCommitMode(logger *slog.Logger) reserveCommitMode {
+	raw := os.Getenv(envReserveCommitMode)
+	mode, known := parseReserveCommitMode(raw)
+	if !known && logger != nil {
+		// A kill switch that silently ignores a typo is not a kill switch.
+		logger.Warn("unknown reserve commit mode; using shared",
+			"env", envReserveCommitMode, "value", raw)
+	}
+	return mode
+}
+
+// parseReserveCommitMode maps the raw value to a mode; known reports whether
+// the value named one ("" and "shared" are shared, "global" is global).
+func parseReserveCommitMode(raw string) (mode reserveCommitMode, known bool) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "shared":
+		return reserveCommitShared, true
+	case "global":
+		return reserveCommitGlobal, true
+	default:
+		return reserveCommitShared, false
+	}
+}
+
+func (m reserveCommitMode) String() string {
+	if m == reserveCommitGlobal {
+		return "global"
+	}
+	return "shared"
+}
+
+// commitLock is the registry lock held across a reservation commit in the
+// configured mode. A value type so the commit path allocates nothing.
+type commitLock struct {
+	r      *Registry
+	global bool
+	site   string
+	write  writeHold
+}
+
+func (r *Registry) commitLock(site string) commitLock {
+	return commitLock{r: r, global: r.reserveCommitMode == reserveCommitGlobal, site: site}
+}
+
+func (l *commitLock) lock() {
+	if l.global {
+		l.write = l.r.lockWrite(l.site)
+	} else {
+		l.r.mu.RLock()
+	}
+}
+
+func (l *commitLock) unlock() {
+	if l.global {
+		l.write.unlock()
+	} else {
+		l.r.mu.RUnlock()
+	}
+}

--- a/coordinator/registry/gate_disconnected_binding.go
+++ b/coordinator/registry/gate_disconnected_binding.go
@@ -1,0 +1,47 @@
+package registry
+
+import "sync/atomic"
+
+// disconnectedGateBinding is a cache-owned identity redirect shared with
+// recorder refs. It retains only an immutable key, never a disconnected
+// Provider or its request/connection state. The cache's existing TTL bounds
+// its lifetime; refs may keep it alive only while an outcome is in flight.
+type disconnectedGateBinding struct {
+	key atomic.Pointer[string]
+}
+
+func newDisconnectedGateBinding(key string) *disconnectedGateBinding {
+	binding := &disconnectedGateBinding{}
+	binding.store(key)
+	return binding
+}
+
+func (binding *disconnectedGateBinding) store(key string) {
+	binding.key.Store(&key)
+}
+
+func (binding *disconnectedGateBinding) load() string {
+	if key := binding.key.Load(); key != nil {
+		return *key
+	}
+	return ""
+}
+
+// retargetDisconnectedGateBindingsLocked moves cached session identities with
+// their fault state. Caller holds gatesMu and the source gate's mu, so a
+// cached ref either records before the migration or detects the redirect
+// after acquiring the source gate. Keep the original disconnect time: it is
+// both the cache TTL anchor and the version-reset ordering signal.
+func (r *Registry) retargetDisconnectedGateBindingsLocked(oldKey, newKey string) {
+	for sessionID, cached := range r.disconnectedStableIDs {
+		if cached.id != oldKey {
+			continue
+		}
+		if cached.binding == nil {
+			cached.binding = newDisconnectedGateBinding(oldKey)
+		}
+		cached.binding.store(newKey)
+		cached.id = newKey
+		r.disconnectedStableIDs[sessionID] = cached
+	}
+}

--- a/coordinator/registry/gate_disconnected_binding_test.go
+++ b/coordinator/registry/gate_disconnected_binding_test.go
@@ -1,0 +1,87 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestDisconnectedGateRefFollowsSharedIdentityEnrichment(t *testing.T) {
+	for _, captureWhileLive := range []bool{false, true} {
+		name := "cached-ref"
+		if captureWhileLive {
+			name = "live-ref-then-disconnect"
+		}
+		t.Run(name, func(t *testing.T) {
+			reg := New(testLogger())
+			const model = "m"
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-CACHED-REF"}
+			bind := func(id string) *Provider {
+				p := makeSchedulerProvider(t, reg, id, model, 100)
+				p.SetAttestationResult(identity)
+				p.SetVersion("0.9.0")
+				return p
+			}
+			old := bind("cached-ref-old")
+			current := bind("cached-ref-current")
+			sibling := bind("cached-ref-sibling")
+			var ref gateRef
+			var source disconnectSource
+			if captureWhileLive {
+				ref = reg.gateForSession(old.ID)
+				source = reg.captureDisconnectSource(old.ID)
+			}
+			reg.DisconnectWithReason(old.ID, DisconnectReasonReadError)
+			if !captureWhileLive {
+				ref = reg.gateForSession(old.ID)
+				source = reg.captureDisconnectSource(old.ID)
+				if ref.disconnectedBinding == nil {
+					t.Fatal("cached resolution did not retain the small identity binding")
+				}
+			}
+			reg.gatesMu.RLock()
+			disconnectedAt := reg.disconnectedStableIDs[old.ID].at
+			reg.gatesMu.RUnlock()
+			shared := ref.g
+			current.SetVersion("0.9.1")
+			// A real post-reset pair state also exercises the lock-free false
+			// flag path after the shared source is emptied by migration.
+			withGateForSession(reg, current.ID, func(g *gateState) {
+				g.dispatchLoadCooldowns[model] = time.Now().Add(time.Minute)
+			})
+			current.SetAttestationResult(&attestation.VerificationResult{
+				Valid: true, PublicKey: identity.PublicKey, SerialNumber: versionResetSerial,
+			})
+			target := current.gate.Load()
+			if target == shared || sibling.gate.Load() != shared || shared.forwardTo.Load() != nil {
+				t.Fatal("precondition: a live sibling must retain the unforwarded source")
+			}
+			reg.gatesMu.RLock()
+			cached := reg.disconnectedStableIDs[old.ID]
+			reg.gatesMu.RUnlock()
+			if cached.id != versionResetStable || !cached.at.Equal(disconnectedAt) {
+				t.Fatalf("cached identity/time = %q/%v, want %q/%v", cached.id, cached.at, versionResetStable, disconnectedAt)
+			}
+
+			hold := reg.lockGate(ref, "breaker")
+			if hold.g != target {
+				hold.unlock()
+				t.Fatal("old-session recorder locked the emptied source instead of the enriched identity")
+			}
+			if !source.supersededBy(hold.g) {
+				hold.unlock()
+				t.Fatal("stale recorder missed the new binary's migrated reset marker")
+			}
+			hold.unlock()
+
+			resolved, has := reg.refHasPairState(ref, gateFlagDispatchLoad)
+			if !has || resolved.g != target || resolved.p != nil {
+				t.Fatal("stale false flag did not re-resolve through the redirected disconnect cache")
+			}
+			if !reg.IsSupersededDisconnectFlush(old.ID, disconnectFlushStatusCode) {
+				t.Fatal("fresh old-session lookup lost the version reset after enrichment")
+			}
+		})
+	}
+}

--- a/coordinator/registry/gate_disconnected_binding_test.go
+++ b/coordinator/registry/gate_disconnected_binding_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 func TestDisconnectedGateRefFollowsSharedIdentityEnrichment(t *testing.T) {
@@ -79,7 +80,7 @@ func TestDisconnectedGateRefFollowsSharedIdentityEnrichment(t *testing.T) {
 			if !has || resolved.g != target || resolved.p != nil {
 				t.Fatal("stale false flag did not re-resolve through the redirected disconnect cache")
 			}
-			if !reg.IsSupersededDisconnectFlush(old.ID, disconnectFlushStatusCode) {
+			if !reg.IsSupersededDisconnectFlush(old.ID, disconnectFlushStatusCode, protocol.CoordinatorCauseProviderDisconnected) {
 				t.Fatal("fresh old-session lookup lost the version reset after enrichment")
 			}
 		})

--- a/coordinator/registry/gate_index.go
+++ b/coordinator/registry/gate_index.go
@@ -1,0 +1,303 @@
+package registry
+
+import "time"
+
+// gate_index.go — the registry side of the per-identity gates: the r.gates /
+// r.sessions index under gatesMu, session → gate resolution (gateRef), the
+// scan's gateOf, and attach/detach at Register / Disconnect. Design, lock
+// order and file map: gate_state.go.
+
+// --- Registry side: the gate index ---
+
+// gatesInit lazily creates the gate index so bare &Registry{} test
+// constructions work without New(). Caller holds gatesMu for writing.
+func (r *Registry) gatesInitLocked() {
+	if r.gates == nil {
+		r.gates = make(map[string]*gateState)
+	}
+	if r.sessions == nil {
+		r.sessions = make(map[string]*Provider)
+	}
+	if r.disconnectedStableIDs == nil {
+		r.disconnectedStableIDs = make(map[string]disconnectedStableID)
+	}
+}
+
+// ensureGateLocked returns the gate for key, creating it on first use. Caller
+// holds gatesMu for writing. A creation past the high-water mark runs the
+// rate-limited inline sweep so the index stays bounded without the eviction
+// loop.
+func (r *Registry) ensureGateLocked(key string, now time.Time) *gateState {
+	r.gatesInitLocked()
+	if g, ok := r.gates[key]; ok {
+		return g
+	}
+	if len(r.gates) > gateSweepHighWater && now.Sub(r.gateSweepAt) > gateSweepMinInterval {
+		r.sweepGatesLocked(now)
+	}
+	g := newGateState(key)
+	g.touched = now // creation counts as activity: see gateState.touched
+	r.gates[key] = g
+	return g
+}
+
+// gateForKey returns the gate filed under an explicit fault key / stable
+// identity (RecordProviderServeOutcome is keyed by the caller's stable id),
+// creating it on first use. One gatesMu.RLock in the common case.
+func (r *Registry) gateForKey(key string) gateRef {
+	r.gatesMu.RLock()
+	g := r.gates[key]
+	r.gatesMu.RUnlock()
+	if g == nil {
+		r.gatesMu.Lock()
+		g = r.ensureGateLocked(key, time.Now())
+		r.gatesMu.Unlock()
+	}
+	return gateRef{g: g.resolve(), key: key, insert: true}
+}
+
+// lookupGateForKey is gateForKey without the insert: nil when the identity has
+// no state.
+func (r *Registry) lookupGateForKey(key string) *gateState {
+	r.gatesMu.RLock()
+	g := r.gates[key]
+	r.gatesMu.RUnlock()
+	return g.resolve()
+}
+
+// gateForSession resolves a live session id to its identity's gate, creating
+// the (session-keyed) gate when the identity has none. Precedence mirrors the
+// old faultKeyLocked: the bound identity of a live session → the identity
+// cached at Disconnect for the trailing ErrorCh flush → the session id itself.
+// Recorders call this; it never touches r.mu.
+func (r *Registry) gateForSession(sessionID string) gateRef {
+	return r.sessionGateRef(sessionID, true)
+}
+
+// lookupSessionGateRef is gateForSession without the insert: ref.g is nil when
+// the session's identity has no state. The recorders that only CLEAR state
+// (and so have nothing to do for an identity without a gate) resolve through
+// this, so a straggling clear for a dead session never files a gate under
+// its id — including when lockGate has to re-resolve.
+func (r *Registry) lookupSessionGateRef(sessionID string) gateRef {
+	return r.sessionGateRef(sessionID, false)
+}
+
+// lookupGateForSession is the plain-pointer form of lookupSessionGateRef for
+// readers (the scan's fallback for a bare provider, the *Active probes,
+// tests): nil when the session's identity has no state.
+func (r *Registry) lookupGateForSession(sessionID string) *gateState {
+	return r.sessionGateRef(sessionID, false).g
+}
+
+func (r *Registry) sessionGateRef(sessionID string, insert bool) gateRef {
+	r.gatesMu.RLock()
+	ref, _ := r.sessionGateRefLocked(sessionID, insert)
+	r.gatesMu.RUnlock()
+	if ref.g == nil && insert {
+		r.gatesMu.Lock()
+		// The session or cached identity may have changed since the miss.
+		// Resolve again before inserting so an enrichment cannot recreate
+		// state under the disconnected session's obsolete key.
+		var key string
+		ref, key = r.sessionGateRefLocked(sessionID, insert)
+		if ref.g == nil {
+			ref.g = r.ensureGateLocked(key, time.Now())
+		}
+		r.gatesMu.Unlock()
+	}
+	ref.g = ref.g.resolve()
+	return ref
+}
+
+// sessionGateRefLocked captures the cached binding in the same index read as
+// the gate. Caller holds gatesMu (either mode).
+func (r *Registry) sessionGateRefLocked(sessionID string, insert bool) (gateRef, string) {
+	g, key, via := r.resolveSessionGateLocked(sessionID)
+	ref := gateRef{g: g, p: via, session: sessionID, insert: insert}
+	if via == nil {
+		if cached, ok := r.disconnectedStableIDs[sessionID]; ok && cached.id == key {
+			ref.disconnectedBinding = cached.binding
+		}
+	}
+	return ref, key
+}
+
+// resolveSessionGateLocked returns the gate a session resolves to (nil when
+// its key has no gate yet), that key, and — when the gate came from a live
+// session's cached pointer — that session's Provider, so the caller can later
+// detect a rebind (gateRef.p). Caller holds gatesMu (either mode).
+func (r *Registry) resolveSessionGateLocked(sessionID string) (g *gateState, key string, via *Provider) {
+	if p := r.sessions[sessionID]; p != nil {
+		if g := p.gate.Load(); g != nil {
+			return g, g.key, p
+		}
+		return r.gates[sessionID], sessionID, nil
+	}
+	if c, ok := r.disconnectedStableIDs[sessionID]; ok && c.id != "" && time.Since(c.at) < disconnectedStableIDTTL {
+		return r.gates[c.id], c.id, nil
+	}
+	return r.gates[sessionID], sessionID, nil
+}
+
+// faultKeyForSession resolves a session provider id to the key its fault state
+// lives under: the bound stable identity (serial/SE-key/account), the identity
+// cached at Disconnect for the trailing ErrorCh flush, or — when no identity
+// was ever available — the session id itself. Takes gatesMu for reading.
+func (r *Registry) faultKeyForSession(sessionID string) string {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	_, key, _ := r.resolveSessionGateLocked(sessionID)
+	return key
+}
+
+// sessionProvider returns the live Provider for a session id without touching
+// r.mu (the recorders that need a budget snapshot read p.BackendCapacity
+// under p.mu). nil when the session is gone.
+func (r *Registry) sessionProvider(sessionID string) *Provider {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return r.sessions[sessionID]
+}
+
+// gateOf returns the gate the scan should consult for p: the pointer cached on
+// the connected Provider (no lock), falling back to a session lookup for a
+// Provider that was never registered (bare test objects). nil-safe result:
+// every gate read treats a nil gate as "no state".
+func (r *Registry) gateOf(p *Provider) *gateState {
+	if p == nil {
+		return nil
+	}
+	if g := p.gate.Load(); g != nil {
+		return g.resolve()
+	}
+	return r.lookupGateForSession(p.ID)
+}
+
+// gateView is the routing read path's handle on a session's gate for one
+// batch of reads: the gate gateOf loaded plus the Provider it was loaded
+// from, so the reads can be confirmed against the pointer afterwards. A value
+// type — the scan allocates nothing.
+//
+// A rebind runs under the session's p.mu (bindStableFaultKey's callers hold
+// it), so a read made under p.mu sees one p.gate for its whole section. Not
+// every dispatch-deciding read is made there — the candidate's capacity-rate
+// penalty (buildCandidateInto) is computed after the scan has released p.mu —
+// and the gate chain's p.mu is its caller's contract, not this file's, so the
+// reads are confirmed independently of that lock. Without it, a gate is read
+// lock-free (or under gate.mu for the per-model maps) holding nothing a rebind
+// respects, and a rebind that lands between the load and the reads can leave
+// the loaded gate saying nothing about the session:
+// migrateGateLocked moves the state to the session's new gate and, when the
+// source is SHARED with another live session, resets the source and
+// republishes it — zeros. A scan trusting that view would dispatch the
+// session past a breaker or cooldown that moved with it. So every batch of
+// reads is confirmed (moved): if p.gate still resolves to the gate that was
+// read, the verdict stands; otherwise the view is rebased on the new gate and
+// the reads run again. Sound without a lock because the migration repoints
+// p.gate BEFORE it resets and republishes the source (all under the source's
+// mu) and Go's atomics are sequentially consistent: a reader whose confirming
+// load still returns the source made its atomic reads before the zeroing
+// stores, and a reader that took the source's mu after the migration finds
+// the pointer moved. Both verdicts are confirmed — a reset source can already
+// carry the sibling session's fresh faults, which are not this session's.
+//
+// Which reads confirm: everything that feeds a dispatch decision — the
+// routing gate (gateStateReasonLocked: the scan, the commit's admit re-check
+// and the preflight), the snapshot's budget clamp (budgetClampedFor) and the
+// candidate's capacity-rate penalty (capacityRatePenaltyFor). Rejected-provider
+// classification (classifyRejectedProvider) also confirms its view because it
+// controls the fail-open rescan and capacity/no-provider response. Gate tallies,
+// fleet_sample rows and warm-pool planning read gateOf unconfirmed: a stale
+// sample there miscounts once and dispatches nothing.
+//
+// No retired check: the sweep drops only gates with no live session, and
+// every read site holds r.mu (Disconnect removes the session under
+// r.mu.Lock) or checks r.providers[p.ID] == p under it, so a live session's
+// gate is never retired underneath a read.
+type gateView struct {
+	p       *Provider
+	g       *gateState
+	rereads int
+}
+
+// gateViewOf loads the gate the routing reads for p consult (gateOf) into a
+// view to confirm them against. nil-safe: a nil or never-registered Provider
+// has no cached gate, and nothing can rebind it.
+func (r *Registry) gateViewOf(p *Provider) gateView {
+	return gateView{p: p, g: r.gateOf(p)}
+}
+
+// moved reports whether the session rebound since the view was loaded — its
+// cached gate no longer resolves to v.g — and, when it did, rebases the view
+// on the session's current gate so the caller re-reads. Bounded by
+// gateRelockMaxRetries like lockGate's re-resolve; at the bound the last
+// view's verdict stands (today's behaviour, no worse).
+func (v *gateView) moved() bool {
+	if v.p == nil || v.rereads >= gateRelockMaxRetries {
+		return false
+	}
+	cur := v.p.gate.Load()
+	if cur == nil {
+		return false // never registered: nothing rebinds a bare Provider
+	}
+	if cur = cur.resolve(); cur == v.g {
+		return false
+	}
+	v.g = cur
+	v.rereads++
+	return true
+}
+
+// attachSessionGate files a freshly registered session under its own id and
+// caches the gate on the Provider. Called by Register (under r.mu; the order
+// r.mu → gatesMu holds).
+func (r *Registry) attachSessionGate(p *Provider) {
+	now := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	g := r.ensureGateLocked(p.ID, now)
+	g.live++
+	p.gate.Store(g)
+	r.sessions[p.ID] = p
+}
+
+// detachSessionGate removes a disconnecting session from the index. stableID
+// is the identity derived at disconnect: when present it is cached so the
+// trailing pending-request flush still resolves the session (its state lives
+// on under the identity's gate — FAULT STATE IS NOT CLEARED ON DISCONNECT);
+// when absent the session-keyed gate is the only thing that ever referenced
+// this identity, so its residue is dropped for hygiene, exactly as the old
+// implementation dropped the session-keyed map entries. Called by Disconnect
+// (under r.mu and p.mu; the order r.mu → p.mu → gatesMu holds).
+func (r *Registry) detachSessionGate(p *Provider, stableID string) {
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	// Live references and later disconnect-cache lookups must date the same
+	// event identically when comparing it with a concurrent version reset.
+	disconnectedAt := time.Now()
+	p.gateDisconnectedAtNS.Store(disconnectedAt.UnixNano())
+	delete(r.sessions, p.ID)
+	g := p.gate.Load()
+	if g != nil {
+		g.live--
+		g.mu.Lock()
+		g.touched = disconnectedAt
+		g.mu.Unlock()
+	}
+	if stableID != "" {
+		r.rememberDisconnectedStableIDLocked(p.ID, stableID, disconnectedAt)
+		return
+	}
+	if g != nil && g.key == p.ID && g.live <= 0 && r.gates[p.ID] == g {
+		delete(r.gates, p.ID)
+	}
+}
+
+// gateCount reports the size of the gate index (tests / observability).
+func (r *Registry) gateCount() int {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return len(r.gates)
+}

--- a/coordinator/registry/gate_index_test.go
+++ b/coordinator/registry/gate_index_test.go
@@ -1,0 +1,186 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the gate index (gate_index.go): session → gate resolution through
+// the disconnect cache, nil-safety of the scan's gate reads, and the routing
+// read path confirming its view against p.gate across a shared-identity
+// rebind (gateView).
+
+// The trailing pending-request flush runs after Disconnect removed the session:
+// its faults must still resolve to the stable identity's gate through the
+// disconnect cache, exactly as the map-keyed faultKeyLocked fallback did.
+func TestDisconnectedTrailingFlushResolvesIdentityGate(t *testing.T) {
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-flush", "m", "SER-FLUSH", 100)
+	reg.Disconnect(p.ID)
+	if got := reg.faultKeyForSession(p.ID); got != "serial:SER-FLUSH" {
+		t.Fatalf("post-disconnect fault key = %q, want the cached identity", got)
+	}
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 502, "provider disconnected")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-FLUSH") || rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("trailing-flush faults must land on the identity's gate, not a session gate")
+	}
+	if !reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("the identity's breaker must be open via the disconnected session id")
+	}
+}
+
+// Gate reads on a Provider that was never registered (bare test objects) and
+// on a nil gate are "no state", never a panic.
+func TestGateReadsAreNilSafe(t *testing.T) {
+	reg := New(testLogger())
+	bare := &Provider{ID: "bare"}
+	g := reg.gateOf(bare)
+	now := time.Now()
+	if g != nil {
+		t.Fatalf("bare provider resolved to a gate: %+v", g)
+	}
+	if g.breakerOpenAt(now.UnixNano()) || g.ejectedAt(now.UnixNano()) || g.dispatchLoadCooled("m", now) ||
+		g.inferenceErrorCooled("m", "base", now) || g.capacityCooled("m", now) ||
+		g.budgetClampActive(reg.budgetClampCfg, "m", now, 0, false, now) {
+		t.Fatal("a nil gate must read as no state")
+	}
+	if pen, rate := g.capacityRatePenalty(reg.capacityRateCfg, "m", now); pen != 0 || rate != 0 {
+		t.Fatal("a nil gate must carry no rate penalty")
+	}
+	if !reg.tryClaimCapacityProbe(bare, "m", now) || !reg.tryClaimCapacityProbe(nil, "m", now) {
+		t.Fatal("a provider with no gate must admit the probe claim")
+	}
+	if reg.ejectionOpenFor(g, "serial:none", now.UnixNano()) {
+		t.Fatal("an unknown identity must not read as ejected")
+	}
+}
+
+// A routing scan that loaded a session's gate just before the session rebound
+// away from a SHARED identity must not trust what it reads there: the
+// migration moves the state to the session's new gate and resets the shared
+// source — now the sibling's alone — to zeros, so an unconfirmed read admits
+// the session past the breaker or cooldown that moved with it.
+// gateStateReasonLocked confirms the verdict against p.gate and re-reads from
+// the new gate. The sibling's view, loaded at the same moment, stays put and
+// reads its identity's (now empty) state: a rebind never makes the OTHER
+// session look faulty. Both read kinds are covered — the breaker (an atomic)
+// and the dispatch-load cooldown (a per-model map under gate.mu) — in both
+// commit modes: the scan's gate and the commit's admit re-check are the same
+// function, and the end-to-end reservation must never land on the rebound
+// session.
+func TestScanRevalidatesGateAcrossSharedRebind(t *testing.T) {
+	const model = "m"
+	cases := []struct {
+		name   string
+		fault  func(reg *Registry, sessionID string)
+		read   func(g *gateState, now time.Time) bool // the unconfirmed read the scan used to make
+		reason GateReason
+	}{
+		{
+			name: "breaker",
+			fault: func(reg *Registry, id string) {
+				for i := 0; i < providerBreakerConsecTrip; i++ {
+					reg.RecordProviderOutcome(id, false, 500, "internal error")
+				}
+			},
+			read:   func(g *gateState, now time.Time) bool { return g.breakerOpenAt(now.UnixNano()) },
+			reason: GateBreaker,
+		},
+		{
+			name:   "dispatch-load cooldown",
+			fault:  func(reg *Registry, id string) { reg.RecordDispatchLoadFailure(id, model) },
+			read:   func(g *gateState, now time.Time) bool { return g.dispatchLoadCooled(model, now) },
+			reason: GateDispatchLoadCooldown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+				reg := New(testLogger())
+				setReserveCommitModeForTest(reg, mode)
+				p1 := makeSchedulerProvider(t, reg, "sess-view-1", model, 100)
+				p2 := makeSchedulerProvider(t, reg, "sess-view-2", model, 100)
+				pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-VIEW"}
+				p1.SetAttestationResult(pk)
+				p2.SetAttestationResult(pk)
+				shared := reg.lookupGateForKey("sekey:PK-VIEW")
+				if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+					t.Fatal("both sessions must share the identity's gate")
+				}
+				tc.fault(reg, p1.ID)
+				now := time.Now()
+				// The scan's gate evaluation on an already-loaded view, under
+				// p.mu as the scan holds it.
+				verdict := func(view *gateView) (ok bool, reason GateReason) {
+					view.p.mu.Lock()
+					defer view.p.mu.Unlock()
+					return reg.gateStateReasonLocked(view, model, RequestTraits{}, now, false, false)
+				}
+				// Precondition: the identity's fault gates both sessions.
+				for _, p := range []*Provider{p1, p2} {
+					view := reg.gateViewOf(p)
+					if ok, reason := verdict(&view); ok || reason != tc.reason {
+						t.Fatalf("pre-rebind verdict for %s = (%v, %v), want gated by %v", p.ID, ok, reason, tc.reason)
+					}
+				}
+
+				// Two scans load the shared gate, one per session...
+				view1, view2 := reg.gateViewOf(p1), reg.gateViewOf(p2)
+				if view1.g != shared || view2.g != shared {
+					t.Fatalf("views = %+v / %+v, want the shared gate", view1, view2)
+				}
+				// ...and p1 enriches to a serial before either reads it.
+				p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-VIEW", SerialNumber: "SER-VIEW"})
+				target := p1.gate.Load()
+				if target == shared || target.key != "serial:SER-VIEW" || p2.gate.Load() != shared {
+					t.Fatalf("after the rebind p1 → %+v, p2 → %+v; want p1 on serial:SER-VIEW and p2 unmoved", target, p2.gate.Load())
+				}
+				// The race: the gate the scan holds now reads clean — the state
+				// moved with p1 and the shared source was reset for p2.
+				if tc.read(shared, now) || !tc.read(target, now) {
+					t.Fatalf("precondition: the %s must have moved from the shared gate to p1's new gate", tc.name)
+				}
+
+				// p1's scan must not admit p1: the view is confirmed against
+				// p.gate, found moved, and re-read from the new gate.
+				if ok, reason := verdict(&view1); ok || reason != tc.reason {
+					t.Fatalf("p1's stale view verdict = (%v, %v), want gated by %v", ok, reason, tc.reason)
+				}
+				if view1.g != target || view1.rereads != 1 {
+					t.Fatalf("p1's view after the verdict = %+v, want rebased on serial:SER-VIEW after one re-read", view1)
+				}
+				// p2's scan reads its own identity, which now has nothing: not
+				// gated, and the view did not move.
+				if ok, reason := verdict(&view2); !ok || reason != GateReasonCount {
+					t.Fatalf("p2's view verdict = (%v, %v), want not gated — a rebind must not make the other session look faulty", ok, reason)
+				}
+				if view2.g != shared || view2.rereads != 0 {
+					t.Fatalf("p2's view after the verdict = %+v, want the shared gate, unmoved", view2)
+				}
+
+				// End to end, in this commit mode: the reservation must never
+				// land on p1 (its fault lives on its new gate); p2's identity is
+				// clean and takes the request.
+				pr := &PendingRequest{
+					RequestID:             "view-" + mode.String() + "-" + tc.name,
+					Model:                 model,
+					EstimatedPromptTokens: 200,
+					RequestedMaxTokens:    128,
+					FirstContentBudgetMS:  10_000,
+					FirstContentDeadline:  time.Now().Add(10 * time.Second),
+				}
+				got, _ := reg.ReserveProviderEx(model, pr)
+				if got == p1 {
+					t.Fatal("the reservation landed on the rebound session past the fault that moved with it")
+				}
+				if got != p2 {
+					t.Fatalf("reservation = %v, want p2 (the sibling's identity carries no state after the move)", got)
+				}
+			})
+		})
+	}
+}

--- a/coordinator/registry/gate_lock.go
+++ b/coordinator/registry/gate_lock.go
@@ -1,0 +1,245 @@
+package registry
+
+import "time"
+
+// gate_lock.go — acquiring a gate for a recorder: gateRef (a resolution that
+// remembers how it was reached), lockGate (validate under gate.mu, re-resolve
+// on a moved or retired gate), the lock-free flag fast path (refHasPairState)
+// and the gate-wait observer. Design, lock order and file map: gate_state.go.
+
+// gateWaitReportThreshold is the gate.mu acquisition wait above which the
+// wait is reported to the gate-wait observer (registry.gate.wait_ms). Below it
+// the lock is doing what it should; above it something is holding a gate too
+// long or the convoy is re-forming on a new lock.
+const gateWaitReportThreshold = time.Millisecond
+
+// lockResolved locks the gate, following a migration that landed between the
+// caller's resolve and the lock. The caller unlocks the RETURNED gate.
+func (g *gateState) lockResolved() *gateState {
+	for {
+		g.mu.Lock()
+		next := g.forwardTo.Load()
+		if next == nil {
+			return g
+		}
+		g.mu.Unlock()
+		g = next
+	}
+}
+
+// gateRef is a recorder's resolution of a gate: the gate plus how it was
+// reached, so that lockGate can prove — under gate.mu — that the gate is
+// still the one the outcome belongs to, and re-resolve when it is not. A
+// value type: the recorder path allocates nothing.
+type gateRef struct {
+	g *gateState
+	// p is the live session whose cached p.gate produced g; nil when g was
+	// reached through the disconnect cache, the bare session id or an
+	// explicit fault key. After the lock,
+	// p.gate.Load() != g means the session rebound to another gate in
+	// between and the outcome belongs there.
+	p *Provider
+	// A disconnected identity can still be enriched by a live sibling. Its
+	// cache-owned redirect validates that move without retaining Provider or
+	// acquiring gatesMu while gate.mu is held.
+	disconnectedBinding *disconnectedGateBinding
+	// Exactly one of session / key names what to re-resolve.
+	session string
+	key     string
+	// insert says whether re-resolution may create the gate (gateForSession /
+	// gateForKey) or must find an existing one (lookupSessionGateRef: the
+	// "clear" recorders, which have nothing to clear on an identity without a
+	// gate and must not file one under a dead session id).
+	insert bool
+}
+
+// currentLocked reports whether g — locked by the caller — is still the gate
+// ref's outcome belongs to: not retired by the sweep, and, when the ref was
+// reached through a live session's cached pointer, still that session's gate.
+func (ref gateRef) currentLocked(g *gateState) bool {
+	if g.retired {
+		return false
+	}
+	return ref.bindingCurrent(g)
+}
+
+// bindingCurrent is safe for the lock-free pair-flag probe as well as the
+// locked validation. All identity redirects publish before resetting src.
+func (ref gateRef) bindingCurrent(g *gateState) bool {
+	if ref.p != nil {
+		// A ref captured while live must switch to the disconnect cache on
+		// drop; a later sibling enrichment redirects that cache, not this
+		// detached Provider's cached gate pointer.
+		return ref.p.gateDisconnectedAtNS.Load() == 0 && ref.p.gate.Load() == g
+	}
+	if ref.disconnectedBinding != nil {
+		return g != nil && ref.disconnectedBinding.load() == g.key
+	}
+	return true
+}
+
+// gateRelockMaxRetries bounds how many times lockGate re-resolves a gate that
+// went stale between the index lookup and the lock, and how many times a
+// routing read re-reads a gate the session moved away from (gateView.moved).
+// One retry is the expected maximum (a rebind or a sweep landed in the
+// window). A recorder that exhausts the optimistic retries stabilizes the
+// index while resolving and acquiring the gate; it never mutates a stale
+// gate merely to bound the number of retries.
+const gateRelockMaxRetries = 4
+
+// lockGate acquires gate.mu for a recorder at the named site. It follows any
+// migration forward (see lockResolved) and then validates, under the lock,
+// that the gate is still current for the ref (currentLocked); a stale gate is
+// released and the ref re-resolved through the index — gatesMu is never
+// taken while a gate.mu is held, so the lock order stands — and locked again.
+// The uncontended path is one TryLock — no clock reads; only a contended
+// acquisition is timed, and only a wait above gateWaitReportThreshold is
+// reported. The caller uses hold.g (the gate actually locked) and calls
+// hold.unlock. A vanished no-insert identity returns a nil gate; callers must
+// treat that hold as a no-op.
+func (r *Registry) lockGate(ref gateRef, site string) gateHold {
+	return r.lockGateWithRetries(ref, site, 0)
+}
+
+// lockGateWithRetries carries the optimistic retry count explicitly so the
+// exhaustion path can be exercised without scheduling several racing rebinds.
+func (r *Registry) lockGateWithRetries(ref gateRef, site string, retries int) gateHold {
+	var wait time.Duration
+	g := ref.g
+	for {
+		if retries >= gateRelockMaxRetries {
+			return r.lockGateWithIndex(ref, site, wait)
+		}
+		if g == nil {
+			return gateHold{r: r, site: site, wait: wait}
+		}
+		if !g.mu.TryLock() {
+			start := time.Now()
+			g.mu.Lock()
+			wait += time.Since(start)
+		}
+		if next := g.forwardTo.Load(); next != nil {
+			g.mu.Unlock()
+			g = next
+			retries++
+			continue
+		}
+		if ref.currentLocked(g) {
+			return gateHold{g: g, r: r, site: site, wait: wait}
+		}
+		// Never retain g after a failed validation: it may still belong to
+		// another live session even if this session's next lookup is empty.
+		g.mu.Unlock()
+		retries++
+		if retries >= gateRelockMaxRetries {
+			continue
+		}
+		ref = r.reresolveGate(ref)
+		g = ref.g
+	}
+}
+
+// lockGateWithIndex is the rare retry-exhaustion path. Holding gatesMu until
+// the current gate is locked prevents a rebind or sweep from invalidating the
+// resolution. The index lock is released before returning the gate, preserving
+// gatesMu -> gate.mu without taking r.mu or p.mu. The write lock permits an
+// inserting recorder to recreate an idle gate retired by a concurrent sweep.
+func (r *Registry) lockGateWithIndex(ref gateRef, site string, wait time.Duration) gateHold {
+	start := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	key := ref.key
+	var g *gateState
+	if key != "" {
+		g = r.gates[key]
+	} else {
+		g, key, _ = r.resolveSessionGateLocked(ref.session)
+	}
+	if g == nil && ref.insert {
+		g = r.ensureGateLocked(key, time.Now())
+	}
+	g = g.resolve()
+	if g == nil {
+		return gateHold{r: r, site: site, wait: wait + time.Since(start)}
+	}
+	g.mu.Lock()
+	return gateHold{g: g, r: r, site: site, wait: wait + time.Since(start)}
+}
+
+// reresolveGate resolves ref again through the index (takes gatesMu; the
+// caller holds no gate.mu).
+func (r *Registry) reresolveGate(ref gateRef) gateRef {
+	if ref.key != "" {
+		return r.gateForKey(ref.key)
+	}
+	return r.sessionGateRef(ref.session, ref.insert)
+}
+
+// refHasPairState is the lock-free "does this identity hold any of the
+// flagged per-model state" fast path for a ref about to be locked, made safe
+// against a rebind: an emptied source gate's flag says "nothing" precisely
+// because the state moved to the session's new gate, so a cleared flag counts
+// only while p.gate still points at ref.g; otherwise the ref is re-resolved
+// and the flag read again. Sound without a lock because the migration
+// repoints p.gate BEFORE it republishes the emptied source (migrateGateLocked)
+// — a reader that sees the cleared flag then sees the moved pointer. A set
+// flag needs no confirmation: the caller proceeds to lockGate, which
+// validates under the lock. Returns the ref to lock. A retired gate needs no
+// handling here: it was idle, so "nothing" is true for the identity.
+func (r *Registry) refHasPairState(ref gateRef, flag uint32) (gateRef, bool) {
+	for retries := 0; ; retries++ {
+		has := ref.g.hasPairState(flag)
+		if has || ref.bindingCurrent(ref.g) {
+			return ref, has
+		}
+		if retries >= gateRelockMaxRetries {
+			// A stale false flag cannot prove there is nothing to clear or
+			// claim. Force the caller through lockGate's validated acquisition.
+			return ref, true
+		}
+		ref = r.reresolveGate(ref)
+	}
+}
+
+// gateHold is an acquired gate.mu. unlock releases the gate and only then
+// reports a long acquisition wait to the observer, so the DogStatsD emit never
+// runs inside the critical section.
+type gateHold struct {
+	g    *gateState
+	r    *Registry
+	site string
+	wait time.Duration
+}
+
+func (h gateHold) unlock() {
+	if h.g != nil {
+		h.g.mu.Unlock()
+	}
+	if h.r != nil && h.wait > gateWaitReportThreshold {
+		if obs := h.r.gateWaitObserver.Load(); obs != nil {
+			(*obs)(h.site, h.wait)
+		}
+	}
+}
+
+// SetGateWaitObserver registers an optional observer for gate.mu acquisition
+// waits above gateWaitReportThreshold on the recorder sites. The api layer
+// turns it into the registry.gate.wait_ms histogram tagged by site, so the
+// per-identity locks that replaced the global write lock are observable. Set
+// once at startup; nil clears it. Thread-safe.
+func (r *Registry) SetGateWaitObserver(fn func(site string, wait time.Duration)) {
+	if fn == nil {
+		r.gateWaitObserver.Store(nil)
+		return
+	}
+	r.gateWaitObserver.Store(&fn)
+}
+
+// HoldGateForTest acquires the gate.mu of the provider's current gate and
+// returns the release function. Test-only (mirrors reservationAfterScan): it
+// lets a test prove a recorder blocks on the identity's gate, not on r.mu, and
+// that a long wait reaches the observer. Production code never calls it.
+func (r *Registry) HoldGateForTest(providerID string) (release func()) {
+	hold := r.lockGate(r.gateForSession(providerID), "test")
+	return hold.g.mu.Unlock
+}

--- a/coordinator/registry/gate_lock_fallback_test.go
+++ b/coordinator/registry/gate_lock_fallback_test.go
@@ -1,0 +1,110 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestVanishedClearRefLeavesLiveSiblingGateUntouched(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		retries int
+	}{{"optimistic", 0}, {"retry-exhaustion", gateRelockMaxRetries}} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			const model = "m"
+			p1 := makeSchedulerProvider(t, reg, "vanished-clear-1", model, 100)
+			p2 := makeSchedulerProvider(t, reg, "vanished-clear-2", model, 100)
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-VANISHED-CLEAR"}
+			p1.SetAttestationResult(identity)
+			p2.SetAttestationResult(identity)
+			reg.RecordDispatchLoadFailure(p1.ID, model)
+			ref, has := reg.refHasPairState(reg.lookupSessionGateRef(p1.ID), gateFlagDispatchLoad)
+			if !has || ref.g != p2.gate.Load() {
+				t.Fatal("precondition: clear must have observed the shared gate's state")
+			}
+			shared := ref.g
+
+			// Interpose after the clear's lookup. The shared gate remains live
+			// for p2, while p1's new anonymous session gate disappears entirely.
+			p1.SetAttestationResult(nil)
+			reg.Disconnect(p1.ID)
+			reg.RecordDispatchLoadFailure(p2.ID, model)
+			if reg.lookupSessionGateRef(p1.ID).g != nil {
+				t.Fatal("precondition: the cleared session must no longer resolve")
+			}
+
+			hold := reg.lockGateWithRetries(ref, "dispatch_load_clear", tc.retries)
+			if hold.g != nil {
+				hold.unlock()
+				t.Fatalf("vanished clear returned gate %q; it could erase a sibling's fresh fault", hold.g.key)
+			}
+			hold.unlock() // A missing identity's hold is safe to release.
+			if p2.gate.Load() != shared || !reg.dispatchLoadCooled(p2.ID, model, time.Now()) {
+				t.Fatal("vanished session's clear disturbed the live sibling's cooldown")
+			}
+			if rawGateForKey(reg, p1.ID) != nil {
+				t.Fatal("a no-insert clear recreated the vanished session gate")
+			}
+		})
+	}
+}
+
+func TestGateRetryExhaustionLocksCurrentSharedBinding(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "exhausted-bind-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "exhausted-bind-2", "m", 100)
+	identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-EXHAUSTED-BIND"}
+	p1.SetAttestationResult(identity)
+	p2.SetAttestationResult(identity)
+	ref := reg.gateForSession(p1.ID)
+	shared := ref.g
+	p1.SetAttestationResult(&attestation.VerificationResult{
+		Valid: true, PublicKey: identity.PublicKey, SerialNumber: "SER-EXHAUSTED-BIND",
+	})
+	target := p1.gate.Load()
+	if target == shared || p2.gate.Load() != shared {
+		t.Fatal("precondition: only the recording session must change gates")
+	}
+
+	// Enter with the optimistic budget consumed, the same state reached after
+	// repeated rebinds. Exhaustion must not waive currentLocked's invariant.
+	hold := reg.lockGateWithRetries(ref, "breaker", gateRelockMaxRetries)
+	if hold.g != target {
+		hold.unlock()
+		t.Fatal("retry exhaustion returned the live sibling's obsolete gate")
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if providerBreakerTripsOf(reg, p1.ID) != 1 || providerBreakerTripsOf(reg, p2.ID) != 0 {
+		t.Fatal("record after retry exhaustion landed on the wrong identity")
+	}
+}
+
+func TestGateRetryExhaustionRecreatesRetiredIdentity(t *testing.T) {
+	reg := New(testLogger())
+	const key = "serial:SER-EXHAUSTED-SWEEP"
+	ref := reg.gateForKey(key)
+	withGateForKey(reg, key, func(g *gateState) {
+		g.touched = time.Now().Add(-gateIdleGrace - time.Minute)
+	})
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, key) != nil {
+		t.Fatal("precondition: identity must have been swept")
+	}
+	hold := reg.lockGateWithRetries(ref, "health_ejection", gateRelockMaxRetries)
+	if hold.g == nil || hold.g == ref.g || hold.g.retired {
+		hold.unlock()
+		t.Fatal("retry exhaustion returned the retired identity gate")
+	}
+	current := hold.g
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if rawGateForKey(reg, key) != current {
+		t.Fatal("recorded gate is absent from the current index")
+	}
+}

--- a/coordinator/registry/gate_lock_test.go
+++ b/coordinator/registry/gate_lock_test.go
@@ -1,0 +1,427 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the recorders' validated gate lock (gate_lock.go): the probe
+// claim's per-identity exclusivity, the wait observer, recorders never
+// blocking behind r.mu, and lockGate / refHasPairState re-resolving a gate
+// that a shared-identity rebind or a sweep invalidated in the window between
+// the index lookup and the lock. The trackers' semantics are covered by
+// their own files; the commit lock mode lives in reserve_commit_test.go.
+
+// Two sessions of one identity racing for the single half-open probe: the
+// check-and-claim under gate.mu lets exactly one through, and the gate reads
+// closed for both afterwards.
+func TestTryClaimCapacityProbeIsExclusivePerIdentity(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := attestSchedulerProvider(t, reg, "sess-probe-1", model, "SER-PROBE", 100)
+	p2 := attestSchedulerProvider(t, reg, "sess-probe-2", model, "SER-PROBE", 100)
+	if reg.gateOf(p1) != reg.gateOf(p2) {
+		t.Fatal("sessions of one identity must share a gate")
+	}
+	for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+		reg.RecordCapacityReject(p1.ID, model)
+	}
+	if !reg.CapacityCooldownActive(p2.ID, model) {
+		t.Fatal("the cooldown must be visible through the sibling session")
+	}
+	expireCapacityCooldown(reg, p1.ID, model)
+	if reg.CapacityCooldownActive(p1.ID, model) {
+		t.Fatal("an expired, unclaimed cooldown must read open")
+	}
+
+	now := time.Now()
+	var claimed atomic.Int32
+	var wg sync.WaitGroup
+	for _, p := range []*Provider{p1, p2, p1, p2} {
+		wg.Add(1)
+		go func(p *Provider) {
+			defer wg.Done()
+			if reg.tryClaimCapacityProbe(p, model, now) {
+				claimed.Add(1)
+			}
+		}(p)
+	}
+	wg.Wait()
+	if claimed.Load() != 1 {
+		t.Fatalf("probe claims = %d, want exactly 1", claimed.Load())
+	}
+	if !reg.CapacityCooldownActive(p1.ID, model) || !reg.CapacityCooldownActive(p2.ID, model) {
+		t.Fatal("the claimed probe must close the gate for every session of the identity")
+	}
+	// No cooldown entry at all: the claim is a lock-free no-op that admits.
+	if !reg.tryClaimCapacityProbe(p1, "other-model", now) {
+		t.Fatal("a pair with no cooldown entry must always claim")
+	}
+}
+
+// A gate.mu wait above the threshold reaches the observer tagged by site — and
+// only then: uncontended recorders report nothing.
+func TestGateWaitObserverReportsLongWaits(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-wait", "m", 100)
+	type seen struct {
+		site string
+		wait time.Duration
+	}
+	var mu sync.Mutex
+	var got []seen
+	reg.SetGateWaitObserver(func(site string, wait time.Duration) {
+		mu.Lock()
+		got = append(got, seen{site, wait})
+		mu.Unlock()
+	})
+
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+	mu.Lock()
+	n := len(got)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("uncontended recorder reported a wait: %+v", got)
+	}
+
+	release := reg.HoldGateForTest(p.ID)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		release()
+	}()
+	reg.RecordProviderOutcome(p.ID, true, 200, "")
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 || got[0].site != "breaker" || got[0].wait < 5*time.Millisecond {
+		t.Fatalf("observer calls = %+v, want one 'breaker' wait of >= 5ms", got)
+	}
+	reg.SetGateWaitObserver(nil)
+}
+
+// An accept on the first-byte path must not queue behind the registry write
+// lock: with r.mu held for writing by someone else, the recorders still run.
+func TestRecordersDoNotTakeTheRegistryWriteLock(t *testing.T) {
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-nolock", "m", "SER-NOLOCK", 100)
+	reg.mu.Lock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reg.RecordCapacityAccept(p.ID, "m")
+		reg.RecordInferenceSuccess(p.ID, "m", "base")
+		reg.RecordProviderOutcome(p.ID, true, 200, "")
+		reg.RecordProviderServeOutcome("serial:SER-NOLOCK", true, 200, "")
+		reg.ClearDispatchLoadCooldown(p.ID, "m")
+		reg.RecordDispatchLoadFailure(p.ID, "m")
+		reg.RecordInferenceError(p.ID, "m", 500, "base")
+		reg.RecordCapacityReject(p.ID, "m")
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		reg.mu.Unlock()
+		t.Fatal("a recorder blocked behind the registry write lock")
+	}
+	reg.mu.Unlock()
+}
+
+// A recorder that resolved a gate SHARED by two sessions just before one of
+// them rebinds (sekey: → serial: enrichment) must land its outcome on the
+// rebinding session's NEW gate — the shared gate stays in the index for the
+// other session, carries no forward, and was emptied by the migration, so
+// only the session's own repointed p.gate can tell the stale holder to move.
+// The other session's recorder, resolved at the same moment, stays put.
+func TestStaleRefFollowsSharedIdentityRebind(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "sess-rebind-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-rebind-2", "m", 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-REBIND"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	shared := reg.lookupGateForKey("sekey:PK-REBIND")
+	if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+		t.Fatal("both sessions must share the identity's gate")
+	}
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+
+	// Two recorders resolve the shared gate, one per session...
+	ref1 := reg.gateForSession(p1.ID)
+	ref2 := reg.gateForSession(p2.ID)
+	if ref1.g != shared || ref1.p != p1 || ref2.g != shared || ref2.p != p2 {
+		t.Fatalf("refs = %+v / %+v, want the shared gate via each session", ref1, ref2)
+	}
+	// ...and p1 enriches to a serial before either takes the lock.
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-REBIND", SerialNumber: "SER-REBIND"})
+	target := p1.gate.Load()
+	if target == shared || target.key != "serial:SER-REBIND" {
+		t.Fatalf("p1's gate after the rebind = %+v, want serial:SER-REBIND", target)
+	}
+	if shared.forwardTo.Load() != nil || rawGateForKey(reg, "sekey:PK-REBIND") != shared {
+		t.Fatal("precondition: the shared gate stays in the index, unforwarded, for p2")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-REBIND") || gateHasBreakerWindow(reg, "sekey:PK-REBIND") {
+		t.Fatal("precondition: the fault history moved to the enriched identity")
+	}
+
+	hold := reg.lockGate(ref1, "test")
+	if hold.g != target {
+		hold.unlock()
+		t.Fatalf("p1's recorder locked %q, want the session's new gate serial:SER-REBIND", hold.g.key)
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if got := providerBreakerTripsOf(reg, p1.ID); got != 1 {
+		t.Fatalf("p1's outcome did not land on its identity: trips=%d", got)
+	}
+	readGateForKey(reg, "sekey:PK-REBIND", func(g *gateState) {
+		if g == nil || g.breakerTrips != 0 || g.outcomes != nil {
+			t.Fatalf("p2's identity must be untouched by p1's stale recorder: %+v", g)
+		}
+	})
+
+	hold = reg.lockGate(ref2, "test")
+	if hold.g != shared {
+		hold.unlock()
+		t.Fatalf("p2's recorder locked %q, want its own (shared) gate", hold.g.key)
+	}
+	hold.g.healthWindowLocked().record(false, time.Now())
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if !gateHasBreakerWindow(reg, "sekey:PK-REBIND") || providerBreakerTripsOf(reg, p2.ID) != 0 {
+		t.Fatal("p2's outcome must land on p2's identity, and only there")
+	}
+}
+
+// A trailing-flush recorder that resolved a disconnected identity's gate just
+// before the sweep dropped it (idle, no live session, past the grace) must not
+// write into the retired gate — the fault would vanish before the identity's
+// next reconnect. lockGate sees retired, re-resolves, and the fault lands on
+// the gate a fresh lookup finds. Both resolution paths: by session id through
+// the disconnect cache (RecordProviderOutcome) and by stable id
+// (RecordProviderServeOutcome).
+func TestStaleRefSurvivesSweepOfDisconnectedGate(t *testing.T) {
+	const key = "serial:SER-SWEEP-RACE"
+	backdate := func(g *gateState) { g.touched = time.Now().Add(-gateIdleGrace - time.Minute) }
+	for _, tc := range []struct {
+		name    string
+		resolve func(reg *Registry, sessionID string) gateRef
+	}{
+		{"by session through the disconnect cache", func(reg *Registry, sessionID string) gateRef { return reg.gateForSession(sessionID) }},
+		{"by stable id", func(reg *Registry, _ string) gateRef { return reg.gateForKey(key) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p := attestSchedulerProvider(t, reg, "sess-sweep-race", "m", "SER-SWEEP-RACE", 100)
+			reg.Disconnect(p.ID)
+			// Nothing was ever recorded on the identity, so its gate is idle;
+			// backdate its creation past the grace so a PRESENT-time sweep
+			// drops it (a future-time sweep would also expire the disconnect
+			// cache the trailing flush resolves through).
+			withGateForKey(reg, key, backdate)
+
+			ref := tc.resolve(reg, p.ID)
+			stale := ref.g
+			if stale == nil || stale.key != key || ref.p != nil {
+				t.Fatalf("pre-sweep ref = %+v, want the disconnected identity's gate with no live session", ref)
+			}
+			reg.sweepGates(time.Now())
+			if rawGateForKey(reg, key) != nil {
+				t.Fatal("precondition: the sweep must drop the idle disconnected gate")
+			}
+
+			hold := reg.lockGate(ref, "test")
+			if hold.g == stale {
+				hold.unlock()
+				t.Fatal("lockGate handed out the gate the sweep retired")
+			}
+			if hold.g.key != key || rawGateForKey(reg, key) != hold.g {
+				hold.unlock()
+				t.Fatalf("re-resolved to %q (in index: %v), want a fresh %s gate", hold.g.key, rawGateForKey(reg, key) == hold.g, key)
+			}
+			now := time.Now()
+			hold.g.healthWindowLocked().record(false, now)
+			hold.g.updatedLocked(now)
+			hold.unlock()
+
+			stale.mu.Lock()
+			retired := stale.retired
+			stale.mu.Unlock()
+			if !retired {
+				t.Fatal("the swept gate must be marked retired under its lock")
+			}
+			if !gateHasBreakerWindow(reg, key) {
+				t.Fatal("the trailing fault must be on the gate a fresh lookup finds")
+			}
+			// The rest of the flush lands on the same gate and trips the
+			// identity's breaker — the reconnecting-zombie signal survives.
+			for i := 1; i < providerBreakerConsecTrip; i++ {
+				reg.RecordProviderOutcome(p.ID, false, 502, "provider disconnected")
+			}
+			if !reg.ProviderBreakerOpen(p.ID) {
+				t.Fatal("the identity's breaker must be open through the disconnected session id")
+			}
+		})
+	}
+}
+
+// A CLEAR recorder (no-insert resolution) whose gate was swept in the window
+// has nothing left to clear: it returns a nil hold rather than retaining the
+// old gate or filing a gate under an identity nothing references.
+func TestClearRefNeverFilesAGateForASweptIdentity(t *testing.T) {
+	const key = "serial:SER-CLEAR-RACE"
+	reg := New(testLogger())
+	p := attestSchedulerProvider(t, reg, "sess-clear-race", "m", "SER-CLEAR-RACE", 100)
+	reg.Disconnect(p.ID)
+	withGateForKey(reg, key, func(g *gateState) { g.touched = time.Now().Add(-gateIdleGrace - time.Minute) })
+
+	ref := reg.lookupSessionGateRef(p.ID)
+	stale := ref.g
+	if stale == nil || stale.key != key || ref.insert {
+		t.Fatalf("pre-sweep lookup ref = %+v, want a no-insert ref to the identity's gate", ref)
+	}
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, key) != nil {
+		t.Fatal("precondition: the sweep must drop the idle disconnected gate")
+	}
+	hold := reg.lockGate(ref, "test")
+	if hold.g != nil {
+		hold.unlock()
+		t.Fatalf("a clear re-resolved to %q; it must return a no-op hold", hold.g.key)
+	}
+	hold.unlock()
+	if rawGateForKey(reg, key) != nil || rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("a clear must not file a gate for a swept identity or a dead session")
+	}
+	// Through the real recorder, on the dead session: still nothing filed.
+	reg.ClearDispatchLoadCooldown(p.ID, "m")
+	reg.RecordInferenceSuccess(p.ID, "m", "base")
+	if reg.gateCount() != 0 {
+		t.Fatalf("gate index after a straggling clear = %d, want 0", reg.gateCount())
+	}
+}
+
+// A reservation commit that resolved the probe's gate just before its session
+// rebound away from a SHARED identity must claim the probe on the session's
+// NEW gate — where the cooldown entry migrated — and leave the other
+// identity's (reset) state untouched. A claim on the old gate would find no
+// entry and admit: a leaked probe through a cooled pair. The claim is the
+// same in both commit modes (the mode only chooses the r.mu lock kind).
+func TestProbeClaimFollowsSharedIdentityRebind(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "m"
+		p1 := makeSchedulerProvider(t, reg, "sess-probe-rebind-1", model, 100)
+		p2 := makeSchedulerProvider(t, reg, "sess-probe-rebind-2", model, 100)
+		pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-PROBE-REBIND"}
+		p1.SetAttestationResult(pk)
+		p2.SetAttestationResult(pk)
+		shared := reg.lookupGateForKey("sekey:PK-PROBE-REBIND")
+		if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+			t.Fatal("both sessions must share the identity's gate")
+		}
+		for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+			reg.RecordCapacityReject(p1.ID, model)
+		}
+		expireCapacityCooldown(reg, p1.ID, model)
+		if reg.CapacityCooldownActive(p1.ID, model) {
+			t.Fatal("precondition: an expired, unclaimed cooldown must read open")
+		}
+
+		// The commit resolves the probe's gate (under p.mu)...
+		ref := reg.probeGateRef(p1)
+		if ref.g != shared || ref.p != p1 {
+			t.Fatalf("probe ref = %+v, want the shared gate via p1", ref)
+		}
+		// ...and p1 enriches to a serial before the claim takes the lock.
+		p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-PROBE-REBIND", SerialNumber: "SER-PROBE-REBIND"})
+		target := p1.gate.Load()
+		if target == shared || target.key != "serial:SER-PROBE-REBIND" {
+			t.Fatalf("p1's gate after the rebind = %+v, want serial:SER-PROBE-REBIND", target)
+		}
+		if !target.hasPairState(gateFlagCapacityCooldown) || shared.hasPairState(gateFlagCapacityCooldown) {
+			t.Fatal("precondition: the cooldown entry moved with the session")
+		}
+
+		now := time.Now()
+		if !reg.claimCapacityProbeRef(ref, model, now) {
+			t.Fatal("the expired, unclaimed probe must be claimable")
+		}
+		readGateForKey(reg, "serial:SER-PROBE-REBIND", func(g *gateState) {
+			if g == nil {
+				t.Fatal("the enriched identity's gate must exist")
+			}
+			if e := g.capacityCooldowns[model]; e == nil || !e.probeAt.Equal(now) {
+				t.Fatalf("the claim must land on the session's new gate: entry=%+v", e)
+			}
+		})
+		readGateForKey(reg, "sekey:PK-PROBE-REBIND", func(g *gateState) {
+			if g == nil {
+				t.Fatal("the shared gate must stay in the index for p2")
+			}
+			if len(g.capacityCooldowns) != 0 {
+				t.Fatalf("the other identity's state must be untouched by the stale claim: %+v", g.capacityCooldowns)
+			}
+		})
+		if !reg.CapacityCooldownActive(p1.ID, model) {
+			t.Fatal("the claimed probe must close the gate for p1's identity")
+		}
+		if reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("p2's identity carries no cooldown after the migration")
+		}
+		// A second commit through the live path sees the fresh claim: exactly
+		// one probe gets through.
+		if reg.tryClaimCapacityProbe(p1, model, now) {
+			t.Fatal("a second claim must see the fresh claim and reject")
+		}
+	})
+}
+
+// The lock-free "no per-model state" fast path the clear recorders and the
+// probe claim take before locking must not trust the flag of a gate the
+// session has moved away from: after a shared-identity rebind the emptied
+// source says "nothing" precisely because the state migrated. refHasPairState
+// re-resolves to the session's new gate; a genuinely empty current gate is
+// reported as such without a re-resolve.
+func TestRefHasPairStateFollowsSharedIdentityRebind(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := makeSchedulerProvider(t, reg, "sess-flag-rebind-1", model, 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-flag-rebind-2", model, 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-FLAG-REBIND"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	shared := reg.lookupGateForKey("sekey:PK-FLAG-REBIND")
+	reg.RecordDispatchLoadFailure(p1.ID, model)
+
+	ref := reg.lookupSessionGateRef(p1.ID) // ClearDispatchLoadCooldown's resolution
+	if ref.g != shared || ref.p != p1 || !shared.hasPairState(gateFlagDispatchLoad) {
+		t.Fatalf("pre-rebind ref = %+v, want the shared gate (with dispatch-load state) via p1", ref)
+	}
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-FLAG-REBIND", SerialNumber: "SER-FLAG-REBIND"})
+	target := p1.gate.Load()
+	if target == shared || shared.hasPairState(gateFlagDispatchLoad) || !target.hasPairState(gateFlagDispatchLoad) {
+		t.Fatal("precondition: the dispatch-load cooldown moved with the session and the shared gate reads empty")
+	}
+
+	got, has := reg.refHasPairState(ref, gateFlagDispatchLoad)
+	if !has || got.g != target || got.p != p1 {
+		t.Fatalf("refHasPairState = (%+v, %v), want the session's new gate with state", got, has)
+	}
+	// Through the real recorder: the completion-time clear lands on the new
+	// identity, so the pair is routable again.
+	reg.ClearDispatchLoadCooldown(p1.ID, model)
+	if reg.dispatchLoadCooled(p1.ID, model, time.Now()) {
+		t.Fatal("the clear must land on the session's new gate")
+	}
+	// A genuinely empty current gate: reported empty, ref unchanged.
+	got, has = reg.refHasPairState(reg.lookupSessionGateRef(p2.ID), gateFlagDispatchLoad)
+	if has || got.g != shared {
+		t.Fatalf("refHasPairState on p2's empty gate = (%+v, %v), want (shared, false)", got, has)
+	}
+}

--- a/coordinator/registry/gate_migrate.go
+++ b/coordinator/registry/gate_migrate.go
@@ -1,0 +1,295 @@
+package registry
+
+import "time"
+
+// gate_migrate.go — identity binds and the migration of accumulated fault
+// state between gates: the forward a migrated-away gate leaves behind
+// (resolve), the merge and reset policy, bindStableFaultKey and
+// migrateGateLocked. Design, lock order and file map: gate_state.go.
+//
+// Rebind semantics. Fault state is keyed by IDENTITY, and a rebind MOVES the
+// identity's accumulated state to the refined identity (session id → sekey:
+// on the first bind, sekey: → serial: on MDA enrichment); the source identity
+// is left with nothing — exactly what the map-keyed implementation did
+// (migrateFaultStateLocked deleted the old key's entries). When the source
+// gate is SHARED with another live session (the same machine connected twice:
+// one SE key, two sessions), that session's identity starts from nothing too:
+// the state was the machine's and now lives under the machine's better key,
+// where the sibling lands at its own enrichment. It is deliberately not
+// copied — mergeLocked does not deduplicate histories, so a copy would
+// double-count every fault (strike lists, health rings, consecutive-fault
+// streaks) the moment the sibling enriches to the same serial. The shared
+// source's reset is published (its atomics zeroed) so the sibling's readers
+// see the move at once. A bind runs under the rebinding session's p.mu, so
+// the routing sections that hold p.mu (the scan's gate chain, the reservation
+// commit through its debit, the alias resolver) never observe the move
+// mid-section; the routing readers also confirm their view against p.gate
+// (gateView) so a read made without p.mu cannot mistake the emptied source
+// for the session's state, and the recorders re-validate under gate.mu
+// (lockGate) for the same reason.
+
+// resolve follows forwardTo to the gate that currently holds this identity's
+// state. Lock-free; one atomic load in the common (not migrated) case.
+// nil-safe.
+func (g *gateState) resolve() *gateState {
+	for g != nil {
+		next := g.forwardTo.Load()
+		if next == nil {
+			return g
+		}
+		g = next
+	}
+	return nil
+}
+
+// mergeLocked folds src's state into g for an identity rebind whose new key
+// ALREADY has history (e.g. this session's sekey:-keyed faults migrating onto
+// a serial: gate populated by a previous connection). Merge policy: expiries
+// and streak recency take the max, trip counts take the max, timestamp
+// histories merge chronologically, health rings merge in timestamp order
+// bounded by the ring size (providerHealthWindow.merge) so an in-progress
+// consecutive-fault streak survives the rebind, and a clamp entry with the
+// later clamp time wins whole. Caller holds BOTH g.mu and src.mu (only the
+// identity bind, under gatesMu.Lock, ever does).
+func (g *gateState) mergeLocked(src *gateState) {
+	if g.identityVersion == "" {
+		g.identityVersion = src.identityVersion
+	}
+	if src.versionResetAt.After(g.versionResetAt) {
+		g.versionResetAt = src.versionResetAt
+	}
+	if len(src.inferenceErrorFlushStrikes) > 0 && g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
+	}
+	for key, stamps := range src.inferenceErrorFlushStrikes {
+		g.inferenceErrorFlushStrikes[key] = mergeChronologicalTimestamps(g.inferenceErrorFlushStrikes[key], stamps)
+	}
+	for model, expiry := range src.dispatchLoadCooldowns {
+		if cur, ok := g.dispatchLoadCooldowns[model]; !ok || expiry.After(cur) {
+			g.dispatchLoadCooldowns[model] = expiry
+		}
+	}
+	for k, strikes := range src.inferenceErrorStrikes {
+		g.inferenceErrorStrikes[k] = mergeChronologicalTimestamps(g.inferenceErrorStrikes[k], strikes)
+	}
+	for k, expiry := range src.inferenceErrorCooldowns {
+		if cur, ok := g.inferenceErrorCooldowns[k]; !ok || expiry.After(cur) {
+			g.inferenceErrorCooldowns[k] = expiry
+		}
+	}
+
+	if src.outcomes != nil {
+		if g.outcomes != nil {
+			g.outcomes.merge(src.outcomes)
+		} else {
+			g.outcomes = src.outcomes
+		}
+	}
+	if src.breakerUntil.After(g.breakerUntil) {
+		g.breakerUntil = src.breakerUntil
+	}
+	if src.breakerTrips > g.breakerTrips {
+		g.breakerTrips = src.breakerTrips
+	}
+
+	for model, strikes := range src.capacityRejectStrikes {
+		g.capacityRejectStrikes[model] = mergeChronologicalTimestamps(g.capacityRejectStrikes[model], strikes)
+	}
+	for model, entry := range src.capacityCooldowns {
+		if cur, ok := g.capacityCooldowns[model]; !ok || entry.expiry.After(cur.expiry) {
+			g.capacityCooldowns[model] = entry
+		}
+	}
+	for model, trips := range src.capacityCooldownTrips {
+		if cur, ok := g.capacityCooldownTrips[model]; !ok || trips > cur {
+			g.capacityCooldownTrips[model] = trips
+		}
+	}
+	for model, entry := range src.budgetClamps {
+		if cur, ok := g.budgetClamps[model]; !ok || entry.clampedAt.After(cur.clampedAt) {
+			g.budgetClamps[model] = entry
+		}
+	}
+	for model, outcomes := range src.capacityRateRejects {
+		g.capacityRateRejects[model] = mergeChronologicalTimestamps(g.capacityRateRejects[model], outcomes)
+	}
+	for model, outcomes := range src.capacityRateAccepts {
+		g.capacityRateAccepts[model] = mergeChronologicalTimestamps(g.capacityRateAccepts[model], outcomes)
+	}
+
+	if src.ejection != nil {
+		if g.ejection != nil {
+			g.ejection.merge(src.ejection)
+		} else {
+			g.ejection = src.ejection
+		}
+	}
+	if src.ejectionUntil.After(g.ejectionUntil) {
+		g.ejectionUntil = src.ejectionUntil
+	}
+	// The last-trip marker travels with the trip count it describes: the
+	// destination's own marker wins when it has trips of its own.
+	if g.ejectionTrips == 0 {
+		g.ejectionLastTripCapacity = src.ejectionLastTripCapacity
+	}
+	if src.ejectionTrips > g.ejectionTrips {
+		g.ejectionTrips = src.ejectionTrips
+	}
+	if src.ejectionCapacityStreak.n > g.ejectionCapacityStreak.n {
+		g.ejectionCapacityStreak = src.ejectionCapacityStreak
+	}
+	if src.touched.After(g.touched) {
+		g.touched = src.touched
+	}
+}
+
+// resetLocked drops every tracker (the key, live count and forwardTo stay).
+// After a migration the source key starts from nothing, as the old map-keyed
+// implementation left it. Caller holds g.mu.
+func (g *gateState) resetLocked() {
+	g.identityVersion = ""
+	g.versionResetAt = time.Time{}
+	clear(g.inferenceErrorFlushStrikes)
+	g.outcomes, g.breakerUntil, g.breakerTrips = nil, time.Time{}, 0
+	g.ejection, g.ejectionUntil, g.ejectionTrips = nil, time.Time{}, 0
+	g.ejectionCapacityStreak, g.ejectionLastTripCapacity = capacityStreak{}, false
+	g.inferenceErrorStrikes = make(map[modelShapeKey][]time.Time)
+	g.inferenceErrorCooldowns = make(map[modelShapeKey]time.Time)
+	g.dispatchLoadCooldowns = make(map[string]time.Time)
+	g.capacityRejectStrikes = make(map[string][]time.Time)
+	g.capacityCooldowns = make(map[string]*capacityCooldownEntry)
+	g.capacityCooldownTrips = make(map[string]int)
+	g.budgetClamps = make(map[string]*budgetClampEntry)
+	g.capacityRateRejects = make(map[string][]time.Time)
+	g.capacityRateAccepts = make(map[string][]time.Time)
+}
+
+// bindStableFaultKey binds a live session to its stable identity so every
+// fault tracker keys by identity and survives reconnects. Called by
+// SetAttestationResult on every (re-)attestation — i.e. BEFORE the session is
+// routable for public traffic — which is what re-attaches a reconnecting
+// machine's accumulated fault state to its fresh session id. An empty stableID
+// (attestation cleared / never valid) unbinds, falling back to session keying;
+// the identity's state stays on its own gate (an unbind never migrates).
+//
+// Only LIVE sessions bind: a re-attestation racing Disconnect must not
+// re-insert an entry Disconnect already removed. Liveness is the sessions
+// index under gatesMu, so this never takes r.mu.
+//
+// Caller holds p.mu (SetAttestationResult, RebindStableFaultKey; lock order
+// r.mu → p.mu → gatesMu → gate.mu). The bind repoints p.gate, and the routing
+// sections that read p.gate and ACT on the verdict do so under p.mu — the
+// reservation commit from its admit re-check through the pending debit
+// (commitProviderReservation, ReserveNextFromPlan), the scan's gate chain
+// (gateStateReasonLocked), the alias resolver's routability read
+// (providerCanRouteBuildLocked) — so with the bind under the same lock none
+// of them can accept a clean gate and then act after the session has moved
+// to an identity that is quarantined. The map-keyed implementation had this
+// for free (the bind and the commit shared r.mu.Lock).
+//
+// Accumulated fault state migrates when the key changes: from the session id
+// on the FIRST bind (strikes recorded pre-attestation live on the session
+// gate), or from the previous identity on a rebind (e.g. sekey: → serial:
+// after MDA enrichment). Without this, a machine near quarantine sheds its
+// history at the exact moment its identity improves. No-op on the common
+// re-attestation with an unchanged identity.
+func (r *Registry) bindStableFaultKey(p *Provider, stableID string) {
+	if p == nil || p.ID == "" {
+		return
+	}
+	now := time.Now()
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	if r.sessions[p.ID] != p {
+		return
+	}
+	targetKey := stableID
+	if targetKey == "" {
+		targetKey = p.ID
+	}
+	cur := p.gate.Load()
+	if cur != nil && cur.key == targetKey {
+		if stableID != "" {
+			cur.mu.Lock()
+			cur.noteIdentityVersionLocked(r, p.Version)
+			cur.updatedLocked(now)
+			cur.mu.Unlock()
+		}
+		return
+	}
+	target := r.ensureGateLocked(targetKey, now)
+	if cur != nil && stableID != "" {
+		// Migrate, and repoint the session INSIDE the migration's locked
+		// section: a lock-free reader that loads p.gate must find either cur's
+		// intact pre-migration view or a target that already carries the
+		// merged state, never an empty target; and a recorder that resolved
+		// cur before this rebind must, once it holds cur.mu, either have
+		// written before the merge (its outcome travels to target) or find
+		// p.gate moved and re-resolve (lockGate) — never write into the
+		// emptied cur. That matters most when cur is SHARED with another
+		// session (cur.live > 1): it stays in the index for that session and
+		// carries no forward, so the session's own pointer is the only thing
+		// that can tell a stale recorder its outcome now belongs to target.
+		// (An unbind never migrates: session keying resumes and the identity
+		// keeps its state.) cur is orphaned when this was its last live
+		// session.
+		r.migrateGateLocked(p, cur, target, cur.live <= 1)
+	} else {
+		p.gate.Store(target)
+	}
+	if stableID != "" {
+		target.mu.Lock()
+		target.noteIdentityVersionLocked(r, p.Version)
+		target.updatedLocked(now)
+		target.mu.Unlock()
+	}
+	target.live++
+	if cur != nil {
+		cur.live--
+	}
+}
+
+// migrateGateLocked re-keys accumulated fault state from src to dst (merge
+// policy in mergeLocked) and repoints p (the session being bound) at dst
+// while BOTH gates are locked, so no recorder can hold src.mu with p still
+// pointing at src after the merge. src is emptied afterwards; when no live
+// session still points at it (orphan) it is forwarded to dst and dropped from
+// the index so stale pointers land on the live state. The only place two gate
+// locks nest; caller holds gatesMu for writing, which serializes migrations.
+func (r *Registry) migrateGateLocked(p *Provider, src, dst *gateState, orphan bool) {
+	if src == dst {
+		p.gate.Store(dst)
+		return
+	}
+	src.mu.Lock()
+	dst.mu.Lock()
+	dst.mergeLocked(src)
+	dst.publishLocked()
+	p.gate.Store(dst)
+	// Redirect cached disconnected sessions while src.mu is still held, so
+	// a recorder that resolved src before this migration cannot write into
+	// the reset source when it remains live for an unenriched sibling.
+	r.retargetDisconnectedGateBindingsLocked(src.key, dst.key)
+	if orphan {
+		// Forward BEFORE resetting, and never republish the orphan: a
+		// lock-free reader that loaded src sees either its intact pre-merge
+		// atomics (stale but conservative — expiries merged by max into dst)
+		// or the forward, never zeros. Locked reads follow the forward.
+		src.forwardTo.Store(dst)
+		if r.gates[src.key] == src {
+			delete(r.gates, src.key)
+		}
+		src.resetLocked()
+	} else {
+		// Still bound to other sessions: it starts from nothing, visibly
+		// (rebind semantics in the file header). Published AFTER the repoint
+		// above, which is what lets a routing reader confirm a view of the
+		// zeros against p.gate (gateView) and a lock-free flag check trust a
+		// cleared flag (refHasPairState).
+		src.resetLocked()
+		src.publishLocked()
+	}
+	dst.mu.Unlock()
+	src.mu.Unlock()
+}

--- a/coordinator/registry/gate_migrate_test.go
+++ b/coordinator/registry/gate_migrate_test.go
@@ -1,0 +1,257 @@
+package registry
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the identity migration (gate_migrate.go): stale cached pointers
+// follow the forward, lock-free readers never see an empty gate mid-rebind,
+// and a shared identity gate stays in the index for its other sessions.
+
+// A recorder that resolved the session's gate just before attestation bound
+// the stable identity must land its outcome on the identity's gate, not on
+// the orphaned session gate: lockGate follows the forward set by the
+// migration, and the orphan is gone from the index.
+func TestStaleGatePointerFollowsIdentityMigration(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-stale", "m", 100)
+	ref := reg.gateForSession(p.ID)
+	stale := ref.g
+	if stale == nil || stale.key != p.ID {
+		t.Fatalf("pre-bind gate = %+v, want the session-keyed gate", stale)
+	}
+
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-STALE"})
+	target := reg.lookupGateForKey("serial:SER-STALE")
+	if target == nil || target.key != "serial:SER-STALE" {
+		t.Fatalf("bind did not file the identity's gate: %+v", target)
+	}
+	if rawGateForKey(reg, p.ID) != nil {
+		t.Fatal("the orphaned session gate must leave the index")
+	}
+	if stale.resolve() != target {
+		t.Fatal("resolve() on the stale pointer must follow the migration forward")
+	}
+	hold := reg.lockGate(ref, "test")
+	if hold.g != target {
+		hold.unlock()
+		t.Fatal("lockGate on the stale pointer must lock the live gate")
+	}
+	hold.g.breakerTrips++
+	hold.g.updatedLocked(time.Now())
+	hold.unlock()
+	if got := providerBreakerTripsOf(reg, p.ID); got != 1 {
+		t.Fatalf("mutation through the stale pointer landed elsewhere: trips=%d", got)
+	}
+	if p.gate.Load() != target {
+		t.Fatal("the provider's cached gate must point at the identity's gate")
+	}
+}
+
+// During a live re-attestation that changes the identity, a lock-free reader
+// must never see the identity's fault state vanish: the orphaned session gate
+// keeps its (conservative) atomics — it is never republished after the reset
+// — and the provider's cached pointer is repointed only once the target
+// carries the merged state.
+func TestMigrationNeverExposesAnEmptyGateToLockFreeReaders(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "sess-mig-view", "m", 100)
+	for i := 0; i < providerBreakerConsecTrip; i++ {
+		reg.RecordProviderOutcome(p.ID, false, 500, "internal error")
+	}
+	stale := p.gate.Load()
+	nowNS := time.Now().UnixNano()
+	if !stale.breakerOpenAt(nowNS) {
+		t.Fatal("precondition: breaker open on the session gate")
+	}
+
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-MIG-VIEW"})
+
+	target := p.gate.Load()
+	if target == stale || target.key != "serial:SER-MIG-VIEW" {
+		t.Fatalf("cached gate after bind = %+v, want the identity's gate", target)
+	}
+	if !target.breakerOpenAt(nowNS) {
+		t.Fatal("the target must carry the merged breaker state when the pointer is repointed")
+	}
+	if !stale.breakerOpenAt(nowNS) {
+		t.Fatal("the orphaned gate's atomics must stay conservative (never republished after the reset)")
+	}
+	if stale.forwardTo.Load() != target || !stale.resolve().breakerOpenAt(nowNS) {
+		t.Fatal("the orphan must forward to the live gate")
+	}
+	if !reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("the breaker must read open through the session after the rebind")
+	}
+}
+
+// A rebind that moves ONE of two sessions bound to the same identity must not
+// orphan the shared gate: the other session still points at it, so it stays
+// in the index (emptied, as the map-keyed implementation left the old key).
+func TestRebindKeepsSharedIdentityGateForOtherSessions(t *testing.T) {
+	reg := New(testLogger())
+	p1 := makeSchedulerProvider(t, reg, "sess-shared-1", "m", 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-shared-2", "m", 100)
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED"})
+	p2.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED"})
+	shared := reg.lookupGateForKey("sekey:PK-SHARED")
+	if shared == nil || p1.gate.Load() != shared || p2.gate.Load() != shared {
+		t.Fatal("both sessions must share the identity's gate")
+	}
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+
+	// p1 enriches to a serial; p2 stays on the SE key.
+	p1.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-SHARED", SerialNumber: "SER-ONE"})
+	if rawGateForKey(reg, "sekey:PK-SHARED") != shared {
+		t.Fatal("the shared gate must stay in the index while another session is bound to it")
+	}
+	if shared.forwardTo.Load() != nil {
+		t.Fatal("a gate with a live session must not be forwarded")
+	}
+	if p2.gate.Load() != shared {
+		t.Fatal("the other session's cached gate must be untouched")
+	}
+	if !gateHasBreakerWindow(reg, "serial:SER-ONE") {
+		t.Fatal("the fault history must have moved to the enriched identity")
+	}
+	if gateHasBreakerWindow(reg, "sekey:PK-SHARED") {
+		t.Fatal("the source identity must start from nothing after the migration")
+	}
+	reg.gatesMu.RLock()
+	live := shared.live
+	reg.gatesMu.RUnlock()
+	if live != 1 {
+		t.Fatalf("shared gate live sessions = %d, want 1", live)
+	}
+}
+
+// A rebind repoints p.gate, and the reservation commit reads p.gate (the
+// admit re-check) and acts on the verdict (the pending debit) inside ONE p.mu
+// section — as do the scan's gate chain and the alias resolver's routability
+// read. If the bind ran outside p.mu, it could land in between: a commit that
+// accepted the session's clean gate would debit a session whose destination
+// gate already carries a breaker (a machine re-enriching to the serial that
+// tripped it last time). So the bind runs under p.mu, and p.gate never changes
+// underneath a p.mu holder: a section that read a clean gate debits that same
+// identity. Both entry points flap the session between a clean identity and a
+// breaker-open one while a "commit" keeps checking; the invariant is exact,
+// the interleaving is the race detector's. Once the flapping stops, the
+// identity's breaker gates the session end to end.
+func TestProviderGateNeverMovesUnderTheProviderLock(t *testing.T) {
+	const model = "m"
+	cases := []struct {
+		name   string
+		clean  func(p *Provider) // binds the session to the CLEAN identity
+		dirty  func(p *Provider) // rebinds it to the quarantined one
+		dstKey string
+	}{
+		{
+			name: "attestation enrichment",
+			clean: func(p *Provider) {
+				p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-BINDLOCK"})
+			},
+			dirty: func(p *Provider) {
+				p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: "PK-BINDLOCK", SerialNumber: "SER-BINDLOCK"})
+			},
+			dstKey: "serial:SER-BINDLOCK",
+		},
+		{
+			name: "account linkage",
+			clean: func(p *Provider) {
+				p.mu.Lock()
+				p.AccountID = "ACCT-CLEAN"
+				p.mu.Unlock()
+				p.RebindStableFaultKey()
+			},
+			dirty: func(p *Provider) {
+				p.mu.Lock()
+				p.AccountID = "ACCT-BINDLOCK"
+				p.mu.Unlock()
+				p.RebindStableFaultKey()
+			},
+			dstKey: "acct:ACCT-BINDLOCK",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p := makeSchedulerProvider(t, reg, "sess-bindlock", model, 100)
+			// A clean alternative, so the end-to-end check below is not the
+			// breaker fail-open (a lone breaker-open provider still serves).
+			other := makeSchedulerProvider(t, reg, "sess-bindlock-other", model, 100)
+			// The quarantined destination: its breaker tripped under a previous
+			// session of the same machine. The breaker travels with the session
+			// on every rebind (mergeLocked keeps the later expiry), so from the
+			// first dirty bind on the session is gated whichever identity it is
+			// on; what the checker asserts is that it never sees the identity
+			// CHANGE underneath it.
+			withGateForKey(reg, tc.dstKey, func(g *gateState) { g.breakerUntil = time.Now().Add(time.Hour) })
+			tc.clean(p)
+			if src := p.gate.Load(); src == nil || src.key == tc.dstKey {
+				t.Fatalf("precondition: the session must start on a gate other than %s, got %+v", tc.dstKey, src)
+			}
+			nowNS := time.Now().UnixNano()
+
+			var moved atomic.Int64
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(2)
+			// The commit: read the gate, decide, act — all under p.mu.
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					p.mu.Lock()
+					g := p.gate.Load()
+					_ = g.breakerOpenAt(nowNS) // the admit re-check
+					runtime.Gosched()
+					runtime.Gosched()
+					if p.gate.Load() != g { // the debit lands on a different identity
+						moved.Add(1)
+					}
+					p.mu.Unlock()
+				}
+			}()
+			// The rebinds.
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 3000; i++ {
+					tc.dirty(p)
+					tc.clean(p)
+				}
+				tc.dirty(p)
+				close(stop)
+			}()
+			wg.Wait()
+			if n := moved.Load(); n != 0 {
+				t.Fatalf("p.gate changed under p.mu %d times: a commit that accepted one identity debited another", n)
+			}
+			g := p.gate.Load()
+			if g == nil || g.key != tc.dstKey || !g.breakerOpenAt(nowNS) {
+				t.Fatalf("after the last rebind p.gate = %+v, want the breaker-open %s", g, tc.dstKey)
+			}
+			// From here the identity's breaker gates the session end to end.
+			pr := &PendingRequest{
+				RequestID:             "bindlock-" + tc.name,
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+			if got, _ := reg.ReserveProviderEx(model, pr); got != other {
+				t.Fatalf("reservation = %v, want %s (the rebound session's identity is breaker-open)", got, other.ID)
+			}
+		})
+	}
+}

--- a/coordinator/registry/gate_state.go
+++ b/coordinator/registry/gate_state.go
@@ -1,0 +1,231 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// gate_state.go — per-identity routing-gate state.
+//
+// Every fault tracker that gates routing — the node-health breaker
+// (provider_breaker.go), stable-identity health ejection (health_ejection.go),
+// the shape-keyed inference-error cooldown (error_cooldown.go), the capacity
+// cooldown / rate window / budget clamp (capacity_cooldown.go, capacity_rate.go,
+// budget_clamp.go) and the dispatch-load cooldown (registry.go) — used to live
+// in global maps guarded by Registry.mu. Recording an outcome therefore took
+// the registry WRITE lock: six times per served request, each acquisition
+// draining the whole batch of fleet-scan readers first (~190 ms in prod). The
+// holders were microseconds; the wait was structural.
+//
+// The state now lives in one gateState per fault key with its own mutex.
+// Recorders resolve the gate, take gate.mu, mutate, release — they never touch
+// r.mu. The scan reads the two hot booleans (breaker open, ejected) from
+// atomics and takes gate.mu only for providers that actually carry per-model
+// state (a flag word says which), so the common per-provider cost is a few
+// atomic loads.
+//
+// LOCK ORDER: r.mu → p.mu → r.gatesMu → gate.mu. Never acquire r.mu or p.mu
+// while holding gatesMu or a gate.mu. Recorders normally take gatesMu for
+// READING (session → gate resolution); first insertion and the rare exhausted
+// retry in lockGateWithIndex take it for writing. Register, Disconnect, the
+// attestation-time identity bind (under the session's p.mu) and the periodic
+// sweep also write the index. Only the identity
+// migration (migrateGateLocked, under gatesMu.Lock) ever holds two gate.mu at
+// once, so there is no ordering problem between gates. There is deliberately
+// NO walk-wide gates lock on the scan: a lock taken for the whole fleet walk
+// with per-completion writers would rebuild the exact convoy this removes.
+//
+// A recorder resolves its gate under gatesMu.RLock and locks it AFTER letting
+// go of gatesMu, so the index can change in between: the identity bind can
+// move the session to another gate, the sweep can drop the gate. The
+// map-keyed implementation had no such window (key resolution and the write
+// shared one r.mu.Lock section), so lockGate re-establishes it: after
+// acquiring gate.mu it checks that the gate is still the one the outcome
+// belongs to (not retired, still the session's cached gate) and otherwise
+// releases, re-resolves through the index and retries. Everything that can
+// invalidate a resolved gate — the forward, the retire flag, the session's
+// repoint — is therefore written while holding that gate's mu. The routing
+// READS are covered two ways. A rebind runs under the session's p.mu
+// (bindStableFaultKey's callers hold it), so a read made under p.mu — the
+// scan's gate chain, the reservation commit from its admit re-check through
+// the pending debit, the alias resolver's routability read — never sees
+// p.gate move mid-section. Independently of that lock, every read that feeds
+// a dispatch decision confirms its verdict against p.gate afterwards and
+// re-reads from the session's new gate when it moved (gateView,
+// gate_index.go); that is what covers the candidate cost read the scan makes
+// after it has released p.mu.
+//
+// Sections under gate.mu must stay per identity and microseconds long.
+//
+// The implementation is split by concern:
+//
+//	gate_state.go       — this header, the gateState struct, its lock-free view
+//	                      (publishLocked and the atomic readers)
+//	gate_index.go       — the registry-side index (r.gates / r.sessions under
+//	                      gatesMu), session → gate resolution, attach/detach
+//	gate_migrate.go     — identity binds and the state migration (forwards,
+//	                      merge and reset policy)
+//	gate_sweep.go       — the per-gate prune and the periodic index sweep
+//	gate_lock.go        — the recorders' validated lock (lockGate), the
+//	                      lock-free flag fast path and the wait observer
+//	gate_commit_mode.go — the EIGENINFERENCE_RESERVE_COMMIT_MODE kill switch
+
+// Bits of gateState.pairFlags: which per-model trackers hold ANY entry for this
+// identity. Published under gate.mu after every mutation; read lock-free by the
+// scan so a provider with no per-model state costs no lock section at all.
+const (
+	gateFlagDispatchLoad uint32 = 1 << iota
+	gateFlagErrorCooldown
+	gateFlagCapacityCooldown
+	gateFlagBudgetClamp
+)
+
+// modelShapeKey identifies an inference-error bucket inside one gate:
+// (model, request shape). Shape is RequestTraits.CooldownShape ("tools" /
+// "base"); see error_cooldown.go.
+type modelShapeKey struct {
+	Model string
+	Shape string
+}
+
+// gateState is the fault state of ONE identity (fault key: serial → SE key →
+// account → session id). Fields below the atomics are guarded by mu.
+type gateState struct {
+	// key is the fault key this state is filed under (immutable).
+	key string
+	mu  sync.Mutex
+
+	// forwardTo is set when this gate has been migrated into another (identity
+	// rebind) and is no longer in r.gates. Holders of a stale pointer follow it
+	// (resolve / lockResolved) so a recorder that resolved the gate just before
+	// the bind lands its outcome on the live state, not on the orphan.
+	forwardTo atomic.Pointer[gateState]
+
+	// live counts connected sessions bound to this gate. Guarded by r.gatesMu
+	// (Register / Disconnect / bind / sweep). A gate with live > 0 is never
+	// swept — deleting it would let the next lookup create a twin.
+	live int
+
+	// Lock-free routing view, published under mu after every mutation.
+	breakerOpenUntilNS atomic.Int64  // 0 when the breaker has never opened
+	ejectionUntilNS    atomic.Int64  // 0 when the identity has never been ejected
+	pairFlags          atomic.Uint32 // gateFlag* bits: which per-model maps are non-empty
+	newestRateRejectNS atomic.Int64  // newest capacity-503 rate reject across models; 0 = none
+
+	// retired is set (under mu, before the index delete) when the sweep drops
+	// this idle gate from r.gates. A recorder that resolved the gate before
+	// the sweep and locks it afterwards must not write here — no lookup will
+	// ever find this gate again — so lockGate re-resolves instead.
+	retired bool
+
+	// touched is when a recorder last mutated this gate, or when it was
+	// created (sweep grace anchor: a fresh gate is not idle-droppable before
+	// the first recorder that resolved it has had a chance to lock it).
+	touched time.Time
+
+	// Node-health breaker (provider_breaker.go).
+	outcomes     *providerHealthWindow // nil until the first recorded fault/success
+	breakerUntil time.Time
+	breakerTrips int
+
+	// Stable-identity health ejection (health_ejection.go).
+	ejection                 *providerHealthWindow
+	ejectionUntil            time.Time
+	ejectionTrips            int
+	ejectionCapacityStreak   capacityStreak
+	ejectionLastTripCapacity bool
+
+	// Inference-error breaker, per (model, shape) (error_cooldown.go).
+	inferenceErrorStrikes      map[modelShapeKey][]time.Time
+	inferenceErrorCooldowns    map[modelShapeKey]time.Time
+	inferenceErrorFlushStrikes map[modelShapeKey][]time.Time
+	identityVersion            string
+	versionResetAt             time.Time
+
+	// Per-model trackers, keyed by model id.
+	dispatchLoadCooldowns map[string]time.Time              // registry.go
+	capacityRejectStrikes map[string][]time.Time            // capacity_cooldown.go
+	capacityCooldowns     map[string]*capacityCooldownEntry // capacity_cooldown.go
+	capacityCooldownTrips map[string]int                    // capacity_cooldown.go
+	budgetClamps          map[string]*budgetClampEntry      // budget_clamp.go
+	capacityRateRejects   map[string][]time.Time            // capacity_rate.go
+	capacityRateAccepts   map[string][]time.Time            // capacity_rate.go
+}
+
+func newGateState(key string) *gateState {
+	return &gateState{
+		key:                     key,
+		inferenceErrorStrikes:   make(map[modelShapeKey][]time.Time),
+		inferenceErrorCooldowns: make(map[modelShapeKey]time.Time),
+		dispatchLoadCooldowns:   make(map[string]time.Time),
+		capacityRejectStrikes:   make(map[string][]time.Time),
+		capacityCooldowns:       make(map[string]*capacityCooldownEntry),
+		capacityCooldownTrips:   make(map[string]int),
+		budgetClamps:            make(map[string]*budgetClampEntry),
+		capacityRateRejects:     make(map[string][]time.Time),
+		capacityRateAccepts:     make(map[string][]time.Time),
+	}
+}
+
+// publishLocked refreshes the lock-free routing view from the guarded state.
+// Call after every mutation, before releasing mu.
+func (g *gateState) publishLocked() {
+	g.breakerOpenUntilNS.Store(unixNanoOrZero(g.breakerUntil))
+	g.ejectionUntilNS.Store(unixNanoOrZero(g.ejectionUntil))
+	var flags uint32
+	if len(g.dispatchLoadCooldowns) > 0 {
+		flags |= gateFlagDispatchLoad
+	}
+	if len(g.inferenceErrorCooldowns) > 0 {
+		flags |= gateFlagErrorCooldown
+	}
+	if len(g.capacityCooldowns) > 0 {
+		flags |= gateFlagCapacityCooldown
+	}
+	if len(g.budgetClamps) > 0 {
+		flags |= gateFlagBudgetClamp
+	}
+	g.pairFlags.Store(flags)
+	var newest int64
+	for _, rejects := range g.capacityRateRejects {
+		if n := len(rejects); n > 0 {
+			if ns := rejects[n-1].UnixNano(); ns > newest {
+				newest = ns
+			}
+		}
+	}
+	g.newestRateRejectNS.Store(newest)
+}
+
+// updatedLocked stamps the mutation time and publishes. Recorders call this at
+// the end of every mutating section.
+func (g *gateState) updatedLocked(now time.Time) {
+	g.touched = now
+	g.publishLocked()
+}
+
+func unixNanoOrZero(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// breakerOpenAt reports whether the node-health breaker is open at nowNS.
+// Lock-free; nil-safe (no gate = no state).
+func (g *gateState) breakerOpenAt(nowNS int64) bool {
+	return g != nil && nowNS < g.breakerOpenUntilNS.Load()
+}
+
+// ejectedAt reports whether the identity is health-ejected at nowNS.
+// Lock-free; nil-safe.
+func (g *gateState) ejectedAt(nowNS int64) bool {
+	return g != nil && nowNS < g.ejectionUntilNS.Load()
+}
+
+// hasPairState reports (lock-free) whether any of the flagged per-model
+// trackers holds an entry. Readers use it to skip the lock section entirely.
+func (g *gateState) hasPairState(flag uint32) bool {
+	return g != nil && g.pairFlags.Load()&flag != 0
+}

--- a/coordinator/registry/gate_state_helpers_test.go
+++ b/coordinator/registry/gate_state_helpers_test.go
@@ -1,0 +1,81 @@
+package registry
+
+// Test helpers for poking per-identity gate state (gate_state.go). The fault
+// trackers' tests used to reach into the global maps under r.mu; these give
+// them the same reach into a gate under gate.mu.
+
+// rawGateForKey returns the gate filed under key in the index WITHOUT
+// following a migration forward — nil when no gate is filed there. Use it to
+// assert that an old identity's state did (or did not) leave residue.
+func rawGateForKey(r *Registry, key string) *gateState {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	return r.gates[key]
+}
+
+// withGateForKey runs fn on the gate for key (created on first use) under its
+// lock and republishes the lock-free view afterwards, so a direct field poke
+// is immediately visible to the routing reads. It does NOT stamp touched (a
+// test that backdates a gate's activity keeps its backdate); use the real
+// recorders to model activity.
+func withGateForKey(r *Registry, key string, fn func(g *gateState)) {
+	hold := r.lockGate(r.gateForKey(key), "test")
+	fn(hold.g)
+	hold.g.publishLocked()
+	hold.unlock()
+}
+
+// withGateForSession is withGateForKey resolving a session id the way the
+// recorders do (bound identity → disconnect cache → session id).
+func withGateForSession(r *Registry, sessionID string, fn func(g *gateState)) {
+	hold := r.lockGate(r.gateForSession(sessionID), "test")
+	fn(hold.g)
+	hold.g.publishLocked()
+	hold.unlock()
+}
+
+// readGateForKey runs fn on the gate filed under key under its lock. fn
+// receives nil when the identity has no gate (so callers can assert absence).
+func readGateForKey(r *Registry, key string, fn func(g *gateState)) {
+	g := r.lookupGateForKey(key)
+	if g == nil {
+		fn(nil)
+		return
+	}
+	g = g.lockResolved()
+	fn(g)
+	g.mu.Unlock()
+}
+
+// readGateForSession is readGateForKey resolving a session id.
+func readGateForSession(r *Registry, sessionID string, fn func(g *gateState)) {
+	g := r.lookupGateForSession(sessionID)
+	if g == nil {
+		fn(nil)
+		return
+	}
+	g = g.lockResolved()
+	fn(g)
+	g.mu.Unlock()
+}
+
+// sessionIndexed reports whether the session id is still in the live session
+// index (the fault-key binding the old faultKeyBySession map recorded).
+func sessionIndexed(r *Registry, sessionID string) bool {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	_, ok := r.sessions[sessionID]
+	return ok
+}
+
+// gateHasBreakerWindow reports whether the identity filed under key has a
+// node-health ring (the old providerOutcomes[key] presence check).
+func gateHasBreakerWindow(r *Registry, key string) bool {
+	g := rawGateForKey(r, key)
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.outcomes != nil
+}

--- a/coordinator/registry/gate_stress_test.go
+++ b/coordinator/registry/gate_stress_test.go
@@ -1,0 +1,191 @@
+package registry
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Recorders and routing reads racing identity rebinds (shared ↔ enriched) and
+// sweeps that keep retiring idle gates: interleaving coverage under -race for
+// lockGate's re-validation and gateView's confirmation. The deterministic
+// tests (gate_lock_test.go, gate_index_test.go) carry the outcome assertions;
+// here the invariants are "no retired gate is ever in the index", "the other
+// session's binding is never disturbed", a quiescent record lands on the
+// session's current gate — and, for a session that flaps between a shared
+// and an enriched identity while carrying a dispatch-load cooldown, the
+// routing read NEVER admits it: the cooldown follows the session through
+// every rebind (mergeLocked keeps the max expiry both ways), so a "not
+// gated" verdict could only come from trusting the emptied shared source.
+func TestGateRecordersRaceRebindsAndSweeps(t *testing.T) {
+	reg := New(testLogger())
+	const model = "m"
+	p1 := makeSchedulerProvider(t, reg, "sess-stress-1", model, 100)
+	p2 := makeSchedulerProvider(t, reg, "sess-stress-2", model, 100)
+	pk := &attestation.VerificationResult{Valid: true, PublicKey: "PK-STRESS"}
+	enriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-STRESS", SerialNumber: "SER-STRESS"}
+	p1.SetAttestationResult(pk)
+	p2.SetAttestationResult(pk)
+	// A disconnected identity that keeps faulting (never idle) and one that
+	// only ever sees successes (always idle: retired and re-created on every
+	// sweep once backdated).
+	gone := attestSchedulerProvider(t, reg, "sess-stress-gone", model, "SER-STRESS-GONE", 100)
+	quiet := attestSchedulerProvider(t, reg, "sess-stress-quiet", model, "SER-STRESS-QUIET", 100)
+	reg.Disconnect(gone.ID)
+	reg.Disconnect(quiet.ID)
+	// A second shared identity whose dispatch-load cooldown is armed once and
+	// never cleared (nothing in the mix below touches it): cooled flaps between
+	// the shared gate and its own serial while readers evaluate its routing
+	// gate. Its sibling keeps the shared gate live.
+	cooled := makeSchedulerProvider(t, reg, "sess-stress-cooled", model, 100)
+	sibling := makeSchedulerProvider(t, reg, "sess-stress-cooled-sibling", model, 100)
+	cooledPK := &attestation.VerificationResult{Valid: true, PublicKey: "PK-COOLED"}
+	cooledEnriched := &attestation.VerificationResult{Valid: true, PublicKey: "PK-COOLED", SerialNumber: "SER-COOLED"}
+	cooled.SetAttestationResult(cooledPK)
+	sibling.SetAttestationResult(cooledPK)
+	reg.RecordDispatchLoadFailure(cooled.ID, model)
+	if !reg.dispatchLoadCooled(cooled.ID, model, time.Now()) {
+		t.Fatal("precondition: the cooled session's pair must be dispatch-load cooled")
+	}
+
+	backdateAll := func() {
+		reg.gatesMu.RLock()
+		gates := make([]*gateState, 0, len(reg.gates))
+		for _, g := range reg.gates {
+			gates = append(gates, g)
+		}
+		reg.gatesMu.RUnlock()
+		past := time.Now().Add(-gateIdleGrace - time.Minute)
+		for _, g := range gates {
+			g.mu.Lock()
+			g.touched = past
+			g.mu.Unlock()
+		}
+	}
+
+	const iters = 1500
+	var wg sync.WaitGroup
+	recorders := []func(i int){
+		func(i int) { reg.RecordProviderOutcome(p1.ID, i%3 != 0, 500, "internal error") },
+		func(i int) { reg.RecordCapacityReject(p1.ID, model) },
+		func(i int) { reg.RecordCapacityAccept(p1.ID, model) },
+		func(i int) { reg.RecordInferenceError(p1.ID, model, 500, "base") },
+		func(i int) { reg.RecordInferenceSuccess(p1.ID, model, "base") },
+		func(i int) { reg.ClearDispatchLoadCooldown(p1.ID, model) },
+		func(i int) { reg.tryClaimCapacityProbe(p1, model, time.Now()) },
+		func(i int) { reg.RecordProviderServeOutcome("sekey:PK-STRESS", i%2 == 0, 500, "internal error") },
+		func(i int) { reg.RecordProviderOutcome(p2.ID, true, 200, "") },
+		func(i int) { reg.RecordProviderOutcome(gone.ID, false, 502, "provider disconnected") },
+		func(i int) { reg.RecordInferenceSuccess(quiet.ID, model, "base") },
+		func(i int) { reg.RecordProviderServeOutcome("serial:SER-STRESS-QUIET", true, 200, "") },
+	}
+	for _, rec := range recorders {
+		wg.Add(1)
+		go func(rec func(int)) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				rec(i)
+			}
+		}(rec)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				p1.SetAttestationResult(enriched)
+			} else {
+				p1.SetAttestationResult(pk)
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			if i%2 == 0 {
+				cooled.SetAttestationResult(cooledEnriched)
+			} else {
+				cooled.SetAttestationResult(cooledPK)
+			}
+		}
+	}()
+	// Routing readers: the scan's gate evaluation for cooled, as the scan runs
+	// it (view loaded, then read under p.mu). admitted counts verdicts that let
+	// the cooled pair through; bounded counts evaluations that hit the re-read
+	// bound (documented fallback to the last view — not a verdict this test
+	// judges).
+	var admitted, bounded atomic.Int32
+	for reader := 0; reader < 2; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				view := reg.gateViewOf(cooled)
+				cooled.mu.Lock()
+				ok, reason := reg.gateStateReasonLocked(&view, model, RequestTraits{}, time.Now(), false, false)
+				cooled.mu.Unlock()
+				if view.rereads >= gateRelockMaxRetries {
+					bounded.Add(1)
+					continue
+				}
+				if ok || reason != GateDispatchLoadCooldown {
+					admitted.Add(1)
+				}
+			}
+		}()
+	}
+	stop := make(chan struct{})
+	sweeperDone := make(chan struct{})
+	go func() {
+		defer close(sweeperDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			backdateAll()
+			reg.sweepGates(time.Now())
+		}
+	}()
+	wg.Wait()
+	close(stop)
+	<-sweeperDone
+
+	reg.gatesMu.RLock()
+	for key, g := range reg.gates {
+		g.mu.Lock()
+		retired := g.retired
+		g.mu.Unlock()
+		if retired {
+			t.Errorf("retired gate %q is still in the index", key)
+		}
+	}
+	reg.gatesMu.RUnlock()
+	if g := p2.gate.Load(); g == nil || g.key != "sekey:PK-STRESS" || rawGateForKey(reg, "sekey:PK-STRESS") != g {
+		t.Fatalf("p2's binding was disturbed: %+v", g)
+	}
+	if n := admitted.Load(); n != 0 {
+		t.Fatalf("%d routing reads admitted the cooled session mid-rebind (want 0; %d hit the re-read bound)", n, bounded.Load())
+	}
+	if n := bounded.Load(); n != 0 {
+		t.Logf("%d routing reads hit the re-read bound", n)
+	}
+	if g := sibling.gate.Load(); g == nil || g.key != "sekey:PK-COOLED" || rawGateForKey(reg, "sekey:PK-COOLED") != g {
+		t.Fatalf("the cooled sibling's binding was disturbed: %+v", g)
+	}
+	if !reg.dispatchLoadCooled(cooled.ID, model, time.Now()) {
+		t.Fatal("the cooled session's pair must still read cooled through its current identity")
+	}
+	p1.SetAttestationResult(enriched)
+	reg.RecordProviderOutcome(p1.ID, false, 500, "internal error")
+	readGateForSession(reg, p1.ID, func(g *gateState) {
+		if g == nil || g.key != "serial:SER-STRESS" || g.outcomes == nil {
+			t.Fatalf("a quiescent fault must land on p1's current gate: %+v", g)
+		}
+	})
+}

--- a/coordinator/registry/gate_sweep.go
+++ b/coordinator/registry/gate_sweep.go
@@ -1,0 +1,143 @@
+package registry
+
+import "time"
+
+// gate_sweep.go — bounding the gate index: the per-gate prune of dead
+// per-model entries and the periodic sweep that retires idle gates no live
+// session references. Design, lock order and file map: gate_state.go.
+
+// gateIdleGrace is how long a gate with no live session must stay idle (every
+// tracker expired or empty and nothing recorded) before the sweep drops it. A
+// disconnected identity keeps its half-open trip memory for at least this long.
+const gateIdleGrace = 10 * time.Minute
+
+// gateSweepHighWater is the gate count above which an insert triggers an
+// inline sweep (rate-limited by gateSweepMinInterval) so the index stays
+// bounded even when the eviction loop is not running. The loop sweeps every
+// timeout/3 (30 s at the default), so with a 60 s minimum interval the inline
+// path — a walk of every gate under gatesMu.Lock, on a recorder's insert —
+// never fires in a process that runs the loop.
+const (
+	gateSweepHighWater   = 4096
+	gateSweepMinInterval = 60 * time.Second
+)
+
+// pruneLocked drops per-model entries that can no longer influence routing
+// and reports whether the whole gate is idle: nothing open, no windowed
+// history, no live per-model state. It mirrors what the old size-triggered
+// map sweeps removed — with one deliberate difference: half-open memory
+// (breaker/cooldown trip counts, an expired cooldown entry awaiting its
+// probe, a fault ring's consecutive-fault counter) is NEVER pruned from a gate
+// that still has a live session, because the old sweeps only ran past 1024
+// entries and the half-open re-arm semantics depend on that memory. Such
+// memory goes only when the whole gate is dropped. Caller holds g.mu.
+func (g *gateState) pruneLocked(r *Registry, now time.Time) (idle bool) {
+	idle = !g.versionHistoryActive(now)
+	for model, expiry := range g.dispatchLoadCooldowns {
+		if !now.Before(expiry) {
+			delete(g.dispatchLoadCooldowns, model)
+		}
+	}
+	for k, expiry := range g.inferenceErrorCooldowns {
+		if !now.Before(expiry) {
+			delete(g.inferenceErrorCooldowns, k)
+		}
+	}
+	for k, strikes := range g.inferenceErrorStrikes {
+		if len(strikes) == 0 || !strikes[len(strikes)-1].Add(inferenceErrorWindow).After(now) {
+			delete(g.inferenceErrorStrikes, k)
+			delete(g.inferenceErrorFlushStrikes, k)
+		}
+	}
+	window := r.capacityCooldownCfg.Window
+	for model, strikes := range g.capacityRejectStrikes {
+		if len(strikes) == 0 || !strikes[len(strikes)-1].Add(window).After(now) {
+			delete(g.capacityRejectStrikes, model)
+		}
+	}
+	for model, e := range g.budgetClamps {
+		if !now.Before(e.clampedAt.Add(r.budgetClampCfg.TTL)) {
+			delete(g.budgetClamps, model)
+		}
+	}
+	for model, outcomes := range g.capacityRateRejects {
+		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
+			delete(g.capacityRateRejects, model)
+		}
+	}
+	for model, outcomes := range g.capacityRateAccepts {
+		if len(outcomes) == 0 || now.Sub(outcomes[len(outcomes)-1]) >= capacityRateWindow {
+			delete(g.capacityRateAccepts, model)
+		}
+	}
+
+	if len(g.dispatchLoadCooldowns)+len(g.inferenceErrorCooldowns)+len(g.inferenceErrorStrikes)+
+		len(g.capacityRejectStrikes)+len(g.budgetClamps)+len(g.capacityRateRejects)+len(g.capacityRateAccepts) > 0 {
+		idle = false
+	}
+	for _, e := range g.capacityCooldowns {
+		// An expired entry with a fresh probe claim is still gating (see
+		// capacityCooldownActiveLocked); one whose claim is stale or absent is
+		// half-open memory only.
+		if now.Before(e.expiry) || (!e.probeAt.IsZero() && now.Before(e.probeAt.Add(capacityProbeOutcomeWindow))) {
+			idle = false
+		}
+	}
+	if now.Before(g.breakerUntil) || now.Before(g.ejectionUntil) {
+		idle = false
+	}
+	if g.outcomes != nil {
+		if total, _ := g.outcomes.windowStats(now, providerBreakerWindow); total > 0 {
+			idle = false
+		}
+	}
+	if g.ejection != nil {
+		if total, _ := g.ejection.windowStats(now, healthEjectionWindow); total > 0 {
+			idle = false
+		}
+	}
+	if g.ejectionCapacityStreak.n > 0 && now.Sub(g.ejectionCapacityStreak.last) <= healthEjectionWindow {
+		idle = false
+	}
+	return idle
+}
+
+// sweepGates bounds the gate index: it prunes dead per-model entries from
+// every gate and drops gates that no live session references once they have
+// been idle for gateIdleGrace. Called from the eviction loop (every
+// timeout/3) and inline from an insert past the high-water mark. Each gate is
+// locked for microseconds; gatesMu is held for the walk, which is why this
+// runs at most every few seconds and never on the request path.
+func (r *Registry) sweepGates(now time.Time) {
+	r.gatesMu.Lock()
+	defer r.gatesMu.Unlock()
+	r.gatesInitLocked()
+	r.sweepGatesLocked(now)
+}
+
+func (r *Registry) sweepGatesLocked(now time.Time) {
+	r.gateSweepAt = now
+	for key, g := range r.gates {
+		g.mu.Lock()
+		idle := g.pruneLocked(r, now)
+		g.publishLocked()
+		drop := idle && g.live <= 0 && now.Sub(g.touched) > gateIdleGrace
+		if drop {
+			// Retire under g.mu BEFORE the index delete: a recorder that
+			// resolved this gate before the walk and locks it afterwards
+			// sees retired and re-resolves (lockGate) instead of writing a
+			// trailing fault into a gate no lookup will ever find again.
+			g.retired = true
+		}
+		g.mu.Unlock()
+		if drop {
+			delete(r.gates, key)
+		}
+	}
+	cutoff := now.Add(-disconnectedStableIDTTL)
+	for k, v := range r.disconnectedStableIDs {
+		if v.at.Before(cutoff) {
+			delete(r.disconnectedStableIDs, k)
+		}
+	}
+}

--- a/coordinator/registry/gate_sweep_test.go
+++ b/coordinator/registry/gate_sweep_test.go
@@ -1,0 +1,64 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the gate sweep (gate_sweep.go): the liveness rule and the idle
+// grace, including a fresh gate's creation counting as activity.
+
+// The sweep never drops a gate a connected session references, drops an
+// identity-less session's gate at Disconnect, and drops a disconnected
+// identity's gate only once it is idle AND past the idle grace.
+func TestGateSweepLivenessRule(t *testing.T) {
+	reg := New(testLogger())
+	anon := makeSchedulerProvider(t, reg, "sess-anon", "m", 100)
+	attested := attestSchedulerProvider(t, reg, "sess-att", "m", "SER-SWEEP", 100)
+	reg.RecordProviderOutcome(attested.ID, false, 500, "internal error")
+
+	reg.sweepGates(time.Now().Add(24 * time.Hour))
+	if rawGateForKey(reg, anon.ID) == nil || rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("gates with a connected session must survive any sweep")
+	}
+
+	reg.Disconnect(anon.ID)
+	if rawGateForKey(reg, anon.ID) != nil {
+		t.Fatal("an identity-less session's gate must be dropped at Disconnect")
+	}
+
+	reg.Disconnect(attested.ID)
+	if rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("a stable identity's gate must survive Disconnect")
+	}
+	// Inside the breaker window / idle grace: kept.
+	reg.sweepGates(time.Now().Add(time.Minute))
+	if rawGateForKey(reg, "serial:SER-SWEEP") == nil {
+		t.Fatal("a recently active identity must not be swept")
+	}
+	// Past every window and the grace: gone.
+	reg.sweepGates(time.Now().Add(gateIdleGrace + providerBreakerWindow + time.Minute))
+	if rawGateForKey(reg, "serial:SER-SWEEP") != nil {
+		t.Fatal("an idle disconnected identity must be swept after the grace")
+	}
+}
+
+// A gate created for an identity with no live session (the trailing flush's
+// first fault, a serve outcome by stable id) counts its creation as activity:
+// it is not idle-droppable before the grace, so the recorder that created it
+// cannot lose the race against a sweep that runs before it takes the lock.
+func TestFreshGateIsNotSweptBeforeTheGrace(t *testing.T) {
+	reg := New(testLogger())
+	ref := reg.gateForSession("sess-ghost")
+	if ref.g == nil || ref.g.key != "sess-ghost" {
+		t.Fatalf("ref = %+v, want a fresh session-keyed gate", ref)
+	}
+	reg.sweepGates(time.Now())
+	if rawGateForKey(reg, "sess-ghost") != ref.g {
+		t.Fatal("a just-created gate must survive the sweep until the grace")
+	}
+	reg.sweepGates(time.Now().Add(gateIdleGrace + time.Minute))
+	if rawGateForKey(reg, "sess-ghost") != nil {
+		t.Fatal("an idle unreferenced gate must be swept once past the grace")
+	}
+}

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -16,13 +16,13 @@ import (
 // to them) — is ejected from routing, re-probed after an exponential cooldown
 // (half-open), and auto-re-admitted on the first success.
 //
-// This file also owns the session→identity fault-key binding
-// (bindStableFaultKey / faultKeyLocked) that the OTHER fault trackers
-// (error_cooldown.go, provider_breaker.go, dispatchLoadCooldowns) key their
-// maps by, so ALL fault state re-attaches when a machine reconnects with a
-// fresh session UUID instead of being wiped (the prod zombie exploit: median
-// 18 sessions/machine/week reset every session-keyed breaker before it could
-// trip).
+// The session→identity fault-key binding (bindStableFaultKey /
+// faultKeyForSession, gate_state.go) that EVERY fault tracker keys by lives
+// with the per-identity gate index, so ALL fault state re-attaches when a
+// machine reconnects with a fresh session UUID instead of being wiped (the
+// prod zombie exploit: median 18 sessions/machine/week reset every
+// session-keyed breaker before it could trip). This file derives the stable
+// identity and owns the ejection breaker itself.
 //
 // FAIL OPEN, like provider_breaker.go: occasional capacity/client sheds never
 // count (only an unbroken zero-success capacity streak does), an un-attestable
@@ -125,288 +125,35 @@ func stableProviderIdentityLocked(p *Provider) string {
 
 // GetProviderStableIdentity resolves a live session providerID to its stable
 // identity, or "" if the provider is gone or un-attestable. For the consumer
-// note* hooks to feed RecordProviderServeOutcome without holding registry locks.
+// note* hooks to feed RecordProviderServeOutcome without holding registry locks:
+// the session index under gatesMu stands in for r.providers, so this never
+// queues behind a registry writer.
 func (r *Registry) GetProviderStableIdentity(providerID string) string {
 	if providerID == "" {
 		return ""
 	}
-	r.mu.RLock()
-	p := r.providers[providerID]
+	r.gatesMu.RLock()
+	p := r.sessions[providerID]
 	cached, hasCached := r.disconnectedStableIDs[providerID]
-	r.mu.RUnlock()
+	r.gatesMu.RUnlock()
 	if p != nil {
 		// This path does NOT hold p.mu (unlike the routing gate), so take it for the
 		// read — guarding against a concurrent SetAttestationResult (live re-attestation
-		// writes p.AttestationResult under p.mu). Not nested with r.mu, so no deadlock.
+		// writes p.AttestationResult under p.mu). Not nested with gatesMu, so no deadlock.
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		return stableProviderIdentityLocked(p)
 	}
-	// Provider already removed from r.providers — typically because Disconnect ran
-	// before the pending-request ErrorCh flush, which carries the 502 "provider
-	// disconnected" faults that characterize a reconnecting zombie. Fall back to the
-	// identity captured at disconnect so those faults are still recorded against the
-	// stable-identity breaker (otherwise the dominant zombie signal is never counted).
+	// Provider already removed from the session index — typically because
+	// Disconnect ran before the pending-request ErrorCh flush, which carries the
+	// 502 "provider disconnected" faults that characterize a reconnecting zombie.
+	// Fall back to the identity captured at disconnect so those faults are still
+	// recorded against the stable-identity breaker (otherwise the dominant zombie
+	// signal is never counted).
 	if hasCached && time.Since(cached.at) < disconnectedStableIDTTL {
 		return cached.id
 	}
 	return ""
-}
-
-// bindStableFaultKey binds a live session id to its stable identity so every
-// fault-tracking map (inference-error cooldowns, node-health breaker,
-// dispatch-load cooldowns) keys by identity and survives reconnects. Called by
-// SetAttestationResult on every (re-)attestation — i.e. BEFORE the session is
-// routable for public traffic — which is what re-attaches a reconnecting
-// machine's accumulated fault state to its fresh session id. An empty stableID
-// (attestation cleared / never valid) unbinds, falling back to session keying.
-func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
-	if sessionID == "" {
-		return
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if stableID == "" {
-		delete(r.faultKeyBySession, sessionID)
-		return
-	}
-	// Only bind LIVE sessions: a re-attestation racing Disconnect must not
-	// re-insert an entry Disconnect already removed (it would leak forever —
-	// nothing cleans that session id again). The disconnectedStableIDs cache
-	// covers post-disconnect resolution.
-	p, live := r.providers[sessionID]
-	if !live {
-		return
-	}
-	// Migrate accumulated fault state when the key changes: from the session id
-	// on the FIRST bind (strikes recorded pre-attestation live under the
-	// faultKeyLocked session fallback), or from the previous identity on a
-	// rebind (e.g. sekey: → serial: after MDA enrichment). Without this, a
-	// machine near quarantine sheds its history at the exact moment its
-	// identity improves. No-op on the common re-attestation with an unchanged
-	// identity.
-	old := r.faultKeyBySession[sessionID]
-	if old == "" {
-		old = sessionID
-	}
-	if old != stableID {
-		r.migrateFaultStateLocked(old, stableID)
-	}
-	r.faultKeyBySession[sessionID] = stableID
-	// Version-changed reconnect reset (version_reset.go): a session that
-	// already reported its binary version binds here on re-attestation;
-	// registration-time binds happen before the version is stored and are
-	// covered by Provider.SetVersion. r.mu → p.mu is the established order.
-	p.mu.Lock()
-	version := p.Version
-	p.mu.Unlock()
-	r.noteIdentityVersionLocked(stableID, version)
-}
-
-// migrateFaultStateLocked re-keys every fault-tracking map entry from oldKey to
-// newKey so accumulated history follows an identity rebind. Merge policy where
-// both keys hold state: expiries and streak recency take the max, trip counts
-// take the max, timestamp histories merge chronologically (their bounded-map
-// sweeps use the tail as the newest entry), and health windows are merged in
-// timestamp order bounded by the ring size (providerHealthWindow.merge) so an
-// in-progress consecutive-fault streak survives the rebind. Caller holds r.mu.
-func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
-	if oldKey == "" || newKey == "" || oldKey == newKey {
-		return
-	}
-
-	// Late disconnect-flush outcomes must follow the same identity as the
-	// migrated windows and reset timestamp. Preserve each drop time so the
-	// migration neither extends the cache TTL nor changes reset ordering.
-	for sessionID, cached := range r.disconnectedStableIDs {
-		if cached.id == oldKey {
-			cached.id = newKey
-			r.disconnectedStableIDs[sessionID] = cached
-		}
-	}
-
-	// Dispatch-load cooldowns: struct keys per (fault key, model).
-	for k, expiry := range r.dispatchLoadCooldowns {
-		if k.FaultKey == oldKey {
-			nk := k
-			nk.FaultKey = newKey
-			if cur, ok := r.dispatchLoadCooldowns[nk]; !ok || expiry.After(cur) {
-				r.dispatchLoadCooldowns[nk] = expiry
-			}
-			delete(r.dispatchLoadCooldowns, k)
-		}
-	}
-
-	// Inference-error strikes/cooldowns: struct keys per (provider, model, shape).
-	for k, strikes := range r.inferenceErrorStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.inferenceErrorStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorStrikes[nk], strikes)
-			delete(r.inferenceErrorStrikes, k)
-		}
-	}
-	for k, expiry := range r.inferenceErrorCooldowns {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.inferenceErrorCooldowns[nk]; !ok || expiry.After(cur) {
-				r.inferenceErrorCooldowns[nk] = expiry
-			}
-			delete(r.inferenceErrorCooldowns, k)
-		}
-	}
-	// Disconnect-flush strike tags, the last-seen binary version, and the
-	// version-reset throttle timestamp follow the identity too
-	// (version_reset.go): an existing version under the new key is the more
-	// recent binding and wins; the later reset timestamp wins so a rebind can
-	// never hand the identity a second reset inside the interval.
-	for k, flush := range r.inferenceErrorFlushStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.inferenceErrorFlushStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorFlushStrikes[nk], flush)
-			delete(r.inferenceErrorFlushStrikes, k)
-		}
-	}
-	if v, ok := r.identityVersions[oldKey]; ok {
-		if _, exists := r.identityVersions[newKey]; !exists {
-			r.identityVersions[newKey] = v
-		}
-		delete(r.identityVersions, oldKey)
-	}
-	if at, ok := r.identityVersionSeenAt[oldKey]; ok {
-		if cur, exists := r.identityVersionSeenAt[newKey]; !exists || at.After(cur) {
-			r.identityVersionSeenAt[newKey] = at
-		}
-		delete(r.identityVersionSeenAt, oldKey)
-	}
-	if at, ok := r.identityVersionResetAt[oldKey]; ok {
-		if cur, exists := r.identityVersionResetAt[newKey]; !exists || at.After(cur) {
-			r.identityVersionResetAt[newKey] = at
-		}
-		delete(r.identityVersionResetAt, oldKey)
-	}
-
-	// Node-health breaker.
-	if w, ok := r.providerOutcomes[oldKey]; ok {
-		if dst, exists := r.providerOutcomes[newKey]; exists {
-			dst.merge(w)
-		} else {
-			r.providerOutcomes[newKey] = w
-		}
-		delete(r.providerOutcomes, oldKey)
-	}
-	if expiry, ok := r.providerBreakerOpenUntil[oldKey]; ok {
-		if cur, exists := r.providerBreakerOpenUntil[newKey]; !exists || expiry.After(cur) {
-			r.providerBreakerOpenUntil[newKey] = expiry
-		}
-		delete(r.providerBreakerOpenUntil, oldKey)
-	}
-	if trips, ok := r.providerBreakerTrips[oldKey]; ok {
-		if cur, exists := r.providerBreakerTrips[newKey]; !exists || trips > cur {
-			r.providerBreakerTrips[newKey] = trips
-		}
-		delete(r.providerBreakerTrips, oldKey)
-	}
-
-	// Capacity-reject cooldown (pair-scoped struct keys).
-	for k, strikes := range r.capacityRejectStrikes {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRejectStrikes[nk] = mergeChronologicalTimestamps(r.capacityRejectStrikes[nk], strikes)
-			delete(r.capacityRejectStrikes, k)
-		}
-	}
-	for k, entry := range r.capacityCooldowns {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.capacityCooldowns[nk]; !ok || entry.expiry.After(cur.expiry) {
-				r.capacityCooldowns[nk] = entry
-			}
-			delete(r.capacityCooldowns, k)
-		}
-	}
-	for k, trips := range r.capacityCooldownTrips {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.capacityCooldownTrips[nk]; !ok || trips > cur {
-				r.capacityCooldownTrips[nk] = trips
-			}
-			delete(r.capacityCooldownTrips, k)
-		}
-	}
-
-	// Gray-box budget clamp: the entry with the LATER clamp time wins whole
-	// (its clampedAt anchors both the TTL and the release-freshness check, and
-	// its acceptedSince belongs to that clamp window).
-	for k, entry := range r.budgetClamps {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			if cur, ok := r.budgetClamps[nk]; !ok || entry.clampedAt.After(cur.clampedAt) {
-				r.budgetClamps[nk] = entry
-			}
-			delete(r.budgetClamps, k)
-		}
-	}
-
-	// Capacity-503 rate windows: union the outcome slices chronologically. The
-	// large-map sweep uses the tail as the newest timestamp, so appending an older
-	// source history after a fresh destination would otherwise delete live state.
-	for k, outcomes := range r.capacityRateRejects {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRateRejects[nk] = mergeChronologicalTimestamps(r.capacityRateRejects[nk], outcomes)
-			delete(r.capacityRateRejects, k)
-		}
-	}
-	for k, outcomes := range r.capacityRateAccepts {
-		if k.ProviderID == oldKey {
-			nk := k
-			nk.ProviderID = newKey
-			r.capacityRateAccepts[nk] = mergeChronologicalTimestamps(r.capacityRateAccepts[nk], outcomes)
-			delete(r.capacityRateAccepts, k)
-		}
-	}
-
-	// Stable-identity health ejection.
-	if w, ok := r.healthEjectionWindows[oldKey]; ok {
-		if dst, exists := r.healthEjectionWindows[newKey]; exists {
-			dst.merge(w)
-		} else {
-			r.healthEjectionWindows[newKey] = w
-		}
-		delete(r.healthEjectionWindows, oldKey)
-	}
-	if until, ok := r.healthEjectionUntil[oldKey]; ok {
-		if cur, exists := r.healthEjectionUntil[newKey]; !exists || until.After(cur) {
-			r.healthEjectionUntil[newKey] = until
-		}
-		delete(r.healthEjectionUntil, oldKey)
-	}
-	if trips, ok := r.healthEjectionTrips[oldKey]; ok {
-		if cur, exists := r.healthEjectionTrips[newKey]; !exists || trips > cur {
-			r.healthEjectionTrips[newKey] = trips
-		}
-		delete(r.healthEjectionTrips, oldKey)
-	}
-	if streak, ok := r.healthEjectionCapacityStreaks[oldKey]; ok {
-		if cur, exists := r.healthEjectionCapacityStreaks[newKey]; !exists || streak.n > cur.n {
-			r.healthEjectionCapacityStreaks[newKey] = streak
-		}
-		delete(r.healthEjectionCapacityStreaks, oldKey)
-	}
-	if lastCap, ok := r.healthEjectionLastTripCapacity[oldKey]; ok {
-		if _, exists := r.healthEjectionLastTripCapacity[newKey]; !exists {
-			r.healthEjectionLastTripCapacity[newKey] = lastCap
-		}
-		delete(r.healthEjectionLastTripCapacity, oldKey)
-	}
 }
 
 // mergeChronologicalTimestamps returns the oldest-to-newest union of two
@@ -437,27 +184,14 @@ func mergeChronologicalTimestamps(dst, src []time.Time) []time.Time {
 	return merged
 }
 
-// faultKeyLocked resolves a session provider id to the key its fault state
-// lives under: the bound stable identity (serial/SE-key/account), the identity
-// cached at Disconnect for the trailing ErrorCh flush, or — when no identity
-// was ever available — the session id itself. READ-ONLY (no map writes), so it
-// is safe under r.mu held in either mode; the routing gates call it under
-// r.mu.RLock.
-func (r *Registry) faultKeyLocked(sessionID string) string {
-	if k, ok := r.faultKeyBySession[sessionID]; ok && k != "" {
-		return k
-	}
-	if c, ok := r.disconnectedStableIDs[sessionID]; ok && c.id != "" && time.Since(c.at) < disconnectedStableIDTTL {
-		return c.id
-	}
-	return sessionID
-}
-
 // disconnectedStableID caches a provider's stable identity at Disconnect time so
 // the trailing pending-request ErrorCh flush can still resolve it.
 type disconnectedStableID struct {
 	id string
 	at time.Time
+	// binding is shared only with short-lived recorder refs, not Provider.
+	// Identity migration updates it under the old gate's mutex before reset.
+	binding *disconnectedGateBinding
 }
 
 // disconnectedStableIDTTL bounds how long a disconnected provider's cached stable
@@ -466,8 +200,8 @@ type disconnectedStableID struct {
 const disconnectedStableIDTTL = 2 * time.Minute
 
 // rememberDisconnectedStableIDLocked caches a provider's stable identity keyed by
-// its about-to-be-removed session id. Caller holds r.mu.
-func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string) {
+// its about-to-be-removed session id. Caller holds gatesMu for writing.
+func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string, disconnectedAt time.Time) {
 	if r.disconnectedStableIDs == nil {
 		r.disconnectedStableIDs = make(map[string]disconnectedStableID)
 	}
@@ -479,9 +213,7 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 			}
 		}
 	}
-	disconnectedAt := time.Now()
-	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: disconnectedAt}
-	r.touchIdentityVersionLocked(stableID, disconnectedAt)
+	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: disconnectedAt, binding: newDisconnectedGateBinding(stableID)}
 }
 
 // RecordProviderServeOutcome feeds one terminal outcome into the stable-identity
@@ -499,65 +231,57 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 //     can never trip;
 //   - everything else (client 4xx, request-shape context overflows,
 //     unattributed codes): neutral.
+//
+// State lives on the identity's gate (gate_state.go), filed under the stable
+// id itself; only gate.mu is taken, never r.mu.
 func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
 	if stableID == "" || !healthEjectionEnabled() {
 		return false, false
 	}
-	hold := r.lockWrite("health_ejection")
+	hold := r.lockGate(r.gateForKey(stableID), "health_ejection")
 	defer hold.unlock()
-	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+	g := hold.g
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
 }
 
-// RecordProviderSessionServeOutcome retains the source session through the
-// ejection mutation so a version reset cannot be followed by an old flush strike.
 func (r *Registry) RecordProviderSessionServeOutcome(sessionID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
-	if sessionID == "" || !healthEjectionEnabled() {
+	if sessionID == "" || !healthEjectionEnabled() || r.faultKeyForSession(sessionID) == sessionID {
 		return false, false
 	}
-	hold := r.lockWrite("health_ejection")
+	source := r.captureDisconnectSource(sessionID)
+	hold := r.lockGate(r.gateForSession(sessionID), "health_ejection")
 	defer hold.unlock()
-	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(sessionID) {
+	g := hold.g
+	if g == nil || g.key == sessionID || (!ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g)) {
 		return false, false
 	}
-	stableID := ""
-	if p := r.providers[sessionID]; p != nil {
-		p.mu.Lock()
-		stableID = stableProviderIdentityLocked(p)
-		p.mu.Unlock()
-	} else if cached, exists := r.disconnectedStableIDs[sessionID]; exists && time.Since(cached.at) < disconnectedStableIDTTL {
-		stableID = cached.id
-	}
-	if stableID == "" {
-		return false, false
-	}
-	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
 }
 
-// recordProviderServeOutcomeLocked requires r.mu and a nonempty stable identity.
-func (r *Registry) recordProviderServeOutcomeLocked(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+func (r *Registry) recordProviderServeOutcomeOnGateLocked(g *gateState, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
 	now := time.Now()
-	r.healthEjectionSweepLocked(now)
+	defer g.updatedLocked(now)
 
 	if ok {
-		r.healthEjectionWindowLocked(stableID).record(true, now)
-		delete(r.healthEjectionCapacityStreaks, stableID)
-		if _, had := r.healthEjectionUntil[stableID]; had {
-			delete(r.healthEjectionUntil, stableID)
-			delete(r.healthEjectionTrips, stableID)
-			delete(r.healthEjectionLastTripCapacity, stableID)
+		g.ejectionWindowLocked().record(true, now)
+		g.ejectionCapacityStreak = capacityStreak{}
+		if !g.ejectionUntil.IsZero() {
+			g.ejectionUntil = time.Time{}
+			g.ejectionTrips = 0
+			g.ejectionLastTripCapacity = false
 			return false, true // half-open probe succeeded → recover
 		}
 		return false, false
 	}
 
 	if providerOutcomeIsFault(statusCode, errStr) {
-		w := r.healthEjectionWindowLocked(stableID)
+		w := g.ejectionWindowLocked()
 		w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
-		if until, had := r.healthEjectionUntil[stableID]; had && now.Before(until) {
+		if now.Before(g.ejectionUntil) {
 			return false, false // already ejected; in-flight faults don't re-arm until cooldown
 		}
-		trips := r.healthEjectionTrips[stableID]
+		trips := g.ejectionTrips
 		halfOpen := trips > 0
 		total, fails := w.windowStats(now, healthEjectionWindow)
 		rateTrip := total >= healthEjectionMinSample &&
@@ -565,104 +289,81 @@ func (r *Registry) recordProviderServeOutcomeLocked(stableID string, ok bool, st
 		if !halfOpen && w.consecFail < healthEjectionConsecTrip && !rateTrip {
 			return false, false
 		}
-		r.healthEjectionUntil[stableID] = now.Add(healthEjectionBackoff(trips))
-		r.healthEjectionTrips[stableID] = trips + 1
-		r.healthEjectionLastTripCapacity[stableID] = false
+		g.ejectionUntil = now.Add(healthEjectionBackoff(trips))
+		g.ejectionTrips = trips + 1
+		g.ejectionLastTripCapacity = false
 		return true, false
 	}
 
 	if isNodeCapacityRejectStrike(statusCode, errStr) {
-		s := r.healthEjectionCapacityStreaks[stableID]
+		s := g.ejectionCapacityStreak
 		if s.n > 0 && now.Sub(s.last) > healthEjectionWindow {
 			s.n = 0 // stale streak: never combine old strikes with a fresh blip
 		}
 		s.n++
 		s.last = now
-		r.healthEjectionCapacityStreaks[stableID] = s
+		g.ejectionCapacityStreak = s
 
-		if until, had := r.healthEjectionUntil[stableID]; had && now.Before(until) {
+		if now.Before(g.ejectionUntil) {
 			return false, false // already ejected; stragglers don't re-arm until cooldown
 		}
-		trips := r.healthEjectionTrips[stableID]
+		trips := g.ejectionTrips
 		// Half-open instant re-arm applies ONLY when the previous trip was
 		// itself capacity-shaped (the black-hole probe failing again): a single
 		// capacity shed is legitimate for a healthy-but-full box and must not
 		// re-arm a FAULT ejection whose cooldown just expired — that identity
 		// needs the full zero-success streak like a fresh one.
-		capacityHalfOpen := trips > 0 && r.healthEjectionLastTripCapacity[stableID]
+		capacityHalfOpen := trips > 0 && g.ejectionLastTripCapacity
 		if !capacityHalfOpen && s.n < healthEjectionCapacityConsecTrip {
 			return false, false
 		}
-		r.healthEjectionUntil[stableID] = now.Add(healthEjectionBackoff(trips))
-		r.healthEjectionTrips[stableID] = trips + 1
-		r.healthEjectionLastTripCapacity[stableID] = true
+		g.ejectionUntil = now.Add(healthEjectionBackoff(trips))
+		g.ejectionTrips = trips + 1
+		g.ejectionLastTripCapacity = true
 		return true, false
 	}
 
 	return false, false
 }
 
-// healthEjectionOpenLocked reports whether routing should skip this stable
-// identity. READ-ONLY (no lazy delete); caller holds r.mu in either mode.
-func (r *Registry) healthEjectionOpenLocked(stableID string, now time.Time) bool {
+// ejectionOpen reports whether routing should skip this stable identity.
+// Resolves the identity's gate; the scan reads the cached p.gate atomically
+// (ejectionOpenFor) and never comes here.
+func (r *Registry) ejectionOpen(stableID string, now time.Time) bool {
 	if stableID == "" {
 		return false
 	}
-	until, ok := r.healthEjectionUntil[stableID]
-	return ok && now.Before(until)
+	return r.lookupGateForKey(stableID).ejectedAt(now.UnixNano())
+}
+
+// ejectionOpenFor is the scan's ejection check for provider p whose stable
+// identity is sid: when the session's cached gate IS the identity's gate (the
+// steady state — bindStableFaultKey filed the session under sid) the answer is
+// one atomic load; only a session whose bind has not caught up with its
+// identity pays a gatesMu.RLock lookup.
+func (r *Registry) ejectionOpenFor(g *gateState, sid string, nowNS int64) bool {
+	if sid == "" {
+		return false
+	}
+	if g != nil && g.key == sid {
+		return g.ejectedAt(nowNS)
+	}
+	return r.lookupGateForKey(sid).ejectedAt(nowNS)
 }
 
 // HealthEjectionOpen reports whether a stable identity is currently ejected.
 // Exposed for tests/observability.
 func (r *Registry) HealthEjectionOpen(stableID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.healthEjectionOpenLocked(stableID, time.Now())
+	return r.ejectionOpen(stableID, time.Now())
 }
 
-func (r *Registry) healthEjectionWindowLocked(stableID string) *providerHealthWindow {
-	w := r.healthEjectionWindows[stableID]
-	if w == nil {
-		w = &providerHealthWindow{}
-		r.healthEjectionWindows[stableID] = w
+// ejectionWindowLocked returns the gate's ejection ring, creating it on first
+// use. Caller holds g.mu.
+func (g *gateState) ejectionWindowLocked() *providerHealthWindow {
+	if g.ejection == nil {
+		g.ejection = &providerHealthWindow{}
 	}
-	return w
-}
-
-// healthEjectionSweepLocked bounds the maps. Stable ids persist across reconnects
-// by design, so only entries idle for longer than the window (no windowed
-// outcomes, no fresh capacity streak, not currently ejected) are reaped, once
-// the maps grow large.
-func (r *Registry) healthEjectionSweepLocked(now time.Time) {
-	if len(r.healthEjectionWindows) > 2048 {
-		for id, w := range r.healthEjectionWindows {
-			if until, had := r.healthEjectionUntil[id]; had && now.Before(until) {
-				continue
-			}
-			if s, ok := r.healthEjectionCapacityStreaks[id]; ok && now.Sub(s.last) <= healthEjectionWindow {
-				continue
-			}
-			if total, _ := w.windowStats(now, healthEjectionWindow); total == 0 {
-				delete(r.healthEjectionWindows, id)
-				delete(r.healthEjectionUntil, id)
-				delete(r.healthEjectionTrips, id)
-				delete(r.healthEjectionCapacityStreaks, id)
-				delete(r.healthEjectionLastTripCapacity, id)
-			}
-		}
-	}
-	// Capacity-only identities (pure black holes) never touch the fault ring,
-	// so their streaks need their own staleness sweep.
-	if len(r.healthEjectionCapacityStreaks) > 2048 {
-		for id, s := range r.healthEjectionCapacityStreaks {
-			if until, had := r.healthEjectionUntil[id]; had && now.Before(until) {
-				continue
-			}
-			if now.Sub(s.last) > healthEjectionWindow {
-				delete(r.healthEjectionCapacityStreaks, id)
-			}
-		}
-	}
+	return g.ejection
 }
 
 // healthEjectionBackoff: base * 2^trips capped at the max (mirrors providerBreakerBackoff).

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // Stable-identity health ejection + the stable fault-key infrastructure.
@@ -234,31 +236,35 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 //
 // State lives on the identity's gate (gate_state.go), filed under the stable
 // id itself; only gate.mu is taken, never r.mu.
-func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCode int, errStr string, causes ...protocol.CoordinatorInferenceErrorCause) (ejected, recovered bool) {
 	if stableID == "" || !healthEjectionEnabled() {
 		return false, false
 	}
 	hold := r.lockGate(r.gateForKey(stableID), "health_ejection")
 	defer hold.unlock()
 	g := hold.g
-	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr, !ok && isDisconnectFlush(statusCode, causes))
 }
 
-func (r *Registry) RecordProviderSessionServeOutcome(sessionID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+func (r *Registry) RecordProviderSessionServeOutcome(sessionID string, ok bool, statusCode int, errStr string, causes ...protocol.CoordinatorInferenceErrorCause) (ejected, recovered bool) {
 	if sessionID == "" || !healthEjectionEnabled() || r.faultKeyForSession(sessionID) == sessionID {
 		return false, false
 	}
-	source := r.captureDisconnectSource(sessionID)
+	flush := !ok && isDisconnectFlush(statusCode, causes)
+	var source disconnectSource
+	if flush {
+		source = r.captureDisconnectSource(sessionID)
+	}
 	hold := r.lockGate(r.gateForSession(sessionID), "health_ejection")
 	defer hold.unlock()
 	g := hold.g
-	if g == nil || g.key == sessionID || (!ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g)) {
+	if g == nil || g.key == sessionID || (flush && source.supersededBy(g)) {
 		return false, false
 	}
-	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr)
+	return r.recordProviderServeOutcomeOnGateLocked(g, ok, statusCode, errStr, !ok && isDisconnectFlush(statusCode, causes))
 }
 
-func (r *Registry) recordProviderServeOutcomeOnGateLocked(g *gateState, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+func (r *Registry) recordProviderServeOutcomeOnGateLocked(g *gateState, ok bool, statusCode int, errStr string, flush bool) (ejected, recovered bool) {
 	now := time.Now()
 	defer g.updatedLocked(now)
 
@@ -276,7 +282,7 @@ func (r *Registry) recordProviderServeOutcomeOnGateLocked(g *gateState, ok bool,
 
 	if providerOutcomeIsFault(statusCode, errStr) {
 		w := g.ejectionWindowLocked()
-		w.recordFault(now, statusCode == disconnectFlushStatusCode)
+		w.recordFault(now, flush)
 
 		if now.Before(g.ejectionUntil) {
 			return false, false // already ejected; in-flight faults don't re-arm until cooldown

--- a/coordinator/registry/health_ejection.go
+++ b/coordinator/registry/health_ejection.go
@@ -174,7 +174,8 @@ func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
 	// re-insert an entry Disconnect already removed (it would leak forever —
 	// nothing cleans that session id again). The disconnectedStableIDs cache
 	// covers post-disconnect resolution.
-	if _, live := r.providers[sessionID]; !live {
+	p, live := r.providers[sessionID]
+	if !live {
 		return
 	}
 	// Migrate accumulated fault state when the key changes: from the session id
@@ -192,6 +193,14 @@ func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
 		r.migrateFaultStateLocked(old, stableID)
 	}
 	r.faultKeyBySession[sessionID] = stableID
+	// Version-changed reconnect reset (version_reset.go): a session that
+	// already reported its binary version binds here on re-attestation;
+	// registration-time binds happen before the version is stored and are
+	// covered by Provider.SetVersion. r.mu → p.mu is the established order.
+	p.mu.Lock()
+	version := p.Version
+	p.mu.Unlock()
+	r.noteIdentityVersionLocked(stableID, version)
 }
 
 // migrateFaultStateLocked re-keys every fault-tracking map entry from oldKey to
@@ -204,6 +213,16 @@ func (r *Registry) bindStableFaultKey(sessionID, stableID string) {
 func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 	if oldKey == "" || newKey == "" || oldKey == newKey {
 		return
+	}
+
+	// Late disconnect-flush outcomes must follow the same identity as the
+	// migrated windows and reset timestamp. Preserve each drop time so the
+	// migration neither extends the cache TTL nor changes reset ordering.
+	for sessionID, cached := range r.disconnectedStableIDs {
+		if cached.id == oldKey {
+			cached.id = newKey
+			r.disconnectedStableIDs[sessionID] = cached
+		}
 	}
 
 	// Dispatch-load cooldowns: struct keys per (fault key, model).
@@ -236,6 +255,37 @@ func (r *Registry) migrateFaultStateLocked(oldKey, newKey string) {
 			}
 			delete(r.inferenceErrorCooldowns, k)
 		}
+	}
+	// Disconnect-flush strike tags, the last-seen binary version, and the
+	// version-reset throttle timestamp follow the identity too
+	// (version_reset.go): an existing version under the new key is the more
+	// recent binding and wins; the later reset timestamp wins so a rebind can
+	// never hand the identity a second reset inside the interval.
+	for k, flush := range r.inferenceErrorFlushStrikes {
+		if k.ProviderID == oldKey {
+			nk := k
+			nk.ProviderID = newKey
+			r.inferenceErrorFlushStrikes[nk] = mergeChronologicalTimestamps(r.inferenceErrorFlushStrikes[nk], flush)
+			delete(r.inferenceErrorFlushStrikes, k)
+		}
+	}
+	if v, ok := r.identityVersions[oldKey]; ok {
+		if _, exists := r.identityVersions[newKey]; !exists {
+			r.identityVersions[newKey] = v
+		}
+		delete(r.identityVersions, oldKey)
+	}
+	if at, ok := r.identityVersionSeenAt[oldKey]; ok {
+		if cur, exists := r.identityVersionSeenAt[newKey]; !exists || at.After(cur) {
+			r.identityVersionSeenAt[newKey] = at
+		}
+		delete(r.identityVersionSeenAt, oldKey)
+	}
+	if at, ok := r.identityVersionResetAt[oldKey]; ok {
+		if cur, exists := r.identityVersionResetAt[newKey]; !exists || at.After(cur) {
+			r.identityVersionResetAt[newKey] = at
+		}
+		delete(r.identityVersionResetAt, oldKey)
 	}
 
 	// Node-health breaker.
@@ -429,7 +479,9 @@ func (r *Registry) rememberDisconnectedStableIDLocked(sessionID, stableID string
 			}
 		}
 	}
-	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: time.Now()}
+	disconnectedAt := time.Now()
+	r.disconnectedStableIDs[sessionID] = disconnectedStableID{id: stableID, at: disconnectedAt}
+	r.touchIdentityVersionLocked(stableID, disconnectedAt)
 }
 
 // RecordProviderServeOutcome feeds one terminal outcome into the stable-identity
@@ -453,6 +505,36 @@ func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCo
 	}
 	hold := r.lockWrite("health_ejection")
 	defer hold.unlock()
+	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+}
+
+// RecordProviderSessionServeOutcome retains the source session through the
+// ejection mutation so a version reset cannot be followed by an old flush strike.
+func (r *Registry) RecordProviderSessionServeOutcome(sessionID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
+	if sessionID == "" || !healthEjectionEnabled() {
+		return false, false
+	}
+	hold := r.lockWrite("health_ejection")
+	defer hold.unlock()
+	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(sessionID) {
+		return false, false
+	}
+	stableID := ""
+	if p := r.providers[sessionID]; p != nil {
+		p.mu.Lock()
+		stableID = stableProviderIdentityLocked(p)
+		p.mu.Unlock()
+	} else if cached, exists := r.disconnectedStableIDs[sessionID]; exists && time.Since(cached.at) < disconnectedStableIDTTL {
+		stableID = cached.id
+	}
+	if stableID == "" {
+		return false, false
+	}
+	return r.recordProviderServeOutcomeLocked(stableID, ok, statusCode, errStr)
+}
+
+// recordProviderServeOutcomeLocked requires r.mu and a nonempty stable identity.
+func (r *Registry) recordProviderServeOutcomeLocked(stableID string, ok bool, statusCode int, errStr string) (ejected, recovered bool) {
 	now := time.Now()
 	r.healthEjectionSweepLocked(now)
 
@@ -470,7 +552,7 @@ func (r *Registry) RecordProviderServeOutcome(stableID string, ok bool, statusCo
 
 	if providerOutcomeIsFault(statusCode, errStr) {
 		w := r.healthEjectionWindowLocked(stableID)
-		w.record(false, now)
+		w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
 		if until, had := r.healthEjectionUntil[stableID]; had && now.Before(until) {
 			return false, false // already ejected; in-flight faults don't re-arm until cooldown

--- a/coordinator/registry/health_ejection_test.go
+++ b/coordinator/registry/health_ejection_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 )
 
+// expireHealthEjection rewinds the identity's ejection expiry into the past,
+// simulating the cooldown elapsing (ejected -> half-open) without sleeping.
+func expireHealthEjection(reg *Registry, sid string) {
+	withGateForKey(reg, sid, func(g *gateState) { g.ejectionUntil = time.Now().Add(-time.Second) })
+}
+
+func healthEjectionTripsOf(reg *Registry, sid string) (trips int) {
+	readGateForKey(reg, sid, func(g *gateState) {
+		if g != nil {
+			trips = g.ejectionTrips
+		}
+	})
+	return trips
+}
+
 func TestStableProviderIdentityLocked_Precedence(t *testing.T) {
 	if got := stableProviderIdentityLocked(&Provider{AttestationResult: &attestation.VerificationResult{Valid: true, SerialNumber: "SER1", PublicKey: "PK1"}, AccountID: "acct1"}); got != "serial:SER1" {
 		t.Errorf("serial must win; got %q", got)
@@ -116,9 +131,7 @@ func TestHealthEjection_CapacityBlackHoleEjects(t *testing.T) {
 
 	// Half-open: after the cooldown elapses, a probe that capacity-rejects
 	// re-arms immediately with a doubled backoff...
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if reg.HealthEjectionOpen(sid) {
 		t.Fatal("cooldown expiry must allow a half-open probe")
 	}
@@ -126,9 +139,7 @@ func TestHealthEjection_CapacityBlackHoleEjects(t *testing.T) {
 		t.Fatal("a capacity reject on the half-open probe must re-arm the ejection")
 	}
 	// ...and a probe that SUCCEEDS recovers the node and clears the streak.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if _, recovered := reg.RecordProviderServeOutcome(sid, true, 200, ""); !recovered {
 		t.Fatal("a successful probe must recover the ejected identity")
 	}
@@ -277,9 +288,7 @@ func TestHealthEjection_CapacityShedDoesNotRearmFaultEjection(t *testing.T) {
 	}
 
 	// Cooldown expires; the half-open probe hits a legitimately full box.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	if ejected, _ := reg.RecordProviderServeOutcome(sid, false, 503, capacityReject); ejected {
 		t.Fatal("one capacity shed must not re-arm a fault ejection")
 	}
@@ -324,9 +333,7 @@ func TestHealthEjection_FirstContentDisarmsCapacityHalfOpen(t *testing.T) {
 	}
 
 	// Cooldown expires (half-open) and the probe produces FIRST CONTENT.
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
 	reg.RecordCapacityAccept(p.ID, model)
 
 	// One straggling capacity reject must NOT re-eject a node that just
@@ -371,10 +378,8 @@ func TestHealthEjection_FirstContentPreservesFaultHalfOpen(t *testing.T) {
 
 	reg.RecordCapacityAccept(p.ID, model)
 
-	reg.mu.Lock()
-	reg.healthEjectionUntil[sid] = time.Now().Add(-time.Second)
-	trips := reg.healthEjectionTrips[sid]
-	reg.mu.Unlock()
+	expireHealthEjection(reg, sid)
+	trips := healthEjectionTripsOf(reg, sid)
 	if trips == 0 {
 		t.Fatal("first content must not wipe a fault ejection's trip count")
 	}

--- a/coordinator/registry/lock_wait.go
+++ b/coordinator/registry/lock_wait.go
@@ -28,9 +28,9 @@ type writeHold struct {
 	obs  *func(site string, wait time.Duration)
 }
 
-// lockWrite is r.mu.Lock() for the request-path recorders (commit, capacity
-// accept/reject, error cooldown, breaker, health ejection, dispatch-load
-// cooldown). With no observer registered it costs one atomic load; with one,
+// lockWrite measures the remaining global write acquisitions, including
+// reservation commits in global compatibility mode. Per-identity recorders
+// use lockGate and its separate observer. With no observer registered it costs one atomic load; with one,
 // it measures the acquisition wait for the returned hold to report on unlock.
 func (r *Registry) lockWrite(site string) writeHold {
 	obs := r.lockWaitObserver.Load()

--- a/coordinator/registry/lock_wait_observer_test.go
+++ b/coordinator/registry/lock_wait_observer_test.go
@@ -37,58 +37,50 @@ func (r *lockWaitRecorder) bySite(site string) []lockWaitSample {
 	return out
 }
 
-// TestLockWriteReportsWaitBySite: every request-path recorder reports its
-// write-lock acquisition to the observer tagged with its own site, and the
-// reported wait reflects time actually spent blocked behind a reader.
+// Global compatibility mode retains the write-wait observer. Per-identity
+// recorders use their separate gate observer in both commit modes.
 func TestLockWriteReportsWaitBySite(t *testing.T) {
+	t.Setenv(envReserveCommitMode, "global")
 	reg := New(testLogger())
 	model := "lock-wait-model"
 	p := planTestProvider(t, reg, "lock-wait-provider", model, 0)
-
-	// No observer registered: the sites still work.
-	reg.ClearDispatchLoadCooldown(p.ID, model)
-
+	other := planTestProvider(t, reg, "lock-wait-other", model, 400)
 	rec := &lockWaitRecorder{}
 	reg.SetLockWaitObserver(rec.observe)
-
-	// Hold the lock for reading while a recorder tries to write.
-	held := make(chan struct{})
-	release := make(chan struct{})
-	go func() {
-		reg.mu.RLock()
-		close(held)
-		<-release
-		reg.mu.RUnlock()
-	}()
-	<-held
-	const hold = 100 * time.Millisecond
-	go func() {
-		time.Sleep(hold)
-		close(release)
-	}()
-	reg.ClearDispatchLoadCooldown(p.ID, model)
-	got := rec.bySite("dispatch_load_cooldown")
-	if len(got) != 1 {
-		t.Fatalf("dispatch_load_cooldown samples = %d, want 1", len(got))
+	reg.mu.RLock()
+	go func() { time.Sleep(100 * time.Millisecond); reg.mu.RUnlock() }()
+	lock := reg.commitLock("commit")
+	lock.lock()
+	lock.unlock()
+	got := rec.bySite("commit")
+	if len(got) != 1 || got[0].wait < 30*time.Millisecond {
+		t.Fatalf("global commit wait: %+v", got)
 	}
-	// Generous floor: the acquisition blocks for close to the whole hold, but
-	// a loaded -race run can delay the caller a few tens of milliseconds.
-	if got[0].wait < 30*time.Millisecond {
-		t.Fatalf("reported wait %s, want at least 30ms (the acquisition blocked behind a reader for %s)", got[0].wait, hold)
+	primary, _, plan := reg.ReserveProviderWithPlan(model, planTestRequest("global-primary", 10, 10))
+	if primary == nil || plan == nil {
+		t.Fatal("primary reservation failed")
 	}
-
-	// Each recorder reports under its own site tag.
+	next, _, _ := reg.ReserveNextFromPlan(planTestRequest("global-next", 10, 10), plan, primary.ID)
+	if next == nil {
+		t.Fatal("plan reservation failed")
+	}
+	if len(rec.bySite("commit_plan")) != 1 {
+		t.Fatal("global plan commit omitted write-wait sample")
+	}
 	reg.RecordCapacityAcceptOutcome(p.ID, model, true)
 	reg.RecordInferenceSuccess(p.ID, model, RequestTraits{}.CooldownShape())
 	reg.RecordProviderOutcome(p.ID, true, 200, "")
 	reg.RecordProviderServeOutcome("stable-"+p.ID, true, 200, "")
-	reg.ReserveProviderWithPlan(model, planTestRequest("lock-wait-req", 10, 10))
-	for _, site := range []string{"capacity_accept", "inference_success", "breaker", "health_ejection", "commit"} {
-		if len(rec.bySite(site)) == 0 {
-			t.Fatalf("site %q reported no lock-wait sample", site)
+	reg.ClearDispatchLoadCooldown(p.ID, model)
+	for _, site := range []string{"capacity_accept", "inference_success", "breaker", "health_ejection", "dispatch_load_cooldown"} {
+		if len(rec.bySite(site)) != 0 {
+			t.Fatalf("gate recorder %s reported a global write wait", site)
 		}
 	}
-	p.RemovePending("lock-wait-req")
+	for _, provider := range []*Provider{p, other} {
+		provider.RemovePending("global-primary")
+		provider.RemovePending("global-next")
+	}
 }
 
 // TestReserveProviderCountsScans: a clean reservation is one scan, a failed
@@ -167,14 +159,16 @@ func TestReserveProviderCountsScans(t *testing.T) {
 	}
 }
 
-func TestDispatchLoadFailureReportsLockWait(t *testing.T) {
+func TestDispatchLoadFailureReportsGateWait(t *testing.T) {
 	reg := New(testLogger())
 	rec := &lockWaitRecorder{}
-	reg.SetLockWaitObserver(rec.observe)
+	reg.SetGateWaitObserver(rec.observe)
+	release := reg.HoldGateForTest("load-failure")
+	go func() { time.Sleep(30 * time.Millisecond); release() }()
 	if !reg.RecordDispatchLoadFailure("load-failure", "model") {
 		t.Fatal("first failure did not start a cooldown")
 	}
 	if got := rec.bySite("dispatch_load_failure"); len(got) != 1 {
-		t.Fatalf("failure lock samples = %d, want 1", len(got))
+		t.Fatalf("failure gate samples = %d, want 1", len(got))
 	}
 }

--- a/coordinator/registry/model_index_test.go
+++ b/coordinator/registry/model_index_test.go
@@ -257,10 +257,7 @@ func TestRoutingWalksIdenticalWithFaultStateWithAndWithoutIndex(t *testing.T) {
 	for i := 0; i < f.reg.capacityCooldownCfg.Threshold+1; i++ {
 		f.reg.RecordCapacityReject(cooledID, model)
 	}
-	f.reg.mu.RLock()
-	cooled := f.reg.capacityCooldownActiveLocked(cooledID, model, benchPendingRequest(model, 0).FirstContentDeadline)
-	f.reg.mu.RUnlock()
-	if !cooled {
+	if !f.reg.capacityCooled(cooledID, model, benchPendingRequest(model, 0).FirstContentDeadline) {
 		t.Fatal("precondition: advertiser capacity-cooled")
 	}
 

--- a/coordinator/registry/pair_keys.go
+++ b/coordinator/registry/pair_keys.go
@@ -2,20 +2,11 @@ package registry
 
 // pair_keys.go — struct keys for the per-(provider, model) maps that used to
 // be "providerID:modelID" string concatenations. A struct key is built with
-// no allocation on the routing hot path (the dispatch-load cooldown gate runs
-// once per provider per scan) and cannot alias across ids that contain the
-// delimiter — the same reasoning as capacityRejectKey and inferenceErrorKey.
-// Iteration-time filtering by provider (Disconnect, pending-load sweeps, the
-// fault-key migration) compares the field instead of parsing a prefix.
-
-// dispatchLoadKey identifies a dispatch-load cooldown bucket
-// (Registry.dispatchLoadCooldowns). FaultKey is the provider's STABLE fault
-// key (faultKeyLocked: serial/SE-key when bound, the session id otherwise) so
-// the cooldown survives a reconnect within its TTL.
-type dispatchLoadKey struct {
-	FaultKey string
-	ModelID  string
-}
+// no allocation and cannot alias across ids that contain the delimiter.
+// Iteration-time filtering by provider (Disconnect, pending-load sweeps)
+// compares the field instead of parsing a prefix. The fault trackers' pair
+// keys are gone: their state is per identity (gate_state.go), keyed inside
+// the gate by model (or modelShapeKey for the inference-error breaker).
 
 // modelLoadKey identifies a pending load_model command
 // (Registry.pendingModelLoads / pendingModelLoadStarted). ProviderID is the

--- a/coordinator/registry/pair_keys_test.go
+++ b/coordinator/registry/pair_keys_test.go
@@ -5,9 +5,10 @@ import (
 	"time"
 )
 
-// TestPairKeysCannotAliasAcrossDelimiter pins the struct-key guarantee the
-// old "providerID:modelID" strings lacked: ("a:b", "c") and ("a", "b:c") are
-// different pairs for both the dispatch-load cooldown and pending model loads.
+// TestPairKeysCannotAliasAcrossDelimiter pins the guarantee the old
+// "providerID:modelID" strings lacked: ("a:b", "c") and ("a", "b:c") are
+// different pairs for both the dispatch-load cooldown (now a per-identity gate
+// keyed inside by model) and pending model loads (a struct key).
 func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 	r := New(testLogger())
 	makeSchedulerProvider(t, r, "a:b", "c", 50)
@@ -16,10 +17,8 @@ func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 	if !r.RecordDispatchLoadFailure("a:b", "c") {
 		t.Fatal("first failure must start a cooldown")
 	}
-	r.mu.RLock()
-	aliased := r.dispatchLoadCooldownActiveLocked("a", "b:c", time.Now())
-	direct := r.dispatchLoadCooldownActiveLocked("a:b", "c", time.Now())
-	r.mu.RUnlock()
+	aliased := r.dispatchLoadCooled("a", "b:c", time.Now())
+	direct := r.dispatchLoadCooled("a:b", "c", time.Now())
 	if aliased || !direct {
 		t.Fatalf("dispatch-load cooldown aliased across ':' (aliased=%v direct=%v)", aliased, direct)
 	}
@@ -34,20 +33,28 @@ func TestPairKeysCannotAliasAcrossDelimiter(t *testing.T) {
 }
 
 // TestDispatchLoadCooldownGateAllocatesNothing pins the hot-path contract for
-// the per-provider cooldown gate.
+// the per-provider cooldown gate, on both the scan's cached-gate path and the
+// session-resolving path.
 func TestDispatchLoadCooldownGateAllocatesNothing(t *testing.T) {
 	r := New(testLogger())
-	makeSchedulerProvider(t, r, "p1", "m", 50)
+	p1 := makeSchedulerProvider(t, r, "p1", "m", 50)
+	p2 := makeSchedulerProvider(t, r, "p2", "m", 50)
 	r.RecordDispatchLoadFailure("p1", "m")
 	now := time.Now()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	hits := 0
 	allocs := testing.AllocsPerRun(200, func() {
-		if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+		if r.gateOf(p1).dispatchLoadCooled("m", now) {
 			hits++
 		}
-		if r.dispatchLoadCooldownActiveLocked("p2", "m", now) {
+		if r.gateOf(p2).dispatchLoadCooled("m", now) {
+			hits++
+		}
+		if r.dispatchLoadCooled("p1", "m", now) {
+			hits++
+		}
+		if r.dispatchLoadCooled("p2", "m", now) {
 			hits++
 		}
 	})
@@ -84,12 +91,10 @@ func TestDisconnectDropsOnlyThatProvidersPendingLoads(t *testing.T) {
 	if !r.HasPendingModelLoad("p10", "m") {
 		t.Fatal("prefix-sharing provider's pending load was dropped")
 	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if r.dispatchLoadCooldownActiveLocked("p1", "m", now) {
+	if r.dispatchLoadCooled("p1", "m", now) {
 		t.Fatal("identity-less disconnected provider's cooldown residue survived")
 	}
-	if !r.dispatchLoadCooldownActiveLocked("p10", "m", now) {
+	if !r.dispatchLoadCooled("p10", "m", now) {
 		t.Fatal("prefix-sharing provider's cooldown was dropped")
 	}
 }

--- a/coordinator/registry/pending_terminal.go
+++ b/coordinator/registry/pending_terminal.go
@@ -1,0 +1,16 @@
+package registry
+
+// HasCompletionIngress reports whether a clean provider terminal
+// (inference_complete) has been ingressed for this attempt. That includes a
+// completion parked on the speculative empty-completion decision, which leaves
+// the pending record in place: a hedge loser that finished empty on time is
+// still "removed != nil" to the dispatcher's cleanup even though nothing is
+// running provider-side. Abandon paths consult it before sending a cancel.
+func (pr *PendingRequest) HasCompletionIngress() bool {
+	if pr == nil {
+		return false
+	}
+	pr.firstContentIngressMu.Lock()
+	defer pr.firstContentIngressMu.Unlock()
+	return !pr.completionIngressAt.IsZero()
+}

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -68,6 +68,16 @@ const (
 type providerHealthOutcome struct {
 	ts time.Time
 	ok bool
+	// flush marks a disconnect-flush (502) fault so a version-changed
+	// reconnect can drop exactly those entries (version_reset.go).
+	flush bool
+}
+
+// recordFault appends one FAULT outcome, tagging it as a disconnect flush
+// when it came from the registry's pending-request flush (status 502).
+func (w *providerHealthWindow) recordFault(now time.Time, flush bool) {
+	w.record(false, now)
+	w.outcomes[(w.head+providerHealthRingSize-1)%providerHealthRingSize].flush = flush
 }
 
 // providerHealthWindow is a fixed-size ring of the most recent
@@ -192,6 +202,10 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 
 	hold := r.lockWrite("breaker")
 	defer hold.unlock()
+	// Recheck under the mutation lock: a version reset can race any API-side check.
+	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+		return false, false
+	}
 	now := time.Now()
 	// Key by the stable fault key (serial/SE-key when bound, session id
 	// otherwise) so breaker state survives reconnect churn — a zombie that
@@ -237,7 +251,7 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 		return false, false
 	}
 	w := r.providerHealthWindowLocked(providerID)
-	w.record(false, now)
+	w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
 	// Already open: the gate is derouting new traffic. In-flight faults are
 	// still recorded above, but must not re-arm until the cooldown elapses

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"strings"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // Per-provider (node-health) circuit breaker.
@@ -201,18 +203,19 @@ func (w *providerHealthWindow) windowStats(now time.Time, window time.Duration) 
 // fault key (serial/SE-key when bound, session id otherwise) so it survives
 // reconnect churn — a zombie that bounces its connection between faults must
 // keep accumulating. Only gate.mu is taken; never r.mu.
-func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode int, errStr string) (opened bool, closed bool) {
+func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode int, errStr string, causes ...protocol.CoordinatorInferenceErrorCause) (opened bool, closed bool) {
 	if providerID == "" {
 		return false, false
 	}
+	flush := !ok && isDisconnectFlush(statusCode, causes)
 	var source disconnectSource
-	if !ok && statusCode == disconnectFlushStatusCode {
+	if flush {
 		source = r.captureDisconnectSource(providerID)
 	}
 	hold := r.lockGate(r.gateForSession(providerID), "breaker")
 	defer hold.unlock()
 	g := hold.g
-	if !ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
+	if flush && source.supersededBy(g) {
 		return false, false
 	}
 
@@ -239,7 +242,7 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 		return false, false
 	}
 	w := g.healthWindowLocked()
-	w.recordFault(now, statusCode == disconnectFlushStatusCode)
+	w.recordFault(now, flush)
 
 	// Already open: the gate is derouting new traffic. In-flight faults are
 	// still recorded above, but must not re-arm until the cooldown elapses

--- a/coordinator/registry/provider_breaker.go
+++ b/coordinator/registry/provider_breaker.go
@@ -21,7 +21,7 @@ import (
 // target and keeps feeding it (one box failed 99/99 for 15+ minutes in prod).
 //
 // This breaker is keyed by NODE only (across every model and shape), via the
-// stable fault key (faultKeyLocked: serial/SE-key when attestation has bound
+// stable fault key (faultKeyForSession: serial/SE-key when attestation has bound
 // one, the session id otherwise) so its state survives reconnect churn: a
 // node returning faults for ~all requests is sick regardless of cause, so it is
 // quarantined fleet-wide, re-probed after an exponential cooldown, and
@@ -34,8 +34,9 @@ import (
 // with the breaker bypassed (see selectBestCandidateLockedFull) so routing can
 // never be zeroed out — mirroring servability.go's fail-open philosophy.
 //
-// r.mu discipline, opportunistic >1024 map sweep, and the transition-bool
-// return all mirror error_cooldown.go.
+// State lives on the identity's gateState (gate_state.go) under gate.mu; the
+// old opportunistic >1024 map sweep is the periodic gate sweep. The
+// transition-bool return mirrors error_cooldown.go.
 const (
 	// providerBreakerConsecTrip: consecutive FAULT outcomes (no success in
 	// between) that open the breaker. A node failing this many in a row is
@@ -195,50 +196,37 @@ func (w *providerHealthWindow) windowStats(now time.Time, window time.Duration) 
 //   - Fault (COUNTED): 500/502/504 always; a 503 whose message indicates a real
 //     fault, and — by default — any 503 not recognized as a capacity shed.
 //   - Success (ok==true): clears the breaker if it had tripped.
+//
+// State lives on the identity's gate (gate_state.go): keyed by the stable
+// fault key (serial/SE-key when bound, session id otherwise) so it survives
+// reconnect churn — a zombie that bounces its connection between faults must
+// keep accumulating. Only gate.mu is taken; never r.mu.
 func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode int, errStr string) (opened bool, closed bool) {
 	if providerID == "" {
 		return false, false
 	}
-
-	hold := r.lockWrite("breaker")
+	var source disconnectSource
+	if !ok && statusCode == disconnectFlushStatusCode {
+		source = r.captureDisconnectSource(providerID)
+	}
+	hold := r.lockGate(r.gateForSession(providerID), "breaker")
 	defer hold.unlock()
-	// Recheck under the mutation lock: a version reset can race any API-side check.
-	if !ok && statusCode == disconnectFlushStatusCode && r.supersededDisconnectFlushLocked(providerID) {
+	g := hold.g
+	if !ok && statusCode == disconnectFlushStatusCode && source.supersededBy(g) {
 		return false, false
 	}
-	now := time.Now()
-	// Key by the stable fault key (serial/SE-key when bound, session id
-	// otherwise) so breaker state survives reconnect churn — a zombie that
-	// bounces its connection between faults must keep accumulating.
-	providerID = r.faultKeyLocked(providerID)
 
-	// Opportunistic sweep (mirrors error_cooldown.go): churned identities are
-	// never re-keyed — bound the maps by dropping expired/idle entries once
-	// they grow.
-	if len(r.providerBreakerOpenUntil) > 1024 {
-		for id, until := range r.providerBreakerOpenUntil {
-			if !now.Before(until) {
-				delete(r.providerBreakerOpenUntil, id)
-				delete(r.providerBreakerTrips, id)
-			}
-		}
-	}
-	if len(r.providerOutcomes) > 1024 {
-		for id, w := range r.providerOutcomes {
-			if total, _ := w.windowStats(now, providerBreakerWindow); total == 0 {
-				delete(r.providerOutcomes, id)
-			}
-		}
-	}
+	now := time.Now()
+	defer g.updatedLocked(now)
 
 	// SUCCESS: a served request proves the node is healthy. Record it, reset the
 	// consecutive-fault counter, and CLOSE the breaker (clearing the exponential
 	// backoff) if it had ever tripped — this is the auto-re-admit on recovery.
 	if ok {
-		r.providerHealthWindowLocked(providerID).record(true, now)
-		if _, had := r.providerBreakerOpenUntil[providerID]; had {
-			delete(r.providerBreakerOpenUntil, providerID)
-			delete(r.providerBreakerTrips, providerID)
+		g.healthWindowLocked().record(true, now)
+		if !g.breakerUntil.IsZero() {
+			g.breakerUntil = time.Time{}
+			g.breakerTrips = 0
 			return false, true
 		}
 		return false, false
@@ -250,13 +238,13 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 	if !providerOutcomeIsFault(statusCode, errStr) {
 		return false, false
 	}
-	w := r.providerHealthWindowLocked(providerID)
+	w := g.healthWindowLocked()
 	w.recordFault(now, statusCode == disconnectFlushStatusCode)
 
 	// Already open: the gate is derouting new traffic. In-flight faults are
 	// still recorded above, but must not re-arm until the cooldown elapses
 	// (the half-open probe handles that below).
-	if until, had := r.providerBreakerOpenUntil[providerID]; had && now.Before(until) {
+	if now.Before(g.breakerUntil) {
 		return false, false
 	}
 
@@ -266,7 +254,7 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 	//     still bad, so re-arm with the next, larger backoff.
 	//   - closed: trip on either the consecutive-fault or the sustained
 	//     fail-rate threshold.
-	trips := r.providerBreakerTrips[providerID]
+	trips := g.breakerTrips
 	halfOpen := trips > 0
 	total, fails := w.windowStats(now, providerBreakerWindow)
 	rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
@@ -274,20 +262,18 @@ func (r *Registry) RecordProviderOutcome(providerID string, ok bool, statusCode 
 		return false, false
 	}
 
-	r.providerBreakerOpenUntil[providerID] = now.Add(providerBreakerBackoff(trips))
-	r.providerBreakerTrips[providerID] = trips + 1
+	g.breakerUntil = now.Add(providerBreakerBackoff(trips))
+	g.breakerTrips = trips + 1
 	return true, false
 }
 
-// providerHealthWindowLocked returns the provider's health ring, creating it on
-// first use. Caller holds r.mu.
-func (r *Registry) providerHealthWindowLocked(providerID string) *providerHealthWindow {
-	w := r.providerOutcomes[providerID]
-	if w == nil {
-		w = &providerHealthWindow{}
-		r.providerOutcomes[providerID] = w
+// healthWindowLocked returns the gate's node-health ring, creating it on first
+// use. Caller holds g.mu.
+func (g *gateState) healthWindowLocked() *providerHealthWindow {
+	if g.outcomes == nil {
+		g.outcomes = &providerHealthWindow{}
 	}
-	return w
+	return g.outcomes
 }
 
 // providerBreakerBackoff returns the cooldown for a provider that has already
@@ -304,24 +290,19 @@ func providerBreakerBackoff(trips int) time.Duration {
 	return cooldown
 }
 
-// providerBreakerOpenLocked reports whether routing should skip this provider
-// because its node-health breaker is OPEN. True iff now is before the open
-// expiry; once now >= expiry it returns false so the next request is allowed
-// through as a half-open probe. READ-ONLY (no lazy delete) so it is safe under
-// r.mu held in either mode — mirrors inferenceErrorCooldownActiveLocked. Caller
-// holds r.mu.
-func (r *Registry) providerBreakerOpenLocked(providerID string, now time.Time) bool {
-	until, ok := r.providerBreakerOpenUntil[r.faultKeyLocked(providerID)]
-	return ok && now.Before(until)
+// breakerOpen reports whether routing should skip this provider because its
+// node-health breaker is OPEN. True iff now is before the open expiry; once
+// now >= expiry it returns false so the next request is allowed through as a
+// half-open probe. Resolves the session's gate; the scan itself reads the
+// cached p.gate atomically (gateState.breakerOpenAt) and never comes here.
+func (r *Registry) breakerOpen(providerID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).breakerOpenAt(now.UnixNano())
 }
 
 // ProviderBreakerOpen reports whether the per-provider node-health breaker is
-// currently quarantining the provider. Exposed for tests/observability; the
-// routing hot path uses providerBreakerOpenLocked under the already-held r.mu.
+// currently quarantining the provider. Exposed for tests/observability.
 func (r *Registry) ProviderBreakerOpen(providerID string) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenLocked(providerID, time.Now())
+	return r.breakerOpen(providerID, time.Now())
 }
 
 // providerOutcomeIsFault classifies a FAILED provider terminal (ok==false) for

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -641,7 +641,7 @@ func TestProviderHealthWindowMerge(t *testing.T) {
 	}
 
 	t.Run("empty source is a no-op", func(t *testing.T) {
-		dst := fill(providerHealthOutcome{at(0), false}, providerHealthOutcome{at(1), false})
+		dst := fill(providerHealthOutcome{ts: at(0), ok: false}, providerHealthOutcome{ts: at(1), ok: false})
 		dst.merge(&providerHealthWindow{})
 		dst.merge(nil)
 		if dst.size != 2 || dst.consecFail != 2 {
@@ -651,15 +651,15 @@ func TestProviderHealthWindowMerge(t *testing.T) {
 
 	t.Run("empty destination adopts the source", func(t *testing.T) {
 		dst := &providerHealthWindow{}
-		dst.merge(fill(providerHealthOutcome{at(0), true}, providerHealthOutcome{at(1), false}))
+		dst.merge(fill(providerHealthOutcome{ts: at(0), ok: true}, providerHealthOutcome{ts: at(1), ok: false}))
 		if dst.size != 2 || dst.consecFail != 1 {
 			t.Fatalf("size=%d consecFail=%d, want 2/1", dst.size, dst.consecFail)
 		}
 	})
 
 	t.Run("interleaved timestamps merge chronologically", func(t *testing.T) {
-		dst := fill(providerHealthOutcome{at(0), false}, providerHealthOutcome{at(2), true}, providerHealthOutcome{at(4), false})
-		src := fill(providerHealthOutcome{at(1), false}, providerHealthOutcome{at(3), false}, providerHealthOutcome{at(5), false})
+		dst := fill(providerHealthOutcome{ts: at(0), ok: false}, providerHealthOutcome{ts: at(2), ok: true}, providerHealthOutcome{ts: at(4), ok: false})
+		src := fill(providerHealthOutcome{ts: at(1), ok: false}, providerHealthOutcome{ts: at(3), ok: false}, providerHealthOutcome{ts: at(5), ok: false})
 		dst.merge(src)
 		if dst.size != 6 {
 			t.Fatalf("size=%d, want 6", dst.size)
@@ -680,8 +680,8 @@ func TestProviderHealthWindowMerge(t *testing.T) {
 	})
 
 	t.Run("trailing success resets the merged streak", func(t *testing.T) {
-		dst := fill(providerHealthOutcome{at(0), false}, providerHealthOutcome{at(1), false})
-		dst.merge(fill(providerHealthOutcome{at(2), true}))
+		dst := fill(providerHealthOutcome{ts: at(0), ok: false}, providerHealthOutcome{ts: at(1), ok: false})
+		dst.merge(fill(providerHealthOutcome{ts: at(2), ok: true}))
 		if dst.consecFail != 0 {
 			t.Fatalf("consecFail=%d, want 0 — the newest merged outcome is a success", dst.consecFail)
 		}

--- a/coordinator/registry/provider_breaker_test.go
+++ b/coordinator/registry/provider_breaker_test.go
@@ -11,29 +11,42 @@ import (
 // error_cooldown_test.go) ---
 
 func providerBreakerOpenAt(r *Registry, id string, now time.Time) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenLocked(id, now)
+	return r.breakerOpen(id, now)
 }
 
-func providerBreakerTripsOf(r *Registry, id string) int {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerTrips[id]
+func providerBreakerTripsOf(r *Registry, id string) (trips int) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			trips = g.breakerTrips
+		}
+	})
+	return trips
 }
 
-func providerBreakerOpenUntilOf(r *Registry, id string) time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.providerBreakerOpenUntil[id]
+func providerBreakerOpenUntilOf(r *Registry, id string) (until time.Time) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			until = g.breakerUntil
+		}
+	})
+	return until
 }
 
 // expireProviderBreaker rewinds a provider's open expiry into the past,
 // simulating the cooldown elapsing (open -> half-open) without sleeping.
 func expireProviderBreaker(r *Registry, id string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
+	withGateForSession(r, id, func(g *gateState) { g.breakerUntil = time.Now().Add(-time.Second) })
+}
+
+// providerHealthWindowOf returns the provider's node-health ring (nil when no
+// fault or success was ever recorded).
+func providerHealthWindowOf(r *Registry, id string) (w *providerHealthWindow) {
+	readGateForSession(r, id, func(g *gateState) {
+		if g != nil {
+			w = g.outcomes
+		}
+	})
+	return w
 }
 
 // seedProviderHealthWindow records a fixed sequence of outcomes (true=success,
@@ -42,12 +55,12 @@ func expireProviderBreaker(r *Registry, id string) {
 // a low consecutive-fault counter) that monotonic RecordProviderOutcome calls
 // could not reach before the consecutive-fault path fires.
 func seedProviderHealthWindow(r *Registry, id string, pattern []bool, now time.Time) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	w := r.providerHealthWindowLocked(id)
-	for _, ok := range pattern {
-		w.record(ok, now)
-	}
+	withGateForSession(r, id, func(g *gateState) {
+		w := g.healthWindowLocked()
+		for _, ok := range pattern {
+			w.record(ok, now)
+		}
+	})
 }
 
 // --- classifier unit tests ---
@@ -368,10 +381,7 @@ func TestProviderBreakerIgnoresHealthySheds(t *testing.T) {
 		t.Fatal("100 healthy sheds must not quarantine a provider")
 	}
 	// Healthy sheds are ignored entirely — no health window is even created.
-	r.mu.RLock()
-	w := r.providerOutcomes[id]
-	r.mu.RUnlock()
-	if w != nil {
+	if w := providerHealthWindowOf(r, id); w != nil {
 		t.Fatalf("healthy sheds must not record into the health ring, got %+v", w)
 	}
 }
@@ -550,8 +560,8 @@ func TestQuickCapacityCheckFailsOpenOnProviderBreaker(t *testing.T) {
 	}
 }
 
-// Disconnect must drop every per-provider breaker map entry so a per-session
-// UUID leaves no residue.
+// Disconnect must drop an identity-less session's breaker state (its gate was
+// keyed by the session UUID, which never recurs) so it leaves no residue.
 func TestDisconnectClearsProviderBreaker(t *testing.T) {
 	reg := New(testLogger())
 	model := "disconnect-breaker-model"
@@ -559,29 +569,30 @@ func TestDisconnectClearsProviderBreaker(t *testing.T) {
 	for i := 0; i < providerBreakerConsecTrip; i++ {
 		reg.RecordProviderOutcome(p.ID, false, 500, "")
 	}
-	reg.mu.RLock()
-	_, hasWin := reg.providerOutcomes[p.ID]
-	_, hasOpen := reg.providerBreakerOpenUntil[p.ID]
-	_, hasTrips := reg.providerBreakerTrips[p.ID]
-	reg.mu.RUnlock()
+	var hasWin, hasOpen, hasTrips bool
+	readGateForKey(reg, p.ID, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		hasWin, hasOpen, hasTrips = g.outcomes != nil, !g.breakerUntil.IsZero(), g.breakerTrips > 0
+	})
 	if !hasWin || !hasOpen || !hasTrips {
 		t.Fatalf("expected breaker state before disconnect: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
 	}
 
 	reg.Disconnect(p.ID)
 
-	reg.mu.RLock()
-	_, hasWin = reg.providerOutcomes[p.ID]
-	_, hasOpen = reg.providerBreakerOpenUntil[p.ID]
-	_, hasTrips = reg.providerBreakerTrips[p.ID]
-	reg.mu.RUnlock()
-	if hasWin || hasOpen || hasTrips {
-		t.Fatalf("Disconnect must drop all breaker state: win=%v open=%v trips=%v", hasWin, hasOpen, hasTrips)
+	if g := rawGateForKey(reg, p.ID); g != nil {
+		t.Fatalf("Disconnect must drop the session-keyed gate, got %+v", g)
+	}
+	if reg.ProviderBreakerOpen(p.ID) {
+		t.Fatal("Disconnect must drop all breaker state")
 	}
 }
 
-// The opportunistic >1024 sweep (mirroring error_cooldown.go) must bound the
-// breaker maps by dropping expired/idle entries.
+// The periodic gate sweep (gate_state.go) must bound the index by dropping
+// identities whose breaker has expired and whose ring has aged out, once no
+// live session references them.
 func TestProviderBreakerMapsBounded(t *testing.T) {
 	r := New(testLogger())
 	for i := 0; i < 1100; i++ {
@@ -590,37 +601,22 @@ func TestProviderBreakerMapsBounded(t *testing.T) {
 			r.RecordProviderOutcome(id, false, 500, "")
 		}
 	}
-	r.mu.Lock()
-	for id := range r.providerBreakerOpenUntil {
-		r.providerBreakerOpenUntil[id] = time.Now().Add(-time.Second)
-	}
-	for _, w := range r.providerOutcomes {
-		for i := range w.outcomes {
-			if !w.outcomes[i].ts.IsZero() {
-				w.outcomes[i].ts = w.outcomes[i].ts.Add(-(providerBreakerWindow + time.Second))
-			}
-		}
-	}
-	openCount := len(r.providerBreakerOpenUntil)
-	winCount := len(r.providerOutcomes)
-	r.mu.Unlock()
-	if openCount < 1000 || winCount < 1000 {
-		t.Fatalf("setup produced too few distinct entries: open=%d win=%d", openCount, winCount)
+	if n := r.gateCount(); n < 1000 {
+		t.Fatalf("setup produced too few distinct gates: %d", n)
 	}
 
-	// A live record triggers the >1024 sweep before recording.
-	r.RecordProviderOutcome("live", false, 500, "")
+	// Past the breaker cooldown, the ring window and the idle grace, every
+	// dead identity is idle. A connected provider's gate stays regardless.
+	live := makeSchedulerProvider(t, r, "live", "m", 50)
+	r.RecordProviderOutcome(live.ID, false, 500, "")
+	r.sweepGates(time.Now().Add(gateIdleGrace + providerBreakerMaxCooldown + time.Second))
 
-	r.mu.RLock()
-	openAfter := len(r.providerBreakerOpenUntil)
-	tripsAfter := len(r.providerBreakerTrips)
-	winAfter := len(r.providerOutcomes)
-	r.mu.RUnlock()
-	if openAfter != 0 {
-		t.Fatalf("expired-breaker sweep should drop every entry (live pair has no open breaker yet), got %d", openAfter)
+	if after := r.gateCount(); after != 1 {
+		t.Fatalf("sweep should leave only the live provider's gate, got %d", after)
 	}
-	if tripsAfter != 0 {
-		t.Fatalf("trip counts must be swept alongside expired breakers, got %d", tripsAfter)
+	winAfter := 0
+	if providerHealthWindowOf(r, live.ID) != nil {
+		winAfter = 1
 	}
 	if winAfter != 1 {
 		t.Fatalf("stale-window sweep should leave only the live entry, got %d", winAfter)

--- a/coordinator/registry/provider_writer.go
+++ b/coordinator/registry/provider_writer.go
@@ -11,11 +11,22 @@ import (
 )
 
 const (
-	providerWriteQueueSize        = 128
-	providerControlQueueSize      = 64
-	providerWriteMinTimeout       = 5 * time.Second
-	providerWriteMaxTimeout       = 30 * time.Second
-	providerWriteBytesPerSecond   = 2 << 20 // 2 MiB/s (~16 Mbps) floor.
+	providerWriteQueueSize = 128
+	// providerControlQueueSize bounds the priority lane. Its frames are tiny
+	// (cancel / challenge / status, ~100 B) so the cost of depth is nil, while a
+	// full lane silently drops a cancel — the one loss path on the coordinator
+	// side of cancel delivery (inference.cancel_send_failed{reason:queue_full}).
+	providerControlQueueSize    = 256
+	providerWriteMinTimeout     = 5 * time.Second
+	providerWriteMaxTimeout     = 30 * time.Second
+	providerWriteBytesPerSecond = 2 << 20 // 2 MiB/s (~16 Mbps) floor.
+	// providerWriteFragmentBytes is the WebSocket fragment size for data-lane
+	// messages larger than one fragment. nhooyr answers peer pings on its READ
+	// goroutine, under a 5s budget, and that pong needs the per-frame write
+	// lock — so a message must never be one multi-second frame (see
+	// writeFrame). 256 KiB keeps ~100 frames per 20 MiB vision request while
+	// bounding the pong's wait to one fragment's wire time.
+	providerWriteFragmentBytes    = 256 << 10
 	providerControlWriteTimeout   = 5 * time.Second
 	providerWriteWatchdogInterval = 250 * time.Millisecond
 	providerWriteDrainErrorString = "provider websocket writer stopped"
@@ -24,6 +35,13 @@ const (
 var errProviderWriterStopped = errors.New(providerWriteDrainErrorString)
 var errProviderWriterQueueFull = errors.New("provider websocket writer queue full")
 var errProviderWriteTimeout = errors.New("provider websocket write timeout")
+
+// Exported forms of the writer's sentinel errors so callers can classify a
+// best-effort control-frame failure (cancel delivery metrics) with errors.Is.
+var (
+	ErrProviderWriterQueueFull = errProviderWriterQueueFull
+	ErrProviderWriterStopped   = errProviderWriterStopped
+)
 
 // TextFrameWriteMetadata describes the writer-owned handoff of a deferred
 // frame. The caller receives it synchronously and remains the sole owner of any
@@ -87,9 +105,9 @@ type providerWriter struct {
 	acceptMu sync.Mutex
 	dead     atomic.Bool
 
-	// writeDeadline is the UnixNano deadline of the in-flight conn.Write
-	// (0 = no write in progress). Published by writeFrame, enforced by
-	// watchWrites.
+	// writeDeadline is the UnixNano deadline of the in-flight socket write of
+	// one whole message (0 = no write in progress). Published by writeFrame,
+	// enforced by watchWrites.
 	writeDeadline atomic.Int64
 	// writeTimedOut records that the watchdog closed the socket due to a
 	// write deadline, so writeFrame can surface a timeout error instead of
@@ -521,10 +539,10 @@ func (w *providerWriter) drainLane(lane chan *providerWriteRequest, err error) {
 
 // watchWrites enforces per-frame write deadlines with one goroutine per
 // connection instead of a goroutine+timer per frame. writeFrame publishes its
-// deadline before the blocking conn.Write and clears it after; when a deadline
-// is exceeded the watchdog closes the socket, which unblocks Write with an
-// error. Granularity is providerWriteWatchdogInterval, acceptable slack on a
-// >=5s timeout floor.
+// deadline before the blocking socket write of a whole message and clears it
+// after; when a deadline is exceeded the watchdog closes the socket, which
+// unblocks the write with an error. Granularity is
+// providerWriteWatchdogInterval, acceptable slack on a >=5s timeout floor.
 func (w *providerWriter) watchWrites(stop <-chan struct{}) {
 	ticker := time.NewTicker(providerWriteWatchdogInterval)
 	defer ticker.Stop()
@@ -547,22 +565,60 @@ func (w *providerWriter) watchWrites(stop <-chan struct{}) {
 	}
 }
 
+// writeFrame puts one whole text message on the wire and returns only once
+// its last frame has been handed to the socket.
+//
+// Messages larger than providerWriteFragmentBytes are sent as a fragmented
+// WebSocket message (RFC 6455 §5.4) rather than one frame. nhooyr's
+// Conn.Write holds the connection's per-frame write lock for the entire
+// message, and its read goroutine answers the peer's pings inline — with a
+// 5s budget to take that same lock. A single 20 MiB vision frame legitimately
+// takes 10–30s at the write-timeout floor, so a provider ping (every 10s)
+// landing mid-frame failed the pong, which nhooyr reports as a READ error
+// ("failed to handle control frame opPing: ... failed to acquire lock"),
+// tearing down the whole provider session and 502-ing every request on it.
+// With msgWriter.Write the lock is held per fragment, so the pong interleaves
+// between continuation frames; the receiver reassembles into one message.
 func (w *providerWriter) writeFrame(data []byte) error {
-	// Do not pass a cancelable/expiring context to nhooyr.Conn.Write: context
-	// expiration is treated as a connection-level failure by the library. The
-	// writer owns timeout/backpressure externally (watchWrites) and closes
-	// unhealthy sockets explicitly with CloseNow.
+	// Do not pass a cancelable/expiring context to nhooyr's Write/Writer:
+	// context expiration is treated as a connection-level failure by the
+	// library. The writer owns timeout/backpressure externally (watchWrites,
+	// one deadline for the whole message) and closes unhealthy sockets
+	// explicitly with CloseNow.
 	timeout := providerWriteTimeout(len(data))
 	if w.timeoutFor != nil {
 		timeout = w.timeoutFor(len(data))
 	}
 	w.writeDeadline.Store(time.Now().Add(timeout).UnixNano())
-	err := w.conn.Write(context.Background(), websocket.MessageText, data)
+	err := writeFragmented(w.conn, data)
 	w.writeDeadline.Store(0)
 	if err != nil && w.writeTimedOut.Load() {
 		return errProviderWriteTimeout
 	}
 	return err
+}
+
+// writeFragmented sends data as one text message: a single frame when it
+// fits in providerWriteFragmentBytes, otherwise ceil(n/fragment) non-FIN
+// frames of at most fragment bytes followed by nhooyr's zero-length FIN
+// continuation. A mid-message write error is returned as-is without
+// attempting the FIN frame; the caller closes the socket on any error, which
+// is also what makes nhooyr's unreleased message-writer lock irrelevant.
+func writeFragmented(conn *websocket.Conn, data []byte) error {
+	if len(data) <= providerWriteFragmentBytes {
+		return conn.Write(context.Background(), websocket.MessageText, data)
+	}
+	mw, err := conn.Writer(context.Background(), websocket.MessageText)
+	if err != nil {
+		return err
+	}
+	for off := 0; off < len(data); off += providerWriteFragmentBytes {
+		end := min(off+providerWriteFragmentBytes, len(data))
+		if _, err := mw.Write(data[off:end]); err != nil {
+			return err
+		}
+	}
+	return mw.Close()
 }
 
 func providerWriteTimeout(frameBytes int) time.Duration {

--- a/coordinator/registry/provider_writer_control_lane_test.go
+++ b/coordinator/registry/provider_writer_control_lane_test.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestProviderWriterControlLaneHoldsCancelsBehindBlockedDataWrite pins the
+// control-lane capacity that bounds silent cancel loss: while one data frame
+// is stuck in its (non-preemptible) socket write, the lane must accept
+// providerControlQueueSize cancels, reject the next with
+// errProviderWriterQueueFull, and drain every accepted one once the data
+// write completes.
+func TestProviderWriterControlLaneHoldsCancelsBehindBlockedDataWrite(t *testing.T) {
+	if providerControlQueueSize < 256 {
+		t.Fatalf("providerControlQueueSize = %d, want >= 256 (control frames are ~100 B; a full lane drops a cancel)", providerControlQueueSize)
+	}
+	release := make(chan struct{})
+	dataStarted := make(chan struct{})
+	var once sync.Once
+	var frames atomic.Int32
+	w := &providerWriter{
+		queue:   make(chan *providerWriteRequest, providerWriteQueueSize),
+		control: make(chan *providerWriteRequest, providerControlQueueSize),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+		writeFrameForTest: func(data []byte) error {
+			if bytes.Contains(data, []byte(`"lane":"data"`)) {
+				once.Do(func() { close(dataStarted) })
+				<-release
+			}
+			frames.Add(1)
+			return nil
+		},
+	}
+	go w.run()
+	t.Cleanup(w.closeNow)
+
+	dataErr := make(chan error, 1)
+	go func() { dataErr <- w.write(context.Background(), []byte(`{"lane":"data"}`)) }()
+	select {
+	case <-dataStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("data frame never reached the socket write")
+	}
+
+	for i := 0; i < providerControlQueueSize; i++ {
+		frame := []byte(fmt.Sprintf(`{"type":"cancel","request_id":"req-%d"}`, i))
+		if err := w.enqueue(context.Background(), frame); err != nil {
+			t.Fatalf("enqueue #%d behind a blocked data write = %v, want nil", i, err)
+		}
+	}
+	if err := w.enqueue(context.Background(), []byte(`{"type":"cancel","request_id":"overflow"}`)); err != errProviderWriterQueueFull {
+		t.Fatalf("enqueue #%d = %v, want errProviderWriterQueueFull", providerControlQueueSize, err)
+	}
+
+	close(release)
+	if err := <-dataErr; err != nil {
+		t.Fatalf("data write = %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for frames.Load() < int32(providerControlQueueSize+1) && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := frames.Load(); got != int32(providerControlQueueSize+1) {
+		t.Fatalf("frames written = %d, want %d (data + every accepted cancel)", got, providerControlQueueSize+1)
+	}
+}

--- a/coordinator/registry/provider_writer_fragment_test.go
+++ b/coordinator/registry/provider_writer_fragment_test.go
@@ -1,0 +1,578 @@
+package registry
+
+// Regression tests for fragmented data-lane writes (writeFragmented).
+//
+// nhooyr's Conn.Write sends a whole message as ONE frame while holding the
+// connection's per-frame write lock, and its read goroutine answers peer
+// pings inline with a 5s budget to take that same lock. A multi-MiB
+// inference frame on a slow provider uplink legitimately takes longer than
+// that, so a provider ping (every 10s) landing mid-frame failed the pong and
+// nhooyr reported it as a READ error — tearing down the whole provider
+// session (2026-08-31 "provider websocket read error" 502 cascade). The
+// tests below reproduce that stall on a live loopback pair and prove that
+// fragmenting the message lets the pong interleave.
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	// stallSocketBufferBytes bounds kernel buffering on both ends of the
+	// loopback pair. Without it the loopback stack (macOS autotunes to 4 MiB
+	// per direction, Linux similar) absorbs most of a multi-MiB message and
+	// the server's write returns long before the client has read it — which
+	// would let the pre-fix single-frame path pass the ping test vacuously.
+	stallSocketBufferBytes = 64 << 10
+	// stallMessageBytes / stallReadChunk / stallReadInterval throttle the
+	// client to ~640 KiB/s, so the 6 MiB message takes ~9.5s on the wire: the
+	// pong must interleave (fixed path) or the 5s pong budget expires (old
+	// path) with a wide margin either way.
+	stallMessageBytes = 6 << 20
+	stallReadChunk    = 64 << 10
+	stallReadInterval = 100 * time.Millisecond
+	// stallPingAfterBytes: the client pings once it has read this much of the
+	// message, i.e. while the bulk of the write is still ahead.
+	stallPingAfterBytes = 256 << 10
+	stallPingTimeout    = 6 * time.Second
+)
+
+// pingStallHarness is a live nhooyr server+client pair with deliberately
+// tiny kernel socket buffers (see stallSocketBufferBytes). The server side
+// runs a Read loop that mirrors api.providerReadLoop — that goroutine is
+// where nhooyr answers pings, so without it no pong is ever written.
+type pingStallHarness struct {
+	serverConn *websocket.Conn
+	clientConn *websocket.Conn
+	// readErr receives the server Read loop's terminal error (once).
+	readErr chan error
+	// inbound receives every text message the server Read loop delivers.
+	inbound chan string
+}
+
+type smallSendBufferListener struct {
+	net.Listener
+}
+
+func (l smallSendBufferListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := c.(*net.TCPConn); ok {
+		_ = tc.SetWriteBuffer(stallSocketBufferBytes)
+	}
+	return c, nil
+}
+
+func newPingStallHarness(t *testing.T) *pingStallHarness {
+	t.Helper()
+	h := &pingStallHarness{
+		readErr: make(chan error, 1),
+		inbound: make(chan string, 16),
+	}
+	serverConnCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Same accept options as api.handleProviderWS (compression stays at
+		// the library default, CompressionDisabled — the production shape).
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+		for {
+			_, data, err := conn.Read(context.Background())
+			if err != nil {
+				h.readErr <- err
+				// api.providerReadLoop's deferred teardown: the session is
+				// gone once Read fails.
+				_ = conn.CloseNow()
+				return
+			}
+			h.inbound <- string(data)
+		}
+	}))
+	srv.Listener = smallSendBufferListener{srv.Listener}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			c, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if tc, ok := c.(*net.TCPConn); ok {
+				_ = tc.SetReadBuffer(stallSocketBufferBytes)
+			}
+			return c, nil
+		},
+	}
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	clientConn, _, err := websocket.Dial(dialCtx, "ws"+strings.TrimPrefix(srv.URL, "http"), &websocket.DialOptions{
+		HTTPClient: &http.Client{Transport: transport},
+	})
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	clientConn.SetReadLimit(-1)
+	t.Cleanup(func() { _ = clientConn.CloseNow() })
+	h.clientConn = clientConn
+
+	select {
+	case h.serverConn = <-serverConnCh:
+		t.Cleanup(func() { _ = h.serverConn.CloseNow() })
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	return h
+}
+
+// stallPayload is an ASCII (valid UTF-8, incompressible-enough) text message
+// of the given size, shaped like a sealed inference_request envelope.
+func stallPayload(n int) []byte {
+	rng := rand.New(rand.NewSource(7))
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	prefix := `{"type":"inference_request","payload":"`
+	suffix := `"}`
+	body := make([]byte, n-len(prefix)-len(suffix))
+	for i := range body {
+		body[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	out := make([]byte, 0, n)
+	out = append(out, prefix...)
+	out = append(out, body...)
+	return append(out, suffix...)
+}
+
+// slowReadResult is what the throttled client reader observed.
+type slowReadResult struct {
+	data []byte
+	err  error
+}
+
+// readMessageSlowly drains one message from the client at stallReadChunk per
+// stallReadInterval. bytesRead is updated after every chunk; pingGate is
+// closed once stallPingAfterBytes have been read.
+func readMessageSlowly(conn *websocket.Conn, bytesRead *atomic.Int64, pingGate chan struct{}) slowReadResult {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	typ, r, err := conn.Reader(ctx)
+	if err != nil {
+		return slowReadResult{err: err}
+	}
+	if typ != websocket.MessageText {
+		return slowReadResult{err: fmt.Errorf("message type = %v, want text", typ)}
+	}
+	var got []byte
+	buf := make([]byte, stallReadChunk)
+	gateOpen := false
+	for {
+		n, err := r.Read(buf)
+		got = append(got, buf[:n]...)
+		total := bytesRead.Add(int64(n))
+		if !gateOpen && total >= stallPingAfterBytes {
+			gateOpen = true
+			close(pingGate)
+		}
+		if errors.Is(err, io.EOF) {
+			return slowReadResult{data: got}
+		}
+		if err != nil {
+			return slowReadResult{data: got, err: err}
+		}
+		time.Sleep(stallReadInterval)
+	}
+}
+
+// TestProviderWriterFragmentedWriteAnswersPingMidMessage is the regression
+// test for the 2026-08-31 provider-session teardown: a peer ping that lands
+// while a multi-second data write is in flight must be answered (the pong
+// interleaves between fragments), the server Read loop must survive, and the
+// peer must still receive the message byte-for-byte.
+//
+// Before writeFragmented this failed: the client's Ping timed out, the server
+// Read loop died with "failed to get reader: failed to handle control frame
+// opPing: failed to write control frame opPong: failed to acquire lock:
+// context deadline exceeded", and the message never completed (see
+// TestUnfragmentedConnWriteStallsPeerPing, which pins that failure mode).
+func TestProviderWriterFragmentedWriteAnswersPingMidMessage(t *testing.T) {
+	t.Parallel()
+	h := newPingStallHarness(t)
+	w := newProviderWriter(h.serverConn)
+	// The reader is throttled below the 2 MiB/s write-timeout floor on
+	// purpose; the watchdog is not what is under test here.
+	w.timeoutFor = func(int) time.Duration { return 60 * time.Second }
+	p := &Provider{Conn: h.serverConn, writer: w}
+	t.Cleanup(p.closeWriterNow)
+
+	payload := stallPayload(stallMessageBytes)
+
+	var bytesRead atomic.Int64
+	pingGate := make(chan struct{})
+	readDone := make(chan slowReadResult, 1)
+	go func() { readDone <- readMessageSlowly(h.clientConn, &bytesRead, pingGate) }()
+
+	writeDone := make(chan error, 1)
+	writeStarted := time.Now()
+	go func() { writeDone <- p.WriteText(context.Background(), payload) }()
+
+	select {
+	case <-pingGate:
+	case res := <-readDone:
+		t.Fatalf("client read finished before the ping gate: %d bytes, err=%v", len(res.data), res.err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the client to read the ping gate")
+	}
+
+	pingCtx, cancelPing := context.WithTimeout(context.Background(), stallPingTimeout)
+	defer cancelPing()
+	pingErr := h.clientConn.Ping(pingCtx)
+	bytesAtPong := bytesRead.Load()
+	if pingErr != nil {
+		t.Fatalf("Ping during in-flight data write = %v (pong could not interleave)", pingErr)
+	}
+	// The pong must have interleaved with the message, not trailed it: the
+	// write is still in progress and the client has not read all of it.
+	select {
+	case err := <-writeDone:
+		t.Fatalf("WriteText already returned (%v) when the pong arrived; the harness did not keep the write in flight", err)
+	default:
+	}
+	if bytesAtPong >= int64(len(payload)) {
+		t.Fatalf("client had read %d of %d bytes when the pong arrived; the pong did not interleave", bytesAtPong, len(payload))
+	}
+
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("WriteText = %v", err)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("timed out waiting for WriteText")
+	}
+	writeTook := time.Since(writeStarted)
+	if writeTook < 5*time.Second {
+		t.Fatalf("WriteText took %v; the throttled reader should have kept it in flight for >5s (nhooyr's pong budget)", writeTook)
+	}
+
+	var res slowReadResult
+	select {
+	case res = <-readDone:
+	case <-time.After(60 * time.Second):
+		t.Fatal("timed out waiting for the client to finish reading")
+	}
+	if res.err != nil {
+		t.Fatalf("client read = %v after %d bytes", res.err, len(res.data))
+	}
+	if string(res.data) != string(payload) {
+		t.Fatalf("client received %d bytes, want %d, or content differs", len(res.data), len(payload))
+	}
+
+	// Positive liveness proof for the server Read loop: it must still deliver
+	// the next inbound frame, and must not have exited.
+	select {
+	case err := <-h.readErr:
+		t.Fatalf("server Read loop exited during the fragmented write: %v", err)
+	default:
+	}
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelWrite()
+	if err := h.clientConn.Write(writeCtx, websocket.MessageText, []byte(`{"type":"heartbeat"}`)); err != nil {
+		t.Fatalf("client write after message: %v", err)
+	}
+	select {
+	case msg := <-h.inbound:
+		if msg != `{"type":"heartbeat"}` {
+			t.Fatalf("server read %q after the fragmented write, want heartbeat", msg)
+		}
+	case err := <-h.readErr:
+		t.Fatalf("server Read loop exited after the fragmented write: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("server Read loop did not deliver the post-message heartbeat")
+	}
+	t.Logf("pong arrived after %d/%d bytes; write took %v", bytesAtPong, len(payload), writeTook)
+}
+
+// TestUnfragmentedConnWriteStallsPeerPing pins the library behavior that
+// motivated writeFragmented, using the pre-fix path (one nhooyr Conn.Write
+// for the whole message) on the same harness: the peer's ping cannot be
+// answered while the frame is in flight, and nhooyr surfaces that as a READ
+// failure containing "failed to handle control frame" — the exact string
+// api.readErrorDisconnectReason classifies. It also proves the harness is
+// sensitive enough that the fragmented test above cannot pass vacuously.
+func TestUnfragmentedConnWriteStallsPeerPing(t *testing.T) {
+	t.Parallel()
+	h := newPingStallHarness(t)
+	payload := stallPayload(stallMessageBytes)
+
+	var bytesRead atomic.Int64
+	pingGate := make(chan struct{})
+	readDone := make(chan slowReadResult, 1)
+	go func() { readDone <- readMessageSlowly(h.clientConn, &bytesRead, pingGate) }()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- h.serverConn.Write(context.Background(), websocket.MessageText, payload)
+	}()
+
+	select {
+	case <-pingGate:
+	case res := <-readDone:
+		t.Fatalf("client read finished before the ping gate: %d bytes, err=%v", len(res.data), res.err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the client to read the ping gate")
+	}
+
+	pingCtx, cancelPing := context.WithTimeout(context.Background(), stallPingTimeout)
+	defer cancelPing()
+	pingErr := h.clientConn.Ping(pingCtx)
+	if pingErr == nil {
+		t.Fatal("Ping succeeded during a single-frame Conn.Write; nhooyr no longer holds the write lock for the whole message — the harness is not exercising the stall")
+	}
+
+	var readErr error
+	select {
+	case readErr = <-h.readErr:
+	case <-time.After(15 * time.Second):
+		t.Fatal("server Read loop did not fail after the unanswered ping")
+	}
+	// This is the string api.readErrorDisconnectReason keys on, and the
+	// lock wait is the mechanism (nhooyr names the opcodes opPing/opPong).
+	for _, want := range []string{"failed to handle control frame", "failed to acquire lock"} {
+		if !strings.Contains(readErr.Error(), want) {
+			t.Fatalf("server Read error = %q, want it to contain %q", readErr, want)
+		}
+	}
+	t.Logf("pre-fix failure mode reproduced: Ping=%v; server Read=%v", pingErr, readErr)
+
+	// The harness tore the socket down on the read failure, so the in-flight
+	// write and the client read both fail: this is the provider-session 502
+	// cascade.
+	select {
+	case err := <-writeDone:
+		if err == nil {
+			t.Fatal("single-frame Write completed after the Read loop died")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for the stalled Write to fail")
+	}
+	select {
+	case res := <-readDone:
+		if res.err == nil {
+			t.Fatalf("client read completed (%d bytes) after the server session died", len(res.data))
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for the client read to fail")
+	}
+}
+
+// rawWSClient speaks just enough RFC 6455 to observe server→client frame
+// boundaries: the HTTP upgrade, then unmasked frame headers. It offers no
+// extensions, so the server side is exactly the production (flate-disabled)
+// framing.
+type rawWSClient struct {
+	conn net.Conn
+	br   *bufio.Reader
+}
+
+type rawFrame struct {
+	fin     bool
+	opcode  byte
+	payload []byte
+}
+
+const (
+	rawOpContinuation = 0x0
+	rawOpText         = 0x1
+)
+
+func dialRawWS(t *testing.T, serverURL string) *rawWSClient {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	conn, err := net.DialTimeout("tcp", u.Host, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial raw tcp: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+
+	var keyBytes [16]byte
+	rand.New(rand.NewSource(time.Now().UnixNano())).Read(keyBytes[:])
+	key := base64.StdEncoding.EncodeToString(keyBytes[:])
+	if _, err := fmt.Fprintf(conn,
+		"GET / HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"+
+			"Sec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n", u.Host, key); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("upgrade status = %d, want 101", resp.StatusCode)
+	}
+	return &rawWSClient{conn: conn, br: br}
+}
+
+func (c *rawWSClient) readFrame() (rawFrame, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(c.br, hdr[:]); err != nil {
+		return rawFrame{}, fmt.Errorf("frame header: %w", err)
+	}
+	f := rawFrame{fin: hdr[0]&0x80 != 0, opcode: hdr[0] & 0x0f}
+	if hdr[1]&0x80 != 0 {
+		return rawFrame{}, errors.New("server frame is masked")
+	}
+	n := uint64(hdr[1] & 0x7f)
+	switch n {
+	case 126:
+		var ext [2]byte
+		if _, err := io.ReadFull(c.br, ext[:]); err != nil {
+			return rawFrame{}, fmt.Errorf("extended length: %w", err)
+		}
+		n = uint64(binary.BigEndian.Uint16(ext[:]))
+	case 127:
+		var ext [8]byte
+		if _, err := io.ReadFull(c.br, ext[:]); err != nil {
+			return rawFrame{}, fmt.Errorf("extended length: %w", err)
+		}
+		n = binary.BigEndian.Uint64(ext[:])
+	}
+	f.payload = make([]byte, n)
+	if _, err := io.ReadFull(c.br, f.payload); err != nil {
+		return rawFrame{}, fmt.Errorf("frame payload (%d bytes): %w", n, err)
+	}
+	return f, nil
+}
+
+// readMessageFrames reads frames until a FIN frame and returns them all.
+func (c *rawWSClient) readMessageFrames() ([]rawFrame, error) {
+	var frames []rawFrame
+	for {
+		f, err := c.readFrame()
+		if err != nil {
+			return frames, err
+		}
+		frames = append(frames, f)
+		if f.fin {
+			return frames, nil
+		}
+	}
+}
+
+// TestProviderWriterFragmentBoundaries checks the wire framing of
+// writeFragmented across the fragment threshold: messages up to one fragment
+// stay a single FIN text frame; larger ones become ceil(n/fragment) non-FIN
+// frames (text, then continuation) of at most fragment bytes, terminated by
+// nhooyr's zero-length FIN continuation — and always reassemble exactly.
+func TestProviderWriterFragmentBoundaries(t *testing.T) {
+	const f = providerWriteFragmentBytes
+	serverConnCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		serverConnCh <- conn
+		// Keep the handler (and the hijacked socket) alive; nothing is read.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	client := dialRawWS(t, srv.URL)
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-serverConnCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket")
+	}
+	w := newProviderWriter(serverConn)
+	t.Cleanup(w.closeNow)
+
+	for _, size := range []int{0, 1, f - 1, f, f + 1, 3*f + 17} {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
+			data := make([]byte, size)
+			rng := rand.New(rand.NewSource(int64(size)))
+			for i := range data {
+				data[i] = byte('a' + rng.Intn(26))
+			}
+			if err := w.write(context.Background(), data); err != nil {
+				t.Fatalf("write %d bytes: %v", size, err)
+			}
+			frames, err := client.readMessageFrames()
+			if err != nil {
+				t.Fatalf("read frames for %d bytes: %v (got %d frames)", size, err, len(frames))
+			}
+
+			var wantFrames int
+			if size <= f {
+				wantFrames = 1
+			} else {
+				wantFrames = (size+f-1)/f + 1
+			}
+			if len(frames) != wantFrames {
+				t.Fatalf("frame count = %d, want %d", len(frames), wantFrames)
+			}
+			var joined []byte
+			for i, fr := range frames {
+				joined = append(joined, fr.payload...)
+				last := i == len(frames)-1
+				wantOpcode := byte(rawOpContinuation)
+				if i == 0 {
+					wantOpcode = rawOpText
+				}
+				if fr.opcode != wantOpcode {
+					t.Fatalf("frame[%d] opcode = %#x, want %#x", i, fr.opcode, wantOpcode)
+				}
+				if fr.fin != last {
+					t.Fatalf("frame[%d] fin = %v, want %v", i, fr.fin, last)
+				}
+				switch {
+				case wantFrames == 1:
+					if len(fr.payload) != size {
+						t.Fatalf("single frame payload = %d, want %d", len(fr.payload), size)
+					}
+				case last:
+					if len(fr.payload) != 0 {
+						t.Fatalf("FIN continuation payload = %d, want 0", len(fr.payload))
+					}
+				case i == wantFrames-2:
+					wantLast := size - (wantFrames-2)*f
+					if len(fr.payload) != wantLast {
+						t.Fatalf("last data fragment payload = %d, want %d", len(fr.payload), wantLast)
+					}
+				default:
+					if len(fr.payload) != f {
+						t.Fatalf("frame[%d] payload = %d, want %d", i, len(fr.payload), f)
+					}
+				}
+			}
+			if string(joined) != string(data) {
+				t.Fatalf("reassembled %d bytes differ from the %d-byte message", len(joined), size)
+			}
+		})
+	}
+}

--- a/coordinator/registry/queue_drain_bench_test.go
+++ b/coordinator/registry/queue_drain_bench_test.go
@@ -1,0 +1,161 @@
+package registry
+
+// Fleet-scale benchmarks for the queue drain that runs on every heartbeat,
+// SetProviderIdle, challenge success, and disconnect. The shape is the
+// 2026-08-31 overload: a 1,300-provider fleet at token-budget capacity with a
+// full (32-deep) queue for one model. Before the dominance skip in
+// drainQueuedRequests every event paid depth × one full fleet scan
+// (~37 ms / 36 MB / 333K allocs); after it an event pays one scan.
+//
+// Run: go test ./registry/ -run='^$' -bench=Drain -benchmem -count=3
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	drainBenchFleetSize  = 1300
+	drainBenchQueueDepth = 32
+	drainBenchModel      = "mlx-community/drain-bench-model-4bit"
+	drainBenchPubKey     = "fX6XYH7p2hmM3ogeXaAsY+p8M6UKD1df/LJUN9Nj9Nw="
+)
+
+func drainBenchProviderID(i int) string { return fmt.Sprintf("drain-prov-%04d", i) }
+
+// drainBenchSlot is a warm slot whose token budget is completely spent, so
+// budget-based admission (freeMemoryAdmits) rejects every request.
+func drainBenchSlot() protocol.BackendSlotCapacity {
+	return protocol.BackendSlotCapacity{
+		Model: drainBenchModel, State: "running", NumRunning: 1, NumWaiting: 0,
+		ActiveTokens: 2048, MaxTokensPotential: 4096,
+		ActiveTokenBudgetUsed: 65536, ActiveTokenBudgetMax: 65536, QueuedTokenBudget: 0,
+		ObservedDecodeTPS: 25, ObservedPrefillTPS: 800,
+		KVBytesPerToken: 65536,
+	}
+}
+
+// buildDrainBenchFleet registers n routable, budget-saturated providers that
+// all serve drainBenchModel, plus a queue holding depth plain requests for it.
+// The TPS registry is seeded with a full 50-sample window per chip so Median()
+// sorts a realistic window during each scan, as in prod.
+func buildDrainBenchFleet(b testing.TB, n, depth int) *Registry {
+	b.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	reg := New(logger)
+	reg.SetModelCatalog([]CatalogEntry{{ID: drainBenchModel, SizeGB: 15}})
+	chips := []string{"M1", "M2", "M3", "M4"}
+	for i := 0; i < n; i++ {
+		chip := chips[i%len(chips)]
+		msg := &protocol.RegisterMessage{
+			Type: protocol.TypeRegister,
+			Hardware: protocol.Hardware{
+				MachineModel: "Mac15,8", ChipName: "Apple " + chip + " Max", ChipFamily: chip, ChipTier: "Max",
+				MemoryGB: 64, MemoryAvailableGB: 60, MemoryBandwidthGBs: 400,
+				CPUCores: protocol.CPUCores{Total: 16, Performance: 12, Efficiency: 4}, GPUCores: 40,
+			},
+			Models: []protocol.ModelInfo{{
+				ID: drainBenchModel, SizeBytes: 15_000_000_000, ModelType: "chat", Quantization: "4bit",
+			}},
+			Backend: BackendMLXSwift, DecodeTPS: 25 + float64(i%10),
+			PublicKey: drainBenchPubKey, EncryptedResponseChunks: true, Version: "0.8.15",
+			PrivacyCapabilities: &protocol.PrivacyCapabilities{
+				TextBackendInprocess: true, TextProxyDisabled: true, PythonRuntimeLocked: true,
+				DangerousModulesBlocked: true, SIPEnabled: true, AntiDebugEnabled: true,
+				CoreDumpsDisabled: true, EnvScrubbed: true,
+			},
+		}
+		p := reg.Register(drainBenchProviderID(i), nil, msg)
+		p.mu.Lock()
+		p.TrustLevel = TrustHardware
+		p.RuntimeVerified = true
+		p.RuntimeManifestChecked = true
+		p.ChallengeVerifiedSIP = true
+		p.LastChallengeVerified = time.Now()
+		p.Version = "0.8.15"
+		p.SystemMetrics = protocol.SystemMetrics{MemoryPressure: 0.3, CPUUsage: 0.2, ThermalState: "nominal"}
+		p.BackendCapacity = &protocol.BackendCapacity{
+			TotalMemoryGB: 64, GPUMemoryActiveGB: 20,
+			Slots: []protocol.BackendSlotCapacity{drainBenchSlot()},
+		}
+		p.WarmModels = []string{drainBenchModel}
+		p.mu.Unlock()
+	}
+	for _, chip := range chips {
+		for s := 0; s < 50; s++ {
+			reg.tpsRegistry.Record(drainBenchModel, chip, 25+float64(s%10))
+		}
+	}
+
+	q := NewRequestQueue(depth*2, 120*time.Second)
+	reg.SetQueue(q)
+	for k := 0; k < depth; k++ {
+		id := fmt.Sprintf("drain-q-%d", k)
+		req := &QueuedRequest{
+			RequestID: id, Model: drainBenchModel, EnqueuedAt: time.Now(),
+			Pending: &PendingRequest{
+				RequestID: id, Model: drainBenchModel,
+				EstimatedPromptTokens: 800, RequestedMaxTokens: 1024,
+			},
+		}
+		if err := q.Enqueue(req); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return reg
+}
+
+// drainBenchHeartbeat is a heartbeat that keeps the provider's slot saturated.
+func drainBenchHeartbeat(i int) *protocol.HeartbeatMessage {
+	active := drainBenchModel
+	return &protocol.HeartbeatMessage{
+		Type: protocol.TypeHeartbeat, Status: "serving", ActiveModel: &active,
+		Stats:         protocol.HeartbeatStats{RequestsServed: int64(100 + i), TokensGenerated: int64(50000 + i)},
+		WarmModels:    []string{drainBenchModel},
+		SystemMetrics: protocol.SystemMetrics{MemoryPressure: 0.35, CPUUsage: 0.22, ThermalState: "nominal"},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64, GPUMemoryActiveGB: 21, GPUMemoryPeakGB: 30, GPUMemoryCacheGB: 2,
+			Slots: []protocol.BackendSlotCapacity{drainBenchSlot()},
+		},
+	}
+}
+
+func requireDrainBenchQueueIntact(b *testing.B, reg *Registry) {
+	b.Helper()
+	if got := reg.Queue().QueueSize(drainBenchModel); got != drainBenchQueueDepth {
+		b.Fatalf("queue depth = %d after benchmark, want %d (fleet was not saturated)", got, drainBenchQueueDepth)
+	}
+}
+
+// BenchmarkDrain_Heartbeat_1300_SaturatedQueue_Depth32 is the 260/s fleet-wide
+// event: a heartbeat from a provider serving the queued model while the whole
+// fleet is at capacity.
+func BenchmarkDrain_Heartbeat_1300_SaturatedQueue_Depth32(b *testing.B) {
+	reg := buildDrainBenchFleet(b, drainBenchFleetSize, drainBenchQueueDepth)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reg.Heartbeat(drainBenchProviderID(i%drainBenchFleetSize), drainBenchHeartbeat(i))
+	}
+	b.StopTimer()
+	requireDrainBenchQueueIntact(b, reg)
+}
+
+// BenchmarkDrain_SetProviderIdle_1300_SaturatedQueue_Depth32 is the
+// completion/cancel/failed-attempt event (16 call sites). Never suppressed,
+// so this row isolates the per-pass cost of the drain itself.
+func BenchmarkDrain_SetProviderIdle_1300_SaturatedQueue_Depth32(b *testing.B) {
+	reg := buildDrainBenchFleet(b, drainBenchFleetSize, drainBenchQueueDepth)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reg.SetProviderIdle(drainBenchProviderID(i % drainBenchFleetSize))
+	}
+	b.StopTimer()
+	requireDrainBenchQueueIntact(b, reg)
+}

--- a/coordinator/registry/queue_drain_coalesce.go
+++ b/coordinator/registry/queue_drain_coalesce.go
@@ -1,0 +1,78 @@
+package registry
+
+// Per-model drain-pass coalescing.
+//
+// A drain pass (drainModelQueuePass) pops the model's queued requests and holds
+// the ones it rejects or skips until it requeues them at the end. Passes for
+// the same model were not otherwise serialized — heartbeats, SetProviderIdle,
+// challenge recoveries, disconnects, and load completions each ran their own —
+// so a trigger landing while a pass held waiters popped an empty queue and did
+// nothing, while the running pass never re-examined what it held: a request it
+// had already rejected, and every later request skipped on that verdict
+// (queue_drain_dominance.go), was requeued against fleet state the trigger had
+// since changed, and nothing rescanned them until the next trigger for the
+// model — up to a heartbeat interval away — although capacity for them existed
+// now. (The saturation mark is installed after the requeue, so a heartbeat
+// that landed mid-pass was not suppressed and armed no trailing pass.)
+//
+// So one pass runs per model at a time. A trigger that finds a pass in flight
+// records itself and returns; the pass, after requeueing, goes around once
+// more with fresh fleet state and empty dominance records, attributed to the
+// trigger that asked. Every trigger's work is therefore done by the pass that
+// was running when it arrived, never later than one extra pass, and N triggers
+// inside one pass cost one rerun.
+
+import "sync"
+
+// queueDrainCoalescer tracks, per model, whether a drain pass is in flight and
+// which trigger arrived while it ran. The zero value is ready to use.
+type queueDrainCoalescer struct {
+	mu      sync.Mutex
+	running map[string]bool
+	// rerun holds the trigger reason of the latest drain that arrived while a
+	// pass for the model was in flight.
+	rerun map[string]string
+}
+
+// begin claims the drain pass for model. It returns false when a pass is
+// already in flight; that pass reruns for reason once it has requeued.
+func (c *queueDrainCoalescer) begin(model, reason string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running[model] {
+		if c.rerun == nil {
+			c.rerun = make(map[string]string)
+		}
+		c.rerun[model] = reason
+		return false
+	}
+	if c.running == nil {
+		c.running = make(map[string]bool)
+	}
+	c.running[model] = true
+	return true
+}
+
+// end is called by the claim holder after a completed pass. When a trigger
+// arrived mid-pass it keeps the claim and returns that trigger's reason with
+// true so the holder runs another pass; otherwise it releases the claim.
+func (c *queueDrainCoalescer) end(model string) (reason string, again bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if reason, ok := c.rerun[model]; ok {
+		delete(c.rerun, model)
+		return reason, true
+	}
+	delete(c.running, model)
+	return "", false
+}
+
+// abandon releases the claim for a pass that did not complete (a panic
+// unwinding through the drain), dropping any rerun request with it, so the
+// model is not pinned unroutable-from-queue by a claim nobody holds.
+func (c *queueDrainCoalescer) abandon(model string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.running, model)
+	delete(c.rerun, model)
+}

--- a/coordinator/registry/queue_drain_dominance.go
+++ b/coordinator/registry/queue_drain_dominance.go
@@ -1,0 +1,123 @@
+package registry
+
+// Per-pass dominance skip for the queue drain (drainQueuedRequestsForModels).
+//
+// A drain pass pops every fresh queued request for a model and asks the
+// scheduler for a provider. Within one pass the fleet state only loses
+// capacity (an admission removes it; a trigger that frees capacity mid-pass
+// does not run its own pass but makes this one rerun with fresh records —
+// queue_drain_coalesce.go), so once a request has been rejected purely on
+// capacity/TTFT, any later request in the same pass that is at least as
+// demanding — same structural eligibility, no smaller prompt or output
+// budget, no looser TTFT ceiling — would get the identical "no candidate"
+// verdict from an identical full fleet scan (~1 ms / 2 MB at 1,300
+// providers). Those requests are requeued without a scan.
+// Anything not provably dominated — a different constraint shape, a strictly
+// smaller request, a looser TTFT ceiling, a cache plan that could shorten
+// prefill — is scanned exactly as before, so a small request behind a large
+// rejected one is still admitted in the same pass.
+
+// drainDominanceKey holds every PendingRequest field that changes which
+// providers pass the structural routing gates in scanCandidatesLocked. Two
+// comparable requests with equal keys see the same eligible provider set.
+type drainDominanceKey struct {
+	requiresVision bool
+	traits         RequestTraits
+}
+
+// drainRejectionRecord is one pure capacity/TTFT rejection observed in the
+// current drain pass for a model.
+type drainRejectionRecord struct {
+	key            drainDominanceKey
+	promptTokens   int
+	maxTokens      int
+	maxTTFTMs      float64
+	ttftRejections int
+}
+
+// drainDominanceComparable reports whether pr's eligible provider set is the
+// plain public fleet for its model, so it can take part in dominance
+// reasoning at all. Owner-scoped, serial-pinned, provider-excluding, and
+// cache-planned requests are always scanned: their eligible sets (or prefill
+// estimates) differ from a plain request's.
+func drainDominanceComparable(pr *PendingRequest) bool {
+	return pr != nil &&
+		!pr.SelfRouteOnly && !pr.PreferOwner &&
+		len(pr.AllowedProviderSerials) == 0 &&
+		len(pr.ExcludedProviderIDs) == 0 &&
+		!pr.CachePlan.present()
+}
+
+// drainPureCapacityRejection reports whether a failed reservation was decided
+// solely by transient gates: no candidate passed, and at least one provider
+// was rejected only for capacity or only for the per-request TTFT ceiling.
+// Deterministic failures (tool-constraint, TTFT-terminal) are handled before
+// this is consulted; a nil provider with CandidateCount > 0 is the commit
+// re-check race, not a fleet verdict.
+func drainPureCapacityRejection(decision RoutingDecision) bool {
+	return decision.CandidateCount == 0 &&
+		(decision.CapacityRejections > 0 || decision.TTFTRejections > 0)
+}
+
+// drainRequestSize normalizes the admission-relevant request size exactly as
+// reserveProvider and buildCandidateWithReason do.
+func drainRequestSize(pr *PendingRequest) (prompt, maxTok int) {
+	prompt = pr.EstimatedPromptTokens
+	if prompt < 0 {
+		prompt = 0
+	}
+	maxTok = pr.RequestedMaxTokens
+	if maxTok <= 0 {
+		maxTok = defaultRequestedMaxTokens
+	}
+	return prompt, maxTok
+}
+
+// drainRejectionRecordFor converts a failed reservation into a dominance
+// record, or reports false when the request or verdict cannot anchor
+// dominance reasoning.
+func drainRejectionRecordFor(pr *PendingRequest, decision RoutingDecision) (drainRejectionRecord, bool) {
+	if !drainDominanceComparable(pr) || !drainPureCapacityRejection(decision) {
+		return drainRejectionRecord{}, false
+	}
+	prompt, maxTok := drainRequestSize(pr)
+	return drainRejectionRecord{
+		key:            drainDominanceKey{requiresVision: pr.RequiresVision, traits: pr.Traits},
+		promptTokens:   prompt,
+		maxTokens:      maxTok,
+		maxTTFTMs:      pr.MaxTTFTMs,
+		ttftRejections: decision.TTFTRejections,
+	}, true
+}
+
+// ttftCeilingNoLooser reports whether a request with ceiling q cannot pass a
+// TTFT gate that rejected a request with ceiling r (0 = no ceiling). A record
+// only carries TTFT rejections when r > 0.
+func ttftCeilingNoLooser(q, r float64) bool {
+	return r <= 0 || (q > 0 && q <= r)
+}
+
+// drainDominated reports whether pr would receive the same pure capacity/TTFT
+// rejection as a request already rejected in this pass, so its fleet scan can
+// be skipped. Capacity admission (freeMemoryAdmits / pooledBudgetAdmits) is
+// monotone in prompt+max tokens and the TTFT estimate is monotone in prompt
+// tokens, so a request that is no smaller on both, with a ceiling no looser,
+// fails every provider the record failed.
+func drainDominated(pr *PendingRequest, rejected []drainRejectionRecord) bool {
+	if len(rejected) == 0 || !drainDominanceComparable(pr) {
+		return false
+	}
+	key := drainDominanceKey{requiresVision: pr.RequiresVision, traits: pr.Traits}
+	prompt, maxTok := drainRequestSize(pr)
+	for i := range rejected {
+		rec := &rejected[i]
+		if rec.key != key || prompt < rec.promptTokens || maxTok < rec.maxTokens {
+			continue
+		}
+		if rec.ttftRejections > 0 && !ttftCeilingNoLooser(pr.MaxTTFTMs, rec.maxTTFTMs) {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/coordinator/registry/queue_drain_suppress.go
+++ b/coordinator/registry/queue_drain_suppress.go
@@ -1,0 +1,169 @@
+package registry
+
+// Heartbeat-triggered queue-drain suppression.
+//
+// Every heartbeat from a provider re-runs the queue drain for the models it
+// serves (Registry.Heartbeat). Fleet-wide that is ~260 passes/s, and under
+// saturation each pass costs a full fleet scan (~1 ms / 2 MB at 1,300
+// providers) only to re-derive "no candidate". Heartbeats almost never free
+// capacity themselves — completions, cancels, failed attempts (SetProviderIdle),
+// challenge recoveries (RecordChallengeSuccess), disconnects, and load_model
+// completions (DrainQueuedRequestsForModel) do, and those triggers are never
+// suppressed. So a heartbeat skips a model whose last drain pass ended in a
+// pure capacity/TTFT rejection less than heartbeatDrainSuppressWindow ago.
+
+import (
+	"sync"
+	"time"
+)
+
+// heartbeatDrainSuppressWindow bounds how soon after a saturated drain pass a
+// HEARTBEAT may trigger another pass for the same model. A suppressed
+// heartbeat is not dropped: it arms ONE trailing pass at the end of the
+// window, so capacity that only a heartbeat could have revealed (a
+// budget-clamp release proof, a lower active-token report replacing the
+// pessimistic pending ledger) is drained at most 20 ms late rather than
+// waiting for the next un-suppressed trigger (the next heartbeat is 5 s
+// away). Every other trigger drains at once.
+const heartbeatDrainSuppressWindow = 20 * time.Millisecond
+
+// queueDrainSuppressor remembers, per model, when a drain pass last ended in a
+// pure capacity/TTFT rejection without admitting anything. The zero value is
+// ready to use; the map is created on first mark.
+type queueDrainSuppressor struct {
+	mu        sync.Mutex
+	saturated map[string]time.Time
+	// trailing marks models for which a suppressed heartbeat has already
+	// armed the end-of-window pass, so N suppressed heartbeats inside one
+	// window cost exactly one trailing drain.
+	trailing map[string]bool
+	// now is a test-only clock seam so the window can be crossed without
+	// sleeping. Production leaves it nil (time.Now).
+	now func() time.Time
+	// afterFunc is a test-only seam for scheduling the trailing pass; nil
+	// means time.AfterFunc. Tests that do not exercise the trailing pass
+	// install a no-op so its goroutine cannot race their fake clock.
+	afterFunc func(time.Duration, func())
+	// trailingDone, when set, is called after a trailing pass completes
+	// (test synchronization; production leaves it nil).
+	trailingDone func(model string)
+}
+
+func (s *queueDrainSuppressor) clock() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// markSaturated records that a drain pass for model just ended saturated.
+func (s *queueDrainSuppressor) markSaturated(model string) {
+	now := s.clock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.saturated == nil {
+		s.saturated = make(map[string]time.Time)
+	}
+	s.saturated[model] = now
+}
+
+// clear forgets the saturation mark for model (a pass admitted a request).
+func (s *queueDrainSuppressor) clear(model string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.saturated, model)
+}
+
+// suppressed reports whether model's last drain pass ended saturated less than
+// heartbeatDrainSuppressWindow ago.
+func (s *queueDrainSuppressor) suppressed(model string) bool {
+	return s.suppressedAt(model, s.clock())
+}
+
+func (s *queueDrainSuppressor) suppressedAt(model string, now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	last, ok := s.saturated[model]
+	return ok && now.Sub(last) < heartbeatDrainSuppressWindow
+}
+
+// unsuppressed returns the subset of models a heartbeat-triggered drain should
+// still visit. It returns models itself when nothing is suppressed.
+func (s *queueDrainSuppressor) unsuppressed(models []string) []string {
+	now := s.clock()
+	var kept []string
+	for i, model := range models {
+		if !s.suppressedAt(model, now) {
+			if kept != nil {
+				kept = append(kept, model)
+			}
+			continue
+		}
+		if kept == nil {
+			kept = append(make([]string, 0, len(models)-1), models[:i]...)
+		}
+	}
+	if kept == nil {
+		return models
+	}
+	return kept
+}
+
+// drainQueuedRequestsForHeartbeat is the heartbeat-triggered drain: identical
+// to drainQueuedRequestsForModelsWithReason(models, DrainTriggerHeartbeat)
+// except that models whose queue was found saturated within
+// heartbeatDrainSuppressWindow are skipped. Capacity-freeing triggers must
+// keep calling drainQueuedRequestsForModelsWithReason directly.
+func (r *Registry) drainQueuedRequestsForHeartbeat(models []string) {
+	if len(models) == 0 {
+		return
+	}
+	kept := r.drainSuppress.unsuppressed(models)
+	if len(kept) != len(models) {
+		r.armTrailingDrains(models, kept)
+	}
+	r.drainQueuedRequestsForModelsWithReason(kept, DrainTriggerHeartbeat)
+}
+
+// armTrailingDrains schedules one end-of-window drain for every model the
+// heartbeat was suppressed on (those in models but not in kept) that does not
+// already have one armed. The trailing pass goes through
+// drainQueuedRequestsForModelsWithReason directly (never suppressed), still
+// attributed to the heartbeat trigger that armed it, and clears its own mark
+// first, so a heartbeat arriving after it runs can arm the next one.
+func (r *Registry) armTrailingDrains(models, kept []string) {
+	keptSet := make(map[string]struct{}, len(kept))
+	for _, m := range kept {
+		keptSet[m] = struct{}{}
+	}
+	s := &r.drainSuppress
+	s.mu.Lock()
+	if s.trailing == nil {
+		s.trailing = make(map[string]bool)
+	}
+	var arm []string
+	for _, m := range models {
+		if _, ok := keptSet[m]; ok || s.trailing[m] {
+			continue
+		}
+		s.trailing[m] = true
+		arm = append(arm, m)
+	}
+	s.mu.Unlock()
+	schedule := s.afterFunc
+	if schedule == nil {
+		schedule = func(d time.Duration, f func()) { time.AfterFunc(d, f) }
+	}
+	for _, model := range arm {
+		model := model
+		schedule(heartbeatDrainSuppressWindow, func() {
+			s.mu.Lock()
+			delete(s.trailing, model)
+			s.mu.Unlock()
+			r.drainQueuedRequestsForModelsWithReason([]string{model}, DrainTriggerHeartbeat)
+			if s.trailingDone != nil {
+				s.trailingDone(model)
+			}
+		})
+	}
+}

--- a/coordinator/registry/queue_drain_test.go
+++ b/coordinator/registry/queue_drain_test.go
@@ -1,0 +1,551 @@
+package registry
+
+// Regression tests for the queue-drain fleet-scan amplifier fix:
+//
+//   - per-pass dominance skip (queue_drain_dominance.go): a saturated pass pays
+//     one fleet scan per distinct rejected request shape, not one per waiter,
+//     while strictly smaller or differently constrained waiters are still
+//     scanned (and admitted) in the same pass;
+//   - heartbeat drain suppression (queue_drain_suppress.go): a heartbeat within
+//     heartbeatDrainSuppressWindow of a saturated pass skips the model; every
+//     capacity-freeing trigger drains synchronously as before;
+//   - drain-pass coalescing (queue_drain_coalesce.go): a trigger that lands
+//     while a pass holds popped waiters makes that pass rerun with fresh fleet
+//     state instead of scanning an empty queue.
+//
+// Every test drives a real Registry with real providers and a real queue and
+// counts full fleet scans through the reservationAfterScan hook, which fires
+// exactly once per scanProviderReservation.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const drainTestModel = "drain-test-model"
+
+// drainTestProvider registers a routable budget-reporting provider for
+// drainTestModel; used == max saturates it.
+func drainTestProvider(t *testing.T, reg *Registry, id string, used, max int64) *Provider {
+	t.Helper()
+	return makeTokenBudgetProvider(t, reg, id, drainTestModel, 100, used, max, 50)
+}
+
+func drainTestSetBudget(p *Provider, used, max int64) {
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetUsed = used
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = max
+	p.mu.Unlock()
+}
+
+// drainTestHeartbeat reports the given budget explicitly so the heartbeat
+// itself never changes the provider's admission state.
+func drainTestHeartbeat(used, max int64) *protocol.HeartbeatMessage {
+	return &protocol.HeartbeatMessage{
+		Type:       protocol.TypeHeartbeat,
+		Status:     "serving",
+		WarmModels: []string{drainTestModel},
+		BackendCapacity: &protocol.BackendCapacity{
+			TotalMemoryGB: 64,
+			Slots: []protocol.BackendSlotCapacity{{
+				Model:                 drainTestModel,
+				State:                 "running",
+				NumRunning:            1,
+				ActiveTokenBudgetUsed: used,
+				ActiveTokenBudgetMax:  max,
+				ObservedDecodeTPS:     50,
+			}},
+		},
+		SystemMetrics: protocol.SystemMetrics{MemoryPressure: 0.1, CPUUsage: 0.1, ThermalState: "nominal"},
+	}
+}
+
+func drainTestPending(id string, prompt, maxTok int) *PendingRequest {
+	return &PendingRequest{
+		RequestID:             id,
+		Model:                 drainTestModel,
+		EstimatedPromptTokens: prompt,
+		RequestedMaxTokens:    maxTok,
+	}
+}
+
+func drainTestEnqueue(t *testing.T, reg *Registry, pr *PendingRequest) *QueuedRequest {
+	t.Helper()
+	req := &QueuedRequest{RequestID: pr.RequestID, Model: pr.Model, Pending: pr}
+	if err := reg.Queue().Enqueue(req); err != nil {
+		t.Fatalf("enqueue %s: %v", pr.RequestID, err)
+	}
+	return req
+}
+
+// drainScanCounter counts full fleet scans via the test-only
+// reservationAfterScan barrier.
+func drainScanCounter(reg *Registry) *atomic.Int64 {
+	n := new(atomic.Int64)
+	reg.reservationAfterScan = func(string) { n.Add(1) }
+	return n
+}
+
+func drainTestQueueOrder(reg *Registry) []string {
+	q := reg.Queue()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	ids := make([]string, 0, len(q.queues[drainTestModel]))
+	for _, req := range q.queues[drainTestModel] {
+		ids = append(ids, req.RequestID)
+	}
+	return ids
+}
+
+func drainTestAwait(t *testing.T, reg *Registry, req *QueuedRequest) *Provider {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	p, err := reg.Queue().WaitForProviderContext(ctx, req)
+	if err != nil {
+		t.Fatalf("waiter %s: %v, want assignment", req.RequestID, err)
+	}
+	return p
+}
+
+func drainTestAssertQueued(t *testing.T, req *QueuedRequest) {
+	t.Helper()
+	select {
+	case p := <-req.ResponseCh:
+		t.Fatalf("waiter %s resolved early (provider=%v), want it kept queued", req.RequestID, p)
+	default:
+	}
+	if req.FailureReason != nil {
+		t.Fatalf("waiter %s FailureReason = %v, want nil", req.RequestID, req.FailureReason)
+	}
+}
+
+func drainTestExpectScans(t *testing.T, scans *atomic.Int64, want int64, event string) {
+	t.Helper()
+	if got := scans.Swap(0); got != want {
+		t.Fatalf("%s performed %d fleet scans, want %d", event, got, want)
+	}
+}
+
+// TestDrainSaturatedQueueScansOncePerEvent is the core regression: with a
+// saturated fleet and a full 32-deep queue of identical waiters, one heartbeat
+// (and one SetProviderIdle) performs exactly ONE fleet scan instead of 32, and
+// the queue is left intact and in order. Fails without the dominance skip.
+func TestDrainSaturatedQueueScansOncePerEvent(t *testing.T) {
+	reg := New(testLogger())
+	for i := 0; i < 3; i++ {
+		drainTestProvider(t, reg, fmt.Sprintf("sat-%d", i), 1000, 1000)
+	}
+	reg.SetQueue(NewRequestQueue(64, 30*time.Second))
+	const depth = 32
+	for i := 0; i < depth; i++ {
+		drainTestEnqueue(t, reg, drainTestPending(fmt.Sprintf("q-%02d", i), 800, 1024))
+	}
+	scans := drainScanCounter(reg)
+
+	reg.Heartbeat("sat-0", drainTestHeartbeat(1000, 1000))
+	drainTestExpectScans(t, scans, 1, "heartbeat on a saturated fleet")
+	order := drainTestQueueOrder(reg)
+	if len(order) != depth {
+		t.Fatalf("queue depth = %d after heartbeat, want %d", len(order), depth)
+	}
+	for i, id := range order {
+		if want := fmt.Sprintf("q-%02d", i); id != want {
+			t.Fatalf("queue[%d] = %s, want %s (order must survive the requeue)", i, id, want)
+		}
+	}
+
+	// SetProviderIdle is never suppressed, and still pays exactly one scan.
+	reg.SetProviderIdle("sat-1")
+	drainTestExpectScans(t, scans, 1, "SetProviderIdle on a saturated fleet")
+	if depth := reg.Queue().QueueSize(drainTestModel); depth != 32 {
+		t.Fatalf("queue depth = %d after SetProviderIdle, want 32", depth)
+	}
+}
+
+// TestDrainAdmitsWhenCapacityFreesAndSmallerWaiterIsNotBlocked pins the two
+// behaviors the skip must not regress: a waiter IS assigned when capacity frees
+// (SetProviderIdle after a budget release), and a strictly smaller waiter behind
+// a larger rejected one is still scanned and admitted — in the same pass — the
+// moment capacity for it appears, even while the larger one stays queued.
+func TestDrainAdmitsWhenCapacityFreesAndSmallerWaiterIsNotBlocked(t *testing.T) {
+	reg := New(testLogger())
+	p := drainTestProvider(t, reg, "box", 990, 1000) // 10 tokens free
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+	big := drainTestEnqueue(t, reg, drainTestPending("big", 800, 1024))
+	small := drainTestEnqueue(t, reg, drainTestPending("small", 10, 16))
+	scans := drainScanCounter(reg)
+
+	// Neither fits in 10 free tokens. small is strictly smaller than big, so
+	// it is scanned rather than skipped on big's verdict.
+	reg.SetProviderIdle(p.ID)
+	drainTestExpectScans(t, scans, 2, "SetProviderIdle with both waiters over capacity")
+	drainTestAssertQueued(t, big)
+	drainTestAssertQueued(t, small)
+	if order := drainTestQueueOrder(reg); len(order) != 2 || order[0] != "big" || order[1] != "small" {
+		t.Fatalf("queue order = %v, want [big small]", order)
+	}
+
+	// 100 tokens free: enough for small (26), not for big (1824).
+	drainTestSetBudget(p, 900, 1000)
+	reg.SetProviderIdle(p.ID)
+	if got := drainTestAwait(t, reg, small); got.ID != p.ID {
+		t.Fatalf("small assigned to %q, want %q", got.ID, p.ID)
+	}
+	drainTestAssertQueued(t, big)
+	// big scanned+rejected, small scanned+admitted; big is re-popped after the
+	// requeue and skipped on its own record: exactly two scans.
+	drainTestExpectScans(t, scans, 2, "SetProviderIdle with capacity for the small waiter")
+	if order := drainTestQueueOrder(reg); len(order) != 1 || order[0] != "big" {
+		t.Fatalf("queue order = %v, want [big]", order)
+	}
+
+	// Full release: big is admitted too.
+	drainTestSetBudget(p, 0, 32_768)
+	reg.SetProviderIdle(p.ID)
+	if got := drainTestAwait(t, reg, big); got.ID != p.ID {
+		t.Fatalf("big assigned to %q, want %q", got.ID, p.ID)
+	}
+	if depth := reg.Queue().QueueSize(drainTestModel); depth != 0 {
+		t.Fatalf("queue depth = %d after full release, want 0", depth)
+	}
+}
+
+// TestDrainOwnerScopedHeadDoesNotBlockPublicWaiters is the fence against a
+// plain "break on first rejection": a self-route waiter rejected on its owner's
+// saturated box says nothing about public capacity, so the plain waiter behind
+// it must still be scanned and assigned to the public provider.
+func TestDrainOwnerScopedHeadDoesNotBlockPublicWaiters(t *testing.T) {
+	reg := New(testLogger())
+	owned := drainTestProvider(t, reg, "owned", 1000, 1000)
+	owned.mu.Lock()
+	owned.AccountID = "acct-1"
+	owned.mu.Unlock()
+	public := drainTestProvider(t, reg, "public", 0, 32_768)
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+
+	selfPR := drainTestPending("self", 800, 1024)
+	selfPR.SelfRouteOnly = true
+	selfPR.OwnerAccountID = "acct-1"
+	self := drainTestEnqueue(t, reg, selfPR)
+	plain := drainTestEnqueue(t, reg, drainTestPending("plain", 800, 1024))
+	scans := drainScanCounter(reg)
+
+	reg.SetProviderIdle(public.ID)
+	if got := drainTestAwait(t, reg, plain); got.ID != public.ID {
+		t.Fatalf("plain waiter assigned to %q, want the public provider %q", got.ID, public.ID)
+	}
+	drainTestAssertQueued(t, self)
+	// self (rejected, not a dominance anchor), plain (admitted), and self again
+	// after the requeue: owner-scoped waiters are always scanned.
+	if got := scans.Load(); got < 2 || got > 3 {
+		t.Fatalf("pass performed %d fleet scans, want 2..3 (plain waiter must be scanned)", got)
+	}
+	if order := drainTestQueueOrder(reg); len(order) != 1 || order[0] != "self" {
+		t.Fatalf("queue order = %v, want [self]", order)
+	}
+}
+
+// drainTestClock installs a controllable clock on the suppressor so the window
+// can be crossed without sleeping, and disables the trailing-pass scheduler:
+// its goroutine would otherwise read the fake clock while the test advances
+// it. Tests that exercise the trailing pass re-enable it explicitly.
+type drainTestClockHandle struct{ v atomic.Pointer[time.Time] }
+
+func (c *drainTestClockHandle) Add(d time.Duration) {
+	t := c.v.Load().Add(d)
+	c.v.Store(&t)
+}
+
+func drainTestClock(reg *Registry) *drainTestClockHandle {
+	h := &drainTestClockHandle{}
+	now := time.Now()
+	h.v.Store(&now)
+	reg.drainSuppress.now = func() time.Time { return *h.v.Load() }
+	reg.drainSuppress.afterFunc = func(time.Duration, func()) {}
+	return h
+}
+
+// TestHeartbeatDrainSuppressedAfterSaturatedPass pins the heartbeat window:
+// after a saturated pass a heartbeat 1 ms later performs zero scans, every
+// capacity-freeing trigger in between still drains, and once the window has
+// elapsed the heartbeat drains again.
+func TestHeartbeatDrainSuppressedAfterSaturatedPass(t *testing.T) {
+	reg := New(testLogger())
+	p := drainTestProvider(t, reg, "box", 1000, 1000)
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+	for i := 0; i < 4; i++ {
+		drainTestEnqueue(t, reg, drainTestPending(fmt.Sprintf("q-%d", i), 800, 1024))
+	}
+	scans := drainScanCounter(reg)
+	clock := drainTestClock(reg)
+	heartbeat := func() { reg.Heartbeat(p.ID, drainTestHeartbeat(1000, 1000)) }
+
+	heartbeat()
+	drainTestExpectScans(t, scans, 1, "first heartbeat")
+	clock.Add(time.Millisecond)
+	heartbeat()
+	drainTestExpectScans(t, scans, 0, "second heartbeat 1 ms later")
+
+	reg.SetProviderIdle(p.ID)
+	drainTestExpectScans(t, scans, 1, "SetProviderIdle inside the window")
+	heartbeat()
+	drainTestExpectScans(t, scans, 0, "heartbeat right after SetProviderIdle")
+
+	reg.RecordChallengeSuccess(p.ID)
+	drainTestExpectScans(t, scans, 1, "RecordChallengeSuccess inside the window")
+	reg.DrainQueuedRequestsForModel(drainTestModel)
+	drainTestExpectScans(t, scans, 1, "explicit DrainQueuedRequestsForModel inside the window")
+
+	clock.Add(heartbeatDrainSuppressWindow)
+	heartbeat()
+	drainTestExpectScans(t, scans, 1, "heartbeat after the window elapsed")
+	if depth := reg.Queue().QueueSize(drainTestModel); depth != 4 {
+		t.Fatalf("queue depth = %d, want 4 (fleet stayed saturated)", depth)
+	}
+}
+
+// TestDrainAdmissionClearsHeartbeatSuppression: a pass that admits a request
+// lifts the saturation mark, so the next heartbeat drains immediately instead
+// of waiting out the window on a stale verdict.
+func TestDrainAdmissionClearsHeartbeatSuppression(t *testing.T) {
+	reg := New(testLogger())
+	p := drainTestProvider(t, reg, "box", 1000, 1000)
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+	first := drainTestEnqueue(t, reg, drainTestPending("first", 800, 1024))
+	scans := drainScanCounter(reg)
+	drainTestClock(reg)
+
+	reg.Heartbeat(p.ID, drainTestHeartbeat(1000, 1000))
+	drainTestExpectScans(t, scans, 1, "saturated heartbeat")
+	if !reg.drainSuppress.suppressed(drainTestModel) {
+		t.Fatal("model not marked saturated after a pure capacity rejection")
+	}
+
+	drainTestSetBudget(p, 0, 32_768)
+	reg.SetProviderIdle(p.ID)
+	if got := drainTestAwait(t, reg, first); got.ID != p.ID {
+		t.Fatalf("first assigned to %q, want %q", got.ID, p.ID)
+	}
+	if reg.drainSuppress.suppressed(drainTestModel) {
+		t.Fatal("saturation mark survived an admitting pass")
+	}
+
+	// Re-saturate and queue a new waiter: the very next heartbeat must scan.
+	drainTestSetBudget(p, 1000, 1000)
+	second := drainTestEnqueue(t, reg, drainTestPending("second", 800, 1024))
+	scans.Store(0)
+	reg.Heartbeat(p.ID, drainTestHeartbeat(1000, 1000))
+	drainTestExpectScans(t, scans, 1, "heartbeat after the mark was cleared")
+	drainTestAssertQueued(t, second)
+}
+
+// TestDrainDominated pins the dominance predicate: only a plain request that
+// is no smaller on both size axes, with the same structural key and (when the
+// anchor saw TTFT rejections) a ceiling no looser, is skipped.
+func TestDrainDominated(t *testing.T) {
+	anchorPR := drainTestPending("anchor", 800, 1024)
+	anchorPR.MaxTTFTMs = 5000
+	capacityOnly := RoutingDecision{CapacityRejections: 3}
+	mixed := RoutingDecision{CapacityRejections: 2, TTFTRejections: 1}
+	capRec, ok := drainRejectionRecordFor(anchorPR, capacityOnly)
+	if !ok {
+		t.Fatal("plain pure-capacity rejection must anchor dominance")
+	}
+	mixedRec, ok := drainRejectionRecordFor(anchorPR, mixed)
+	if !ok {
+		t.Fatal("plain mixed capacity/TTFT rejection must anchor dominance")
+	}
+	if _, ok := drainRejectionRecordFor(anchorPR, RoutingDecision{CandidateCount: 1}); ok {
+		t.Fatal("commit-race verdict (CandidateCount > 0) must not anchor dominance")
+	}
+	if _, ok := drainRejectionRecordFor(anchorPR, RoutingDecision{VisionRejections: 2}); ok {
+		t.Fatal("structural-only rejection must not anchor dominance")
+	}
+	selfPR := drainTestPending("self", 800, 1024)
+	selfPR.SelfRouteOnly = true
+	if _, ok := drainRejectionRecordFor(selfPR, capacityOnly); ok {
+		t.Fatal("owner-scoped rejection must not anchor dominance")
+	}
+
+	cases := []struct {
+		name string
+		mut  func(pr *PendingRequest)
+		rec  drainRejectionRecord
+		want bool
+	}{
+		{"same size", func(*PendingRequest) {}, capRec, true},
+		{"larger prompt and max", func(pr *PendingRequest) { pr.EstimatedPromptTokens = 900; pr.RequestedMaxTokens = 2048 }, capRec, true},
+		{"smaller prompt", func(pr *PendingRequest) { pr.EstimatedPromptTokens = 799 }, capRec, false},
+		{"smaller max", func(pr *PendingRequest) { pr.RequestedMaxTokens = 1023 }, capRec, false},
+		{"default max normalizes", func(pr *PendingRequest) { pr.RequestedMaxTokens = 0 }, capRec, false},
+		{"vision differs", func(pr *PendingRequest) { pr.RequiresVision = true }, capRec, false},
+		{"traits differ", func(pr *PendingRequest) { pr.Traits.HasTools = true }, capRec, false},
+		{"self-route", func(pr *PendingRequest) { pr.SelfRouteOnly = true }, capRec, false},
+		{"prefer-owner", func(pr *PendingRequest) { pr.PreferOwner = true }, capRec, false},
+		{"serial-pinned", func(pr *PendingRequest) { pr.AllowedProviderSerials = []string{"S1"} }, capRec, false},
+		{"excluded providers", func(pr *PendingRequest) { pr.ExcludedProviderIDs = []string{"p1"} }, capRec, false},
+		{"cache plan", func(pr *PendingRequest) {
+			pr.CachePlan = CachePlan{
+				ModelAggregateHash: "agg", PromptContractID: "contract", CacheScope: "scope",
+				PromptTokenCount: 800, Boundaries: []protocol.PrefixCacheAnchor{{}},
+			}
+		}, capRec, false},
+		{"capacity-only anchor ignores looser ceiling", func(pr *PendingRequest) { pr.MaxTTFTMs = 0 }, capRec, true},
+		{"mixed anchor, same ceiling", func(*PendingRequest) {}, mixedRec, true},
+		{"mixed anchor, tighter ceiling", func(pr *PendingRequest) { pr.MaxTTFTMs = 4000 }, mixedRec, true},
+		{"mixed anchor, looser ceiling", func(pr *PendingRequest) { pr.MaxTTFTMs = 6000 }, mixedRec, false},
+		{"mixed anchor, no ceiling", func(pr *PendingRequest) { pr.MaxTTFTMs = 0 }, mixedRec, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := drainTestPending("q", 800, 1024)
+			pr.MaxTTFTMs = 5000
+			tc.mut(pr)
+			if got := drainDominated(pr, []drainRejectionRecord{tc.rec}); got != tc.want {
+				t.Fatalf("drainDominated = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if drainDominated(drainTestPending("q", 800, 1024), nil) {
+		t.Fatal("no anchors must never dominate")
+	}
+}
+
+// TestQueueDrainSuppressorUnsuppressed pins the heartbeat model filter: the
+// input slice is returned untouched when nothing is suppressed, suppressed
+// models are dropped in order, and the window expires.
+func TestQueueDrainSuppressorUnsuppressed(t *testing.T) {
+	var s queueDrainSuppressor
+	start := time.Now()
+	now := start
+	s.now = func() time.Time { return now }
+	models := []string{"a", "b", "c"}
+	if got := s.unsuppressed(models); len(got) != 3 || &got[0] != &models[0] {
+		t.Fatalf("unsuppressed with no marks = %v, want the input slice", got)
+	}
+	s.markSaturated("b")
+	now = start.Add(time.Millisecond)
+	if got := s.unsuppressed(models); len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Fatalf("unsuppressed = %v, want [a c]", got)
+	}
+	now = start
+	s.markSaturated("a")
+	s.markSaturated("c")
+	now = start.Add(time.Millisecond)
+	if got := s.unsuppressed(models); len(got) != 0 {
+		t.Fatalf("unsuppressed with every model marked = %v, want empty", got)
+	}
+	now = start.Add(heartbeatDrainSuppressWindow)
+	if got := s.unsuppressed(models); len(got) != 3 {
+		t.Fatalf("unsuppressed after the window = %v, want all models", got)
+	}
+	now = start.Add(time.Millisecond)
+	s.clear("b")
+	if got := s.unsuppressed(models); len(got) != 1 || got[0] != "b" {
+		t.Fatalf("unsuppressed after clear(b) = %v, want [b]", got)
+	}
+}
+
+// TestHeartbeatDrainSuppressionArmsTrailingPass: a suppressed heartbeat is not
+// dropped — it arms ONE end-of-window pass, so capacity that only a heartbeat
+// could reveal is drained at most heartbeatDrainSuppressWindow late instead of
+// waiting for the next un-suppressed trigger (the next heartbeat, 5 s away).
+// Several suppressed heartbeats inside one window share a single trailing pass.
+func TestHeartbeatDrainSuppressionArmsTrailingPass(t *testing.T) {
+	reg := New(testLogger())
+	p := drainTestProvider(t, reg, "box", 1000, 1000)
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+	for i := 0; i < 4; i++ {
+		drainTestEnqueue(t, reg, drainTestPending(fmt.Sprintf("q-%d", i), 800, 1024))
+	}
+	scans := drainScanCounter(reg)
+	clock := drainTestClock(reg)
+	// Real scheduler for this test; completion is observed through the seam
+	// so the fake clock is never advanced while a trailing pass is running.
+	reg.drainSuppress.afterFunc = nil
+	done := make(chan string, 4)
+	reg.drainSuppress.trailingDone = func(model string) { done <- model }
+	heartbeat := func() { reg.Heartbeat(p.ID, drainTestHeartbeat(1000, 1000)) }
+	waitTrailing := func(what string) {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: trailing pass never ran", what)
+		}
+	}
+
+	heartbeat()
+	drainTestExpectScans(t, scans, 1, "first heartbeat")
+	clock.Add(time.Millisecond)
+	heartbeat()
+	heartbeat()
+	heartbeat()
+	drainTestExpectScans(t, scans, 0, "three heartbeats inside the window")
+	waitTrailing("first window")
+	drainTestExpectScans(t, scans, 1, "trailing pass after the first window")
+
+	// The trailing pass ended saturated again and the arm was consumed, so a
+	// later suppressed heartbeat arms a fresh one.
+	clock.Add(time.Millisecond)
+	heartbeat()
+	drainTestExpectScans(t, scans, 0, "heartbeat inside the second window")
+	waitTrailing("second window")
+	drainTestExpectScans(t, scans, 1, "trailing pass after the second window")
+}
+
+// TestDrainTriggerMidPassRerunsHeldWaiters pins the coalescing fence
+// (queue_drain_coalesce.go). Pass A (SetProviderIdle) pops first — scanned and
+// rejected on a saturated box — and second, skipped on first's verdict. Before
+// A's next pop a heartbeat exposes the whole budget and runs its own drain,
+// which finds the queue empty: both waiters are held by A. Without coalescing
+// A requeues both on the stale verdict and nothing rescans them until the
+// next trigger for the model; with it, the heartbeat's drain asks A to go
+// around once more, and both waiters are assigned before SetProviderIdle
+// returns — with the trailing-pass scheduler disabled, so a trailing drain
+// cannot be what rescued them.
+func TestDrainTriggerMidPassRerunsHeldWaiters(t *testing.T) {
+	reg := New(testLogger())
+	p := drainTestProvider(t, reg, "box", 1000, 1000)
+	reg.SetQueue(NewRequestQueue(8, 30*time.Second))
+	first := drainTestEnqueue(t, reg, drainTestPending("first", 800, 1024))
+	second := drainTestEnqueue(t, reg, drainTestPending("second", 800, 1024))
+	scans := drainScanCounter(reg)
+	drainTestClock(reg)
+
+	pops := 0
+	reg.drainBeforePop = func(model string) {
+		pops++
+		if pops == 3 {
+			reg.Heartbeat(p.ID, drainTestHeartbeat(0, 32_768))
+		}
+	}
+	reg.SetProviderIdle(p.ID)
+	reg.drainBeforePop = nil
+
+	if got := drainTestAwait(t, reg, first); got.ID != p.ID {
+		t.Fatalf("first assigned to %q, want %q", got.ID, p.ID)
+	}
+	if got := drainTestAwait(t, reg, second); got.ID != p.ID {
+		t.Fatalf("second assigned to %q, want %q", got.ID, p.ID)
+	}
+	// first scanned+rejected by A, nothing by the heartbeat's drain (the queue
+	// was empty), both scanned+admitted by the rerun.
+	drainTestExpectScans(t, scans, 3, "SetProviderIdle with a mid-pass heartbeat")
+	// The rerun is attributed to the trigger that asked for it.
+	if first.DrainTrigger != DrainTriggerHeartbeat || second.DrainTrigger != DrainTriggerHeartbeat {
+		t.Fatalf("DrainTrigger = (%q, %q), want both %q (the rerun ran for the heartbeat)",
+			first.DrainTrigger, second.DrainTrigger, DrainTriggerHeartbeat)
+	}
+	if depth := reg.Queue().QueueSize(drainTestModel); depth != 0 {
+		t.Fatalf("queue depth = %d, want 0", depth)
+	}
+	if reg.drainSuppress.suppressed(drainTestModel) {
+		t.Fatal("an admitting rerun left the saturation mark in place")
+	}
+}

--- a/coordinator/registry/race_disabled_test.go
+++ b/coordinator/registry/race_disabled_test.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package registry
+
+// raceDetectorEnabled is false when the test binary was built without -race.
+const raceDetectorEnabled = false

--- a/coordinator/registry/race_enabled_test.go
+++ b/coordinator/registry/race_enabled_test.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package registry
+
+// raceDetectorEnabled is true when the test binary was built with -race. The
+// detector serializes goroutines heavily enough that throughput assertions
+// (parallel speed-up guards) are meaningless under it.
+const raceDetectorEnabled = true

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -853,7 +853,12 @@ type Provider struct {
 	// distinguish "never enrolled" from "enrolled but unresponsive".
 	MDMFailureReason string
 
-	Status           ProviderStatus
+	Status ProviderStatus
+	// drainingUntil is non-zero while the provider has declared itself
+	// draining (heartbeat status "draining" or a typed draining rejection);
+	// routing skips it until its next idle/serving heartbeat or the TTL
+	// (drain_state.go). Guarded by p.mu.
+	drainingUntil    time.Time
 	Conn             *websocket.Conn
 	writer           *providerWriter
 	LastHeartbeat    time.Time
@@ -2121,6 +2126,13 @@ type Registry struct {
 	providers map[string]*Provider
 
 	queue *RequestQueue
+	// drainSuppress rate-limits HEARTBEAT-triggered queue drains per model
+	// after a saturated pass (queue_drain_suppress.go). Zero value ready.
+	drainSuppress queueDrainSuppressor
+	// drainPasses runs one queue-drain pass per model at a time and reruns it
+	// for triggers that landed mid-pass (queue_drain_coalesce.go). Zero value
+	// ready.
+	drainPasses queueDrainCoalescer
 
 	MinTrustLevel TrustLevel
 
@@ -2206,6 +2218,10 @@ type Registry struct {
 	// shared reading after winner selection and before the serialized commit.
 	// Production leaves it nil; tests set it before starting concurrent scans.
 	reservationAfterScan func(model string)
+	// drainBeforePop is a test-only barrier invoked with no locks held before
+	// every pop of a queue-drain pass, so a test can interleave a trigger at a
+	// chosen point of the pass. Production leaves it nil.
+	drainBeforePop func(model string)
 
 	// modelIndex maps advertised model id → providers advertising it, so the
 	// per-request fleet walks visit only providers that can pass the first
@@ -2350,7 +2366,10 @@ type Registry struct {
 	// keyed by its (now-removed) session id, so the pending-request ErrorCh flush —
 	// which runs AFTER Disconnect deletes the provider and carries the 502 "provider
 	// disconnected" faults that define a reconnecting zombie — can still resolve the
-	// identity and record those faults against the stable-identity breaker.
+	// identity and record those faults against the stable-identity breaker. The
+	// entry also dates the drop: a flush strike from a session dropped at or
+	// before the identity's last version-changed reset is discarded as already
+	// accounted for (version_reset.go, IsSupersededDisconnectFlush).
 	disconnectedStableIDs map[string]disconnectedStableID
 	// faultKeyBySession maps a LIVE session id to its stable identity
 	// (serial/SE-key/account). Bound by SetAttestationResult, removed on
@@ -2362,6 +2381,18 @@ type Registry struct {
 	// wiping it (the prod zombie exploit: median 18 sessions/machine/week
 	// reset every session-keyed breaker before it could trip).
 	faultKeyBySession map[string]string
+	// identityVersions / inferenceErrorFlushStrikes back the version-changed
+	// reconnect reset (version_reset.go): the last binary version seen per
+	// stable identity, the time of its last reset (rate limit), and the subset
+	// of inferenceErrorStrikes that came from the disconnect flush (502) so
+	// exactly those can be removed when the identity returns on a new binary.
+	// Lazily created; guarded by r.mu; migrated on rebind; NOT cleared on
+	// Disconnect.
+	identityVersions           map[string]string
+	identityVersionResetAt     map[string]time.Time
+	identityVersionSeenAt      map[string]time.Time
+	identityVersionSweepAt     time.Time
+	inferenceErrorFlushStrikes map[inferenceErrorKey][]time.Time
 
 	// evictStrikes counts consecutive eviction sweeps a provider has been stale.
 	// A provider is only evicted after STALE on two sweeps in a row, so a single
@@ -4131,6 +4162,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	// loaded. Clear stale state so challenge checks never compare against a
 	// provider-injected identifier.
 	p.CurrentModel = currentModel
+	// Drain awareness (drain_state.go): "draining" arms the routing skip,
+	// "idle"/"serving" clear it. Independent of p.Status below — a draining
+	// provider keeps its online/serving accounting; only routing changes.
+	applyHeartbeatDrainStateLocked(p, msg.Status, now)
 	// Only update status from heartbeat if provider is not actively serving
 	// (serving status is managed by request lifecycle). Crucially, an
 	// untrusted provider must NOT transition back to StatusOnline here —
@@ -4167,8 +4202,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 
 	// Heartbeats can make a recovered slot routable again (for example after a
 	// crash auto-restart). Drain matching queues using the canonical scheduler
-	// rather than the legacy direct queue assignment path.
-	r.drainQueuedRequestsForModelsWithReason(providerModelIDs(p), DrainTriggerHeartbeat)
+	// rather than the legacy direct queue assignment path. Heartbeats are the
+	// one trigger that is rate-limited after a saturated pass
+	// (queue_drain_suppress.go); every capacity-freeing trigger drains at once.
+	r.drainQueuedRequestsForHeartbeat(providerModelIDs(p))
 
 	// If queue drain didn't satisfy all pending requests (no warm provider),
 	// check if a cold provider should swap models to serve queued demand —
@@ -5015,16 +5052,28 @@ func mergeHeartbeatSessionStats(previous, current protocol.HeartbeatStats) proto
 	return merged
 }
 
-// Disconnect removes a provider from the registry and cleans up pending requests.
+// Disconnect removes a provider from the registry and cleans up pending
+// requests. This is the ABRUPT path: the flushed terminals carry
+// CoordinatorCauseProviderDisconnected and strike the provider's stable
+// identity. The provider read loop, which knows how the socket ended, calls
+// DisconnectWithReason (disconnect_reason.go) so a graceful peer close flushes
+// with the health-neutral restart cause instead.
 func (r *Registry) Disconnect(id string) {
-	r.disconnectProvider(id, nil, 0)
+	r.disconnectWithCause(id, protocol.CoordinatorCauseProviderDisconnected)
+}
+
+// disconnectWithCause preserves the read loop's graceful/abrupt classification
+// for unconditional disconnects. Eviction adds an identity/freshness guard.
+func (r *Registry) disconnectWithCause(id string, cause protocol.CoordinatorInferenceErrorCause) {
+	r.disconnectProvider(id, nil, 0, cause)
 }
 
 // disconnectProvider applies an optional eviction guard atomically with removal.
 // expected is the exact session observed by the stale scan; nil is an ordinary
 // unconditional disconnect. Both its identity and latest heartbeat are checked
-// while r.mu and p.mu exclude replacement and heartbeat updates.
-func (r *Registry) disconnectProvider(id string, expected *Provider, timeout time.Duration) bool {
+// while r.mu and p.mu exclude replacement and heartbeat updates. The supplied
+// cause is stamped on every flushed pending-request terminal.
+func (r *Registry) disconnectProvider(id string, expected *Provider, timeout time.Duration, cause protocol.CoordinatorInferenceErrorCause) bool {
 	var disconnectedModels []string
 	r.mu.Lock()
 	p, ok := r.providers[id]
@@ -5075,6 +5124,11 @@ func (r *Registry) disconnectProvider(id string, expected *Provider, timeout tim
 			for key := range r.inferenceErrorCooldowns {
 				if key.ProviderID == id {
 					delete(r.inferenceErrorCooldowns, key)
+				}
+			}
+			for key := range r.inferenceErrorFlushStrikes {
+				if key.ProviderID == id {
+					delete(r.inferenceErrorFlushStrikes, key)
 				}
 			}
 			for key := range r.dispatchLoadCooldowns {
@@ -5135,7 +5189,8 @@ func (r *Registry) disconnectProvider(id string, expected *Provider, timeout tim
 					RequestID:        reqID,
 					Error:            "provider disconnected",
 					StatusCode:       502,
-					CoordinatorCause: protocol.CoordinatorCauseProviderDisconnected,
+					ErrorReason:      disconnectFlushErrorReason(cause),
+					CoordinatorCause: cause,
 				}
 			}()
 			func() {
@@ -6460,6 +6515,7 @@ func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration)
 				return
 			case <-ticker.C:
 				r.evictStale(timeout)
+				r.sweepIdentityVersionHistory(time.Now())
 			}
 		}
 	})
@@ -6539,7 +6595,7 @@ func (r *Registry) evictStale(timeout time.Duration) {
 	for _, p := range toEvict {
 		// A heartbeat may recover this session after the read scan, or the
 		// same id may name a replacement. Revalidate inside the removal lock.
-		if r.disconnectProvider(p.ID, p, timeout) {
+		if r.disconnectProvider(p.ID, p, timeout, protocol.CoordinatorCauseProviderDisconnected) {
 			r.logger.Warn("evicted stale provider", "provider_id", p.ID, "timeout", timeout)
 		}
 	}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -1042,9 +1042,17 @@ type Provider struct {
 
 	// registry back-pointer, set once in Register (nil for bare test Providers).
 	// SetAttestationResult uses it to bind this session's id to its stable
-	// identity so the fault-tracking maps (breakers/cooldowns) key by identity
-	// and survive reconnect churn. Read-only after Register.
+	// identity so the fault-tracking state (breakers/cooldowns) keys by identity
+	// and survives reconnect churn. Read-only after Register.
 	registry *Registry
+	// gate is this session's current routing-gate state (gate_state.go): the
+	// session-keyed gate from Register until attestation binds the stable
+	// identity, then the identity's gate. Atomic so the scan (under p.mu) and
+	// the recorders (without p.mu) read it without another lock; written only
+	// under r.gatesMu (attachSessionGate / bindStableFaultKey). nil for a bare
+	// test Provider — every gate read treats nil as "no state".
+	gate                 atomic.Pointer[gateState]
+	gateDisconnectedAtNS atomic.Int64
 }
 
 // providerSupportsPrivateTextLocked is the SINGLE routing chokepoint for
@@ -1918,6 +1926,7 @@ func (p *Provider) HardUntrustEpoch() uint64 {
 // marshal the Provider snapshot.
 func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	if result == nil {
 		p.AttestationResult = nil
 	} else {
@@ -1926,16 +1935,17 @@ func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) 
 			[]string(nil), result.RuntimeCapabilities...)
 		p.AttestationResult = &snapshot
 	}
-	// Re-derive the stable identity while p.mu is held, then bind it OUTSIDE
-	// p.mu (bindStableFaultKey takes r.mu; the established order is r.mu →
-	// p.mu, so taking r.mu here while holding p.mu could deadlock). Binding at
-	// attestation time is what re-attaches a reconnecting machine's fault
-	// state (breakers/cooldowns keyed by serial/SE-key) to its fresh session
-	// id BEFORE it becomes routable — public routing requires attestation.
-	id, stableID, r := p.ID, stableProviderIdentityLocked(p), p.registry
-	p.mu.Unlock()
-	if r != nil {
-		r.bindStableFaultKey(id, stableID)
+	// Re-derive the stable identity and bind it while p.mu is STILL held
+	// (lock order r.mu → p.mu → gatesMu → gate.mu; bindStableFaultKey takes the
+	// last two). The bind — which repoints p.gate — must not land inside a
+	// section that reads p.gate and acts on it under p.mu: the reservation
+	// commit's admit re-check through its pending debit, the scan's gate chain,
+	// the alias resolver's routability read. Binding at attestation time is what
+	// re-attaches a reconnecting machine's fault state (breakers/cooldowns keyed
+	// by serial/SE-key) to its fresh session id BEFORE it becomes routable —
+	// public routing requires attestation.
+	if r := p.registry; r != nil {
+		r.bindStableFaultKey(p, stableProviderIdentityLocked(p))
 	}
 }
 
@@ -1946,14 +1956,12 @@ func (p *Provider) SetAttestationResult(result *attestation.VerificationResult) 
 // identity resolves to the ACCOUNT fallback — attestation absent (Open Mode)
 // or invalid — would otherwise never bind: all its fault state would key by
 // session UUID and be wiped on reconnect. Same lock discipline as
-// SetAttestationResult: derive under p.mu, bind OUTSIDE it (bindStableFaultKey
-// takes r.mu; the established order is r.mu → p.mu).
+// SetAttestationResult: derive AND bind under p.mu.
 func (p *Provider) RebindStableFaultKey() {
 	p.mu.Lock()
-	id, stableID, r := p.ID, stableProviderIdentityLocked(p), p.registry
-	p.mu.Unlock()
-	if r != nil {
-		r.bindStableFaultKey(id, stableID)
+	defer p.mu.Unlock()
+	if r := p.registry; r != nil {
+		r.bindStableFaultKey(p, stableProviderIdentityLocked(p))
 	}
 }
 
@@ -2256,143 +2264,45 @@ type Registry struct {
 	pendingModelLoads       map[modelLoadKey]time.Time // value: expiry (see pair_keys.go)
 	pendingModelLoadStarted map[modelLoadKey]time.Time
 
-	// dispatchLoadCooldowns: provider-model pairs that rejected a dispatch with a
-	// load failure ("insufficient memory"). Routing skips the pair until expiry —
-	// it would instant-503 again, and without this the scheduler re-picks it
-	// (looks idle), causing the dispatch→503→retry storms seen in prod. Cleared
-	// on re-registration and on a served request for the pair.
-	dispatchLoadCooldowns map[dispatchLoadKey]time.Time // value: expiry (see pair_keys.go)
-
-	// inferenceErrorStrikes / inferenceErrorCooldowns implement the error-class
-	// circuit breaker for provider-side inference failures: a (provider, model,
-	// shape) triple that returns repeated 5xx errors (e.g. the deterministic
-	// Gemma chat-template render crash on tool schemas) enters a routing
-	// cool-down so retries fall to OTHER providers instead of burning every
-	// attempt on the same broken pair. 4xx (client-shape) errors never count.
-	//
-	// The key is SHAPE-KEYED (inferenceErrorKey) rather than a "providerID:modelID"
-	// string concat. Shape-keying fixes the root bug where a clean non-tool
-	// success reset the SHARED strike counter, so in mixed traffic a deterministic
-	// tool/template failure interleaved with text successes never reached the
-	// 2-strike threshold and the broken provider was never quarantined for tools.
-	// Strikes now accumulate per shape ("tools" independent of "base"), a success
-	// clears only its own shape bucket, and the struct key also closes the
-	// threat-model colon-collision note (a provider or model id containing ':'
-	// could previously alias another pair). Strikes slide over inferenceErrorWindow.
-	// Guarded by r.mu like dispatchLoadCooldowns. See error_cooldown.go.
-	inferenceErrorStrikes   map[inferenceErrorKey][]time.Time // recent 5xx strike times per (provider, model, shape)
-	inferenceErrorCooldowns map[inferenceErrorKey]time.Time   // cool-down expiry per (provider, model, shape)
-
-	// providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips
-	// implement the per-provider (node-health) circuit breaker, SEPARATE from
-	// and ADDITIONAL to the shape-keyed inference-error breaker above. It
-	// quarantines a whole provider that returns GENUINE-FAULT errors
-	// (500/502/504, or a fault-shaped 503 — internal error, crash, the opaque
-	// Foundation string) for ~all of its requests, regardless
-	// of model/shape — the case the inference-error breaker misses because it
-	// skips 503. After an exponential cooldown it re-probes and auto-re-admits
-	// on the first success. Capacity-class sheds (4xx/429 and token-budget /
-	// KV-headroom / draining 503s) never count — a healthy-but-busy provider.
-	// The breaker FAILS OPEN: when it would deroute every provider for a model,
-	// selection re-scans with it bypassed (selectBestCandidateLockedFull) so a
-	// bad fleet-wide rollout cannot zero out routing. Guarded by r.mu like the
-	// maps above. Keyed by the stable fault key (faultKeyLocked) and NOT
-	// cleared on Disconnect — state re-attaches on reconnect; only a provider
-	// with no stable identity has its session-keyed residue dropped. See
-	// provider_breaker.go.
-	providerOutcomes         map[string]*providerHealthWindow // per-provider sliding fault/success ring
-	providerBreakerOpenUntil map[string]time.Time             // breaker-open expiry per provider
-	providerBreakerTrips     map[string]int                   // trip count per provider (exponential backoff)
-
-	// capacityRejectStrikes / capacityCooldowns / capacityCooldownTrips
-	// implement the capacity-reject routing cooldown (capacity_cooldown.go),
-	// SEPARATE from every breaker above — all of which deliberately IGNORE
-	// capacity-class rejections (sound for occasional sheds from a busy box,
-	// catastrophic for a box that capacity-rejects EVERYTHING while its
-	// idle-looking heartbeats keep winning the cost scheduler: the 2026-07
-	// black-hole incident, 7 boxes, ~9k rejects/30min, zero successes). A
-	// (provider, model) pair that accumulates threshold-many capacity rejects
-	// inside the window with ZERO interleaved accepts enters a routing
-	// cooldown with exponential re-trip backoff; any accept (first content
-	// chunk or clean completion) clears all three entries. Config is
-	// env-tunable (EIGENINFERENCE_CAPACITY_COOLDOWN_*), loaded at
-	// construction. Guarded by r.mu like the maps above.
-	capacityCooldownCfg   capacityCooldownConfig
-	capacityRejectStrikes map[capacityRejectKey][]time.Time            // recent capacity-reject strikes per (provider, model)
-	capacityCooldowns     map[capacityRejectKey]*capacityCooldownEntry // cooldown expiry + half-open probe claim per (provider, model)
-	capacityCooldownTrips map[capacityRejectKey]int                    // trip count per (provider, model) (exponential backoff)
-
-	// budgetClamps implements the gray-box budget clamp (budget_clamp.go):
-	// after a capacity-shaped 503, admission stops believing the pair's
-	// stale-optimistic heartbeat budget and treats the slot as FULL until the
-	// provider proves recovery (fresh heartbeat with headroom + an accept) or
-	// the clamp TTL fail-opens. Keyed by stable fault identity; migrated on
-	// rebind; NOT cleared on Disconnect. Guarded by r.mu.
-	budgetClampCfg budgetClampConfig
-	budgetClamps   map[capacityRejectKey]*budgetClampEntry
-
-	// capacityRateRejects / capacityRateAccepts implement the capacity-503
-	// rate penalty (capacity_rate.go): sliding windows of capacity rejects and
-	// served dispatches per (stable identity, model). Unlike every breaker
-	// above there is NO accept-triggered reset — the rate is exactly the
-	// gray-box signal the zero-interleaved-accepts discriminators are blind
-	// to. Keyed by stable fault identity; migrated on rebind; NOT cleared on
-	// Disconnect. Guarded by r.mu.
-	capacityRateCfg     capacityRateConfig
-	capacityRateRejects map[capacityRejectKey][]time.Time
-	capacityRateAccepts map[capacityRejectKey][]time.Time
-
-	// Stable-identity health ejection (health_ejection.go). Keyed by a STABLE
-	// identity (serial/SE-key/account), NOT the session UUID, and DELIBERATELY
-	// NOT deleted on Disconnect — so a zombie that fails ~every request while
-	// reconnecting constantly still accumulates to the ejection threshold.
-	healthEjectionWindows map[string]*providerHealthWindow // stable-id sliding fault/success ring
-	healthEjectionUntil   map[string]time.Time             // ejection-open expiry per stable id
-	healthEjectionTrips   map[string]int                   // trip count per stable id (exponential backoff)
-	// healthEjectionCapacityStreaks counts CONSECUTIVE capacity-shaped 5xx
-	// rejections (zero interleaved successes) per stable identity — the
-	// capacity black-hole signature that every fault breaker deliberately
-	// ignores (prod: 13,333 "token_budget"-shaped 503s, 100% error rate, 90
-	// min, never ejected). Any success clears the streak, so a busy-but-
-	// serving box can never trip. See health_ejection.go.
-	healthEjectionCapacityStreaks map[string]capacityStreak
-	// healthEjectionLastTripCapacity records whether an identity's most recent
-	// ejection came from the capacity streak (true) or the fault path (false).
-	// The capacity branch's half-open instant re-arm applies only to capacity
-	// trips: a single capacity shed — legitimate for a healthy-but-full box —
-	// must not re-arm a FAULT ejection whose cooldown just expired.
-	healthEjectionLastTripCapacity map[string]bool
-	// disconnectedStableIDs caches a provider's stable identity at Disconnect time,
-	// keyed by its (now-removed) session id, so the pending-request ErrorCh flush —
-	// which runs AFTER Disconnect deletes the provider and carries the 502 "provider
-	// disconnected" faults that define a reconnecting zombie — can still resolve the
-	// identity and record those faults against the stable-identity breaker. The
-	// entry also dates the drop: a flush strike from a session dropped at or
-	// before the identity's last version-changed reset is discarded as already
-	// accounted for (version_reset.go, IsSupersededDisconnectFlush).
+	// Per-identity routing-gate state (gate_state.go). Every fault tracker —
+	// the dispatch-load cooldown, the shape-keyed inference-error breaker
+	// (error_cooldown.go), the node-health breaker (provider_breaker.go), the
+	// capacity cooldown / rate window / budget clamp (capacity_cooldown.go,
+	// capacity_rate.go, budget_clamp.go) and stable-identity health ejection
+	// (health_ejection.go) — lives on the gateState of the provider's STABLE
+	// fault key (serial → SE key → account → session id), each gate with its
+	// own mutex. Recorders take gate.mu only, never r.mu: the six per-request
+	// write acquisitions of r.mu that convoyed behind the fleet-scan readers
+	// are gone. gates is keyed by fault key; sessions indexes LIVE session ids
+	// to their Provider (whose p.gate caches the current gate) so recorders
+	// resolve a session without r.mu; disconnectedStableIDs caches a
+	// provider's stable identity at Disconnect time, keyed by its now-removed
+	// session id, so the trailing pending-request ErrorCh flush — which
+	// carries the 502 "provider disconnected" faults that define a
+	// reconnecting zombie — still resolves the identity. All three under
+	// gatesMu: RLock to resolve, Lock only in Register / Disconnect / the
+	// attestation-time bind / the periodic sweep. Fault state is keyed by
+	// identity and NOT cleared on Disconnect — it re-attaches on reconnect
+	// (the prod zombie exploit: median 18 sessions/machine/week reset every
+	// session-keyed breaker before it could trip).
+	gatesMu               sync.RWMutex
+	gates                 map[string]*gateState
+	sessions              map[string]*Provider
 	disconnectedStableIDs map[string]disconnectedStableID
-	// faultKeyBySession maps a LIVE session id to its stable identity
-	// (serial/SE-key/account). Bound by SetAttestationResult, removed on
-	// Disconnect (the disconnectedStableIDs cache covers the trailing flush).
-	// Every fault-tracking map above (inference-error cooldowns, node-health
-	// breaker, dispatch-load cooldowns) keys by faultKeyLocked(sessionID) —
-	// the stable identity when bound, the session id itself otherwise — so a
-	// reconnecting machine re-attaches its accumulated fault state instead of
-	// wiping it (the prod zombie exploit: median 18 sessions/machine/week
-	// reset every session-keyed breaker before it could trip).
-	faultKeyBySession map[string]string
-	// identityVersions / inferenceErrorFlushStrikes back the version-changed
-	// reconnect reset (version_reset.go): the last binary version seen per
-	// stable identity, the time of its last reset (rate limit), and the subset
-	// of inferenceErrorStrikes that came from the disconnect flush (502) so
-	// exactly those can be removed when the identity returns on a new binary.
-	// Lazily created; guarded by r.mu; migrated on rebind; NOT cleared on
-	// Disconnect.
-	identityVersions           map[string]string
-	identityVersionResetAt     map[string]time.Time
-	identityVersionSeenAt      map[string]time.Time
-	identityVersionSweepAt     time.Time
-	inferenceErrorFlushStrikes map[inferenceErrorKey][]time.Time
+	gateSweepAt           time.Time
+	// gateWaitObserver, when set, is told about gate.mu acquisition waits above
+	// gateWaitReportThreshold, tagged by recorder site (SetGateWaitObserver).
+	gateWaitObserver atomic.Pointer[func(site string, wait time.Duration)]
+
+	// reserveCommitMode selects whether the reservation commit holds r.mu for
+	// reading (shared, default) or writing (global — the kill switch). Read
+	// once from EIGENINFERENCE_RESERVE_COMMIT_MODE at construction.
+	reserveCommitMode reserveCommitMode
+
+	// Env-tunable tracker configs, read once at construction.
+	capacityCooldownCfg capacityCooldownConfig
+	budgetClampCfg      budgetClampConfig
+	capacityRateCfg     capacityRateConfig
 
 	// evictStrikes counts consecutive eviction sweeps a provider has been stale.
 	// A provider is only evicted after STALE on two sweeps in a row, so a single
@@ -2471,42 +2381,27 @@ type modelLoadAction struct {
 // New creates a new Registry.
 func New(logger *slog.Logger) *Registry {
 	return &Registry{
-		providers:                      make(map[string]*Provider),
-		queue:                          NewRequestQueueFromEnv(),
-		MinTrustLevel:                  TrustHardware,
-		tpsRegistry:                    NewTPSRegistry(),
-		modelProviders:                 make(map[string]*atomic.Int64),
-		pendingModelLoads:              make(map[modelLoadKey]time.Time),
-		pendingModelLoadStarted:        make(map[modelLoadKey]time.Time),
-		dispatchLoadCooldowns:          make(map[dispatchLoadKey]time.Time),
-		inferenceErrorStrikes:          make(map[inferenceErrorKey][]time.Time),
-		inferenceErrorCooldowns:        make(map[inferenceErrorKey]time.Time),
-		providerOutcomes:               make(map[string]*providerHealthWindow),
-		providerBreakerOpenUntil:       make(map[string]time.Time),
-		providerBreakerTrips:           make(map[string]int),
-		capacityCooldownCfg:            loadCapacityCooldownConfig(),
-		capacityRejectStrikes:          make(map[capacityRejectKey][]time.Time),
-		capacityCooldowns:              make(map[capacityRejectKey]*capacityCooldownEntry),
-		capacityCooldownTrips:          make(map[capacityRejectKey]int),
-		budgetClampCfg:                 loadBudgetClampConfig(),
-		budgetClamps:                   make(map[capacityRejectKey]*budgetClampEntry),
-		capacityRateCfg:                loadCapacityRateConfig(),
-		capacityRateRejects:            make(map[capacityRejectKey][]time.Time),
-		capacityRateAccepts:            make(map[capacityRejectKey][]time.Time),
-		healthEjectionWindows:          make(map[string]*providerHealthWindow),
-		healthEjectionUntil:            make(map[string]time.Time),
-		healthEjectionTrips:            make(map[string]int),
-		healthEjectionCapacityStreaks:  make(map[string]capacityStreak),
-		healthEjectionLastTripCapacity: make(map[string]bool),
-		disconnectedStableIDs:          make(map[string]disconnectedStableID),
-		faultKeyBySession:              make(map[string]string),
-		evictStrikes:                   make(map[string]int),
-		cacheRouting:                   newCacheRoutingTracker(defaultCacheRoutingTTL, defaultCacheRoutingMaxHolders),
-		cacheActivation:                newCacheActivationGate(defaultCacheRoutingActivationPct, defaultCacheRoutingMaxPlanQPS),
-		cacheRoutingMode:               CacheRoutingOff,
-		cacheRoutingMaxDiscountMs:      defaultCacheRoutingMaxDiscountMs,
-		cacheRoutingMaxCostFraction:    defaultCacheRoutingMaxCostFraction,
-		logger:                         logger,
+		providers:                   make(map[string]*Provider),
+		queue:                       NewRequestQueueFromEnv(),
+		MinTrustLevel:               TrustHardware,
+		tpsRegistry:                 NewTPSRegistry(),
+		modelProviders:              make(map[string]*atomic.Int64),
+		pendingModelLoads:           make(map[modelLoadKey]time.Time),
+		pendingModelLoadStarted:     make(map[modelLoadKey]time.Time),
+		gates:                       make(map[string]*gateState),
+		sessions:                    make(map[string]*Provider),
+		disconnectedStableIDs:       make(map[string]disconnectedStableID),
+		reserveCommitMode:           loadReserveCommitMode(logger),
+		capacityCooldownCfg:         loadCapacityCooldownConfig(),
+		budgetClampCfg:              loadBudgetClampConfig(),
+		capacityRateCfg:             loadCapacityRateConfig(),
+		evictStrikes:                make(map[string]int),
+		cacheRouting:                newCacheRoutingTracker(defaultCacheRoutingTTL, defaultCacheRoutingMaxHolders),
+		cacheActivation:             newCacheActivationGate(defaultCacheRoutingActivationPct, defaultCacheRoutingMaxPlanQPS),
+		cacheRoutingMode:            CacheRoutingOff,
+		cacheRoutingMaxDiscountMs:   defaultCacheRoutingMaxDiscountMs,
+		cacheRoutingMaxCostFraction: defaultCacheRoutingMaxCostFraction,
+		logger:                      logger,
 	}
 }
 
@@ -2562,42 +2457,56 @@ func (r *Registry) CacheRoutingConfigSnapshot() CacheRoutingConfig {
 // RecordDispatchLoadFailure puts a provider-model pair on a routing cool-down
 // after the provider rejected a dispatch with a load failure. Returns true
 // when this call started a new cool-down (false when one was already live),
-// so callers can emit metrics without double-counting the retry storm. Keyed
-// by the provider's stable fault key (faultKeyLocked) so the cool-down
-// survives a reconnect within its TTL.
+// so callers can emit metrics without double-counting the retry storm. Lives
+// on the provider's stable-identity gate (gate_state.go) so the cool-down
+// survives a reconnect within its TTL; takes only gate.mu.
 func (r *Registry) RecordDispatchLoadFailure(providerID, modelID string) bool {
-	hold := r.lockWrite("dispatch_load_failure")
+	hold := r.lockGate(r.gateForSession(providerID), "dispatch_load_failure")
 	defer hold.unlock()
+	g := hold.g
 	now := time.Now()
-	// Opportunistic sweep: bound the map by dropping expired entries when it
-	// grows (churned identities are never re-keyed).
-	if len(r.dispatchLoadCooldowns) > 1024 {
-		for key, expiry := range r.dispatchLoadCooldowns {
-			if !now.Before(expiry) {
-				delete(r.dispatchLoadCooldowns, key)
-			}
-		}
-	}
-	key := dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}
-	expiry, active := r.dispatchLoadCooldowns[key]
+	expiry, active := g.dispatchLoadCooldowns[modelID]
 	active = active && now.Before(expiry)
-	r.dispatchLoadCooldowns[key] = now.Add(dispatchLoadCooldownTTL)
+	g.dispatchLoadCooldowns[modelID] = now.Add(dispatchLoadCooldownTTL)
+	g.updatedLocked(now)
 	return !active
 }
 
 // ClearDispatchLoadCooldown removes the cool-down for one provider-model pair
 // (called when the pair serves a request successfully — it can load after all).
+// Runs at request completion; takes only the identity's gate.mu.
 func (r *Registry) ClearDispatchLoadCooldown(providerID, modelID string) {
-	hold := r.lockWrite("dispatch_load_cooldown")
+	ref, has := r.refHasPairState(r.lookupSessionGateRef(providerID), gateFlagDispatchLoad)
+	if !has {
+		return // nothing to clear — the common case, one lock-free flag load
+	}
+	hold := r.lockGate(ref, "dispatch_load_clear")
 	defer hold.unlock()
-	delete(r.dispatchLoadCooldowns, dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID})
+	g := hold.g
+	if g == nil {
+		return
+	}
+
+	delete(g.dispatchLoadCooldowns, modelID)
+	g.updatedLocked(time.Now())
 }
 
-// dispatchLoadCooldownActiveLocked reports whether routing should skip the pair.
-// READ-ONLY (no lazy delete) — some callers hold only r.mu.RLock. Caller holds
-// r.mu in either mode.
-func (r *Registry) dispatchLoadCooldownActiveLocked(providerID, modelID string, now time.Time) bool {
-	expiry, ok := r.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: r.faultKeyLocked(providerID), ModelID: modelID}]
+// dispatchLoadCooled reports whether routing should skip the pair. Resolves
+// the session's gate; the scan uses the cached p.gate directly.
+func (r *Registry) dispatchLoadCooled(providerID, modelID string, now time.Time) bool {
+	return r.lookupGateForSession(providerID).dispatchLoadCooled(modelID, now)
+}
+
+// dispatchLoadCooled is the gate-level check: lock-free "no cooldown on any
+// model" fast path, otherwise one short gate.mu section. READ-ONLY (no lazy
+// delete). nil-safe.
+func (g *gateState) dispatchLoadCooled(modelID string, now time.Time) bool {
+	if !g.hasPairState(gateFlagDispatchLoad) {
+		return false
+	}
+	g = g.lockResolved()
+	expiry, ok := g.dispatchLoadCooldowns[modelID]
+	g.mu.Unlock()
 	return ok && now.Before(expiry)
 }
 
@@ -2982,7 +2891,15 @@ func (r *Registry) providerCanRouteBuildLocked(p *Provider, buildID string, minT
 	) {
 		return false
 	}
-	if r.dispatchLoadCooldownActiveLocked(p.ID, buildID, now) {
+	// The session's current gate, read under p.mu — which the identity bind
+	// also holds (bindStableFaultKey) — so a rebind cannot repoint p.gate, or
+	// migrate the cooldown away from the gate read here, mid-check. Without
+	// that, a read of a shared source gate emptied by this session's own
+	// rebind would say "not cooled" and let an alias resolve to a Desired
+	// build whose only provider is cooled (the request then queues or 429s
+	// instead of taking the routable Previous build). No gateView
+	// confirmation is needed under p.mu.
+	if r.gateOf(p).dispatchLoadCooled(buildID, now) {
 		return false
 	}
 	if p.BackendCapacity != nil {
@@ -3879,6 +3796,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 		return existing
 	}
 	r.providers[id] = p
+	r.attachSessionGate(p)
 	p.mu.Lock()
 	r.modelIndex.sync(p)
 	p.mu.Unlock()
@@ -5099,47 +5017,18 @@ func (r *Registry) disconnectProvider(id string, expected *Provider, timeout tim
 			}
 		}
 		p.detachModelIndexLocked(r)
-		// FAULT STATE IS NOT CLEARED ON DISCONNECT. Every fault-tracking map
+		// FAULT STATE IS NOT CLEARED ON DISCONNECT. Every fault tracker
 		// (node-health breaker, inference-error cooldowns, dispatch-load
-		// cooldowns, health ejection) keys by the STABLE identity when one is
-		// bound, so it must survive reconnect churn — wiping it here was the
-		// zombie exploit. Only when the provider never had a stable identity
-		// (sid == "": its fault key WAS this session id, which never recurs)
-		// is the session-keyed residue dropped for hygiene.
-		//
-		// Cache the stable identity (keyed by this session id) before the pending
-		// flush below: GetProviderStableIdentity and faultKeyLocked fall back to it
-		// so the 502 "provider disconnected" faults — the dominant reconnecting-
-		// zombie signal — are still recorded against the stable-identity state even
-		// though the provider is already gone from r.providers.
-		if sid := stableProviderIdentityLocked(p); sid != "" {
-			r.rememberDisconnectedStableIDLocked(id, sid)
-		} else {
-			delete(r.providerOutcomes, id)
-			delete(r.providerBreakerOpenUntil, id)
-			delete(r.providerBreakerTrips, id)
-			for key := range r.inferenceErrorStrikes {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorStrikes, key)
-				}
-			}
-			for key := range r.inferenceErrorCooldowns {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorCooldowns, key)
-				}
-			}
-			for key := range r.inferenceErrorFlushStrikes {
-				if key.ProviderID == id {
-					delete(r.inferenceErrorFlushStrikes, key)
-				}
-			}
-			for key := range r.dispatchLoadCooldowns {
-				if key.FaultKey == id {
-					delete(r.dispatchLoadCooldowns, key)
-				}
-			}
-		}
-		delete(r.faultKeyBySession, id)
+		// cooldowns, health ejection, capacity trackers) lives on the STABLE
+		// identity's gate when one is bound, so it must survive reconnect
+		// churn — wiping it here was the zombie exploit. detachSessionGate
+		// caches the identity (keyed by this session id) before the pending
+		// flush below so the 502 "provider disconnected" faults — the dominant
+		// reconnecting-zombie signal — still resolve to it even though the
+		// provider is already gone from r.providers; only a provider that never
+		// had a stable identity (sid == "": its gate WAS this session id, which
+		// never recurs) has its session-keyed residue dropped for hygiene.
+		r.detachSessionGate(p, stableProviderIdentityLocked(p))
 		disconnectedModels = make([]string, 0, len(p.Models))
 		for _, m := range p.Models {
 			disconnectedModels = append(disconnectedModels, m.ID)
@@ -6517,7 +6406,6 @@ func (r *Registry) StartEvictionLoop(ctx context.Context, timeout time.Duration)
 				return
 			case <-ticker.C:
 				r.evictStale(timeout)
-				r.sweepIdentityVersionHistory(time.Now())
 			}
 		}
 	})
@@ -6601,6 +6489,11 @@ func (r *Registry) evictStale(timeout time.Duration) {
 			r.logger.Warn("evicted stale provider", "provider_id", p.ID, "timeout", timeout)
 		}
 	}
+
+	// Bound the per-identity gate index on the same cadence (gate_state.go):
+	// prunes dead per-model entries and drops gates no live session references
+	// once idle. Off the request path and outside r.mu.
+	r.sweepGates(now)
 }
 
 // evictStrikeThreshold is how many consecutive stale sweeps trigger eviction.

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -4010,14 +4010,15 @@ func (r *Registry) RemoveProviderBySerial(serialOrID string, force bool) (online
 	return online
 }
 
-// Heartbeat updates the provider's status and stats.
-func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
+// Heartbeat updates the provider's status and stats and reports whether the
+// snapshot was accepted. Rejected stale snapshots still advance liveness.
+func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) bool {
 	r.mu.RLock()
 	p, ok := r.providers[id]
 	if !ok {
 		r.mu.RUnlock()
 		r.logger.Warn("heartbeat from unknown provider", "provider_id", id)
-		return
+		return false
 	}
 
 	// Work from registry-owned copies so clamping and retention never mutate the
@@ -4071,7 +4072,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 			p.mu.Unlock()
 			r.logger.Debug("discarding stale capacity heartbeat",
 				"provider_id", id, "seq", msg.BackendCapacity.CapacitySeq, "applied_seq", appliedSeq)
-			return
+			return false
 		}
 		p.capacitySeq = msg.BackendCapacity.CapacitySeq
 		// Seq-stamping providers implement the wave-2 capacity protocol:
@@ -4215,6 +4216,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) {
 	// (model_swap_coalesce.go). Drain work can outlast the planning window,
 	// so claim against the current time rather than the heartbeat timestamp.
 	r.triggerModelSwapsFromHeartbeat(time.Now())
+	return true
 }
 
 // SendLoadModel instructs a provider to eagerly load a model so it becomes

--- a/coordinator/registry/request_path_probe_test.go
+++ b/coordinator/registry/request_path_probe_test.go
@@ -1,0 +1,136 @@
+package registry
+
+// Request-path lock probes. They reuse the fleet fixture from
+// fleet_scale_bench_test.go and separate three questions:
+//   A. do RLock-only fleet walks parallelize?               (RequestPathWalkParallel)
+//   B. what does one writer wait under N concurrent walks?  (RequestPathWalkParallelWithWriter)
+//   C. scan+commit+per-request recorders, serial vs parallel (RequestPathSerial / RequestPathParallel)
+//
+// C is the one that measures the change this branch makes: before it, every
+// commit and every completion recorder took the registry WRITE lock, so the
+// parallel variant ran at ~1x the serial one (each writer drained the whole
+// reader batch). TestRequestPathParallelSpeedup (reserve_commit_test.go) pins
+// the ratio so a walk-wide lock cannot sneak back.
+//
+//	go test ./registry/ -run xxx -bench 'RequestPath' -benchtime 2s -benchmem
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func BenchmarkRequestPathWalkParallel(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			model := f.models[n%len(f.models)]
+			c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false)
+			if c == 0 {
+				b.Fatal("no candidates")
+			}
+			n++
+		}
+	})
+}
+
+// One background writer records a provider outcome every 2 ms (~500/s, the
+// prod per-request recorder rate) while RunParallel walkers scan the fleet.
+// Reports the mean and max writer wait.
+func BenchmarkRequestPathWalkParallelWithWriter(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	var waitNS, waitMax, calls atomic.Int64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		t := time.NewTicker(2 * time.Millisecond)
+		defer t.Stop()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				id := f.ids[i%len(f.ids)]
+				i++
+				t0 := time.Now()
+				f.reg.RecordProviderOutcome(id, true, 200, "")
+				d := time.Since(t0).Nanoseconds()
+				waitNS.Add(d)
+				calls.Add(1)
+				for {
+					m := waitMax.Load()
+					if d <= m || waitMax.CompareAndSwap(m, d) {
+						break
+					}
+				}
+			}
+		}
+	}()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			model := f.models[n%len(f.models)]
+			c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false)
+			if c == 0 {
+				b.Fatal("no candidates")
+			}
+			n++
+		}
+	})
+	b.StopTimer()
+	close(stop)
+	<-done
+	if n := calls.Load(); n > 0 {
+		b.ReportMetric(float64(waitNS.Load())/float64(n)/1e3, "writer_wait_us/op")
+		b.ReportMetric(float64(waitMax.Load())/1e3, "writer_wait_max_us")
+	}
+}
+
+// requestPathOnce mirrors the per-request registry write sequence of a served
+// request: commit (inside ReserveProviderEx) + first-content accept + the
+// three completion recorders + the completion-time cooldown clear.
+func requestPathOnce(tb testing.TB, f *benchFleet, model string, n int) {
+	pr := benchPendingRequest(model, n)
+	p, _ := f.reg.ReserveProviderEx(model, pr)
+	if p == nil {
+		tb.Fatal("no provider reserved")
+	}
+	f.reg.RecordCapacityAccept(p.ID, model)
+	f.reg.RecordInferenceSuccess(p.ID, model, "")
+	f.reg.RecordCapacityAcceptOutcome(p.ID, model, false)
+	f.reg.RecordProviderOutcome(p.ID, true, 200, "")
+	if sid := f.reg.GetProviderStableIdentity(p.ID); sid != "" {
+		f.reg.RecordProviderServeOutcome(sid, true, 200, "")
+	}
+	f.reg.ClearDispatchLoadCooldown(p.ID, model)
+	p.RemovePending(pr.RequestID)
+}
+
+func BenchmarkRequestPathSerial(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		requestPathOnce(b, f, f.models[i%len(f.models)], i)
+	}
+}
+
+func BenchmarkRequestPathParallel(b *testing.B) {
+	f := buildBenchFleet(b, benchFleetProviders, benchFleetModels)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := 0
+		for pb.Next() {
+			requestPathOnce(b, f, f.models[n%len(f.models)], n)
+			n++
+		}
+	})
+}

--- a/coordinator/registry/reserve_commit_test.go
+++ b/coordinator/registry/reserve_commit_test.go
@@ -1,0 +1,666 @@
+package registry
+
+import (
+	"fmt"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+// Tests for the reservation commit without the global write lock (shared
+// mode) against the fleet-wide serialized commit (global mode, the kill
+// switch): the two must admit exactly the same amount, the routing gates must
+// decide identically under concurrent recorders, and the request path must
+// actually parallelize — the whole point of the change.
+
+// setReserveCommitModeForTest switches the reservation commit lock mode on a
+// registry that already exists (the env is read once at construction).
+func setReserveCommitModeForTest(r *Registry, mode reserveCommitMode) {
+	r.reserveCommitMode = mode
+}
+
+func TestParseReserveCommitMode(t *testing.T) {
+	cases := map[string]struct {
+		mode  reserveCommitMode
+		known bool
+	}{
+		"":         {reserveCommitShared, true},
+		"shared":   {reserveCommitShared, true},
+		"anything": {reserveCommitShared, false}, // a typo falls back to shared AND is reported
+		"global":   {reserveCommitGlobal, true},
+		" GLOBAL ": {reserveCommitGlobal, true},
+	}
+	for raw, want := range cases {
+		mode, known := parseReserveCommitMode(raw)
+		if mode != want.mode || known != want.known {
+			t.Errorf("parseReserveCommitMode(%q) = (%s, %v), want (%s, %v)", raw, mode, known, want.mode, want.known)
+		}
+	}
+	t.Setenv(envReserveCommitMode, "")
+	if New(testLogger()).reserveCommitMode != reserveCommitShared {
+		t.Fatal("a registry built without EIGENINFERENCE_RESERVE_COMMIT_MODE must default to shared")
+	}
+}
+
+func forEachCommitMode(t *testing.T, body func(t *testing.T, mode reserveCommitMode)) {
+	for _, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+		t.Run(mode.String(), func(t *testing.T) { body(t, mode) })
+	}
+}
+
+func pendingCountOf(p *Provider) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.pendingCount()
+}
+
+// TestReserveCommitAdmitsExactlyTheSerialCapacityUnderConcurrency: N
+// goroutines committing against ONE provider admit exactly as many requests
+// as a serial loop does (the provider's capacity), the pending set holds
+// exactly those requests, and releasing them returns the count to zero — in
+// both commit modes. This is the no-double-booking invariant: the admit
+// re-check and the pending debit share one p.mu section.
+func TestReserveCommitAdmitsExactlyTheSerialCapacityUnderConcurrency(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "commit-cap-model"
+		p := makeSchedulerProvider(t, reg, "capped", model, 100)
+		p.mu.Lock()
+		p.BackendCapacity.Slots[0].MaxConcurrency = 4
+		p.mu.Unlock()
+		newReq := func(i int) *PendingRequest {
+			return &PendingRequest{
+				RequestID:             fmt.Sprintf("%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+		}
+
+		// The provider's capacity, measured serially.
+		var serial []*PendingRequest
+		for i := 0; i < 64; i++ {
+			pr := newReq(i)
+			got, _ := reg.ReserveProviderEx(model, pr)
+			if got == nil {
+				break
+			}
+			serial = append(serial, pr)
+		}
+		capacity := len(serial)
+		if capacity < 2 || capacity > 4 {
+			t.Fatalf("serial capacity = %d, want 2..4 (MaxConcurrency 4) for the test to mean anything", capacity)
+		}
+		for _, pr := range serial {
+			p.RemovePending(pr.RequestID)
+		}
+		if n := pendingCountOf(p); n != 0 {
+			t.Fatalf("pending after release = %d, want 0", n)
+		}
+
+		const workers = 32
+		for round := 0; round < 5; round++ {
+			reqs := make([]*PendingRequest, workers)
+			var admitted atomic.Int32
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			for i := range reqs {
+				reqs[i] = newReq(1000 + round*workers + i)
+				wg.Add(1)
+				go func(pr *PendingRequest) {
+					defer wg.Done()
+					<-start
+					got, _ := reg.ReserveProviderEx(model, pr)
+					if got == nil {
+						return
+					}
+					if got != p {
+						t.Errorf("reserved a stranger: %v", got)
+					}
+					admitted.Add(1)
+				}(reqs[i])
+			}
+			close(start)
+			wg.Wait()
+			if int(admitted.Load()) != capacity {
+				t.Fatalf("round %d: %d admitted concurrently, serial capacity is %d", round, admitted.Load(), capacity)
+			}
+			if n := pendingCountOf(p); n != capacity {
+				t.Fatalf("round %d: pending set holds %d, want %d", round, n, capacity)
+			}
+			released := 0
+			for _, pr := range reqs {
+				if pr.ProviderID != p.ID {
+					continue
+				}
+				if p.RemovePending(pr.RequestID) == nil {
+					t.Fatalf("round %d: admitted request %s missing from the pending set", round, pr.RequestID)
+				}
+				released++
+			}
+			if released != capacity {
+				t.Fatalf("round %d: %d requests carry the provider id, %d were admitted", round, released, capacity)
+			}
+			if n := pendingCountOf(p); n != 0 {
+				t.Fatalf("round %d: pending after release = %d, want 0", round, n)
+			}
+		}
+	})
+}
+
+// TestReserveNextFromPlanAdmitsExactlyTheSerialCapacityUnderConcurrency is the
+// plan-path twin of the test above: N goroutines, each consuming its own plan
+// whose next entry is the same capped alternate, admit exactly the serial
+// capacity — the snapshot, admit re-check, probe claim and debit share one
+// p.mu hold in tryReserve too, in both commit modes.
+func TestReserveNextFromPlanAdmitsExactlyTheSerialCapacityUnderConcurrency(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "plan-cap-model"
+		// The winner is only there to be excluded from every plan; the
+		// alternate is the capped provider every plan consumes next.
+		winner := makeSchedulerProvider(t, reg, "plan-winner", model, 100)
+		alt := makeSchedulerProvider(t, reg, "plan-alt", model, 100)
+		alt.mu.Lock()
+		alt.BackendCapacity.Slots[0].MaxConcurrency = 4
+		alt.mu.Unlock()
+		newReq := func(i int) *PendingRequest {
+			return &PendingRequest{
+				RequestID:             fmt.Sprintf("plan-%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+		}
+		planFor := func(pr *PendingRequest) *DispatchPlan {
+			reg.mu.RLock()
+			scan := reg.scanCandidatesLocked(model, pr, false)
+			reg.mu.RUnlock()
+			var w *routingCandidate
+			for _, c := range scan.pool {
+				if c.provider == winner {
+					w = c
+				}
+			}
+			if w == nil {
+				t.Fatal("winner missing from the scan pool")
+			}
+			// The alternate is the plan's only entry while it has headroom and
+			// drops out of the scan pool (hence the plan) once it is full.
+			plan := newDispatchPlan(model, scan, w)
+			if plan.Len() > 1 || (plan.Len() == 1 && plan.entries[0].provider != alt) {
+				t.Fatalf("plan must hold at most the alternate, got %d entries", plan.Len())
+			}
+			return plan
+		}
+
+		var serial []*PendingRequest
+		for i := 0; i < 64; i++ {
+			pr := newReq(i)
+			plan := planFor(pr)
+			if plan.Len() == 0 {
+				break
+			}
+			got, _, _ := reg.ReserveNextFromPlan(pr, plan)
+			if got == nil {
+				break
+			}
+			serial = append(serial, pr)
+		}
+		capacity := len(serial)
+		if capacity < 2 || capacity > 4 {
+			t.Fatalf("serial plan capacity = %d, want 2..4", capacity)
+		}
+		for _, pr := range serial {
+			alt.RemovePending(pr.RequestID)
+		}
+
+		const workers = 32
+		for round := 0; round < 5; round++ {
+			reqs := make([]*PendingRequest, workers)
+			plans := make([]*DispatchPlan, workers)
+			for i := range reqs {
+				reqs[i] = newReq(1000 + round*workers + i)
+				plans[i] = planFor(reqs[i])
+				if plans[i].Len() != 1 {
+					t.Fatalf("round %d: plan %d must hold the idle alternate", round, i)
+				}
+			}
+			var admitted atomic.Int32
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			for i := range reqs {
+				wg.Add(1)
+				go func(pr *PendingRequest, plan *DispatchPlan) {
+					defer wg.Done()
+					<-start
+					got, _, _ := reg.ReserveNextFromPlan(pr, plan)
+					if got == nil {
+						return
+					}
+					if got != alt {
+						t.Errorf("plan reserved a stranger: %v", got)
+					}
+					admitted.Add(1)
+				}(reqs[i], plans[i])
+			}
+			close(start)
+			wg.Wait()
+			if int(admitted.Load()) != capacity {
+				t.Fatalf("round %d: %d admitted concurrently through plans, serial capacity is %d", round, admitted.Load(), capacity)
+			}
+			if n := pendingCountOf(alt); n != capacity {
+				t.Fatalf("round %d: pending set holds %d, want %d", round, n, capacity)
+			}
+			for _, pr := range reqs {
+				if pr.ProviderID == alt.ID {
+					alt.RemovePending(pr.RequestID)
+				}
+			}
+			if n := pendingCountOf(alt); n != 0 {
+				t.Fatalf("round %d: pending after release = %d, want 0", round, n)
+			}
+		}
+	})
+}
+
+// TestCommitProbeClaimAdmitsExactlyOneAcrossSessions drives the half-open
+// probe claim end to end through ReserveProviderEx: two sessions of ONE
+// identity serve the model, the identity's capacity cooldown has expired, and
+// N concurrent reservations must admit exactly one request — the probe — with
+// the gate closed to everyone else afterwards. Commits on different providers
+// do not share p.mu; only the check-and-claim under gate.mu makes this exact.
+func TestCommitProbeClaimAdmitsExactlyOneAcrossSessions(t *testing.T) {
+	forEachCommitMode(t, func(t *testing.T, mode reserveCommitMode) {
+		reg := New(testLogger())
+		setReserveCommitModeForTest(reg, mode)
+		const model = "probe-race-model"
+		p1 := attestSchedulerProvider(t, reg, "probe-sess-1", model, "SER-PROBE-RACE", 100)
+		p2 := attestSchedulerProvider(t, reg, "probe-sess-2", model, "SER-PROBE-RACE", 100)
+		for i := 0; i < reg.capacityCooldownCfg.Threshold; i++ {
+			reg.RecordCapacityReject(p1.ID, model)
+		}
+		if !reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("precondition: the identity's cooldown must gate both sessions")
+		}
+		expireCapacityCooldown(reg, p1.ID, model)
+
+		const workers = 16
+		reqs := make([]*PendingRequest, workers)
+		var admitted atomic.Int32
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := range reqs {
+			reqs[i] = &PendingRequest{
+				RequestID:             fmt.Sprintf("probe-%s-%d", mode, i),
+				Model:                 model,
+				EstimatedPromptTokens: 200,
+				RequestedMaxTokens:    128,
+				FirstContentBudgetMS:  10_000,
+				FirstContentDeadline:  time.Now().Add(10 * time.Second),
+			}
+			wg.Add(1)
+			go func(pr *PendingRequest) {
+				defer wg.Done()
+				<-start
+				if got, _ := reg.ReserveProviderEx(model, pr); got != nil {
+					admitted.Add(1)
+				}
+			}(reqs[i])
+		}
+		close(start)
+		wg.Wait()
+		if admitted.Load() != 1 {
+			t.Fatalf("%d reservations admitted through an expired cooldown, want exactly the one probe", admitted.Load())
+		}
+		if n := pendingCountOf(p1) + pendingCountOf(p2); n != 1 {
+			t.Fatalf("pending across the identity's sessions = %d, want 1", n)
+		}
+		if !reg.CapacityCooldownActive(p1.ID, model) || !reg.CapacityCooldownActive(p2.ID, model) {
+			t.Fatal("the claimed probe must close the gate for both sessions")
+		}
+	})
+}
+
+// commitModeFleets builds one fleet-scale fixture per commit mode with the same
+// fault script applied: a breaker-open advertiser, a health-ejected advertiser,
+// a capacity-cooled advertiser, a dispatch-load-cooled advertiser, a
+// tools-shape inference-error-cooled advertiser and a budget-clamped
+// advertiser (one that reports a token budget). Returns the fleets and the
+// faulted provider ids by fault kind.
+func commitModeFleets(t *testing.T, model string) (map[reserveCommitMode]*benchFleet, map[string]string) {
+	t.Helper()
+	fleets := map[reserveCommitMode]*benchFleet{}
+	for _, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+		f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+		setReserveCommitModeForTest(f.reg, mode)
+		fleets[mode] = f
+	}
+	ref := fleets[reserveCommitShared]
+	var budgeted, others []int
+	for i := range ref.ids {
+		if !benchProviderAdvertises(ref, i, model) {
+			continue
+		}
+		// Even providers carry a live token budget for their primary model
+		// (benchHeartbeat), which is what the clamp gates.
+		if i%2 == 0 && ref.models[i%benchFleetModels] == model && len(budgeted) < 1 {
+			budgeted = append(budgeted, i)
+		} else {
+			others = append(others, i)
+		}
+	}
+	if len(budgeted) < 1 || len(others) < 8 {
+		t.Fatalf("fixture too small: budgeted=%d others=%d", len(budgeted), len(others))
+	}
+	faulted := map[string]string{
+		"breaker":           ref.ids[others[0]],
+		"ejected":           ref.ids[others[1]],
+		"capacity_cooldown": ref.ids[others[2]],
+		"dispatch_load":     ref.ids[others[3]],
+		"error_cooldown":    ref.ids[others[4]],
+		"budget_clamp":      ref.ids[budgeted[0]],
+	}
+	for _, f := range fleets {
+		r := f.reg
+		for i := 0; i < providerBreakerConsecTrip; i++ {
+			r.RecordProviderOutcome(faulted["breaker"], false, 500, "internal error")
+		}
+		r.mu.RLock()
+		ejectedP := r.providers[faulted["ejected"]]
+		r.mu.RUnlock()
+		ejectedP.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-MODE-EJECT"})
+		for i := 0; i < healthEjectionConsecTrip+1; i++ {
+			r.RecordProviderServeOutcome("serial:SER-MODE-EJECT", false, 500, "boom")
+		}
+		for i := 0; i < r.capacityCooldownCfg.Threshold+1; i++ {
+			r.RecordCapacityReject(faulted["capacity_cooldown"], model)
+		}
+		r.RecordDispatchLoadFailure(faulted["dispatch_load"], model)
+		for i := 0; i < inferenceErrorThreshold; i++ {
+			r.RecordInferenceError(faulted["error_cooldown"], model, 500, RequestTraits{HasTools: true}.CooldownShape())
+		}
+		r.RecordCapacityReject(faulted["budget_clamp"], model)
+		if !r.ProviderBreakerOpen(faulted["breaker"]) || !r.HealthEjectionOpen("serial:SER-MODE-EJECT") ||
+			!r.CapacityCooldownActive(faulted["capacity_cooldown"], model) ||
+			!r.dispatchLoadCooled(faulted["dispatch_load"], model, time.Now()) ||
+			!r.InferenceErrorCooldownActive(faulted["error_cooldown"], model, RequestTraits{HasTools: true}.CooldownShape()) ||
+			!r.BudgetClampActive(faulted["budget_clamp"], model) {
+			t.Fatal("precondition: every fault kind must be armed")
+		}
+	}
+	return fleets, faulted
+}
+
+// TestGateDecisionsIdenticalAcrossCommitModesUnderConcurrentRecorders: with
+// the same fault script the routing walks (eligible pool, tallies, preflight
+// verdicts) are identical in both commit modes, before and after a phase of
+// concurrent scans, reservations and recorders — the recorders never touch
+// r.mu, so the race detector is what proves the interleavings are safe, and
+// the gate-level outcomes of every faulted provider match across modes.
+func TestGateDecisionsIdenticalAcrossCommitModesUnderConcurrentRecorders(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	fleets, faulted := commitModeFleets(t, benchFleetModelID(0))
+	model := benchFleetModelID(0)
+	shapes := []struct {
+		name   string
+		traits RequestTraits
+	}{
+		{name: "plain"},
+		{name: "tools", traits: RequestTraits{HasTools: true}},
+	}
+	compareWalks := func(stage string) {
+		t.Helper()
+		for _, shape := range shapes {
+			var want walkOutcome
+			for i, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+				pr := benchPendingRequest(model, 0)
+				pr.Traits = shape.traits
+				got := runWalks(fleets[mode].reg, model, pr, shape.traits, false)
+				if i == 0 {
+					want = got
+					continue
+				}
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("%s/%s: walks differ across commit modes\n shared: %+v\n global: %+v", stage, shape.name, want, got)
+				}
+			}
+			for kind, id := range faulted {
+				pr := benchPendingRequest(model, 0)
+				pr.Traits = shape.traits
+				got := runWalks(fleets[reserveCommitShared].reg, model, pr, shape.traits, false)
+				for _, poolID := range got.pool {
+					if poolID == id && (kind != "error_cooldown" || shape.name == "tools") {
+						t.Fatalf("%s/%s: %s provider %s is in the eligible pool", stage, shape.name, kind, id)
+					}
+				}
+			}
+		}
+		now := time.Now()
+		for kind, id := range faulted {
+			var want gateOutcomes
+			for i, mode := range []reserveCommitMode{reserveCommitShared, reserveCommitGlobal} {
+				r := fleets[mode].reg
+				r.mu.RLock()
+				p := r.providers[id]
+				r.mu.RUnlock()
+				got := collectGateOutcomes(r, p, model, now)
+				if i == 0 {
+					want = got
+					continue
+				}
+				if got != want {
+					t.Fatalf("%s: %s provider gate outcomes differ across commit modes\n shared: %+v\n global: %+v", stage, kind, want, got)
+				}
+			}
+		}
+	}
+	compareWalks("before")
+
+	// Concurrent phase: scans, reservations and every per-request recorder on
+	// HEALTHY advertisers (their gate decisions cannot change), interleaved
+	// with the faulted providers' state being read by every scan. Identical
+	// scripts on both fleets; the interleaving itself is what the race
+	// detector checks.
+	healthy := func(f *benchFleet) []string {
+		var out []string
+		for i, id := range f.ids {
+			if !benchProviderAdvertises(f, i, model) {
+				continue
+			}
+			isFaulted := false
+			for _, fid := range faulted {
+				if fid == id {
+					isFaulted = true
+				}
+			}
+			if !isFaulted {
+				out = append(out, id)
+			}
+		}
+		return out
+	}
+	for mode, f := range fleets {
+		r := f.reg
+		ids := healthy(f)
+		const workers, iters = 8, 120
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				for i := 0; i < iters; i++ {
+					id := ids[(w*iters+i)%len(ids)]
+					switch i % 7 {
+					case 0:
+						pr := benchPendingRequest(model, 100_000+w*iters+i)
+						if p, _ := r.ReserveProviderEx(model, pr); p != nil {
+							p.RemovePending(pr.RequestID)
+						}
+					case 1:
+						r.QuickCapacityCheckForRequest(model, 600, 512, RequestTraits{HasTools: i%2 == 0}, false)
+					case 2:
+						r.RecordProviderOutcome(id, true, 200, "")
+					case 3:
+						r.RecordCapacityAccept(id, model)
+					case 4:
+						r.RecordInferenceSuccess(id, model, "base")
+					case 5:
+						if sid := r.GetProviderStableIdentity(id); sid != "" {
+							r.RecordProviderServeOutcome(sid, true, 200, "")
+						}
+						r.ClearDispatchLoadCooldown(id, model)
+					case 6:
+						r.PredictServable(model, 600, 600, 512, 128_000, RequestTraits{}, false)
+					}
+				}
+			}(w)
+		}
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("%s: concurrent phase failed", mode)
+		}
+	}
+	compareWalks("after")
+}
+
+// TestRequestPathParallelSpeedup guards against the walk-wide-lock regression:
+// scan + commit + the five per-request recorders must parallelize. Before this
+// branch the parallel variant ran at ~1.0–1.3x the serial one (every writer
+// drained the fleet-scan reader batch) while a read-only fleet walk on the
+// same box parallelized ~3.5x; with per-identity gates and the read-locked
+// commit the request path must reach at least 4x at 16 threads.
+//
+// The machine's own parallel ceiling is measured alongside (a pure RLock
+// fleet walk, no writers): a box busy with other work cannot show 4x for ANY
+// lock design, so on such a box the guard falls back to the relative
+// property — the request path parallelizes at least 60% as well as the
+// read-only walk — which the old global-write-lock path fails by a wide
+// margin (1.2x vs 3.5x). Each quantity is the best of three interleaved
+// fixed-work measurements so load drifting between them does not fake a
+// ratio. A box
+// whose 1-minute load average exceeds twice GOMAXPROCS cannot measure
+// parallelism at all (lock-holder preemption dominates every scheme); the
+// numbers are logged and the guard skips. Also skipped under the race
+// detector (it serializes goroutines) and on small machines.
+func TestRequestPathParallelSpeedup(t *testing.T) {
+	if raceDetectorEnabled {
+		t.Skip("throughput guard is meaningless under the race detector")
+	}
+	if testing.Short() {
+		t.Skip("-short")
+	}
+	procs := runtime.GOMAXPROCS(0)
+	if procs < 8 {
+		t.Skipf("GOMAXPROCS=%d; the speed-up guard needs >= 8", procs)
+	}
+	f := buildBenchFleet(t, benchFleetProviders, benchFleetModels)
+	walk := func(n int) {
+		model := f.models[n%len(f.models)]
+		if c, _, _, _, _ := f.reg.QuickCapacityCheckWithTTFTForRequest(model, 600, 512, RequestTraits{}, false); c == 0 {
+			t.Fatal("no candidates")
+		}
+	}
+	var seq atomic.Int64
+	path := func(n int) {
+		requestPathOnce(t, f, f.models[n%len(f.models)], n)
+	}
+	// Fixed work per measurement (no iteration search): ops calls, serially or
+	// split evenly across GOMAXPROCS goroutines; the result is ns per op.
+	const ops = 2000
+	timeOps := func(op func(int), parallel bool) int64 {
+		start := time.Now()
+		if !parallel {
+			for i := 0; i < ops; i++ {
+				op(int(seq.Add(1)))
+			}
+			return time.Since(start).Nanoseconds() / ops
+		}
+		var wg sync.WaitGroup
+		per := ops / procs
+		for w := 0; w < procs; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < per; i++ {
+					op(int(seq.Add(1)))
+				}
+			}()
+		}
+		wg.Wait()
+		return time.Since(start).Nanoseconds() / int64(per*procs)
+	}
+	measure := map[string]func() int64{
+		"read serial":   func() int64 { return timeOps(walk, false) },
+		"read parallel": func() int64 { return timeOps(walk, true) },
+		"path serial":   func() int64 { return timeOps(path, false) },
+		"path parallel": func() int64 { return timeOps(path, true) },
+	}
+	order := []string{"read serial", "read parallel", "path serial", "path parallel"}
+	best := map[string]int64{}
+	for round := 0; round < 3; round++ {
+		for _, name := range order {
+			ns := measure[name]()
+			if cur, ok := best[name]; !ok || ns < cur {
+				best[name] = ns
+			}
+		}
+	}
+	readSpeedup := float64(best["read serial"]) / float64(best["read parallel"])
+	pathSpeedup := float64(best["path serial"]) / float64(best["path parallel"])
+	load, load1 := loadAverage()
+	t.Logf("read-only walk: serial %v/op, parallel %v/op, speed-up %.2fx (the box's ceiling)",
+		time.Duration(best["read serial"]), time.Duration(best["read parallel"]), readSpeedup)
+	t.Logf("request path: serial %v/op, parallel %v/op at %d threads, speed-up %.2fx (%s)",
+		time.Duration(best["path serial"]), time.Duration(best["path parallel"]), procs, pathSpeedup, load)
+	if load1 > 2*float64(procs) {
+		t.Skipf("box saturated (1-minute load %.0f on %d procs): parallelism cannot be measured here", load1, procs)
+	}
+	if readSpeedup >= 4 {
+		if pathSpeedup < 4 {
+			t.Fatalf("request path parallel speed-up %.2fx at %d threads, want >= 4x (a walk-wide lock is back?)", pathSpeedup, procs)
+		}
+		return
+	}
+	// Busy box: hold the relative property instead.
+	if pathSpeedup < 0.6*readSpeedup {
+		t.Fatalf("request path parallel speed-up %.2fx is below 60%% of the read-only walk's %.2fx on this box (a walk-wide lock is back?)",
+			pathSpeedup, readSpeedup)
+	}
+	t.Logf("busy box (read-only ceiling %.2fx < 4x): asserted the relative property only", readSpeedup)
+}
+
+// loadAverage returns uptime's load-average text and the parsed 1-minute
+// value (0 when unavailable).
+func loadAverage() (text string, load1 float64) {
+	out, err := exec.Command("uptime").Output()
+	if err != nil {
+		return "load n/a", 0
+	}
+	text = "load n/a"
+	if i := strings.Index(string(out), "load"); i >= 0 {
+		text = strings.TrimSpace(string(out)[i:])
+	}
+	// "load averages: 1.23 4.56 7.89" (darwin) / "load average: 1.23, 4.56, 7.89" (linux)
+	fields := strings.Fields(strings.NewReplacer(",", " ", ":", " ").Replace(text))
+	for i, fld := range fields {
+		if strings.HasPrefix(fld, "average") && i+1 < len(fields) {
+			fmt.Sscanf(fields[i+1], "%f", &load1)
+			break
+		}
+	}
+	return text, load1
+}

--- a/coordinator/registry/routing_rejection_classification.go
+++ b/coordinator/registry/routing_rejection_classification.go
@@ -1,0 +1,28 @@
+package registry
+
+import "time"
+
+// classifyRejectedProvider identifies the rejection states that control the
+// fail-open rescan and the capacity/no-provider response. These are routing
+// decisions, so a view loaded before a shared-identity rebind must be confirmed
+// before its now-empty source gate can suppress either classification.
+// Caller holds r.mu and no p.mu; p.mu stays held through the reads and their
+// confirmation, preventing another rebind from invalidating the new view.
+func (r *Registry) classifyRejectedProvider(view gateView, model string, traits RequestTraits, selfRouteOwner, ignoreProviderBreaker bool, now time.Time) (breaker, capacity bool) {
+	p := view.p
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for {
+		g := view.g
+		breaker = !ignoreProviderBreaker && (g.breakerOpenAt(now.UnixNano()) ||
+			(healthEjectionEnabled() && r.ejectionOpenFor(g, stableProviderIdentityLocked(p), now.UnixNano())))
+		// Only a pair that otherwise passes routing is transient capacity.
+		// A simultaneous structural failure must remain no-provider, and drain
+		// marks use the same capacity path as a provider's reject cooldown.
+		capacity = (providerDrainingLocked(p, now) || g.capacityCooled(model, now)) &&
+			r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, true)
+		if !view.moved() {
+			return breaker, capacity
+		}
+	}
+}

--- a/coordinator/registry/routing_rejection_classification_test.go
+++ b/coordinator/registry/routing_rejection_classification_test.go
@@ -1,0 +1,90 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestRejectedProviderClassificationFollowsSharedRebind(t *testing.T) {
+	setHealthEjectionEnabledForTest(t, true)
+	for _, tc := range []struct {
+		name              string
+		set               func(*gateState, time.Time)
+		breaker, capacity bool
+	}{
+		{"breaker", func(g *gateState, until time.Time) { g.breakerUntil = until }, true, false},
+		{"ejection", func(g *gateState, until time.Time) { g.ejectionUntil = until }, true, false},
+		{"capacity", func(g *gateState, until time.Time) {
+			g.capacityCooldowns["m"] = &capacityCooldownEntry{expiry: until}
+		}, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p1 := makeSchedulerProvider(t, reg, "classify-rebind-1", "m", 100)
+			p2 := makeSchedulerProvider(t, reg, "classify-rebind-2", "m", 100)
+			identity := &attestation.VerificationResult{Valid: true, PublicKey: "PK-CLASSIFY"}
+			p1.SetAttestationResult(identity)
+			p2.SetAttestationResult(identity)
+			now := time.Now()
+			withGateForSession(reg, p1.ID, func(g *gateState) { tc.set(g, now.Add(time.Minute)) })
+			// The snapshot rejected p1, then classification loaded its shared
+			// gate. Enrichment occurs before classification reads that gate.
+			reg.mu.RLock()
+			var snapshot routingSnapshot
+			ok, _ := reg.snapshotProviderIntoLockedEx(&snapshot, p1, "m", RequestTraits{}, false, false, now)
+			reg.mu.RUnlock()
+			if ok {
+				t.Fatal("precondition: the snapshot must reject the provider")
+			}
+			view := reg.gateViewOf(p1)
+			p1.SetAttestationResult(&attestation.VerificationResult{
+				Valid: true, PublicKey: identity.PublicKey, SerialNumber: "SER-CLASSIFY",
+			})
+			if view.g == p1.gate.Load() || view.g != p2.gate.Load() ||
+				view.g.breakerOpenAt(now.UnixNano()) || view.g.ejectedAt(now.UnixNano()) || view.g.capacityCooled("m", now) {
+				t.Fatal("precondition: the loaded source must be the sibling's emptied gate")
+			}
+			reg.mu.RLock()
+			breaker, capacity := reg.classifyRejectedProvider(view, "m", RequestTraits{}, false, false, now)
+			reg.mu.RUnlock()
+			if breaker != tc.breaker || capacity != tc.capacity {
+				t.Fatalf("classification = breaker:%v capacity:%v, want %v/%v", breaker, capacity, tc.breaker, tc.capacity)
+			}
+			breakerCount, capacityCount := 0, 0
+			if breaker {
+				breakerCount++
+			}
+			if capacity {
+				capacityCount++
+			}
+			if shouldBypassBreakerFailOpen(nil, breakerCount, capacityCount, 0) != tc.breaker {
+				t.Fatal("moved gate produced the wrong fail-open rescan decision")
+			}
+		})
+	}
+}
+
+func TestRejectedProviderClassificationKeepsDrainTransient(t *testing.T) {
+	reg := New(testLogger())
+	p := makeSchedulerProvider(t, reg, "classify-draining", "m", 100)
+	p.mu.Lock()
+	p.drainingUntil = time.Now().Add(time.Minute)
+	p.mu.Unlock()
+	reg.mu.RLock()
+	scan := reg.scanCandidatesLocked("m", &PendingRequest{Model: "m", RequestedMaxTokens: 32}, false)
+	reg.mu.RUnlock()
+	if scan.candidateCount != 0 || scan.capacityRejections != 1 || scan.breakerRejected != 0 {
+		t.Fatalf("draining scan = candidates:%d capacity:%d breaker:%d", scan.candidateCount, scan.capacityRejections, scan.breakerRejected)
+	}
+	p.mu.Lock()
+	p.RuntimeVerified = false
+	p.mu.Unlock()
+	reg.mu.RLock()
+	scan = reg.scanCandidatesLocked("m", &PendingRequest{Model: "m", RequestedMaxTokens: 32}, false)
+	reg.mu.RUnlock()
+	if scan.capacityRejections != 0 {
+		t.Fatal("a draining provider that also fails structural gates counted as transient capacity")
+	}
+}

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -1201,13 +1201,15 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 			// ignoreCapacityCooldown re-run of the shared gate keeps a pair that
 			// ALSO fails a structural gate out of the count; both checks are
 			// cheap and only run on the already-rare drop path.
-			if r.capacityCooldownActiveLocked(p.ID, model, now) {
-				p.mu.Lock()
-				otherwiseRoutable := r.providerPassesRoutingGatesLockedEx(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker, true)
-				p.mu.Unlock()
-				if otherwiseRoutable {
-					capacityRejections++
-				}
+			// A draining provider (drain_state.go) is the same transient
+			// class: present, serving the model, back after its restart.
+			p.mu.Lock()
+			transient := r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)
+			otherwiseRoutable := transient &&
+				r.providerPassesRoutingGatesLockedEx(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker, true)
+			p.mu.Unlock()
+			if otherwiseRoutable {
+				capacityRejections++
 			}
 			continue
 		}
@@ -1715,7 +1717,13 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	// keep winning the cost scheduler. A busy box that is also SERVING never
 	// trips this (any accept resets the streak), and the pair is re-probed once
 	// its TTL expires. See capacity_cooldown.go.
-	if !ignoreCapacityCooldown && r.capacityCooldownActiveLocked(p.ID, model, now) {
+	// A DRAINING provider (heartbeat status "draining" or a typed draining
+	// rejection — drain_state.go) rides the same transient branch: it refuses
+	// every dispatch until it restarts, so it is skipped here and counted as
+	// a capacityRejection by the scan/preflight re-check, never as absence.
+	// It is tallied under GateCapacityCooldown on the routing record.
+	if !ignoreCapacityCooldown &&
+		(r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) {
 		return false, GateCapacityCooldown
 	}
 	// Skip a provider quarantined by the per-provider node-health breaker: a
@@ -2840,7 +2848,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			// never fit the hardware counts as modelTooLarge — never as
 			// transient capacity, or a fleet of undersized cooled boxes would
 			// read as "busy, retry" for a model that will never fit.
-			if r.capacityCooldownActiveLocked(p.ID, model, now) &&
+			if (r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) &&
 				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) &&
 				p.SystemMetrics.ThermalState != "critical" &&
 				(!requiresVision || r.providerServesVisionModelLocked(p, model, false)) {
@@ -3173,88 +3181,154 @@ func (r *Registry) drainQueuedRequestsForModelsWithReason(models []string, reaso
 		return
 	}
 	for _, model := range models {
-		var skipped []*QueuedRequest
-		requeueSkipped := func() {
-			for i := len(skipped) - 1; i >= 0; i-- {
-				queue.RequeueFront(skipped[i])
-			}
-			skipped = nil
-		}
-		for {
-			req := queue.PopNextFresh(model)
-			if req == nil {
-				requeueSkipped()
-				break
-			}
-			if req.Pending == nil {
-				req.Pending = &PendingRequest{
-					RequestID:          req.RequestID,
-					Model:              model,
-					RequestedMaxTokens: defaultRequestedMaxTokens,
-				}
-			}
-			// Queue time spends the same absolute first-content clock as
-			// parsing, admission, and provider dispatch. Refresh immediately
-			// before reservation so hard TTFT admission never reuses the
-			// enqueue-time ceiling.
-			if !req.Pending.RefreshFirstContentBudget(time.Now()) {
-				req.failWithReason(ErrQueueFirstContentDeadline)
-				continue
-			}
-			provider, decision := r.ReserveProviderEx(model, req.Pending)
-			// Queue context for the routing record: where the request sat at
-			// enqueue and which event ran the drain that produced this decision.
-			decision.QueuePosition = req.EnqueuePosition
-			decision.QueueDepth = req.DepthAtEnqueue
-			decision.DrainTrigger = reason
-			if provider == nil {
-				if req.Pending.Traits.RequiresToolConstraint &&
-					!r.hasToolConstraintProviderForPending(model, req.Pending) {
-					req.DrainTrigger = reason
-					req.Decision = decision
-					req.failWithReason(ErrQueueToolConstraintUnavailable)
-					continue
-				}
-				// A pure-TTFT rejection (hard-reject mode, no capacity-rejected
-				// provider that could free up) is deterministic for this pass:
-				// requeueing would only make the waiter hang until maxWait for
-				// the same answer. Fail it now; the API waiter turns
-				// ErrQueueTTFTTooSlow into the standard ttft_too_slow 429 using
-				// the decision's BestTTFTMs for Retry-After.
-				if drainRejectionTTFTTerminal(req.Pending, decision) {
-					req.DrainTrigger = reason
-					req.Decision = decision
-					req.failWithReason(ErrQueueTTFTTooSlow)
-					continue
-				}
-				skipped = append(skipped, req)
-				continue
-			}
-			req.DrainTrigger = reason
-			req.Decision = decision
-			requeueSkipped()
+		r.drainModelQueue(queue, model, reason)
+	}
+}
 
-			releaseReservation := func() {
-				provider.RemovePending(req.Pending.RequestID)
-				r.SetProviderIdle(provider.ID)
-			}
-			if !req.offerAssignment(provider, releaseReservation) {
-				releaseReservation()
-				continue
-			}
-			if req.beforeAssignmentSend != nil {
-				req.beforeAssignmentSend()
-			}
-			select {
-			case req.ResponseCh <- provider:
-				// The reservation remains scheduler-owned until the waiter
-				// acknowledges it in WaitForProviderContext. Cancellation after
-				// this buffered send rejects the published assignment and runs
-				// releaseReservation exactly once.
-			case <-req.Done():
-				req.rejectAssignment()
-				continue
+// drainModelQueue runs the drain pass for one model under the per-model claim
+// (queue_drain_coalesce.go): a trigger that finds a pass in flight hands its
+// reason to that pass and returns, and the pass reruns once for it after
+// requeueing. A pass that does not complete releases the claim on the way out
+// so a recovered panic cannot leave the model undrainable.
+func (r *Registry) drainModelQueue(queue *RequestQueue, model, reason string) {
+	if !r.drainPasses.begin(model, reason) {
+		return
+	}
+	released := false
+	defer func() {
+		if !released {
+			r.drainPasses.abandon(model)
+		}
+	}()
+	for {
+		r.drainModelQueuePass(queue, model, reason)
+		next, again := r.drainPasses.end(model)
+		if !again {
+			released = true
+			return
+		}
+		reason = next
+	}
+}
+
+// drainModelQueuePass pops every fresh queued request for model once and
+// either assigns it, fails it deterministically, or requeues it in order.
+// Fleet state is read live per scan; verdicts are reused within the pass only
+// through the dominance skip, whose records this pass owns.
+func (r *Registry) drainModelQueuePass(queue *RequestQueue, model, reason string) {
+	var skipped []*QueuedRequest
+	// rejected anchors the per-pass dominance skip (queue_drain_dominance.go)
+	// and deliberately survives requeueSkipped: an admission only removes
+	// capacity, so this pass's verdicts stay valid for the requeued waiters
+	// the next PopNextFresh hands back.
+	var rejected []drainRejectionRecord
+	admitted := 0
+	saturated := false
+	requeueSkipped := func() {
+		for i := len(skipped) - 1; i >= 0; i-- {
+			queue.RequeueFront(skipped[i])
+		}
+		skipped = nil
+	}
+	for {
+		if r.drainBeforePop != nil {
+			r.drainBeforePop(model)
+		}
+		req := queue.PopNextFresh(model)
+		if req == nil {
+			requeueSkipped()
+			break
+		}
+		if req.Pending == nil {
+			req.Pending = &PendingRequest{
+				RequestID:          req.RequestID,
+				Model:              model,
+				RequestedMaxTokens: defaultRequestedMaxTokens,
 			}
 		}
+		// Queue time spends the same absolute first-content clock as
+		// parsing, admission, and provider dispatch. Refresh immediately
+		// before reservation so hard TTFT admission never reuses the
+		// enqueue-time ceiling.
+		if !req.Pending.RefreshFirstContentBudget(time.Now()) {
+			req.failWithReason(ErrQueueFirstContentDeadline)
+			continue
+		}
+		// A waiter at least as demanding as one this pass already rejected
+		// purely on capacity/TTFT gets the same verdict from the same fleet
+		// state; requeue it without paying for another full fleet scan.
+		if drainDominated(req.Pending, rejected) {
+			saturated = true
+			skipped = append(skipped, req)
+			continue
+		}
+		provider, decision := r.ReserveProviderEx(model, req.Pending)
+		// Queue context for the routing record: where the request sat at
+		// enqueue and which event ran the drain that produced this decision.
+		decision.QueuePosition = req.EnqueuePosition
+		decision.QueueDepth = req.DepthAtEnqueue
+		decision.DrainTrigger = reason
+		if provider == nil {
+			if req.Pending.Traits.RequiresToolConstraint &&
+				!r.hasToolConstraintProviderForPending(model, req.Pending) {
+				req.DrainTrigger = reason
+				req.Decision = decision
+				req.failWithReason(ErrQueueToolConstraintUnavailable)
+				continue
+			}
+			// A pure-TTFT rejection (hard-reject mode, no capacity-rejected
+			// provider that could free up) is deterministic for this pass:
+			// requeueing would only make the waiter hang until maxWait for
+			// the same answer. Fail it now; the API waiter turns
+			// ErrQueueTTFTTooSlow into the standard ttft_too_slow 429 using
+			// the decision's BestTTFTMs for Retry-After.
+			if drainRejectionTTFTTerminal(req.Pending, decision) {
+				req.DrainTrigger = reason
+				req.Decision = decision
+				req.failWithReason(ErrQueueTTFTTooSlow)
+				continue
+			}
+			if rec, ok := drainRejectionRecordFor(req.Pending, decision); ok {
+				rejected = append(rejected, rec)
+			}
+			saturated = saturated || drainPureCapacityRejection(decision)
+			skipped = append(skipped, req)
+			continue
+		}
+		admitted++
+		req.DrainTrigger = reason
+		req.Decision = decision
+		requeueSkipped()
+
+		releaseReservation := func() {
+			provider.RemovePending(req.Pending.RequestID)
+			r.SetProviderIdle(provider.ID)
+		}
+		if !req.offerAssignment(provider, releaseReservation) {
+			releaseReservation()
+			continue
+		}
+		if req.beforeAssignmentSend != nil {
+			req.beforeAssignmentSend()
+		}
+		select {
+		case req.ResponseCh <- provider:
+			// The reservation remains scheduler-owned until the waiter
+			// acknowledges it in WaitForProviderContext. Cancellation after
+			// this buffered send rejects the published assignment and runs
+			// releaseReservation exactly once.
+		case <-req.Done():
+			req.rejectAssignment()
+			continue
+		}
+	}
+	// Heartbeat-triggered passes are suppressed for a short window after
+	// a saturated pass (queue_drain_suppress.go); an admission proves
+	// capacity moved and lifts the mark.
+	switch {
+	case admitted > 0:
+		r.drainSuppress.clear(model)
+	case saturated:
+		r.drainSuppress.markSaturated(model)
 	}
 }

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -492,8 +492,10 @@ type providerReservationScan struct {
 //
 // In-flight token-budget ledger: the reservation itself IS the debit. Expensive
 // fleet scans share r.mu for reading; the winner is then re-snapshotted and
-// committed inside a short r.mu WRITE section. addPendingLocked records the
-// request before that section ends, so every later commit sees the debit through
+// committed inside a short section under the winner's p.mu (r.mu is only read
+// — see commitProviderReservation; the global mode is the kill switch).
+// addPendingLocked records the request before that section ends, so every
+// later commit on that provider sees the debit through
 // fillSnapshotPendingAndPool and freeMemoryAdmits (including the reconstructed
 // whole-box pool) before it can reserve. Concurrent scans therefore do not
 // double-spend reported headroom across models. Heartbeat re-sync remains safe:
@@ -537,7 +539,7 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 			return nil, failedDecision(), nil
 		}
 
-		// AdmitUS covers the commit phase: the write-lock wait plus the
+		// AdmitUS covers the commit phase: the lock waits plus the
 		// current-state re-check and the pending debit.
 		tCommitStart := time.Now()
 		provider, candidate, outcome, rejected := r.commitProviderReservation(
@@ -575,8 +577,8 @@ func (r *Registry) reserveProvider(model string, pr *PendingRequest, wantPlan bo
 
 // scanProviderReservation performs the expensive fleet walk under a shared
 // registry lock. Concurrent requests may scan together; no provider capacity is
-// consumed until commitProviderReservation acquires the short write section and
-// revalidates the winner against current cross-model pending debits.
+// consumed until commitProviderReservation takes the winner's p.mu and
+// revalidates it against current cross-model pending debits.
 func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, excludeIDs ...string) providerReservationScan {
 	// Profiler stamps: scan-lock wait (from here to the scan RLock) and the
 	// scan itself land on the decision as LockWaitUS / ScanUS; ~25 ns each.
@@ -640,19 +642,34 @@ func (r *Registry) scanProviderReservation(model string, pr *PendingRequest, exc
 	return result
 }
 
-// commitProviderReservation is the short serialized phase. It repeats the full
+// commitProviderReservation is the short commit phase. It repeats the full
 // current-state capacity chain before adding the pending debit, so concurrent
 // scans cannot double-spend a provider's shared cross-model token pool.
+//
+// Locking (reserveCommitShared, the default): r.mu is held for READING — the
+// commit needs the provider identity, catalog and cache-routing configuration
+// to be stable, not the fleet to be frozen — and everything that decides the
+// reservation runs under the winner's p.mu in ONE section: the fresh snapshot,
+// the cost rebuild, the "winner unchanged since scan" compare, the admit
+// re-check, the probe claim and the pending debit. Double-booking is prevented
+// where it always was (providerCanAdmitLockedEx + addPendingLocked under
+// p.mu); the herd compare is exact because it compares the winner's own
+// counters read under the same p.mu that debits them; the half-open probe
+// claim is check-and-claim under gate.mu. Nothing here drains the fleet-scan
+// reader batch, which is what each write acquisition cost before.
+// reserveCommitGlobal takes r.mu for writing instead — the previous
+// fleet-wide serialization, kept as the kill switch.
 func (r *Registry) commitProviderReservation(
 	model string,
 	pr *PendingRequest,
 	scan providerReservationScan,
 	excludeIDs ...string,
 ) (*Provider, *routingCandidate, reservationCommitOutcome, RoutingDecision) {
-	hold := r.lockWrite("commit")
-	defer hold.unlock()
+	lock := r.commitLock("commit")
+	lock.lock()
+	defer lock.unlock()
 
-	// The shared scan and write-lock wait consume the same absolute request
+	// The shared scan and any lock wait consume the same absolute request
 	// clock as queueing and provider handoff. Never debit capacity for work whose
 	// first-content budget is already gone. One clock read serves the whole
 	// commit section (deadline, re-snapshot, cost, admit, probe claim).
@@ -677,8 +694,8 @@ func (r *Registry) commitProviderReservation(
 
 	// A breaker bypass is valid only while breaker-open providers remain the
 	// sole route. Re-run the normal pass at commit time; this rare emergency path
-	// may scan under the write lock so a newly healthy provider cannot race the
-	// fail-open decision.
+	// re-scans under the commit lock so a newly healthy provider is preferred
+	// over the fail-open choice.
 	if scan.candidates.ignoreProviderBreaker {
 		normalWinner, normal := r.selectBestCandidateScanLocked(
 			model, pr, false, excludeIDs...)
@@ -689,6 +706,8 @@ func (r *Registry) commitProviderReservation(
 		}
 	}
 
+	// Ownership / serial filters take p.mu themselves — evaluate them before
+	// the commit section below acquires it.
 	owned := providerOwnedBy(p, pr.OwnerAccountID)
 	if pr.SelfRouteOnly && !owned {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
@@ -703,19 +722,20 @@ func (r *Registry) commitProviderReservation(
 		}
 	}
 	relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
-	snapshot, ok := r.snapshotProviderLockedEx(
-		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now)
-	if !ok {
+
+	// Commit section: snapshot, cost, compare, admit and debit under ONE p.mu
+	// hold, so no other commit can change this provider between the compare
+	// and the debit.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var snapshot routingSnapshot
+	if ok, _ := r.snapshotProviderIntoPLockedEx(
+		&snapshot, p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now); !ok {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
-	if pr.RequiresVision {
-		p.mu.Lock()
-		servesVision := r.providerServesVisionModelLocked(p, model, relaxTrust)
-		p.mu.Unlock()
-		if !servesVision {
-			return nil, nil, reservationCandidateRejected,
-				routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
-		}
+	if pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust) {
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, rejectVisionUnsupported, false)
 	}
 	candidate, reason, ok := r.buildCandidateWithReason(snapshot, pr, now)
 	if !ok {
@@ -727,11 +747,13 @@ func (r *Registry) commitProviderReservation(
 		return nil, nil, reservationCandidateRejected,
 			routingDecisionForCommitRejection(model, rejectNone, true)
 	}
-	r.applyCacheRoutingDiscount(p, model, pr, candidate)
+	r.applyCacheRoutingDiscountPLocked(p, model, pr, candidate)
 
 	// Another reservation changed this winner after the shared scan. Re-scan the
 	// fleet so cost ranking observes that debit instead of herding the whole scan
-	// cohort onto the formerly-cheapest provider.
+	// cohort onto the formerly-cheapest provider. The counters compared here
+	// were read under the p.mu this section still holds, so a concurrent commit
+	// on the same provider is either fully before (and visible) or fully after.
 	if snapshot.pendingForModel != selected.snapshot.pendingForModel ||
 		snapshot.totalPending != selected.snapshot.totalPending ||
 		candidate.effectiveQueue != selected.effectiveQueue ||
@@ -739,17 +761,21 @@ func (r *Registry) commitProviderReservation(
 		return nil, nil, reservationNeedsRescan, RoutingDecision{}
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	if !r.providerCanAdmitLockedEx(
 		p, model, pr.Traits, relaxTrust, scan.candidates.ignoreProviderBreaker, now) ||
 		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
 		return nil, nil, reservationCandidateRejected, RoutingDecision{}
 	}
+	// Half-open capacity probe: check-and-claim under gate.mu (p.mu → gate.mu).
+	// A pair whose expired cooldown was claimed by a concurrent commit for the
+	// same identity is closed again; reject rather than leak a second probe.
+	if !r.tryClaimCapacityProbe(p, model, now) {
+		return nil, nil, reservationCandidateRejected,
+			routingDecisionForCommitRejection(model, rejectCapacity, false)
+	}
 
 	pr.ProviderID = p.ID
 	p.addPendingLocked(pr)
-	r.claimCapacityProbeLocked(p.ID, model, now)
 	if p.Status != StatusUntrusted && p.Status != StatusOffline {
 		p.Status = StatusServing
 	}
@@ -881,15 +907,27 @@ func routingDecisionForCandidate(model string, provider *Provider, candidate *ro
 }
 
 // applyCacheRoutingDiscount reads the candidate's own snapshot (the scan
-// builds it in place; no copy is taken).
+// builds it in place; no copy is taken). The caller does NOT hold p.mu (the
+// scan): the hint currency check takes it.
 func (r *Registry) applyCacheRoutingDiscount(p *Provider, model string, pr *PendingRequest, candidate *routingCandidate) {
-	if len(pr.cacheRoutingHints) == 0 {
-		return
-	}
 	hint, ok := pr.cacheRoutingHints[p.ID]
 	if !ok || !hint.currentForProvider(p, model) {
 		return
 	}
+	r.applyCacheHintDiscount(hint, candidate)
+}
+
+// applyCacheRoutingDiscountPLocked is applyCacheRoutingDiscount for a caller
+// that already holds p.mu (the reservation commit).
+func (r *Registry) applyCacheRoutingDiscountPLocked(p *Provider, model string, pr *PendingRequest, candidate *routingCandidate) {
+	hint, ok := pr.cacheRoutingHints[p.ID]
+	if !ok || !hint.currentForProviderLocked(p, model) {
+		return
+	}
+	r.applyCacheHintDiscount(hint, candidate)
+}
+
+func (r *Registry) applyCacheHintDiscount(hint cacheRoutingHint, candidate *routingCandidate) {
 	prefillTPS := resolvePrefillTPS(&candidate.snapshot)
 	if prefillTPS <= 0 || math.IsNaN(prefillTPS) || math.IsInf(prefillTPS, 0) {
 		return
@@ -1174,41 +1212,12 @@ func (r *Registry) scanCandidatesLocked(model string, pr *PendingRequest, ignore
 		if !ok {
 			arena.release(c)
 			scan.tallyGate(gateReason)
-			// Count providers a breaker-bypassed fail-open re-scan COULD rescue: those
-			// dropped by the node-health breaker OR the stable-identity health-ejection
-			// gate (both are bypassed when ignoreProviderBreaker is set). Without
-			// counting ejection here, ejecting EVERY provider for a model would leave
-			// winner==nil with breakerRejected==0, so shouldBypassBreakerFailOpen would
-			// NOT fire and the model would be zeroed out. Only meaningful on the normal pass.
-			if !ignoreProviderBreaker {
-				if r.providerBreakerOpenLocked(p.ID, now) {
-					breakerRejected++
-				} else if healthEjectionEnabled() {
-					// p.mu is not held here (snapshot released it); take it for the
-					// identity read (r.mu→p.mu is the established order).
-					p.mu.Lock()
-					sid := stableProviderIdentityLocked(p)
-					p.mu.Unlock()
-					if sid != "" && r.healthEjectionOpenLocked(sid, now) {
-						breakerRejected++
-					}
-				}
+			breaker, capacity := r.classifyRejectedProvider(
+				r.gateViewOf(p), model, pr.Traits, relaxTrust, ignoreProviderBreaker, now)
+			if breaker {
+				breakerRejected++
 			}
-			// A pair dropped ONLY by the capacity-reject cooldown is TRANSIENT
-			// capacity, not structural absence — count it as a capacityRejection
-			// (mirroring quickCapacityCheck) so an all-cooled model classifies as
-			// over_capacity (429/queue material) rather than no_provider. The
-			// ignoreCapacityCooldown re-run of the shared gate keeps a pair that
-			// ALSO fails a structural gate out of the count; both checks are
-			// cheap and only run on the already-rare drop path.
-			// A draining provider (drain_state.go) is the same transient
-			// class: present, serving the model, back after its restart.
-			p.mu.Lock()
-			transient := r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)
-			otherwiseRoutable := transient &&
-				r.providerPassesRoutingGatesLockedEx(p, model, pr.Traits, relaxTrust, now, ignoreProviderBreaker, true)
-			p.mu.Unlock()
-			if otherwiseRoutable {
+			if capacity {
 				capacityRejections++
 			}
 			continue
@@ -1695,58 +1704,17 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	if ok, reason := r.providerServesRoutableModelReasonLocked(p, model, selfRouteOwner); !ok {
 		return false, reason
 	}
-	// Skip a provider-model pair cooling down after a dispatch-time load
-	// failure ("insufficient memory") — it would instant-503 again, burning a
-	// dispatch attempt.
-	if r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
-		return false, GateDispatchLoadCooldown
-	}
-	// Skip a triple quarantined by the inference-error circuit breaker for THIS
-	// request shape: repeated provider-side (5xx) failures — e.g. a deterministic
-	// chat-template render crash on tool schemas — mean a retry here fails
-	// identically, so routing must fall to a different provider. Shape-keyed so a
-	// tool failure does not deroute clean text traffic. Cleared by
-	// RecordInferenceSuccess (same shape) or by TTL expiry.
-	if r.inferenceErrorCooldownActiveLocked(p.ID, model, traits.CooldownShape(), now) {
-		return false, GateErrorCooldown
-	}
-	// Skip a (provider, model) pair quarantined by the capacity-reject cooldown:
-	// it kept capacity-rejecting with ZERO interleaved accepts (the black-hole
-	// signature — e.g. a box whose engine misreports its token budget), so a
-	// dispatch here is a guaranteed bounce while its idle-looking heartbeats
-	// keep winning the cost scheduler. A busy box that is also SERVING never
-	// trips this (any accept resets the streak), and the pair is re-probed once
-	// its TTL expires. See capacity_cooldown.go.
-	// A DRAINING provider (heartbeat status "draining" or a typed draining
-	// rejection — drain_state.go) rides the same transient branch: it refuses
-	// every dispatch until it restarts, so it is skipped here and counted as
-	// a capacityRejection by the scan/preflight re-check, never as absence.
-	// It is tallied under GateCapacityCooldown on the routing record.
-	if !ignoreCapacityCooldown &&
-		(r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) {
+	// The identity's fault-tracker gates (gate_state.go): cached on the
+	// connected provider, so the five reads are atomic loads for a provider
+	// with no fault state and one short gate.mu section per tracker that has
+	// state — and confirmed against p.gate afterwards (gateView), so a rebind
+	// landing mid-read cannot hand the scan an emptied gate.
+	if !ignoreCapacityCooldown && providerDrainingLocked(p, now) {
 		return false, GateCapacityCooldown
 	}
-	// Skip a provider quarantined by the per-provider node-health breaker: a
-	// node returning GENUINE-FAULT errors (500/502/504 or a
-	// fault-shaped 503) for ~all of its requests is sick regardless of model or
-	// shape, so it is derouted fleet-wide. This catches the node that fault-503s
-	// every request — invisible to the shape-keyed inference-error breaker above
-	// (which skips 503 as a capacity signal). Honored on the normal routing
-	// path; the selectBestCandidateLockedFull fail-open pass sets
-	// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
-	if !ignoreProviderBreaker && r.providerBreakerOpenLocked(p.ID, now) {
-		return false, GateBreaker
-	}
-	// Skip a provider EJECTED by the stable-identity health breaker (health_ejection.go):
-	// a node whose serial/SE-key/account has collapsed to a near-total served-fault
-	// rate is derouted even across reconnects (the session breaker above is wiped on
-	// every disconnect, which the constantly-disconnecting zombies exploit). Same
-	// fail-open contract: skipped on the ignoreProviderBreaker rescan, and an
-	// un-attestable provider (empty stable id) is never ejected.
-	if !ignoreProviderBreaker && healthEjectionEnabled() {
-		if sid := stableProviderIdentityLocked(p); sid != "" && r.healthEjectionOpenLocked(sid, now) {
-			return false, GateEjection
-		}
+	view := r.gateViewOf(p)
+	if ok, reason := r.gateStateReasonLocked(&view, model, traits, now, ignoreProviderBreaker, ignoreCapacityCooldown); !ok {
+		return false, reason
 	}
 	// Liveness/trust/privacy core. selfRouteOwner relaxes ONLY the hardware-trust
 	// floor (to TrustNone) and private-only admission for a caller's own
@@ -1767,36 +1735,86 @@ func (r *Registry) providerRoutingGateReasonLockedEx(p *Provider, model string, 
 	return true, GateReasonCount
 }
 
-// snapshotProviderLockedEx builds a routing snapshot for p, returning ok=false
-// when p fails any structural/privacy/capacity/trait gate. selfRouteOwner is
-// true when this is a self-route request and p is owned by the requesting
-// account. It (1) drops the hardware-trust floor to TrustNone — a personal Mac
-// will not be MDM/MDA enrolled, so without this it would be unroutable to its
-// own owner — and (2) admits a private-only machine, which is otherwise
-// excluded from the public fleet. Every privacy-critical gate (RuntimeVerified,
-// private-text support, challenge freshness) still applies, so plaintext is
-// never exposed and only the genuinely-signed provider binary serves. traits
-// carry the request shape into the shape-keyed inference-error cooldown and the
-// render-broken / version-floor eligibility gates.
-//
-// ignoreProviderBreaker is threaded into the routing gate: only the
-// selectBestCandidateLockedFull fail-open fallback pass sets it true (to bypass
-// the node-health breaker); every other caller passes false. (The former
-// breaker-honored wrapper snapshotProviderLocked is gone — the fleet walks use
-// snapshotProviderIntoLockedEx directly.) now is the scan clock: hot-path callers
-// walk the whole fleet and must read the wall clock ONCE per scan, not once
-// per provider (runtime.walltime was ~35% of the reservation scan at fleet
-// scale); every time-keyed gate below (challenge freshness, cooldowns,
-// breaker, clamp) evaluates against that single instant.
-func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (routingSnapshot, bool) {
-	var snap routingSnapshot
-	ok, _ := r.snapshotProviderIntoLockedEx(&snap, p, model, traits, selfRouteOwner, ignoreProviderBreaker, now)
-	return snap, ok
+// gateStateReasonLocked evaluates the five fault-tracker gates for the session
+// behind view against its identity's gate and returns the first closed one
+// (GateReasonCount when all pass), in the documented gate precedence. The
+// verdict is confirmed against p.gate (gateView.moved) and re-read from the
+// session's new gate when a rebind landed between the view's load and the
+// reads — the scan, the commit's admit re-check and the preflight all come
+// through here, so none of them can dispatch a session past a breaker or
+// cooldown that moved with it. Caller holds p.mu (for the identity read).
+func (r *Registry) gateStateReasonLocked(view *gateView, model string, traits RequestTraits, now time.Time, ignoreProviderBreaker, ignoreCapacityCooldown bool) (bool, GateReason) {
+	nowNS := now.UnixNano()
+	for {
+		g := view.g
+		reason := GateReasonCount
+		switch {
+		// Skip a provider-model pair cooling down after a dispatch-time load
+		// failure ("insufficient memory") — it would instant-503 again, burning a
+		// dispatch attempt.
+		case g.dispatchLoadCooled(model, now):
+			reason = GateDispatchLoadCooldown
+		// Skip a triple quarantined by the inference-error circuit breaker for THIS
+		// request shape: repeated provider-side (5xx) failures — e.g. a deterministic
+		// chat-template render crash on tool schemas — mean a retry here fails
+		// identically, so routing must fall to a different provider. Shape-keyed so a
+		// tool failure does not deroute clean text traffic. Cleared by
+		// RecordInferenceSuccess (same shape) or by TTL expiry.
+		case g.inferenceErrorCooled(model, traits.CooldownShape(), now):
+			reason = GateErrorCooldown
+		// Skip a (provider, model) pair quarantined by the capacity-reject cooldown:
+		// it kept capacity-rejecting with ZERO interleaved accepts (the black-hole
+		// signature — e.g. a box whose engine misreports its token budget), so a
+		// dispatch here is a guaranteed bounce while its idle-looking heartbeats
+		// keep winning the cost scheduler. A busy box that is also SERVING never
+		// trips this (any accept resets the streak), and the pair is re-probed once
+		// its TTL expires. See capacity_cooldown.go.
+		case !ignoreCapacityCooldown && g.capacityCooled(model, now):
+			reason = GateCapacityCooldown
+		// Skip a provider quarantined by the per-provider node-health breaker: a
+		// node returning GENUINE-FAULT errors (500/502/504 or a
+		// fault-shaped 503) for ~all of its requests is sick regardless of model or
+		// shape, so it is derouted fleet-wide. This catches the node that fault-503s
+		// every request — invisible to the shape-keyed inference-error breaker above
+		// (which skips 503 as a capacity signal). Honored on the normal routing
+		// path; the selectBestCandidateLockedFull fail-open pass sets
+		// ignoreProviderBreaker so a bad fleet-wide rollout can't deroute everyone.
+		case !ignoreProviderBreaker && g.breakerOpenAt(nowNS):
+			reason = GateBreaker
+		// Skip a provider EJECTED by the stable-identity health breaker (health_ejection.go):
+		// a node whose serial/SE-key/account has collapsed to a near-total served-fault
+		// rate is derouted even across reconnects (the session breaker above is wiped on
+		// every disconnect, which the constantly-disconnecting zombies exploit). Same
+		// fail-open contract: skipped on the ignoreProviderBreaker rescan, and an
+		// un-attestable provider (empty stable id) is never ejected.
+		case !ignoreProviderBreaker && healthEjectionEnabled() && r.ejectionOpenFor(g, stableProviderIdentityLocked(view.p), nowNS):
+			reason = GateEjection
+		}
+		if !view.moved() {
+			return reason == GateReasonCount, reason
+		}
+	}
 }
 
-// snapshotProviderIntoLockedEx is snapshotProviderLockedEx writing into
-// caller-owned storage instead of returning the (large) snapshot by value,
-// and naming WHICH gate dropped a failing provider. The fleet walks
+// snapshotProviderIntoLockedEx builds a routing snapshot for p into
+// caller-owned storage, returning ok=false and the closed GateReason when p
+// fails any structural/privacy/capacity/trait gate. selfRouteOwner is true
+// when this is a self-route request and p is owned by the requesting account:
+// it (1) drops the hardware-trust floor to TrustNone — a personal Mac will not
+// be MDM/MDA enrolled, so without this it would be unroutable to its own owner
+// — and (2) admits a private-only machine, which is otherwise excluded from
+// the public fleet. Every privacy-critical gate (RuntimeVerified, private-text
+// support, challenge freshness) still applies. traits carry the request shape
+// into the shape-keyed inference-error cooldown and the render-broken /
+// version-floor eligibility gates. ignoreProviderBreaker is threaded into the
+// routing gate: only the selectBestCandidateLockedFull fail-open fallback pass
+// sets it true. now is the scan clock: hot-path callers walk the whole fleet
+// and must read the wall clock ONCE per scan, not once per provider; every
+// time-keyed gate (challenge freshness, cooldowns, breaker, clamp) evaluates
+// against that single instant.
+//
+// Writes into caller-owned storage instead of returning the (large) snapshot
+// by value, and names WHICH gate dropped a failing provider. The fleet walks
 // (scanCandidatesLocked, PredictServable) and the fleet sampler
 // (slotEligibilityReasonLocked) hand it the final resting place of the
 // snapshot — a candidate-arena slot or a reused buffer — so a routable
@@ -1810,7 +1828,15 @@ func (r *Registry) snapshotProviderLockedEx(p *Provider, model string, traits Re
 func (r *Registry) snapshotProviderIntoLockedEx(dst *routingSnapshot, p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (bool, GateReason) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	return r.snapshotProviderIntoPLockedEx(dst, p, model, traits, selfRouteOwner, ignoreProviderBreaker, now)
+}
 
+// snapshotProviderIntoPLockedEx is snapshotProviderIntoLockedEx for a caller
+// that ALREADY holds p.mu — the reservation commit and the plan consumption,
+// which take the snapshot, rebuild the cost, compare and debit inside one p.mu
+// section so nothing can change the provider in between. Caller holds r.mu
+// (either mode) and p.mu.
+func (r *Registry) snapshotProviderIntoPLockedEx(dst *routingSnapshot, p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) (bool, GateReason) {
 	if ok, reason := r.providerRoutingGateReasonLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false); !ok {
 		return false, reason
 	}
@@ -1890,9 +1916,11 @@ func (r *Registry) snapshotProviderIntoLockedEx(dst *routingSnapshot, p *Provide
 	// p.LastHeartbeat is when the CURRENT BackendCapacity was delivered
 	// (Heartbeat stamps both in one critical section), which is what the
 	// release-freshness check compares against the clamp time. p.mu and r.mu
-	// are both held here (see lock discipline above).
+	// are both held here (see lock discipline above); the clamp read is one
+	// lock-free flag load unless the identity actually carries a clamp, and is
+	// confirmed against p.gate like the gates above (gateView).
 	rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-	snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+	snap.budgetClamped = r.budgetClampedFor(p, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 	return true, GateReasonCount
 }
@@ -2262,7 +2290,7 @@ func (r *Registry) buildCandidateInto(c *routingCandidate, pr *PendingRequest, n
 	// proportionally to its windowed reject rate. A soft derater, never an
 	// ejection: the candidate stays in the pool, so a degraded-but-only fleet
 	// still serves, and the penalty decays as outcomes age out of the window.
-	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyLocked(snap.provider.ID, snap.model, now)
+	capacityRateMs, capacityRejectRate := r.capacityRatePenaltyFor(snap.provider, snap.model, now)
 	cost := statePenalty + queueMs + pendingMs + backlogMs + thisReqMs + healthMs + capacityRateMs
 
 	// Estimated time-to-first-token for this candidate. Used for the
@@ -2848,7 +2876,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			// never fit the hardware counts as modelTooLarge — never as
 			// transient capacity, or a fleet of undersized cooled boxes would
 			// read as "busy, retry" for a model that will never fit.
-			if (r.capacityCooldownActiveLocked(p.ID, model, now) || providerDrainingLocked(p, now)) &&
+			if (r.gateOf(p).capacityCooled(model, now) || providerDrainingLocked(p, now)) &&
 				r.providerPassesRoutingGatesLockedEx(p, model, traits, false, now, true, true) &&
 				p.SystemMetrics.ThermalState != "critical" &&
 				(!requiresVision || r.providerServesVisionModelLocked(p, model, false)) {
@@ -2952,7 +2980,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 		// (including the budgetless-snapshot hold for reconnecting sessions)
 		// so the preflight cannot report capacity that routing then refuses.
 		rawRemaining := snap.activeTokenBudgetMax - snap.activeTokenBudgetUsed - snap.queuedTokenBudget
-		snap.budgetClamped = r.budgetClampActiveLocked(p.ID, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
+		snap.budgetClamped = r.budgetClampedFor(p, model, p.LastHeartbeat, rawRemaining, snap.activeTokenBudgetMax > 0, now)
 
 		p.mu.Unlock()
 

--- a/coordinator/registry/stable_fault_key_test.go
+++ b/coordinator/registry/stable_fault_key_test.go
@@ -29,12 +29,10 @@ func attestSchedulerProvider(t *testing.T, reg *Registry, sessionID, model, seri
 }
 
 func faultKeyOf(r *Registry, sessionID string) string {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.faultKeyLocked(sessionID)
+	return r.faultKeyForSession(sessionID)
 }
 
-// faultKeyLocked precedence: bound identity → disconnect cache → session id.
+// faultKeyForSession precedence: bound identity → disconnect cache → session id.
 func TestFaultKeyBindingLifecycle(t *testing.T) {
 	reg := New(testLogger())
 	p := attestSchedulerProvider(t, reg, "sess-bind", "m", "SER-BIND", 50)
@@ -61,10 +59,7 @@ func TestFaultKeyBindingLifecycle(t *testing.T) {
 	// resolves the trailing ErrorCh-flush faults.
 	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "SER-BIND"})
 	reg.Disconnect("sess-bind")
-	reg.mu.RLock()
-	_, hasBinding := reg.faultKeyBySession["sess-bind"]
-	reg.mu.RUnlock()
-	if hasBinding {
+	if sessionIndexed(reg, "sess-bind") {
 		t.Fatal("Disconnect must remove the live session binding")
 	}
 	if got := faultKeyOf(reg, "sess-bind"); got != "serial:SER-BIND" {
@@ -96,10 +91,8 @@ func TestInvalidAttestationDoesNotBindStableFaultKey(t *testing.T) {
 	for i := 0; i < providerBreakerConsecTrip; i++ {
 		reg.RecordProviderOutcome("sess-evil", false, 500, "internal error")
 	}
-	reg.mu.RLock()
-	_, victimPoisoned := reg.providerOutcomes["serial:"+victim]
-	_, sessionKeyed := reg.providerOutcomes["sess-evil"]
-	reg.mu.RUnlock()
+	victimPoisoned := gateHasBreakerWindow(reg, "serial:"+victim)
+	sessionKeyed := gateHasBreakerWindow(reg, "sess-evil")
 	if victimPoisoned {
 		t.Fatal("faults from an invalid attestation poisoned the victim's serial-keyed state")
 	}
@@ -113,10 +106,7 @@ func TestInvalidAttestationDoesNotBindStableFaultKey(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-evil"); got != "serial:SER-REAL" {
 		t.Fatalf("valid attestation must bind, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["serial:SER-REAL"]
-	reg.mu.RUnlock()
-	if !migrated {
+	if !gateHasBreakerWindow(reg, "serial:SER-REAL") {
 		t.Fatal("session-keyed fault state must migrate on the first valid bind")
 	}
 
@@ -167,10 +157,8 @@ func TestFaultStateMigratesOnIdentityRebind(t *testing.T) {
 	}
 
 	// Old keys must not retain orphaned state.
-	reg.mu.RLock()
-	_, sekeyOrphan := reg.providerOutcomes["sekey:PK-MIG"]
-	_, sessOrphan := reg.providerOutcomes["sess-mig"]
-	reg.mu.RUnlock()
+	sekeyOrphan := gateHasBreakerWindow(reg, "sekey:PK-MIG")
+	sessOrphan := gateHasBreakerWindow(reg, "sess-mig")
 	if sekeyOrphan || sessOrphan {
 		t.Fatalf("fault state orphaned under old keys (sekey=%v session=%v)", sekeyOrphan, sessOrphan)
 	}
@@ -338,14 +326,20 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.Disconnect("sess-1")
 
 	stableKey := "serial:" + serial
+	var hasWin, hasOpen, hasStrikes, hasDLC bool
+	readGateForKey(reg, stableKey, func(g *gateState) {
+		if g == nil {
+			return
+		}
+		hasWin = g.outcomes != nil
+		hasOpen = !g.breakerUntil.IsZero()
+		_, hasStrikes = g.inferenceErrorStrikes[modelShapeKey{Model: model, Shape: "base"}]
+		_, hasDLC = g.dispatchLoadCooldowns[model]
+	})
 	reg.mu.RLock()
-	_, hasWin := reg.providerOutcomes[stableKey]
-	_, hasOpen := reg.providerBreakerOpenUntil[stableKey]
-	_, hasStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: stableKey, ModelID: model, Shape: "base"}]
-	_, hasDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: stableKey, ModelID: model}]
 	_, hasPending := reg.pendingModelLoads[modelLoadKey{ProviderID: "sess-1", ModelID: model}]
-	_, hasBinding := reg.faultKeyBySession["sess-1"]
 	reg.mu.RUnlock()
+	hasBinding := sessionIndexed(reg, "sess-1")
 	if !hasWin || !hasOpen || !hasStrikes || !hasDLC {
 		t.Fatalf("identity-keyed fault state must survive Disconnect: win=%v open=%v strikes=%v dlc=%v",
 			hasWin, hasOpen, hasStrikes, hasDLC)
@@ -363,43 +357,39 @@ func TestDisconnectKeepsStableFaultStateCleansSessionState(t *testing.T) {
 	reg.RecordInferenceError("sess-anon", model, 500, "base")
 	reg.RecordDispatchLoadFailure("sess-anon", model)
 	reg.Disconnect("sess-anon")
-	reg.mu.RLock()
-	_, anonWin := reg.providerOutcomes["sess-anon"]
-	_, anonStrikes := reg.inferenceErrorStrikes[inferenceErrorKey{ProviderID: "sess-anon", ModelID: model, Shape: "base"}]
-	_, anonDLC := reg.dispatchLoadCooldowns[dispatchLoadKey{FaultKey: "sess-anon", ModelID: model}]
-	reg.mu.RUnlock()
-	if anonWin || anonStrikes || anonDLC {
-		t.Fatalf("session-keyed residue of an identity-less provider must be dropped: win=%v strikes=%v dlc=%v",
-			anonWin, anonStrikes, anonDLC)
+	if g := rawGateForKey(reg, "sess-anon"); g != nil {
+		t.Fatalf("session-keyed residue of an identity-less provider must be dropped, gate still filed: %+v", g)
+	}
+	if reg.ProviderBreakerOpen("sess-anon") || reg.InferenceErrorCooldownActive("sess-anon", model, "base") ||
+		reg.dispatchLoadCooled("sess-anon", model, time.Now()) {
+		t.Fatal("session-keyed residue of an identity-less provider must not gate")
 	}
 }
 
-// REQUIRED: stale identities expire — the capacity-streak map is bounded by
-// the health-ejection sweep once it grows past its cap.
+// REQUIRED: stale identities expire — an identity whose only state is a
+// capacity streak older than the window is idle, and the gate sweep drops it
+// once no live session references it and the idle grace has passed.
 func TestHealthEjectionCapacityStreakSweep(t *testing.T) {
 	reg := New(testLogger())
 	const rejectStr = "token_budget_exhausted: request exceeds active token budget"
 	for i := 0; i < 2100; i++ {
 		reg.RecordProviderServeOutcome(fmt.Sprintf("serial:churned-%d", i), false, 503, rejectStr)
 	}
-	reg.mu.Lock()
-	for id, s := range reg.healthEjectionCapacityStreaks {
-		s.last = s.last.Add(-(healthEjectionWindow + time.Second))
-		reg.healthEjectionCapacityStreaks[id] = s
-	}
-	size := len(reg.healthEjectionCapacityStreaks)
-	reg.mu.Unlock()
-	if size < 2050 {
-		t.Fatalf("setup produced too few streak entries: %d", size)
+	if n := reg.gateCount(); n < 2050 {
+		t.Fatalf("setup produced too few streak gates: %d", n)
 	}
 
-	// The next record sweeps the stale identities before recording.
-	reg.RecordProviderServeOutcome("serial:live", false, 503, rejectStr)
+	// A live identity records just before the sweep runs far enough in the
+	// future for the churned streaks to have aged out; its own fresh streak
+	// (touched now) keeps it.
+	future := time.Now().Add(gateIdleGrace + healthEjectionWindow + time.Second)
+	withGateForKey(reg, "serial:live", func(g *gateState) {
+		g.ejectionCapacityStreak = capacityStreak{n: 1, last: future}
+		g.touched = future
+	})
+	reg.sweepGates(future)
 
-	reg.mu.RLock()
-	after := len(reg.healthEjectionCapacityStreaks)
-	reg.mu.RUnlock()
-	if after != 1 {
+	if after := reg.gateCount(); after != 1 {
 		t.Fatalf("sweep must drop every stale identity, leaving only the live one; got %d", after)
 	}
 }
@@ -413,11 +403,9 @@ func TestHealthEjectionCapacityStreakStaleReset(t *testing.T) {
 	for i := 0; i < healthEjectionCapacityConsecTrip-1; i++ {
 		reg.RecordProviderServeOutcome(sid, false, 503, rejectStr)
 	}
-	reg.mu.Lock()
-	s := reg.healthEjectionCapacityStreaks[sid]
-	s.last = s.last.Add(-(healthEjectionWindow + time.Second))
-	reg.healthEjectionCapacityStreaks[sid] = s
-	reg.mu.Unlock()
+	withGateForKey(reg, sid, func(g *gateState) {
+		g.ejectionCapacityStreak.last = g.ejectionCapacityStreak.last.Add(-(healthEjectionWindow + time.Second))
+	})
 
 	if ejected, _ := reg.RecordProviderServeOutcome(sid, false, 503, rejectStr); ejected {
 		t.Fatal("a fresh strike after a stale streak must restart the count, not eject")
@@ -452,10 +440,8 @@ func TestAccountLinkageBindsStableFaultKey(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-acct-1"); got != "acct:"+acct {
 		t.Fatalf("account linkage must bind the acct: fallback, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["acct:"+acct]
-	_, sessOrphan := reg.providerOutcomes["sess-acct-1"]
-	reg.mu.RUnlock()
+	migrated := gateHasBreakerWindow(reg, "acct:"+acct)
+	sessOrphan := gateHasBreakerWindow(reg, "sess-acct-1")
 	if !migrated || sessOrphan {
 		t.Fatalf("pre-link session-keyed faults must migrate to the acct: key (migrated=%v orphan=%v)", migrated, sessOrphan)
 	}
@@ -508,10 +494,7 @@ func TestInvalidReattestationKeepsAccountBinding(t *testing.T) {
 	if got := faultKeyOf(reg, "sess-acct-reatt"); got != "serial:SER-REAL-REATT" {
 		t.Fatalf("valid attestation must upgrade the binding, got %q", got)
 	}
-	reg.mu.RLock()
-	_, migrated := reg.providerOutcomes["serial:SER-REAL-REATT"]
-	reg.mu.RUnlock()
-	if !migrated {
+	if !gateHasBreakerWindow(reg, "serial:SER-REAL-REATT") {
 		t.Fatal("acct:-keyed fault state must migrate to the upgraded serial: key")
 	}
 }
@@ -549,12 +532,19 @@ func TestFaultStreakSurvivesIdentityEnrichmentMidStreak(t *testing.T) {
 		t.Fatalf("enrichment must rebind to the serial key, got %q", got)
 	}
 
-	reg.mu.RLock()
-	w := reg.providerOutcomes["serial:"+serial]
-	he := reg.healthEjectionWindows["serial:"+serial]
-	_, orphan := reg.providerOutcomes["sekey:PK-MERGE"]
-	_, heOrphan := reg.healthEjectionWindows["sekey:PK-MERGE"]
-	reg.mu.RUnlock()
+	var w, he *providerHealthWindow
+	readGateForKey(reg, "serial:"+serial, func(g *gateState) {
+		if g != nil {
+			w, he = g.outcomes, g.ejection
+		}
+	})
+	orphan := gateHasBreakerWindow(reg, "sekey:PK-MERGE")
+	heOrphan := false
+	if g := rawGateForKey(reg, "sekey:PK-MERGE"); g != nil {
+		g.mu.Lock()
+		heOrphan = g.ejection != nil
+		g.mu.Unlock()
+	}
 	if orphan || heOrphan {
 		t.Fatalf("source windows must be deleted after the merge (breaker=%v ejection=%v)", orphan, heOrphan)
 	}

--- a/coordinator/registry/version_history.go
+++ b/coordinator/registry/version_history.go
@@ -2,94 +2,14 @@ package registry
 
 import "time"
 
-// Keep departed identities beyond both the disconnect-cache TTL and the reset
-// throttle/fault windows. Live identities and active quarantines are retained.
+// Version history shares the existing identity gate and its periodic sweep.
+// Retain departed versions beyond the disconnect-cache and reset windows;
+// live sessions and active faults also keep their gate through pruneLocked.
 const identityVersionRetention = 20 * time.Minute
-const identityVersionSweepInterval = time.Minute
 
-func (r *Registry) touchIdentityVersionLocked(stableID string, now time.Time) {
-	if _, exists := r.identityVersions[stableID]; !exists {
-		return
-	}
-	if r.identityVersionSeenAt == nil {
-		r.identityVersionSeenAt = make(map[string]time.Time)
-	}
-	r.identityVersionSeenAt[stableID] = now
-}
-
-// sweepIdentityVersionHistory also runs from the eviction loop, so departed
-// identities expire even when new registrations stop. Registration runs the
-// same sweep opportunistically; both paths share the rate limit under r.mu.
-func (r *Registry) sweepIdentityVersionHistory(now time.Time) {
-	r.mu.RLock()
-	due := len(r.identityVersions) > 0 && now.Sub(r.identityVersionSweepAt) >= identityVersionSweepInterval
-	r.mu.RUnlock()
-	if !due {
-		return
-	}
-	hold := r.lockWrite("version_history")
-	defer hold.unlock()
-	r.pruneIdentityVersionsLocked(now)
-}
-
-func (r *Registry) pruneIdentityVersionsLocked(now time.Time) {
-	if now.Sub(r.identityVersionSweepAt) < identityVersionSweepInterval {
-		return
-	}
-	r.identityVersionSweepAt = now
-	retained := make(map[string]bool, len(r.faultKeyBySession))
-	for _, stableID := range r.faultKeyBySession {
-		retained[stableID] = true
-	}
-	for key, until := range r.inferenceErrorCooldowns {
-		if now.Before(until) {
-			retained[key.ProviderID] = true
-		}
-	}
-	for stableID, until := range r.providerBreakerOpenUntil {
-		if now.Before(until) {
-			retained[stableID] = true
-		}
-	}
-	for stableID, until := range r.healthEjectionUntil {
-		if now.Before(until) {
-			retained[stableID] = true
-		}
-	}
-	for key, strikes := range r.inferenceErrorStrikes {
-		if len(strikes) > 0 && now.Sub(strikes[len(strikes)-1]) < inferenceErrorWindow {
-			retained[key.ProviderID] = true
-		}
-	}
-	for stableID, window := range r.providerOutcomes {
-		if total, _ := window.windowStats(now, providerBreakerWindow); total > 0 {
-			retained[stableID] = true
-		}
-	}
-	for stableID, window := range r.healthEjectionWindows {
-		if total, _ := window.windowStats(now, healthEjectionWindow); total > 0 {
-			retained[stableID] = true
-		}
-	}
-	for stableID, streak := range r.healthEjectionCapacityStreaks {
-		if streak.n > 0 && now.Sub(streak.last) < healthEjectionWindow {
-			retained[stableID] = true
-		}
-	}
-	cutoff := now.Add(-identityVersionRetention)
-	for stableID := range r.identityVersions {
-		seen, known := r.identityVersionSeenAt[stableID]
-		if !known {
-			// Bare test registries or pre-populated history get one full grace
-			// window rather than being discarded at their first sweep.
-			r.touchIdentityVersionLocked(stableID, now)
-			continue
-		}
-		if retained[stableID] || !seen.Before(cutoff) || !r.identityVersionResetAt[stableID].Before(cutoff) {
-			continue
-		}
-		delete(r.identityVersions, stableID)
-		delete(r.identityVersionResetAt, stableID)
-		delete(r.identityVersionSeenAt, stableID)
-	}
+// Caller holds gate.mu. touched records both outcome activity and disconnect,
+// so even a long-lived idle session receives a full reconnect grace window.
+func (g *gateState) versionHistoryActive(now time.Time) bool {
+	return g.identityVersion != "" && (now.Sub(g.touched) <= identityVersionRetention ||
+		(!g.versionResetAt.IsZero() && now.Sub(g.versionResetAt) <= identityVersionRetention))
 }

--- a/coordinator/registry/version_history.go
+++ b/coordinator/registry/version_history.go
@@ -1,0 +1,95 @@
+package registry
+
+import "time"
+
+// Keep departed identities beyond both the disconnect-cache TTL and the reset
+// throttle/fault windows. Live identities and active quarantines are retained.
+const identityVersionRetention = 20 * time.Minute
+const identityVersionSweepInterval = time.Minute
+
+func (r *Registry) touchIdentityVersionLocked(stableID string, now time.Time) {
+	if _, exists := r.identityVersions[stableID]; !exists {
+		return
+	}
+	if r.identityVersionSeenAt == nil {
+		r.identityVersionSeenAt = make(map[string]time.Time)
+	}
+	r.identityVersionSeenAt[stableID] = now
+}
+
+// sweepIdentityVersionHistory also runs from the eviction loop, so departed
+// identities expire even when new registrations stop. Registration runs the
+// same sweep opportunistically; both paths share the rate limit under r.mu.
+func (r *Registry) sweepIdentityVersionHistory(now time.Time) {
+	r.mu.RLock()
+	due := len(r.identityVersions) > 0 && now.Sub(r.identityVersionSweepAt) >= identityVersionSweepInterval
+	r.mu.RUnlock()
+	if !due {
+		return
+	}
+	hold := r.lockWrite("version_history")
+	defer hold.unlock()
+	r.pruneIdentityVersionsLocked(now)
+}
+
+func (r *Registry) pruneIdentityVersionsLocked(now time.Time) {
+	if now.Sub(r.identityVersionSweepAt) < identityVersionSweepInterval {
+		return
+	}
+	r.identityVersionSweepAt = now
+	retained := make(map[string]bool, len(r.faultKeyBySession))
+	for _, stableID := range r.faultKeyBySession {
+		retained[stableID] = true
+	}
+	for key, until := range r.inferenceErrorCooldowns {
+		if now.Before(until) {
+			retained[key.ProviderID] = true
+		}
+	}
+	for stableID, until := range r.providerBreakerOpenUntil {
+		if now.Before(until) {
+			retained[stableID] = true
+		}
+	}
+	for stableID, until := range r.healthEjectionUntil {
+		if now.Before(until) {
+			retained[stableID] = true
+		}
+	}
+	for key, strikes := range r.inferenceErrorStrikes {
+		if len(strikes) > 0 && now.Sub(strikes[len(strikes)-1]) < inferenceErrorWindow {
+			retained[key.ProviderID] = true
+		}
+	}
+	for stableID, window := range r.providerOutcomes {
+		if total, _ := window.windowStats(now, providerBreakerWindow); total > 0 {
+			retained[stableID] = true
+		}
+	}
+	for stableID, window := range r.healthEjectionWindows {
+		if total, _ := window.windowStats(now, healthEjectionWindow); total > 0 {
+			retained[stableID] = true
+		}
+	}
+	for stableID, streak := range r.healthEjectionCapacityStreaks {
+		if streak.n > 0 && now.Sub(streak.last) < healthEjectionWindow {
+			retained[stableID] = true
+		}
+	}
+	cutoff := now.Add(-identityVersionRetention)
+	for stableID := range r.identityVersions {
+		seen, known := r.identityVersionSeenAt[stableID]
+		if !known {
+			// Bare test registries or pre-populated history get one full grace
+			// window rather than being discarded at their first sweep.
+			r.touchIdentityVersionLocked(stableID, now)
+			continue
+		}
+		if retained[stableID] || !seen.Before(cutoff) || !r.identityVersionResetAt[stableID].Before(cutoff) {
+			continue
+		}
+		delete(r.identityVersions, stableID)
+		delete(r.identityVersionResetAt, stableID)
+		delete(r.identityVersionSeenAt, stableID)
+	}
+}

--- a/coordinator/registry/version_history_test.go
+++ b/coordinator/registry/version_history_test.go
@@ -11,38 +11,31 @@ func TestVersionHistoryRetentionKeepsLiveRecentAndQuarantinedIdentities(t *testi
 	live := bindVersionedSession(t, r, "live-history", "0.9.0", false)
 	now := time.Now()
 	stale := now.Add(-identityVersionRetention - time.Minute)
-	r.mu.Lock()
-	r.identityVersionSeenAt[versionResetStable] = stale
-	for _, id := range []string{"departed", "recent", "quarantined", "recent-reset", "fault-window"} {
-		r.identityVersions[id] = "0.9.0"
-		r.identityVersionSeenAt[id] = stale
+	for _, id := range []string{versionResetStable, "departed", "recent", "quarantined", "recent-reset", "fault-window"} {
+		withGateForKey(r, id, func(g *gateState) {
+			g.identityVersion = "0.9.0"
+			g.touched = stale
+		})
 	}
-	r.identityVersionSeenAt["recent"] = now
-	r.identityVersionResetAt = map[string]time.Time{"departed": stale, "recent-reset": now}
-	r.providerBreakerOpenUntil["quarantined"] = now.Add(time.Minute)
-	r.providerOutcomes["fault-window"] = &providerHealthWindow{}
-	r.providerOutcomes["fault-window"].recordFault(now, false)
-	r.identityVersionSweepAt = time.Time{}
-	r.mu.Unlock()
-	r.sweepIdentityVersionHistory(now)
-	r.mu.RLock()
+	withGateForKey(r, "recent", func(g *gateState) { g.touched = now })
+	withGateForKey(r, "departed", func(g *gateState) { g.versionResetAt = stale })
+	withGateForKey(r, "recent-reset", func(g *gateState) { g.versionResetAt = now })
+	withGateForKey(r, "quarantined", func(g *gateState) { g.breakerUntil = now.Add(time.Minute) })
+	withGateForKey(r, "fault-window", func(g *gateState) { g.healthWindowLocked().recordFault(now, false) })
+	r.sweepGates(now)
 	for _, id := range []string{versionResetStable, "recent", "quarantined", "recent-reset", "fault-window"} {
-		if _, kept := r.identityVersions[id]; !kept {
+		if rawGateForKey(r, id) == nil {
 			t.Errorf("active or recent identity %q was removed", id)
 		}
 	}
-	if _, kept := r.identityVersions["departed"]; kept || len(r.identityVersionResetAt) != 1 {
+	if rawGateForKey(r, "departed") != nil {
 		t.Error("departed version/reset history was retained")
 	}
-	r.mu.RUnlock()
-	// A long-lived session starts its reconnect grace when it disconnects,
-	// not when it originally announced the version.
+	// The reconnect grace starts at disconnect, even if the live provider's
+	// last version observation and outcome were older than the retention.
 	r.Disconnect(live.ID)
-	r.sweepIdentityVersionHistory(now.Add(identityVersionSweepInterval))
-	r.mu.RLock()
-	_, kept := r.identityVersions[versionResetStable]
-	r.mu.RUnlock()
-	if !kept {
+	r.sweepGates(now.Add(time.Minute))
+	if rawGateForKey(r, versionResetStable) == nil {
 		t.Fatal("disconnect did not preserve the recent reconnect window")
 	}
 }
@@ -50,27 +43,23 @@ func TestVersionHistoryRetentionKeepsLiveRecentAndQuarantinedIdentities(t *testi
 func TestVersionHistoryChurnDoesNotRetainDepartedVersionsForever(t *testing.T) {
 	r := New(testLogger())
 	now := time.Now()
-	r.mu.Lock()
-	r.identityVersions = make(map[string]string)
-	r.identityVersionResetAt = make(map[string]time.Time)
 	for minute := range 120 {
 		at := now.Add(time.Duration(minute) * time.Minute)
 		for i := range 100 {
 			id := fmt.Sprintf("departed-%d-%d", minute, i)
-			r.identityVersions[id] = "0.9.1"
-			r.identityVersionResetAt[id] = at
-			r.touchIdentityVersionLocked(id, at)
+			withGateForKey(r, id, func(g *gateState) {
+				g.identityVersion = "0.9.1"
+				g.touched = at
+				g.versionResetAt = at
+			})
 		}
-		r.pruneIdentityVersionsLocked(at)
-		if len(r.identityVersions) > 2100 {
-			t.Fatalf("version history grew past its retention window: %d", len(r.identityVersions))
+		r.sweepGates(at)
+		if count := r.gateCount(); count > 2100 {
+			t.Fatalf("version history grew past its retention window: %d", count)
 		}
 	}
-	r.mu.Unlock()
-	r.sweepIdentityVersionHistory(now.Add(3 * time.Hour))
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	if len(r.identityVersions)+len(r.identityVersionSeenAt)+len(r.identityVersionResetAt) != 0 {
+	r.sweepGates(now.Add(3 * time.Hour))
+	if r.gateCount() != 0 {
 		t.Fatal("idle sweep did not release departed version metadata")
 	}
 }

--- a/coordinator/registry/version_history_test.go
+++ b/coordinator/registry/version_history_test.go
@@ -1,0 +1,76 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestVersionHistoryRetentionKeepsLiveRecentAndQuarantinedIdentities(t *testing.T) {
+	r := New(testLogger())
+	live := bindVersionedSession(t, r, "live-history", "0.9.0", false)
+	now := time.Now()
+	stale := now.Add(-identityVersionRetention - time.Minute)
+	r.mu.Lock()
+	r.identityVersionSeenAt[versionResetStable] = stale
+	for _, id := range []string{"departed", "recent", "quarantined", "recent-reset", "fault-window"} {
+		r.identityVersions[id] = "0.9.0"
+		r.identityVersionSeenAt[id] = stale
+	}
+	r.identityVersionSeenAt["recent"] = now
+	r.identityVersionResetAt = map[string]time.Time{"departed": stale, "recent-reset": now}
+	r.providerBreakerOpenUntil["quarantined"] = now.Add(time.Minute)
+	r.providerOutcomes["fault-window"] = &providerHealthWindow{}
+	r.providerOutcomes["fault-window"].recordFault(now, false)
+	r.identityVersionSweepAt = time.Time{}
+	r.mu.Unlock()
+	r.sweepIdentityVersionHistory(now)
+	r.mu.RLock()
+	for _, id := range []string{versionResetStable, "recent", "quarantined", "recent-reset", "fault-window"} {
+		if _, kept := r.identityVersions[id]; !kept {
+			t.Errorf("active or recent identity %q was removed", id)
+		}
+	}
+	if _, kept := r.identityVersions["departed"]; kept || len(r.identityVersionResetAt) != 1 {
+		t.Error("departed version/reset history was retained")
+	}
+	r.mu.RUnlock()
+	// A long-lived session starts its reconnect grace when it disconnects,
+	// not when it originally announced the version.
+	r.Disconnect(live.ID)
+	r.sweepIdentityVersionHistory(now.Add(identityVersionSweepInterval))
+	r.mu.RLock()
+	_, kept := r.identityVersions[versionResetStable]
+	r.mu.RUnlock()
+	if !kept {
+		t.Fatal("disconnect did not preserve the recent reconnect window")
+	}
+}
+
+func TestVersionHistoryChurnDoesNotRetainDepartedVersionsForever(t *testing.T) {
+	r := New(testLogger())
+	now := time.Now()
+	r.mu.Lock()
+	r.identityVersions = make(map[string]string)
+	r.identityVersionResetAt = make(map[string]time.Time)
+	for minute := range 120 {
+		at := now.Add(time.Duration(minute) * time.Minute)
+		for i := range 100 {
+			id := fmt.Sprintf("departed-%d-%d", minute, i)
+			r.identityVersions[id] = "0.9.1"
+			r.identityVersionResetAt[id] = at
+			r.touchIdentityVersionLocked(id, at)
+		}
+		r.pruneIdentityVersionsLocked(at)
+		if len(r.identityVersions) > 2100 {
+			t.Fatalf("version history grew past its retention window: %d", len(r.identityVersions))
+		}
+	}
+	r.mu.Unlock()
+	r.sweepIdentityVersionHistory(now.Add(3 * time.Hour))
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.identityVersions)+len(r.identityVersionSeenAt)+len(r.identityVersionResetAt) != 0 {
+		t.Fatal("idle sweep did not release departed version metadata")
+	}
+}

--- a/coordinator/registry/version_reset.go
+++ b/coordinator/registry/version_reset.go
@@ -2,220 +2,133 @@ package registry
 
 import "time"
 
-// Version-changed reconnect reset (R1, upgrade waves).
-//
-// The Swift provider's auto-update restart exits the process without a
-// WebSocket close frame (ProcessLifecycle.restartAfterUpdate → launchctl
-// kickstart -k → exit), so the coordinator books it as an ABRUPT drop and the
-// flush of every in-flight request lands as a 502 strike on the provider's
-// STABLE identity — deliberately, because that flush is the reconnecting-
-// zombie signal. A fleet upgrade therefore returned every box quarantined
-// (2026-08-31: inference-error cooldowns for 5 min, node breakers, ejections).
-//
-// The distinguishing fact is only known on RECONNECT: the same identity comes
-// back running a DIFFERENT binary version. When that happens, exactly the
-// disconnect-flush strikes — the 502s — are removed from the identity's
-// windows and each quarantine is re-evaluated against what remains, so:
-//   - a healthy box that died mid-upgrade with work in flight comes back
-//     clean;
-//   - genuine 500/504 faults recorded BEFORE the restart are kept, and a
-//     breaker whose trip still holds without the 502s stays open;
-//   - a zombie that churns on the SAME version keeps every strike — the
-//     reset never fires without a version change.
-//
-// The 502 status is the flush marker throughout the registry (see
-// RecordInferenceError: "502 — disconnect flush"). Providers do not originate
-// 502s except the rare encryption_failure terminal, which is acceptable
-// collateral: it says nothing about the NEW binary either.
-//
-// Two seams observe the version because registration binds the identity
-// BEFORE the api layer stores RegisterMessage.Version: bindStableFaultKey
-// (re-attestation on an already-versioned session) and Provider.SetVersion
-// (registration on an already-bound session). Both funnel into
-// noteIdentityVersionLocked; only a CHANGE from the last version seen for the
-// identity triggers the reset. State lives in identityVersions and
-// inferenceErrorFlushStrikes (Registry, guarded by r.mu; lazily created so
-// bare test registries work). The flush tags live exactly as long as the
-// strikes they mark: RecordInferenceError slides them out of the breaker
-// window with the strikes and RecordInferenceSuccess drops them with the
-// history, so an identity that never changes version cannot accumulate them.
-//
-// The flush strikes are recorded by the request goroutines that drain the
-// flushed ErrorCh, not by Disconnect itself, so they can land AFTER the reset:
-// registration evicts a same-serial predecessor (DisconnectDuplicatesBySerial)
-// and stores the new version on the same goroutine, and a slow consumer can
-// trail a normal reconnect. A reset that ran first cleared nothing, consumed
-// the interval, and the late strikes would then quarantine the NEW binary for
-// the old one's death. IsSupersededDisconnectFlush closes that order: a 502
-// attributed to a session that was dropped at or before its identity's last
-// reset (disconnectedStableIDs dates every drop) is discarded under each
-// tracker mutation lock, with an API-side early return as an optimization — exactly the
-// strikes the reset would have removed, and none from a session that died
-// after it (same-version churn and a throttled version change keep striking).
-
-// disconnectFlushStatusCode is the status the pending-request flush injects
-// (registry.disconnectWithCause) and the marker the fault windows tag.
+// Version changes clear only disconnect-flush faults, at most once per
+// identityVersionResetMinInterval. Reset history and fault mutations share
+// gate.mu so a trailing old-session 502 cannot re-poison a new binary.
 const disconnectFlushStatusCode = 502
-
-// identityVersionResetMinInterval bounds how often one stable identity can
-// have its flush strikes cleared by a version change. RegisterMessage.Version
-// is provider-asserted and observed before release evidence, so a modified
-// binary alternating two version strings could otherwise launder every
-// reconnect's flush strikes; a genuine upgrade (or rollback) changes version
-// once per rollout, and the strikes it would clear expire within the 5-minute
-// cooldown anyway, so one reset per interval loses nothing legitimate.
 const identityVersionResetMinInterval = 10 * time.Minute
 
-// SetVersion stores the provider's reported binary version and, when the
-// session is already bound to a stable identity, runs the version-changed
-// reset for that identity. Registration calls it after attestation has bound
-// the session, which is why the check lives here as well as in
-// bindStableFaultKey.
+// SetVersion observes the bound identity while p.mu excludes a concurrent
+// rebind. The index lock stabilizes lookup until the gate has been acquired.
 func (p *Provider) SetVersion(version string) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.Version = version
-	id, r := p.ID, p.registry
-	p.mu.Unlock()
+	r := p.registry
 	if r == nil || version == "" {
 		return
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if stableID := r.faultKeyBySession[id]; stableID != "" {
-		r.noteIdentityVersionLocked(stableID, version)
+	r.gatesMu.RLock()
+	if r.sessions[p.ID] != p {
+		r.gatesMu.RUnlock()
+		return
 	}
+	g := p.gate.Load()
+	if g == nil || g.key == p.ID {
+		r.gatesMu.RUnlock()
+		return
+	}
+	g = g.lockResolved()
+	r.gatesMu.RUnlock()
+	defer g.mu.Unlock()
+	now := time.Now()
+	g.noteIdentityVersionLocked(r, version)
+	g.updatedLocked(now)
 }
 
-// IsSupersededDisconnectFlush reports whether a disconnect-flush strike
-// (statusCode 502) attributed to sessionID comes from a session that was
-// dropped at or before its stable identity's most recent version-changed
-// reset — a strike the reset would have removed had the consumer recorded it
-// first. The api layer discards such a strike before it reaches any tracker.
-// Anything else — a live session, a session the registry never dated (no
-// stable identity at disconnect), an identity that has never reset, or a drop
-// that happened after the last reset — is not superseded and records as usual,
-// which keeps the once-per-interval throttle intact: a throttled version
-// change stamps no new reset, so the strikes of the session that died after
-// the consumed reset still land.
+// disconnectSource captures the session while holding the index lock. A live
+// reference can disconnect after lookup; its atomic timestamp then supplies
+// the drop time without taking p.mu while a recorder holds gate.mu.
+type disconnectSource struct {
+	p  *Provider
+	at time.Time
+}
+
+func (r *Registry) captureDisconnectSource(sessionID string) disconnectSource {
+	r.gatesMu.RLock()
+	defer r.gatesMu.RUnlock()
+	if p := r.sessions[sessionID]; p != nil {
+		return disconnectSource{p: p}
+	}
+	return disconnectSource{at: r.disconnectedStableIDs[sessionID].at}
+}
+func (source disconnectSource) supersededBy(g *gateState) bool {
+	at := source.at
+	if source.p != nil {
+		if ns := source.p.gateDisconnectedAtNS.Load(); ns != 0 {
+			at = time.Unix(0, ns)
+		}
+	}
+	return g != nil && !at.IsZero() && !g.versionResetAt.IsZero() && !g.versionResetAt.Before(at)
+}
 func (r *Registry) IsSupersededDisconnectFlush(sessionID string, statusCode int) bool {
 	if statusCode != disconnectFlushStatusCode || sessionID == "" {
 		return false
 	}
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.supersededDisconnectFlushLocked(sessionID)
-}
-
-// supersededDisconnectFlushLocked is IsSupersededDisconnectFlush's check under
-// r.mu (either mode): read-only against disconnectedStableIDs and
-// identityVersionResetAt.
-func (r *Registry) supersededDisconnectFlushLocked(sessionID string) bool {
-	if _, live := r.providers[sessionID]; live {
+	source := r.captureDisconnectSource(sessionID)
+	ref := r.lookupSessionGateRef(sessionID)
+	if ref.g == nil {
 		return false
 	}
-	c, ok := r.disconnectedStableIDs[sessionID]
-	if !ok || c.id == "" {
-		return false
-	}
-	resetAt, ok := r.identityVersionResetAt[c.id]
-	return ok && !resetAt.Before(c.at)
+	hold := r.lockGate(ref, "disconnect_flush")
+	defer hold.unlock()
+	return source.supersededBy(hold.g)
 }
 
-// noteIdentityVersionLocked records the binary version now running under a
-// stable identity and clears the identity's disconnect-flush strikes when it
-// differs from the last version seen. A first observation only records.
-// Caller holds r.mu.
-func (r *Registry) noteIdentityVersionLocked(stableID, version string) {
-	if stableID == "" || version == "" {
+func (g *gateState) noteIdentityVersionLocked(r *Registry, version string) {
+	if version == "" {
 		return
 	}
-	if r.identityVersions == nil {
-		r.identityVersions = make(map[string]string)
+	previous := g.identityVersion
+	g.identityVersion = version
+	if previous == "" || previous == version {
+		return
 	}
+	// Date the reset at its mutation boundary, after gate acquisition. A bind
+	// can wait behind a disconnect on the index; its earlier lookup timestamp
+	// must not make a reset performed afterward predate that disconnect.
 	now := time.Now()
-	r.pruneIdentityVersionsLocked(now)
-	prev, seen := r.identityVersions[stableID]
-	r.identityVersions[stableID] = version
-	r.touchIdentityVersionLocked(stableID, now)
-	if !seen || prev == version {
-		return
-	}
-	if r.identityVersionResetAt == nil {
-		r.identityVersionResetAt = make(map[string]time.Time)
-	}
-	if last, ok := r.identityVersionResetAt[stableID]; ok && now.Sub(last) < identityVersionResetMinInterval {
+	if !g.versionResetAt.IsZero() && now.Sub(g.versionResetAt) < identityVersionResetMinInterval {
 		r.logger.Warn("provider version changed again within the reset interval: disconnect-flush strikes retained",
-			"stable_id", stableID, "previous_version", prev, "version", version, "since_last_reset", now.Sub(last))
+			"stable_id", g.key, "previous_version", previous, "version", version, "since_last_reset", now.Sub(g.versionResetAt))
 		return
 	}
-	r.identityVersionResetAt[stableID] = now
-	if r.clearDisconnectFlushStrikesLocked(stableID, now) {
+	g.versionResetAt = now
+	if g.clearDisconnectFlushStrikesLocked(now) {
 		r.logger.Info("provider reconnected on a new binary version: disconnect-flush strikes cleared from its fault trackers",
-			"stable_id", stableID, "previous_version", prev, "version", version)
+			"stable_id", g.key, "previous_version", previous, "version", version)
 	}
 }
 
-// noteInferenceFlushStrikeLocked tags one inference-error strike as a
-// disconnect flush so the version reset can remove exactly that strike later.
-// Caller holds r.mu; key is already stable-keyed.
-func (r *Registry) noteInferenceFlushStrikeLocked(key inferenceErrorKey, at time.Time) {
-	if r.inferenceErrorFlushStrikes == nil {
-		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+func (g *gateState) noteInferenceFlushStrikeLocked(key modelShapeKey, at time.Time) {
+	if g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
 	}
-	if len(r.inferenceErrorFlushStrikes) > 1024 {
-		for k := range r.inferenceErrorFlushStrikes {
-			if _, live := r.inferenceErrorStrikes[k]; !live {
-				delete(r.inferenceErrorFlushStrikes, k)
-			}
-		}
-	}
-	r.inferenceErrorFlushStrikes[key] = append(r.inferenceErrorFlushStrikes[key], at)
+	g.inferenceErrorFlushStrikes[key] = append(g.inferenceErrorFlushStrikes[key], at)
 }
-
-// pruneInferenceFlushStrikesLocked drops the key's flush tags that have left
-// the breaker window, mirroring RecordInferenceError's slide of the main
-// strike list so a tag never outlives the strike it marks. Deletes the key
-// when nothing remains. Caller holds r.mu; key is already stable-keyed.
-func (r *Registry) pruneInferenceFlushStrikesLocked(key inferenceErrorKey, now time.Time) {
-	flush, ok := r.inferenceErrorFlushStrikes[key]
-	if !ok {
-		return
-	}
+func (g *gateState) pruneInferenceFlushStrikesLocked(key modelShapeKey, now time.Time) {
+	flush := g.inferenceErrorFlushStrikes[key]
 	kept := flush[:0]
-	for _, ts := range flush {
-		if now.Sub(ts) < inferenceErrorWindow {
-			kept = append(kept, ts)
+	for _, stamp := range flush {
+		if now.Sub(stamp) < inferenceErrorWindow {
+			kept = append(kept, stamp)
 		}
 	}
 	if len(kept) == 0 {
-		delete(r.inferenceErrorFlushStrikes, key)
-		return
+		delete(g.inferenceErrorFlushStrikes, key)
+	} else {
+		g.inferenceErrorFlushStrikes[key] = kept
 	}
-	r.inferenceErrorFlushStrikes[key] = kept
 }
 
-// clearDisconnectFlushStrikesLocked removes the disconnect-flush (502)
-// strikes recorded under stableID from the inference-error breaker, the
-// node-health breaker, and the health-ejection window, then re-evaluates each
-// quarantine against the remaining history: one that no longer meets its own
-// trip condition closes (trip counters reset so the next genuine fault does
-// not re-arm as a half-open probe); one still justified by other faults stays.
-// Returns whether anything was removed. Caller holds r.mu.
-func (r *Registry) clearDisconnectFlushStrikesLocked(stableID string, now time.Time) (cleared bool) {
-	// Inference-error breaker: (identity, model, shape) buckets.
-	for key, flush := range r.inferenceErrorFlushStrikes {
-		if key.ProviderID != stableID {
-			continue
-		}
-		delete(r.inferenceErrorFlushStrikes, key)
-		if len(flush) == 0 {
-			continue
-		}
-		strikes := r.inferenceErrorStrikes[key]
-		kept := make([]time.Time, 0, len(strikes))
-		for _, ts := range strikes {
-			if !containsTimestamp(flush, ts) {
-				kept = append(kept, ts)
+func (g *gateState) clearDisconnectFlushStrikesLocked(now time.Time) (cleared bool) {
+	for key, flush := range g.inferenceErrorFlushStrikes {
+		delete(g.inferenceErrorFlushStrikes, key)
+		strikes := g.inferenceErrorStrikes[key]
+		kept := strikes[:0]
+		for _, stamp := range strikes {
+			if !containsTimestamp(flush, stamp) {
+				kept = append(kept, stamp)
 			}
 		}
 		if len(kept) == len(strikes) {
@@ -223,44 +136,37 @@ func (r *Registry) clearDisconnectFlushStrikesLocked(stableID string, now time.T
 		}
 		cleared = true
 		if len(kept) == 0 {
-			delete(r.inferenceErrorStrikes, key)
+			delete(g.inferenceErrorStrikes, key)
 		} else {
-			r.inferenceErrorStrikes[key] = kept
+			g.inferenceErrorStrikes[key] = kept
 		}
 		inWindow := 0
-		for _, ts := range kept {
-			if now.Sub(ts) < inferenceErrorWindow {
+		for _, stamp := range kept {
+			if now.Sub(stamp) < inferenceErrorWindow {
 				inWindow++
 			}
 		}
 		if inWindow < inferenceErrorThreshold {
-			delete(r.inferenceErrorCooldowns, key)
+			delete(g.inferenceErrorCooldowns, key)
 		}
 	}
-
-	// Node-health breaker.
-	if w := r.providerOutcomes[stableID]; w != nil && w.dropFlushFaults() {
+	if w := g.outcomes; w != nil && w.dropFlushFaults() {
 		cleared = true
 		total, fails := w.windowStats(now, providerBreakerWindow)
 		rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
 		if w.consecFail < providerBreakerConsecTrip && !rateTrip {
-			delete(r.providerBreakerOpenUntil, stableID)
-			delete(r.providerBreakerTrips, stableID)
+			g.breakerUntil = time.Time{}
+			g.breakerTrips = 0
 		}
 	}
-
-	// Stable-identity health ejection (fault path only: a capacity-streak
-	// ejection was never fed by 502s and is left alone).
-	if w := r.healthEjectionWindows[stableID]; w != nil && w.dropFlushFaults() {
+	if w := g.ejection; w != nil && w.dropFlushFaults() {
 		cleared = true
 		total, fails := w.windowStats(now, healthEjectionWindow)
-		rateTrip := total >= healthEjectionMinSample &&
-			float64(total-fails) < healthEjectionMinSuccessRate*float64(total)
-		if !r.healthEjectionLastTripCapacity[stableID] &&
-			w.consecFail < healthEjectionConsecTrip && !rateTrip {
-			delete(r.healthEjectionUntil, stableID)
-			delete(r.healthEjectionTrips, stableID)
-			delete(r.healthEjectionLastTripCapacity, stableID)
+		rateTrip := total >= healthEjectionMinSample && float64(total-fails) < healthEjectionMinSuccessRate*float64(total)
+		if !g.ejectionLastTripCapacity && w.consecFail < healthEjectionConsecTrip && !rateTrip {
+			g.ejectionUntil = time.Time{}
+			g.ejectionTrips = 0
+			g.ejectionLastTripCapacity = false
 		}
 	}
 	return cleared

--- a/coordinator/registry/version_reset.go
+++ b/coordinator/registry/version_reset.go
@@ -1,12 +1,23 @@
 package registry
 
-import "time"
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
 
 // Version changes clear only disconnect-flush faults, at most once per
 // identityVersionResetMinInterval. Reset history and fault mutations share
 // gate.mu so a trailing old-session 502 cannot re-poison a new binary.
 const disconnectFlushStatusCode = 502
 const identityVersionResetMinInterval = 10 * time.Minute
+
+// Only the non-wire coordinator cause can identify a disconnect flush.
+// A provider-authored 502 (including encryption failure) is a genuine fault.
+func isDisconnectFlush(statusCode int, causes []protocol.CoordinatorInferenceErrorCause) bool {
+	return statusCode == disconnectFlushStatusCode && len(causes) == 1 &&
+		causes[0] == protocol.CoordinatorCauseProviderDisconnected
+}
 
 // SetVersion observes the bound identity while p.mu excludes a concurrent
 // rebind. The index lock stabilizes lookup until the gate has been acquired.
@@ -61,8 +72,8 @@ func (source disconnectSource) supersededBy(g *gateState) bool {
 	}
 	return g != nil && !at.IsZero() && !g.versionResetAt.IsZero() && !g.versionResetAt.Before(at)
 }
-func (r *Registry) IsSupersededDisconnectFlush(sessionID string, statusCode int) bool {
-	if statusCode != disconnectFlushStatusCode || sessionID == "" {
+func (r *Registry) IsSupersededDisconnectFlush(sessionID string, statusCode int, causes ...protocol.CoordinatorInferenceErrorCause) bool {
+	if !isDisconnectFlush(statusCode, causes) || sessionID == "" {
 		return false
 	}
 	source := r.captureDisconnectSource(sessionID)

--- a/coordinator/registry/version_reset.go
+++ b/coordinator/registry/version_reset.go
@@ -1,0 +1,309 @@
+package registry
+
+import "time"
+
+// Version-changed reconnect reset (R1, upgrade waves).
+//
+// The Swift provider's auto-update restart exits the process without a
+// WebSocket close frame (ProcessLifecycle.restartAfterUpdate → launchctl
+// kickstart -k → exit), so the coordinator books it as an ABRUPT drop and the
+// flush of every in-flight request lands as a 502 strike on the provider's
+// STABLE identity — deliberately, because that flush is the reconnecting-
+// zombie signal. A fleet upgrade therefore returned every box quarantined
+// (2026-08-31: inference-error cooldowns for 5 min, node breakers, ejections).
+//
+// The distinguishing fact is only known on RECONNECT: the same identity comes
+// back running a DIFFERENT binary version. When that happens, exactly the
+// disconnect-flush strikes — the 502s — are removed from the identity's
+// windows and each quarantine is re-evaluated against what remains, so:
+//   - a healthy box that died mid-upgrade with work in flight comes back
+//     clean;
+//   - genuine 500/504 faults recorded BEFORE the restart are kept, and a
+//     breaker whose trip still holds without the 502s stays open;
+//   - a zombie that churns on the SAME version keeps every strike — the
+//     reset never fires without a version change.
+//
+// The 502 status is the flush marker throughout the registry (see
+// RecordInferenceError: "502 — disconnect flush"). Providers do not originate
+// 502s except the rare encryption_failure terminal, which is acceptable
+// collateral: it says nothing about the NEW binary either.
+//
+// Two seams observe the version because registration binds the identity
+// BEFORE the api layer stores RegisterMessage.Version: bindStableFaultKey
+// (re-attestation on an already-versioned session) and Provider.SetVersion
+// (registration on an already-bound session). Both funnel into
+// noteIdentityVersionLocked; only a CHANGE from the last version seen for the
+// identity triggers the reset. State lives in identityVersions and
+// inferenceErrorFlushStrikes (Registry, guarded by r.mu; lazily created so
+// bare test registries work). The flush tags live exactly as long as the
+// strikes they mark: RecordInferenceError slides them out of the breaker
+// window with the strikes and RecordInferenceSuccess drops them with the
+// history, so an identity that never changes version cannot accumulate them.
+//
+// The flush strikes are recorded by the request goroutines that drain the
+// flushed ErrorCh, not by Disconnect itself, so they can land AFTER the reset:
+// registration evicts a same-serial predecessor (DisconnectDuplicatesBySerial)
+// and stores the new version on the same goroutine, and a slow consumer can
+// trail a normal reconnect. A reset that ran first cleared nothing, consumed
+// the interval, and the late strikes would then quarantine the NEW binary for
+// the old one's death. IsSupersededDisconnectFlush closes that order: a 502
+// attributed to a session that was dropped at or before its identity's last
+// reset (disconnectedStableIDs dates every drop) is discarded under each
+// tracker mutation lock, with an API-side early return as an optimization — exactly the
+// strikes the reset would have removed, and none from a session that died
+// after it (same-version churn and a throttled version change keep striking).
+
+// disconnectFlushStatusCode is the status the pending-request flush injects
+// (registry.disconnectWithCause) and the marker the fault windows tag.
+const disconnectFlushStatusCode = 502
+
+// identityVersionResetMinInterval bounds how often one stable identity can
+// have its flush strikes cleared by a version change. RegisterMessage.Version
+// is provider-asserted and observed before release evidence, so a modified
+// binary alternating two version strings could otherwise launder every
+// reconnect's flush strikes; a genuine upgrade (or rollback) changes version
+// once per rollout, and the strikes it would clear expire within the 5-minute
+// cooldown anyway, so one reset per interval loses nothing legitimate.
+const identityVersionResetMinInterval = 10 * time.Minute
+
+// SetVersion stores the provider's reported binary version and, when the
+// session is already bound to a stable identity, runs the version-changed
+// reset for that identity. Registration calls it after attestation has bound
+// the session, which is why the check lives here as well as in
+// bindStableFaultKey.
+func (p *Provider) SetVersion(version string) {
+	p.mu.Lock()
+	p.Version = version
+	id, r := p.ID, p.registry
+	p.mu.Unlock()
+	if r == nil || version == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if stableID := r.faultKeyBySession[id]; stableID != "" {
+		r.noteIdentityVersionLocked(stableID, version)
+	}
+}
+
+// IsSupersededDisconnectFlush reports whether a disconnect-flush strike
+// (statusCode 502) attributed to sessionID comes from a session that was
+// dropped at or before its stable identity's most recent version-changed
+// reset — a strike the reset would have removed had the consumer recorded it
+// first. The api layer discards such a strike before it reaches any tracker.
+// Anything else — a live session, a session the registry never dated (no
+// stable identity at disconnect), an identity that has never reset, or a drop
+// that happened after the last reset — is not superseded and records as usual,
+// which keeps the once-per-interval throttle intact: a throttled version
+// change stamps no new reset, so the strikes of the session that died after
+// the consumed reset still land.
+func (r *Registry) IsSupersededDisconnectFlush(sessionID string, statusCode int) bool {
+	if statusCode != disconnectFlushStatusCode || sessionID == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.supersededDisconnectFlushLocked(sessionID)
+}
+
+// supersededDisconnectFlushLocked is IsSupersededDisconnectFlush's check under
+// r.mu (either mode): read-only against disconnectedStableIDs and
+// identityVersionResetAt.
+func (r *Registry) supersededDisconnectFlushLocked(sessionID string) bool {
+	if _, live := r.providers[sessionID]; live {
+		return false
+	}
+	c, ok := r.disconnectedStableIDs[sessionID]
+	if !ok || c.id == "" {
+		return false
+	}
+	resetAt, ok := r.identityVersionResetAt[c.id]
+	return ok && !resetAt.Before(c.at)
+}
+
+// noteIdentityVersionLocked records the binary version now running under a
+// stable identity and clears the identity's disconnect-flush strikes when it
+// differs from the last version seen. A first observation only records.
+// Caller holds r.mu.
+func (r *Registry) noteIdentityVersionLocked(stableID, version string) {
+	if stableID == "" || version == "" {
+		return
+	}
+	if r.identityVersions == nil {
+		r.identityVersions = make(map[string]string)
+	}
+	now := time.Now()
+	r.pruneIdentityVersionsLocked(now)
+	prev, seen := r.identityVersions[stableID]
+	r.identityVersions[stableID] = version
+	r.touchIdentityVersionLocked(stableID, now)
+	if !seen || prev == version {
+		return
+	}
+	if r.identityVersionResetAt == nil {
+		r.identityVersionResetAt = make(map[string]time.Time)
+	}
+	if last, ok := r.identityVersionResetAt[stableID]; ok && now.Sub(last) < identityVersionResetMinInterval {
+		r.logger.Warn("provider version changed again within the reset interval: disconnect-flush strikes retained",
+			"stable_id", stableID, "previous_version", prev, "version", version, "since_last_reset", now.Sub(last))
+		return
+	}
+	r.identityVersionResetAt[stableID] = now
+	if r.clearDisconnectFlushStrikesLocked(stableID, now) {
+		r.logger.Info("provider reconnected on a new binary version: disconnect-flush strikes cleared from its fault trackers",
+			"stable_id", stableID, "previous_version", prev, "version", version)
+	}
+}
+
+// noteInferenceFlushStrikeLocked tags one inference-error strike as a
+// disconnect flush so the version reset can remove exactly that strike later.
+// Caller holds r.mu; key is already stable-keyed.
+func (r *Registry) noteInferenceFlushStrikeLocked(key inferenceErrorKey, at time.Time) {
+	if r.inferenceErrorFlushStrikes == nil {
+		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+	}
+	if len(r.inferenceErrorFlushStrikes) > 1024 {
+		for k := range r.inferenceErrorFlushStrikes {
+			if _, live := r.inferenceErrorStrikes[k]; !live {
+				delete(r.inferenceErrorFlushStrikes, k)
+			}
+		}
+	}
+	r.inferenceErrorFlushStrikes[key] = append(r.inferenceErrorFlushStrikes[key], at)
+}
+
+// pruneInferenceFlushStrikesLocked drops the key's flush tags that have left
+// the breaker window, mirroring RecordInferenceError's slide of the main
+// strike list so a tag never outlives the strike it marks. Deletes the key
+// when nothing remains. Caller holds r.mu; key is already stable-keyed.
+func (r *Registry) pruneInferenceFlushStrikesLocked(key inferenceErrorKey, now time.Time) {
+	flush, ok := r.inferenceErrorFlushStrikes[key]
+	if !ok {
+		return
+	}
+	kept := flush[:0]
+	for _, ts := range flush {
+		if now.Sub(ts) < inferenceErrorWindow {
+			kept = append(kept, ts)
+		}
+	}
+	if len(kept) == 0 {
+		delete(r.inferenceErrorFlushStrikes, key)
+		return
+	}
+	r.inferenceErrorFlushStrikes[key] = kept
+}
+
+// clearDisconnectFlushStrikesLocked removes the disconnect-flush (502)
+// strikes recorded under stableID from the inference-error breaker, the
+// node-health breaker, and the health-ejection window, then re-evaluates each
+// quarantine against the remaining history: one that no longer meets its own
+// trip condition closes (trip counters reset so the next genuine fault does
+// not re-arm as a half-open probe); one still justified by other faults stays.
+// Returns whether anything was removed. Caller holds r.mu.
+func (r *Registry) clearDisconnectFlushStrikesLocked(stableID string, now time.Time) (cleared bool) {
+	// Inference-error breaker: (identity, model, shape) buckets.
+	for key, flush := range r.inferenceErrorFlushStrikes {
+		if key.ProviderID != stableID {
+			continue
+		}
+		delete(r.inferenceErrorFlushStrikes, key)
+		if len(flush) == 0 {
+			continue
+		}
+		strikes := r.inferenceErrorStrikes[key]
+		kept := make([]time.Time, 0, len(strikes))
+		for _, ts := range strikes {
+			if !containsTimestamp(flush, ts) {
+				kept = append(kept, ts)
+			}
+		}
+		if len(kept) == len(strikes) {
+			continue
+		}
+		cleared = true
+		if len(kept) == 0 {
+			delete(r.inferenceErrorStrikes, key)
+		} else {
+			r.inferenceErrorStrikes[key] = kept
+		}
+		inWindow := 0
+		for _, ts := range kept {
+			if now.Sub(ts) < inferenceErrorWindow {
+				inWindow++
+			}
+		}
+		if inWindow < inferenceErrorThreshold {
+			delete(r.inferenceErrorCooldowns, key)
+		}
+	}
+
+	// Node-health breaker.
+	if w := r.providerOutcomes[stableID]; w != nil && w.dropFlushFaults() {
+		cleared = true
+		total, fails := w.windowStats(now, providerBreakerWindow)
+		rateTrip := total >= providerBreakerMinVolume && float64(fails) > providerBreakerFailRate*float64(total)
+		if w.consecFail < providerBreakerConsecTrip && !rateTrip {
+			delete(r.providerBreakerOpenUntil, stableID)
+			delete(r.providerBreakerTrips, stableID)
+		}
+	}
+
+	// Stable-identity health ejection (fault path only: a capacity-streak
+	// ejection was never fed by 502s and is left alone).
+	if w := r.healthEjectionWindows[stableID]; w != nil && w.dropFlushFaults() {
+		cleared = true
+		total, fails := w.windowStats(now, healthEjectionWindow)
+		rateTrip := total >= healthEjectionMinSample &&
+			float64(total-fails) < healthEjectionMinSuccessRate*float64(total)
+		if !r.healthEjectionLastTripCapacity[stableID] &&
+			w.consecFail < healthEjectionConsecTrip && !rateTrip {
+			delete(r.healthEjectionUntil, stableID)
+			delete(r.healthEjectionTrips, stableID)
+			delete(r.healthEjectionLastTripCapacity, stableID)
+		}
+	}
+	return cleared
+}
+
+// dropFlushFaults rebuilds the ring without its disconnect-flush faults and
+// recomputes consecFail as the remaining tail's trailing fault run. Returns
+// whether any entry was dropped.
+func (w *providerHealthWindow) dropFlushFaults() (dropped bool) {
+	entries := w.chronological()
+	kept := entries[:0]
+	for _, o := range entries {
+		if o.flush {
+			dropped = true
+			continue
+		}
+		kept = append(kept, o)
+	}
+	if !dropped {
+		return false
+	}
+	*w = providerHealthWindow{}
+	for _, o := range kept {
+		w.outcomes[w.head] = o
+		w.head = (w.head + 1) % providerHealthRingSize
+		w.size++
+		if o.ok {
+			w.consecFail = 0
+		} else {
+			w.consecFail++
+		}
+	}
+	return true
+}
+
+// containsTimestamp reports whether ts equals any entry in list. Flush strikes
+// are appended with the exact time.Time value the main strike list received,
+// so equality identifies the same strike.
+func containsTimestamp(list []time.Time, ts time.Time) bool {
+	for _, t := range list {
+		if t.Equal(ts) {
+			return true
+		}
+	}
+	return false
+}

--- a/coordinator/registry/version_reset_fault_test.go
+++ b/coordinator/registry/version_reset_fault_test.go
@@ -1,0 +1,35 @@
+package registry
+
+import "testing"
+
+func TestVersionResetRetainsGenuine502BeforeAndAfterReconnect(t *testing.T) {
+	for _, afterReset := range []bool{false, true} {
+		name := "faults_before_reset"
+		if afterReset {
+			name = "late_faults_after_reset"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := New(testLogger())
+			bindVersionedSession(t, r, "old", "0.9.0", true)
+			recordFaults := func() {
+				for range 8 {
+					r.RecordInferenceError("old", "m", 502, "base")
+					r.RecordProviderOutcome("old", false, 502, "encryption failure")
+					r.RecordProviderSessionServeOutcome("old", false, 502, "encryption failure")
+				}
+			}
+			if !afterReset {
+				recordFaults()
+			}
+			dropAbruptlyUnrecorded(t, r, "old")
+			bindVersionedSession(t, r, "new", "0.9.1", false)
+			if afterReset {
+				recordFaults()
+			}
+			assertIdentityQuarantine(t, r, "new", true)
+			if r.IsSupersededDisconnectFlush("old", 502) {
+				t.Fatal("status-only 502 was classified as a coordinator disconnect flush")
+			}
+		})
+	}
+}

--- a/coordinator/registry/version_reset_gate_test.go
+++ b/coordinator/registry/version_reset_gate_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 )
 
 // Reset and all three trailing-fault recorders must remain independent of the
@@ -21,11 +23,11 @@ func TestVersionResetAndLateFlushDoNotWaitForRegistryLock(t *testing.T) {
 			go func() {
 				p.SetVersion("0.9.1")
 				for range 8 {
-					r.RecordInferenceError("old", "m", 502, "base")
-					r.RecordProviderOutcome("old", false, 502, "provider disconnected")
-					r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected")
+					r.RecordInferenceError("old", "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected)
+					r.RecordProviderOutcome("old", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
+					r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 				}
-				done <- r.IsSupersededDisconnectFlush("old", 502)
+				done <- r.IsSupersededDisconnectFlush("old", 502, protocol.CoordinatorCauseProviderDisconnected)
 			}()
 			select {
 			case superseded := <-done:

--- a/coordinator/registry/version_reset_gate_test.go
+++ b/coordinator/registry/version_reset_gate_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+// Reset and all three trailing-fault recorders must remain independent of the
+// fleet lock in both reservation modes. Otherwise the wave integration puts
+// the old write-lock convoy back on request completion.
+func TestVersionResetAndLateFlushDoNotWaitForRegistryLock(t *testing.T) {
+	for _, mode := range []string{"shared", "global"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv(envReserveCommitMode, mode)
+			r := New(testLogger())
+			bindVersionedSession(t, r, "old", "0.9.0", true)
+			dieAbruptlyWithFlush(t, r, "old")
+			p := bindVersionedSession(t, r, "new", "0.9.0", true)
+			r.mu.Lock()
+			done := make(chan bool, 1)
+			go func() {
+				p.SetVersion("0.9.1")
+				for range 8 {
+					r.RecordInferenceError("old", "m", 502, "base")
+					r.RecordProviderOutcome("old", false, 502, "provider disconnected")
+					r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected")
+				}
+				done <- r.IsSupersededDisconnectFlush("old", 502)
+			}()
+			select {
+			case superseded := <-done:
+				r.mu.Unlock()
+				if !superseded {
+					t.Fatal("old-session flush was not superseded by the version reset")
+				}
+			case <-time.After(2 * time.Second):
+				r.mu.Unlock()
+				<-done
+				t.Fatal("version reset or late-flush recorder waited for the registry lock")
+			}
+			assertIdentityQuarantine(t, r, "new", false)
+		})
+	}
+}

--- a/coordinator/registry/version_reset_test.go
+++ b/coordinator/registry/version_reset_test.go
@@ -200,9 +200,7 @@ func TestVersionChangedReconnect_ResetIsRateLimitedPerIdentity(t *testing.T) {
 	assertIdentityQuarantine(t, r, "s3", true)
 
 	// Once the interval has elapsed the reset is available again.
-	r.mu.Lock()
-	r.identityVersionResetAt[versionResetStable] = time.Now().Add(-identityVersionResetMinInterval - time.Second)
-	r.mu.Unlock()
+	withGateForKey(r, versionResetStable, func(g *gateState) { g.versionResetAt = time.Now().Add(-identityVersionResetMinInterval - time.Second) })
 	bindVersionedSession(t, r, "s4", "0.9.3", false)
 	assertIdentityQuarantine(t, r, "s4", false)
 }
@@ -218,7 +216,8 @@ func TestVersionChangedReconnect_ResetIsRateLimitedPerIdentity(t *testing.T) {
 func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 	r := New(testLogger())
 	bindVersionedSession(t, r, "s1", "0.9.0", true)
-	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+	key := modelShapeKey{Model: "m", Shape: "base"}
+	g := r.gateForSession("s1").g
 
 	const flushed = 10_000
 	now := time.Now()
@@ -228,20 +227,22 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 		// breaker window, the rest are hours old.
 		seed = append(seed, now.Add(-time.Duration(flushed-i)*2*time.Second))
 	}
-	r.mu.Lock()
-	r.inferenceErrorStrikes[key] = append([]time.Time(nil), seed...)
-	if r.inferenceErrorFlushStrikes == nil {
-		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+	g.mu.Lock()
+	g.inferenceErrorStrikes[key] = append([]time.Time(nil), seed...)
+	if g.inferenceErrorFlushStrikes == nil {
+		g.inferenceErrorFlushStrikes = make(map[modelShapeKey][]time.Time)
 	}
-	r.inferenceErrorFlushStrikes[key] = append([]time.Time(nil), seed...)
-	r.mu.Unlock()
+	g.inferenceErrorFlushStrikes[key] = append([]time.Time(nil), seed...)
+	g.publishLocked()
+	g.mu.Unlock()
 
 	r.RecordInferenceError("s1", "m", 502, "base")
 
-	r.mu.Lock()
-	strikes := append([]time.Time(nil), r.inferenceErrorStrikes[key]...)
-	flush := append([]time.Time(nil), r.inferenceErrorFlushStrikes[key]...)
-	r.mu.Unlock()
+	g.mu.Lock()
+	strikes := append([]time.Time(nil), g.inferenceErrorStrikes[key]...)
+	flush := append([]time.Time(nil), g.inferenceErrorFlushStrikes[key]...)
+	g.publishLocked()
+	g.mu.Unlock()
 	if len(strikes) == 0 {
 		t.Fatal("main strike list is empty after a recorded flush")
 	}
@@ -268,10 +269,11 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 
 	// A served request clears the shape's history — tags included.
 	r.RecordInferenceSuccess("s1", "m", "base")
-	r.mu.Lock()
-	_, strikesLeft := r.inferenceErrorStrikes[key]
-	_, flushLeft := r.inferenceErrorFlushStrikes[key]
-	r.mu.Unlock()
+	g.mu.Lock()
+	_, strikesLeft := g.inferenceErrorStrikes[key]
+	_, flushLeft := g.inferenceErrorFlushStrikes[key]
+	g.publishLocked()
+	g.mu.Unlock()
 	if strikesLeft || flushLeft {
 		t.Fatalf("after success: strikes present=%v flush tags present=%v, want both cleared", strikesLeft, flushLeft)
 	}
@@ -283,19 +285,22 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 func TestInferenceFlushStrikes_NonFlushStrikePrunesTags(t *testing.T) {
 	r := New(testLogger())
 	bindVersionedSession(t, r, "s1", "0.9.0", true)
-	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+	key := modelShapeKey{Model: "m", Shape: "base"}
+	g := r.gateForSession("s1").g
 
 	stale := time.Now().Add(-2 * inferenceErrorWindow)
-	r.mu.Lock()
-	r.inferenceErrorStrikes[key] = []time.Time{stale}
-	r.inferenceErrorFlushStrikes = map[inferenceErrorKey][]time.Time{key: {stale}}
-	r.mu.Unlock()
+	g.mu.Lock()
+	g.inferenceErrorStrikes[key] = []time.Time{stale}
+	g.inferenceErrorFlushStrikes = map[modelShapeKey][]time.Time{key: {stale}}
+	g.publishLocked()
+	g.mu.Unlock()
 
 	r.RecordInferenceError("s1", "m", 500, "base")
 
-	r.mu.Lock()
-	flush, present := r.inferenceErrorFlushStrikes[key]
-	r.mu.Unlock()
+	g.mu.Lock()
+	flush, present := g.inferenceErrorFlushStrikes[key]
+	g.publishLocked()
+	g.mu.Unlock()
 	if present {
 		t.Fatalf("stale flush tag survived a non-flush strike: %v", flush)
 	}
@@ -389,10 +394,9 @@ func TestVersionResetThrottle_FollowsIdentityRebind(t *testing.T) {
 	s3.SetVersion("0.9.2")
 	assertIdentityQuarantineKeyed(t, r, "s3", serialID, true)
 
-	r.mu.RLock()
-	_, orphan := r.identityVersionResetAt[sekeyID]
-	_, moved := r.identityVersionResetAt[serialID]
-	r.mu.RUnlock()
+	orphan := rawGateForKey(r, sekeyID) != nil
+	moved := false
+	readGateForKey(r, serialID, func(g *gateState) { moved = g != nil && !g.versionResetAt.IsZero() })
 	if orphan || !moved {
 		t.Fatalf("reset timestamp after rebind: under old key=%v, under new key=%v; want moved", orphan, moved)
 	}
@@ -412,12 +416,14 @@ func TestMigrateFaultState_ResetTimestampKeepsLater(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := New(testLogger())
-			r.mu.Lock()
-			r.identityVersionResetAt = map[string]time.Time{"old": tc.src, "new": tc.dst}
-			r.migrateFaultStateLocked("old", "new")
-			got, ok := r.identityVersionResetAt["new"]
-			_, orphan := r.identityVersionResetAt["old"]
-			r.mu.Unlock()
+			withGateForKey(r, "old", func(g *gateState) { g.versionResetAt = tc.src })
+			withGateForKey(r, "new", func(g *gateState) { g.versionResetAt = tc.dst })
+			r.gatesMu.Lock()
+			r.migrateGateLocked(&Provider{}, r.gates["old"], r.gates["new"], true)
+			got := r.gates["new"].versionResetAt
+			ok := !got.IsZero()
+			_, orphan := r.gates["old"]
+			r.gatesMu.Unlock()
 			if !ok || !got.Equal(newer) {
 				t.Fatalf("merged reset timestamp = %v (present=%v), want %v", got, ok, newer)
 			}

--- a/coordinator/registry/version_reset_test.go
+++ b/coordinator/registry/version_reset_test.go
@@ -62,13 +62,13 @@ func dieAbruptlyWithFlush(t *testing.T, r *Registry, id string) {
 		t.Fatalf("stable identity after disconnect = %q, want %q", sid, versionResetStable)
 	}
 	for i := 0; i < 2; i++ {
-		r.RecordInferenceError(id, "m", 502, "base")
+		r.RecordInferenceError(id, "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected)
 	}
 	for i := 0; i < 5; i++ {
-		r.RecordProviderOutcome(id, false, 502, "provider disconnected")
+		r.RecordProviderOutcome(id, false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 	}
 	for i := 0; i < 8; i++ {
-		r.RecordProviderServeOutcome(sid, false, 502, "provider disconnected")
+		r.RecordProviderServeOutcome(sid, false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 	}
 }
 
@@ -236,7 +236,7 @@ func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
 	g.publishLocked()
 	g.mu.Unlock()
 
-	r.RecordInferenceError("s1", "m", 502, "base")
+	r.RecordInferenceError("s1", "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected)
 
 	g.mu.Lock()
 	strikes := append([]time.Time(nil), g.inferenceErrorStrikes[key]...)
@@ -326,13 +326,13 @@ func dieAbruptlyWithFlushKeyed(t *testing.T, r *Registry, id, stable string) {
 		t.Fatalf("stable identity after disconnect = %q, want %q", sid, stable)
 	}
 	for i := 0; i < 2; i++ {
-		r.RecordInferenceError(id, "m", 502, "base")
+		r.RecordInferenceError(id, "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected)
 	}
 	for i := 0; i < 5; i++ {
-		r.RecordProviderOutcome(id, false, 502, "provider disconnected")
+		r.RecordProviderOutcome(id, false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 	}
 	for i := 0; i < 8; i++ {
-		r.RecordProviderServeOutcome(stable, false, 502, "provider disconnected")
+		r.RecordProviderServeOutcome(stable, false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 	}
 }
 
@@ -461,23 +461,23 @@ func TestSupersededDisconnectFlush_DatesTheDropAgainstTheReset(t *testing.T) {
 	r := New(testLogger())
 	bindVersionedSession(t, r, "s1", "0.9.0", true)
 	dropAbruptlyUnrecorded(t, r, "s1")
-	if r.IsSupersededDisconnectFlush("s1", 502) {
+	if r.IsSupersededDisconnectFlush("s1", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("no reset has run: the flush strike must record")
 	}
 
 	// Registration order: the eviction above already happened when SetVersion
 	// runs the reset against empty windows.
 	bindVersionedSession(t, r, "s2", "0.9.1", false)
-	if !r.IsSupersededDisconnectFlush("s1", 502) {
+	if !r.IsSupersededDisconnectFlush("s1", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("s1 was dropped before the version reset: its flush strike is superseded")
 	}
 	if r.IsSupersededDisconnectFlush("s1", 500) {
 		t.Fatal("only the disconnect-flush status is superseded, never a genuine fault")
 	}
-	if r.IsSupersededDisconnectFlush("s2", 502) {
+	if r.IsSupersededDisconnectFlush("s2", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("a live session is never superseded")
 	}
-	if r.IsSupersededDisconnectFlush("nobody", 502) {
+	if r.IsSupersededDisconnectFlush("nobody", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("an unknown session is never superseded")
 	}
 
@@ -486,10 +486,10 @@ func TestSupersededDisconnectFlush_DatesTheDropAgainstTheReset(t *testing.T) {
 	// (dropped after the only reset) must still land.
 	dropAbruptlyUnrecorded(t, r, "s2")
 	bindVersionedSession(t, r, "s3", "0.9.2", false)
-	if r.IsSupersededDisconnectFlush("s2", 502) {
+	if r.IsSupersededDisconnectFlush("s2", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("s2 was dropped after the last reset (the next one was throttled): its flush strike must record")
 	}
-	if !r.IsSupersededDisconnectFlush("s1", 502) {
+	if !r.IsSupersededDisconnectFlush("s1", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("s1's verdict does not change with later sessions")
 	}
 }
@@ -503,7 +503,7 @@ func TestSupersededDisconnectFlush_UnattestedSessionIsNotDated(t *testing.T) {
 	p := r.Register("anon", nil, msg)
 	p.SetVersion("0.9.0")
 	dropAbruptlyUnrecorded(t, r, "anon")
-	if r.IsSupersededDisconnectFlush("anon", 502) {
+	if r.IsSupersededDisconnectFlush("anon", 502, protocol.CoordinatorCauseProviderDisconnected) {
 		t.Fatal("a session without a stable identity is never superseded")
 	}
 }
@@ -517,13 +517,17 @@ func TestVersionResetInterleavedWithTrackerWrites(t *testing.T) {
 			r := New(testLogger())
 			bindVersionedSession(t, r, "old", "0.9.0", true)
 			dropAbruptlyUnrecorded(t, r, "old")
-			if r.IsSupersededDisconnectFlush("old", 502) {
+			if r.IsSupersededDisconnectFlush("old", 502, protocol.CoordinatorCauseProviderDisconnected) {
 				t.Fatal("API precheck before the reset must allow the old flush")
 			}
 			writes := []func(){
-				func() { r.RecordInferenceError("old", "m", 502, "base") },
-				func() { r.RecordProviderOutcome("old", false, 502, "provider disconnected") },
-				func() { r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected") },
+				func() { r.RecordInferenceError("old", "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected) },
+				func() {
+					r.RecordProviderOutcome("old", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
+				},
+				func() {
+					r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
+				},
 			}
 			for _, write := range writes[:split] {
 				for range 8 {
@@ -566,9 +570,9 @@ func TestVersionResetSurvivesDisconnectedIdentityEnrichment(t *testing.T) {
 	current := bindKey("current-key-session", "0.9.1")
 	enrich(current)
 	for range 8 {
-		r.RecordInferenceError("old-key-session", "m", 502, "base")
-		r.RecordProviderOutcome("old-key-session", false, 502, "provider disconnected")
-		r.RecordProviderSessionServeOutcome("old-key-session", false, 502, "provider disconnected")
+		r.RecordInferenceError("old-key-session", "m", 502, "base", protocol.CoordinatorCauseProviderDisconnected)
+		r.RecordProviderOutcome("old-key-session", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
+		r.RecordProviderSessionServeOutcome("old-key-session", false, 502, "provider disconnected", protocol.CoordinatorCauseProviderDisconnected)
 	}
 	// Reconnecting through the weaker identity must not resurrect the old
 	// binary's flushes when the same serial is attested again.

--- a/coordinator/registry/version_reset_test.go
+++ b/coordinator/registry/version_reset_test.go
@@ -1,0 +1,575 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Version-changed reconnect reset (version_reset.go), live-isolated on a real
+// Registry: sessions register, bind a serial identity, die abruptly with work
+// in flight (the flush the 2026-08-31 upgrade wave produced), and reconnect.
+
+const versionResetSerial = "SER-UPGRADE"
+const versionResetStable = "serial:" + versionResetSerial
+
+// bindVersionedSession registers a session, stores its binary version, and
+// binds it to the serial identity. versionFirst=true is the re-attestation
+// order (version already stored when bindStableFaultKey runs); false is the
+// registration order (attestation binds BEFORE the api stores the version,
+// so Provider.SetVersion must run the check).
+func bindVersionedSession(t *testing.T, r *Registry, id, version string, versionFirst bool) *Provider {
+	t.Helper()
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+	p := r.Register(id, nil, msg)
+	bind := func() {
+		p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: versionResetSerial})
+	}
+	if versionFirst {
+		p.SetVersion(version)
+		bind()
+	} else {
+		bind()
+		p.SetVersion(version)
+	}
+	return p
+}
+
+// dieAbruptlyWithFlush parks requests on the session, drops it without a close
+// frame, and records the flush terminals the consumers feed: enough 502s to
+// trip the inference-error cooldown (2), the node breaker (5), and the
+// identity ejection (8) — roughly one upgraded box's worth in the incident.
+func dieAbruptlyWithFlush(t *testing.T, r *Registry, id string) {
+	t.Helper()
+	p := r.GetProvider(id)
+	if p == nil {
+		t.Fatalf("provider %s not registered", id)
+	}
+	for i := 0; i < 3; i++ {
+		p.AddPending(&PendingRequest{
+			RequestID: fmt.Sprintf("%s-req-%d", id, i),
+			Model:     "m",
+			ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+		})
+	}
+	r.DisconnectWithReason(id, DisconnectReasonReadError)
+	sid := r.GetProviderStableIdentity(id)
+	if sid != versionResetStable {
+		t.Fatalf("stable identity after disconnect = %q, want %q", sid, versionResetStable)
+	}
+	for i := 0; i < 2; i++ {
+		r.RecordInferenceError(id, "m", 502, "base")
+	}
+	for i := 0; i < 5; i++ {
+		r.RecordProviderOutcome(id, false, 502, "provider disconnected")
+	}
+	for i := 0; i < 8; i++ {
+		r.RecordProviderServeOutcome(sid, false, 502, "provider disconnected")
+	}
+}
+
+// assertIdentityQuarantine checks all three fault trackers for the identity,
+// querying the inference-error cooldown and node breaker through queryID
+// (a live session id resolves via faultKeyBySession, a dead one via the
+// disconnect cache) and the ejection through the stable id.
+func assertIdentityQuarantine(t *testing.T, r *Registry, queryID string, want bool) {
+	t.Helper()
+	if got := r.InferenceErrorCooldownActive(queryID, "m", "base"); got != want {
+		t.Errorf("InferenceErrorCooldownActive(%s) = %v, want %v", queryID, got, want)
+	}
+	if got := r.ProviderBreakerOpen(queryID); got != want {
+		t.Errorf("ProviderBreakerOpen(%s) = %v, want %v", queryID, got, want)
+	}
+	if got := r.HealthEjectionOpen(versionResetStable); got != want {
+		t.Errorf("HealthEjectionOpen(%s) = %v, want %v", versionResetStable, got, want)
+	}
+}
+
+func TestVersionChangedReconnect_ClearsDisconnectFlushStrikes(t *testing.T) {
+	for _, versionFirst := range []bool{true, false} {
+		name := "registration order (bind then SetVersion)"
+		if versionFirst {
+			name = "re-attestation order (SetVersion then bind)"
+		}
+		t.Run(name, func(t *testing.T) {
+			r := New(testLogger())
+			bindVersionedSession(t, r, "s1", "0.9.0", true)
+			dieAbruptlyWithFlush(t, r, "s1")
+			assertIdentityQuarantine(t, r, "s1", true)
+
+			bindVersionedSession(t, r, "s2", "0.9.1", versionFirst)
+			assertIdentityQuarantine(t, r, "s2", false)
+			if r.InferenceErrorCooldownActive(versionResetStable, "m", "base") {
+				t.Errorf("cooldown still active under the stable id after the version bump")
+			}
+		})
+	}
+}
+
+func TestSameVersionReconnect_RetainsDisconnectFlushStrikes(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	dieAbruptlyWithFlush(t, r, "s1")
+	assertIdentityQuarantine(t, r, "s1", true)
+
+	// The zombie signature: same binary, churning reconnects. Nothing resets.
+	bindVersionedSession(t, r, "s2", "0.9.0", false)
+	assertIdentityQuarantine(t, r, "s2", true)
+}
+
+// A version bump removes ONLY the flush 502s: genuine 500 faults recorded on
+// the old binary still satisfy every trip condition, so the quarantines stay.
+func TestVersionChangedReconnect_KeepsGenuineFaults(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	for i := 0; i < 2; i++ {
+		r.RecordInferenceError("s1", "m", 500, "base")
+	}
+	for i := 0; i < 5; i++ {
+		r.RecordProviderOutcome("s1", false, 500, "internal error")
+	}
+	for i := 0; i < 8; i++ {
+		r.RecordProviderServeOutcome(versionResetStable, false, 500, "internal error")
+	}
+	assertIdentityQuarantine(t, r, "s1", true)
+	dieAbruptlyWithFlush(t, r, "s1")
+
+	bindVersionedSession(t, r, "s2", "0.9.1", false)
+	assertIdentityQuarantine(t, r, "s2", true)
+}
+
+// The first version ever observed for an identity only records it: strikes
+// accumulated before any version was known (coordinator restart, un-versioned
+// legacy session) are not wiped by the first versioned reconnect.
+func TestVersionReconnect_FirstObservationOnlyRecords(t *testing.T) {
+	r := New(testLogger())
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+	p := r.Register("s0", nil, msg)
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: versionResetSerial})
+	dieAbruptlyWithFlush(t, r, "s0")
+	assertIdentityQuarantine(t, r, "s0", true)
+
+	bindVersionedSession(t, r, "s1", "0.9.5", false)
+	assertIdentityQuarantine(t, r, "s1", true)
+}
+
+// A graceful (peer-close) flush never strikes in the first place, so nothing
+// is left to reset: the reconnect on any version finds a clean identity.
+func TestGracefulDisconnect_NoStrikesToReset(t *testing.T) {
+	r := New(testLogger())
+	p := bindVersionedSession(t, r, "s1", "0.9.0", true)
+	for i := 0; i < 3; i++ {
+		p.AddPending(&PendingRequest{
+			RequestID: fmt.Sprintf("s1-req-%d", i),
+			Model:     "m",
+			ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+		})
+	}
+	r.DisconnectWithReason("s1", DisconnectReasonPeerClose)
+	// The api layer's noteInferenceError gates on the provider_restart reason
+	// before any Record* call, so the registry sees no strikes at all.
+	assertIdentityQuarantine(t, r, "s1", false)
+	bindVersionedSession(t, r, "s2", "0.9.0", false)
+	assertIdentityQuarantine(t, r, "s2", false)
+}
+
+// RegisterMessage.Version is provider-asserted, so the reset is rate-limited
+// per identity: a second version change inside identityVersionResetMinInterval
+// retains the strikes (a modified binary alternating two version strings
+// cannot launder every reconnect), and the reset is available again once the
+// interval has elapsed (a genuine later rollout).
+func TestVersionChangedReconnect_ResetIsRateLimitedPerIdentity(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	dieAbruptlyWithFlush(t, r, "s1")
+	assertIdentityQuarantine(t, r, "s1", true)
+
+	// First version change: reset consumed.
+	bindVersionedSession(t, r, "s2", "0.9.1", false)
+	assertIdentityQuarantine(t, r, "s2", false)
+	dieAbruptlyWithFlush(t, r, "s2")
+	assertIdentityQuarantine(t, r, "s2", true)
+
+	// Second change inside the interval: strikes retained.
+	bindVersionedSession(t, r, "s3", "0.9.2", false)
+	assertIdentityQuarantine(t, r, "s3", true)
+
+	// Once the interval has elapsed the reset is available again.
+	r.mu.Lock()
+	r.identityVersionResetAt[versionResetStable] = time.Now().Add(-identityVersionResetMinInterval - time.Second)
+	r.mu.Unlock()
+	bindVersionedSession(t, r, "s4", "0.9.3", false)
+	assertIdentityQuarantine(t, r, "s4", false)
+}
+
+// TestInferenceFlushStrikes_BoundedForSameVersionIdentity: an identity that
+// churns on the SAME binary version never triggers the version reset, so its
+// disconnect-flush tags were append-only — the main strikes slid out of the
+// breaker window and a success deleted them, but every flushed request kept a
+// time.Time under the identity forever. Seed 10,000 flushed requests spread
+// over hours (each also in the main strike list, exactly as RecordInferenceError
+// writes them), record one more flush, and the tag slice must be bounded by
+// the breaker window and remain a subset of the strikes; a success clears it.
+func TestInferenceFlushStrikes_BoundedForSameVersionIdentity(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+
+	const flushed = 10_000
+	now := time.Now()
+	seed := make([]time.Time, 0, flushed)
+	for i := 0; i < flushed; i++ {
+		// One flush every 2 s, the newest 2 s ago: ~30 fall inside the 60 s
+		// breaker window, the rest are hours old.
+		seed = append(seed, now.Add(-time.Duration(flushed-i)*2*time.Second))
+	}
+	r.mu.Lock()
+	r.inferenceErrorStrikes[key] = append([]time.Time(nil), seed...)
+	if r.inferenceErrorFlushStrikes == nil {
+		r.inferenceErrorFlushStrikes = make(map[inferenceErrorKey][]time.Time)
+	}
+	r.inferenceErrorFlushStrikes[key] = append([]time.Time(nil), seed...)
+	r.mu.Unlock()
+
+	r.RecordInferenceError("s1", "m", 502, "base")
+
+	r.mu.Lock()
+	strikes := append([]time.Time(nil), r.inferenceErrorStrikes[key]...)
+	flush := append([]time.Time(nil), r.inferenceErrorFlushStrikes[key]...)
+	r.mu.Unlock()
+	if len(strikes) == 0 {
+		t.Fatal("main strike list is empty after a recorded flush")
+	}
+	// The bound is the breaker window: everything older than 60 s is gone.
+	// 30 seeded entries at most survive (2 s spacing) plus the strike just
+	// recorded; allow the wall clock a little drift.
+	if len(flush) > int(inferenceErrorWindow/(2*time.Second))+2 {
+		t.Fatalf("flush tags = %d after %d historical flushes, want the slice bounded by the %s window", len(flush), flushed, inferenceErrorWindow)
+	}
+	if len(flush) > len(strikes) {
+		t.Fatalf("flush tags (%d) outnumber live strikes (%d)", len(flush), len(strikes))
+	}
+	for _, ts := range flush {
+		if !containsTimestamp(strikes, ts) {
+			t.Fatalf("flush tag %v marks a strike that is no longer in the window", ts)
+		}
+		if now.Sub(ts) >= inferenceErrorWindow+time.Second {
+			t.Fatalf("flush tag %v is older than the breaker window", ts)
+		}
+	}
+	if !containsTimestamp(flush, strikes[len(strikes)-1]) {
+		t.Fatal("the flush just recorded is not tagged")
+	}
+
+	// A served request clears the shape's history — tags included.
+	r.RecordInferenceSuccess("s1", "m", "base")
+	r.mu.Lock()
+	_, strikesLeft := r.inferenceErrorStrikes[key]
+	_, flushLeft := r.inferenceErrorFlushStrikes[key]
+	r.mu.Unlock()
+	if strikesLeft || flushLeft {
+		t.Fatalf("after success: strikes present=%v flush tags present=%v, want both cleared", strikesLeft, flushLeft)
+	}
+}
+
+// TestInferenceFlushStrikes_NonFlushStrikePrunesTags: the tags slide out of
+// the window on EVERY counted strike, not only on a 502, so they can never
+// reference a strike the main list has already dropped.
+func TestInferenceFlushStrikes_NonFlushStrikePrunesTags(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	key := inferenceErrorKey{ProviderID: versionResetStable, ModelID: "m", Shape: "base"}
+
+	stale := time.Now().Add(-2 * inferenceErrorWindow)
+	r.mu.Lock()
+	r.inferenceErrorStrikes[key] = []time.Time{stale}
+	r.inferenceErrorFlushStrikes = map[inferenceErrorKey][]time.Time{key: {stale}}
+	r.mu.Unlock()
+
+	r.RecordInferenceError("s1", "m", 500, "base")
+
+	r.mu.Lock()
+	flush, present := r.inferenceErrorFlushStrikes[key]
+	r.mu.Unlock()
+	if present {
+		t.Fatalf("stale flush tag survived a non-flush strike: %v", flush)
+	}
+}
+
+// dieAbruptlyWithFlushKeyed is dieAbruptlyWithFlush for a session bound to an
+// arbitrary stable identity (the serial fixture above is hardcoded).
+func dieAbruptlyWithFlushKeyed(t *testing.T, r *Registry, id, stable string) {
+	t.Helper()
+	p := r.GetProvider(id)
+	if p == nil {
+		t.Fatalf("provider %s not registered", id)
+	}
+	for i := 0; i < 3; i++ {
+		p.AddPending(&PendingRequest{
+			RequestID: fmt.Sprintf("%s-req-%d", id, i),
+			Model:     "m",
+			ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+		})
+	}
+	r.DisconnectWithReason(id, DisconnectReasonReadError)
+	if sid := r.GetProviderStableIdentity(id); sid != stable {
+		t.Fatalf("stable identity after disconnect = %q, want %q", sid, stable)
+	}
+	for i := 0; i < 2; i++ {
+		r.RecordInferenceError(id, "m", 502, "base")
+	}
+	for i := 0; i < 5; i++ {
+		r.RecordProviderOutcome(id, false, 502, "provider disconnected")
+	}
+	for i := 0; i < 8; i++ {
+		r.RecordProviderServeOutcome(stable, false, 502, "provider disconnected")
+	}
+}
+
+func assertIdentityQuarantineKeyed(t *testing.T, r *Registry, queryID, stable string, want bool) {
+	t.Helper()
+	if got := r.InferenceErrorCooldownActive(queryID, "m", "base"); got != want {
+		t.Errorf("InferenceErrorCooldownActive(%s) = %v, want %v", queryID, got, want)
+	}
+	if got := r.ProviderBreakerOpen(queryID); got != want {
+		t.Errorf("ProviderBreakerOpen(%s) = %v, want %v", queryID, got, want)
+	}
+	if got := r.HealthEjectionOpen(stable); got != want {
+		t.Errorf("HealthEjectionOpen(%s) = %v, want %v", stable, got, want)
+	}
+}
+
+// TestVersionResetThrottle_FollowsIdentityRebind: the per-identity reset
+// timestamp must migrate with the identity on a sekey: → serial: rebind (MDA
+// enrichment of a live session). Otherwise the serial identity starts with no
+// throttle record and a second version change inside the 10-minute interval
+// clears its flush strikes again — the laundering the interval exists to stop.
+func TestVersionResetThrottle_FollowsIdentityRebind(t *testing.T) {
+	r := New(testLogger())
+	const pk, serial = "PK-REBIND", "SER-REBIND"
+	const sekeyID, serialID = "sekey:" + pk, "serial:" + serial
+	register := func(id string) *Provider {
+		msg := testRegisterMessage()
+		msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+		return r.Register(id, nil, msg)
+	}
+	attestSEKey := func(p *Provider) {
+		p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: pk})
+	}
+
+	// s1 on 0.9.0 binds the SE-key identity and dies abruptly with work in flight.
+	s1 := register("s1")
+	s1.SetVersion("0.9.0")
+	attestSEKey(s1)
+	dieAbruptlyWithFlushKeyed(t, r, "s1", sekeyID)
+	assertIdentityQuarantineKeyed(t, r, "s1", sekeyID, true)
+
+	// s2 on 0.9.1: the version change consumes the identity's one reset.
+	s2 := register("s2")
+	attestSEKey(s2)
+	s2.SetVersion("0.9.1")
+	assertIdentityQuarantineKeyed(t, r, "s2", sekeyID, false)
+	dieAbruptlyWithFlushKeyed(t, r, "s2", sekeyID)
+	assertIdentityQuarantineKeyed(t, r, "s2", sekeyID, true)
+
+	// s3 binds the SE key, is enriched to the serial (rebind), and only then
+	// reports a third version. The reset consumed under sekey: still throttles
+	// the serial: identity.
+	s3 := register("s3")
+	attestSEKey(s3)
+	s3.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: pk, SerialNumber: serial})
+	if got := faultKeyOf(r, "s3"); got != serialID {
+		t.Fatalf("enriched attestation must rebind to the serial key, got %q", got)
+	}
+	s3.SetVersion("0.9.2")
+	assertIdentityQuarantineKeyed(t, r, "s3", serialID, true)
+
+	r.mu.RLock()
+	_, orphan := r.identityVersionResetAt[sekeyID]
+	_, moved := r.identityVersionResetAt[serialID]
+	r.mu.RUnlock()
+	if orphan || !moved {
+		t.Fatalf("reset timestamp after rebind: under old key=%v, under new key=%v; want moved", orphan, moved)
+	}
+}
+
+// Both keys holding a reset timestamp merge to the LATER one, whichever side
+// it is on, so a rebind can never shorten the interval.
+func TestMigrateFaultState_ResetTimestampKeepsLater(t *testing.T) {
+	older := time.Now().Add(-5 * time.Minute)
+	newer := time.Now()
+	for _, tc := range []struct {
+		name     string
+		src, dst time.Time
+	}{
+		{"newer source wins", newer, older},
+		{"newer destination kept", older, newer},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(testLogger())
+			r.mu.Lock()
+			r.identityVersionResetAt = map[string]time.Time{"old": tc.src, "new": tc.dst}
+			r.migrateFaultStateLocked("old", "new")
+			got, ok := r.identityVersionResetAt["new"]
+			_, orphan := r.identityVersionResetAt["old"]
+			r.mu.Unlock()
+			if !ok || !got.Equal(newer) {
+				t.Fatalf("merged reset timestamp = %v (present=%v), want %v", got, ok, newer)
+			}
+			if orphan {
+				t.Fatal("reset timestamp orphaned under the old key")
+			}
+		})
+	}
+}
+
+// dropAbruptlyUnrecorded parks a request on the session and drops it without a
+// close frame, leaving the flush 502 in the consumer's ErrorCh UNRECORDED —
+// the state registration's duplicate-serial eviction leaves the old session
+// in while it goes on to store the new version.
+func dropAbruptlyUnrecorded(t *testing.T, r *Registry, id string) {
+	t.Helper()
+	p := r.GetProvider(id)
+	if p == nil {
+		t.Fatalf("provider %s not registered", id)
+	}
+	p.AddPending(&PendingRequest{
+		RequestID: id + "-req",
+		Model:     "m",
+		ErrorCh:   make(chan protocol.InferenceErrorMessage, 1),
+	})
+	r.DisconnectWithReason(id, DisconnectReasonReadError)
+}
+
+// The predicate behind the api-side discard of late flush strikes: a 502 from
+// a session dropped at or before its identity's last version-changed reset is
+// superseded; a live session, a non-flush status, an identity that never
+// reset, and a session dropped after the reset (including under a THROTTLED
+// version change, which stamps no new reset) are not.
+func TestSupersededDisconnectFlush_DatesTheDropAgainstTheReset(t *testing.T) {
+	r := New(testLogger())
+	bindVersionedSession(t, r, "s1", "0.9.0", true)
+	dropAbruptlyUnrecorded(t, r, "s1")
+	if r.IsSupersededDisconnectFlush("s1", 502) {
+		t.Fatal("no reset has run: the flush strike must record")
+	}
+
+	// Registration order: the eviction above already happened when SetVersion
+	// runs the reset against empty windows.
+	bindVersionedSession(t, r, "s2", "0.9.1", false)
+	if !r.IsSupersededDisconnectFlush("s1", 502) {
+		t.Fatal("s1 was dropped before the version reset: its flush strike is superseded")
+	}
+	if r.IsSupersededDisconnectFlush("s1", 500) {
+		t.Fatal("only the disconnect-flush status is superseded, never a genuine fault")
+	}
+	if r.IsSupersededDisconnectFlush("s2", 502) {
+		t.Fatal("a live session is never superseded")
+	}
+	if r.IsSupersededDisconnectFlush("nobody", 502) {
+		t.Fatal("an unknown session is never superseded")
+	}
+
+	// The new binary dies too, and a THIRD version arrives inside the reset
+	// interval: throttled, so no new reset is stamped and s2's flush strikes
+	// (dropped after the only reset) must still land.
+	dropAbruptlyUnrecorded(t, r, "s2")
+	bindVersionedSession(t, r, "s3", "0.9.2", false)
+	if r.IsSupersededDisconnectFlush("s2", 502) {
+		t.Fatal("s2 was dropped after the last reset (the next one was throttled): its flush strike must record")
+	}
+	if !r.IsSupersededDisconnectFlush("s1", 502) {
+		t.Fatal("s1's verdict does not change with later sessions")
+	}
+}
+
+// No stable identity at disconnect → the registry never dated the drop and
+// the strike keys by the session id anyway: not superseded.
+func TestSupersededDisconnectFlush_UnattestedSessionIsNotDated(t *testing.T) {
+	r := New(testLogger())
+	msg := testRegisterMessage()
+	msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+	p := r.Register("anon", nil, msg)
+	p.SetVersion("0.9.0")
+	dropAbruptlyUnrecorded(t, r, "anon")
+	if r.IsSupersededDisconnectFlush("anon", 502) {
+		t.Fatal("a session without a stable identity is never superseded")
+	}
+}
+
+// A reset can occur after the API precheck or between any pair of tracker
+// writes. Every write retains the session id and checks inside its mutation
+// lock; earlier writes are removed by the reset and later ones are discarded.
+func TestVersionResetInterleavedWithTrackerWrites(t *testing.T) {
+	for split := 0; split <= 3; split++ {
+		t.Run(fmt.Sprintf("reset_after_%d_trackers", split), func(t *testing.T) {
+			r := New(testLogger())
+			bindVersionedSession(t, r, "old", "0.9.0", true)
+			dropAbruptlyUnrecorded(t, r, "old")
+			if r.IsSupersededDisconnectFlush("old", 502) {
+				t.Fatal("API precheck before the reset must allow the old flush")
+			}
+			writes := []func(){
+				func() { r.RecordInferenceError("old", "m", 502, "base") },
+				func() { r.RecordProviderOutcome("old", false, 502, "provider disconnected") },
+				func() { r.RecordProviderSessionServeOutcome("old", false, 502, "provider disconnected") },
+			}
+			for _, write := range writes[:split] {
+				for range 8 {
+					write()
+				}
+			}
+			bindVersionedSession(t, r, "new", "0.9.1", false)
+			for _, write := range writes[split:] {
+				for range 8 {
+					write()
+				}
+			}
+			assertIdentityQuarantine(t, r, "new", false)
+		})
+	}
+}
+
+// A disconnect cache must follow an identity enrichment just like the fault
+// windows and reset timestamp. Otherwise a late old-session flush recreates
+// the emptied sekey history and a later same-version reconnect merges those
+// superseded faults back into the serial identity.
+func TestVersionResetSurvivesDisconnectedIdentityEnrichment(t *testing.T) {
+	r := New(testLogger())
+	const publicKey = "version-reset-shared-se-key"
+	bindKey := func(id, version string) *Provider {
+		msg := testRegisterMessage()
+		msg.Models = []protocol.ModelInfo{{ID: "m", ModelType: "chat"}}
+		p := r.Register(id, nil, msg)
+		p.SetAttestationResult(&attestation.VerificationResult{Valid: true, PublicKey: publicKey})
+		p.SetVersion(version)
+		return p
+	}
+	enrich := func(p *Provider) {
+		p.SetAttestationResult(&attestation.VerificationResult{
+			Valid: true, PublicKey: publicKey, SerialNumber: versionResetSerial,
+		})
+	}
+	bindKey("old-key-session", "0.9.0")
+	dropAbruptlyUnrecorded(t, r, "old-key-session")
+	current := bindKey("current-key-session", "0.9.1")
+	enrich(current)
+	for range 8 {
+		r.RecordInferenceError("old-key-session", "m", 502, "base")
+		r.RecordProviderOutcome("old-key-session", false, 502, "provider disconnected")
+		r.RecordProviderSessionServeOutcome("old-key-session", false, 502, "provider disconnected")
+	}
+	// Reconnecting through the weaker identity must not resurrect the old
+	// binary's flushes when the same serial is attested again.
+	next := bindKey("next-key-session", "0.9.1")
+	enrich(next)
+	assertIdentityQuarantine(t, r, next.ID, false)
+	if got := r.GetProviderStableIdentity("old-key-session"); got != versionResetStable {
+		t.Fatalf("disconnected identity = %q, want enriched %q", got, versionResetStable)
+	}
+}

--- a/coordinator/registry/version_reset_timestamp_test.go
+++ b/coordinator/registry/version_reset_timestamp_test.go
@@ -1,0 +1,44 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDisconnectSourcesAgreeAtVersionResetBoundary(t *testing.T) {
+	r := New(testLogger())
+	p := bindVersionedSession(t, r, "disconnect-timestamp", "0.8.1", false)
+	// A recorder can resolve the live Provider before Disconnect, then reach
+	// the gate after another recorder has resolved the disconnect cache.
+	liveSource := r.captureDisconnectSource(p.ID)
+	r.DisconnectWithReason(p.ID, DisconnectReasonReadError)
+	cachedSource := r.captureDisconnectSource(p.ID)
+	if liveSource.p != p || cachedSource.p != nil || cachedSource.at.IsZero() {
+		t.Fatal("expected one live reference and one cached disconnect source")
+	}
+	droppedNS := p.gateDisconnectedAtNS.Load()
+	if droppedNS == 0 {
+		t.Fatal("disconnect did not date the live reference")
+	}
+	g := r.lookupGateForKey(versionResetStable)
+	if g == nil {
+		t.Fatal("disconnect lost the stable identity's gate")
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	// Model the exact cutoff of a reset concurrent with detachment. With two
+	// clock reads, the live source is superseded here but the later cache
+	// timestamp lets the same old 502 poison the reset gate. A single event
+	// timestamp gives both recorder paths the same decision at the boundary.
+	g.versionResetAt = time.Unix(0, droppedNS)
+	if !liveSource.supersededBy(g) || !cachedSource.supersededBy(g) {
+		t.Fatalf("sources disagree at reset cutoff: live=%v cached=%v live_at=%s cached_at=%s",
+			liveSource.supersededBy(g), cachedSource.supersededBy(g), g.versionResetAt, cachedSource.at)
+	}
+	// A reset preceding that disconnect must retain both strikes, preserving
+	// same-version churn and the version-reset throttle's later-fault rule.
+	g.versionResetAt = time.Unix(0, droppedNS-1)
+	if liveSource.supersededBy(g) || cachedSource.supersededBy(g) {
+		t.Fatal("a reset before the disconnect suppressed a later flush")
+	}
+}

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -688,7 +688,7 @@ func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now 
 	if p.Status == StatusOffline || p.Status == StatusUntrusted || p.PrivateOnly {
 		return warmPoolCandidate{}, warmColdOfflineUntrust
 	}
-	if r.providerHasPendingLoad(p.ID) || r.dispatchLoadCooldownActiveLocked(p.ID, model, now) {
+	if r.providerHasPendingLoad(p.ID) || r.gateOf(p).dispatchLoadCooled(model, now) {
 		return warmPoolCandidate{}, warmColdPendingLoad
 	}
 	if p.pendingCount() != 0 || warmPoolBackendSlotBusyLocked(p) {

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -234,6 +234,15 @@ type InferenceRouteOutcome struct {
 	// is loud rather than silent. json:"-" keeps it out of every API payload and
 	// neither store impl persists it.
 	InvalidTTFT bool `json:"-"`
+
+	// QueueExit is a transient (never-persisted) marker on the terminal outcome
+	// of a request that left the coordinator queue without a provider attempt
+	// being dispatched (client gone, queue_deadline, queue_timeout,
+	// ttft_too_slow, tool-constraint unavailable). The route-outcome funnel
+	// counts such an exit on inference.queue_outcome instead of
+	// inference.attempt_outcome, so the per-model attempt denominator only
+	// counts attempts a provider actually received.
+	QueueExit bool `json:"-"`
 }
 
 // InferenceRouteOutcomeUpdate is one outcome update addressed to a route row,

--- a/docs/architecture/request-outcome-observability.md
+++ b/docs/architecture/request-outcome-observability.md
@@ -1,6 +1,6 @@
 # Request Outcome Observability
 
-> Last updated: 2026-09-04 · commit `73df54ad0`
+> Last updated: 2026-09-04 · commit `6f364e64b`
 
 Every inference request the coordinator dispatches ends in exactly one terminal outcome, and that outcome is recorded three ways: a closed `final_status` / `error_class` / `error_reason` triple on the `inference_routes` row, a per-attempt `request_profiles` row with separate `client_outcome` and `provider_outcome` columns, and a small set of low-cardinality Datadog counters. Requests refused before dispatch land in the `request_rejections` ledger instead. This page explains the taxonomy as the code implements it, where each value is decided, and what is still not modelled.
 
@@ -158,6 +158,12 @@ Queued exits carry the transient `QueueExit` marker and instead increment
 (`coordinator/api/attempt_outcome_metrics.go`, `emitAttemptOutcomeMetric`;
 `coordinator/api/dispatch.go`, `queuedExitOutcome`).
 
+`inference.request_outcome_or_view{model,class}` also counts a TTFT rejection
+on the first reservation scan as `rate_limited`, even though that branch does
+not write a retry rejection row. The request-level outcome is independent of
+the retry-only ledger/legacy dispatch metrics
+(`coordinator/api/dispatch.go`, `dispatchPrimary`).
+
 `inference.cancel_sent{cause,model}` counts cancels accepted by the provider
 writer; a full/stopped writer increments `inference.cancel_send_failed{reason}`.
 `inference.cancel_to_terminal_ms{terminal,model,cause}` starts at the first
@@ -169,6 +175,12 @@ even if stray chunks arrived. `inference.cancelled_terminal` includes
 so an immediate terminal cannot observe an unmarked accepted cancel.
 Enqueue acceptance does not prove a frame reached the provider (`coordinator/api/cancel_lifecycle.go`,
 `sendRecordedCancel`, `resolveCancelledTerminal`, `emitExpiredCancelEntries`).
+The zombie tracker keeps at most `zombieCancelMaxEntries = 4096` entries.
+Insertions at the cap evict one least-recently-active ID with constant-time
+list operations; they do not force an expiry scan. TTL and warning-state
+cleanup remain rate-limited to `zombieSweepEvery`
+(`coordinator/api/zombie_eviction.go`, `makeRoomLocked`;
+`coordinator/api/zombie_stream.go`, `sweepLocked`).
 
 ### Read surfaces
 

--- a/docs/architecture/request-outcome-observability.md
+++ b/docs/architecture/request-outcome-observability.md
@@ -1,6 +1,6 @@
 # Request Outcome Observability
 
-> Last updated: 2026-09-04 · commit `d574bd5af`
+> Last updated: 2026-09-04 · commit `73df54ad0`
 
 Every inference request the coordinator dispatches ends in exactly one terminal outcome, and that outcome is recorded three ways: a closed `final_status` / `error_class` / `error_reason` triple on the `inference_routes` row, a per-attempt `request_profiles` row with separate `client_outcome` and `provider_outcome` columns, and a small set of low-cardinality Datadog counters. Requests refused before dispatch land in the `request_rejections` ledger instead. This page explains the taxonomy as the code implements it, where each value is decided, and what is still not modelled.
 
@@ -144,11 +144,31 @@ All counters go through `ddIncr`/`ddHistogram`, which are no-ops when Datadog is
 | `inference.timing.{parse_ms,reserve_ms,route_ms,encrypt_ms,queue_wait_ms,dispatch_ms,total_duration_ms}` | `model`, `final_status` | `emitTimingDecompositionMetric` (`coordinator/api/timing_metrics.go`) | histograms of the same values persisted on the route row; zero segments are skipped |
 | `inference.partial_success` | `model`, `error_class` | `handleComplete` when `consumerGone` (`coordinator/api/partial_success_metrics.go`) | subset of `inference.completions`; `error_class` is always `client_gone_after_commit_provider_completed` |
 | `inference.no_terminal_after_cancel` | `model` | `settlement.go` grace expiry | payout gap: refunded, provider unpaid |
-| `routing.client_gone` | `model`, `prompt_bucket`, `chip_family`, `phase` | `emitClientGone` (`coordinator/api/prompt_buckets.go`) from pre-commit arms (`phase:before_first_token`) and from `handleComplete`, `handleInferenceError`, settlement expiry (`phase:after_commit`) | at most one per request; `chip_family` is `unknown` when unobserved |
+| `routing.client_gone` | `model`, `prompt_bucket`, `chip_family`, `phase`, `deadline_bucket` | `emitClientGone` (`coordinator/api/prompt_buckets.go`) from pre-commit arms (`phase:before_first_token`) and from `handleComplete`, `handleInferenceError`, settlement expiry (`phase:after_commit`) | at most one per request; `chip_family` uses the fixed vocabulary in `coordinator/api/chip_family_tags.go`; `deadline_bucket` distinguishes early aborts from cancellations at the first-content deadline |
 | `inference.ttft_ms`, `inference.decode_tps` | `model`, `kv_backend`, `kv_backend_fallback` | `handleComplete` (`coordinator/api/kv_backend_metrics.go`) | the same values written to `inference_routes.actual_ttft_ms` / `actual_decode_tps`; skipped when unmeasurable |
 | `routing.unservable_reclassified` | `model` | dispatch-exhausted backstop in `dispatch.go` | a provider token-budget/KV/context `5xx` turned into an uptime-neutral `429` |
 
 `kv_backend` uses the heartbeat vocabulary (`paged`, `contiguous`, `unspecified`, `other`, `unknown`) and `kv_backend_fallback` the slot's `kv_backend_fallback_reason` (`none` is a real value). Attribution follows the slot that served, is sticky for the provider session (`coordinator/registry/kv_backend.go`), and is never coerced: a request that never reached a slot is `unknown`/`unknown`. Nothing consults `kv_backend` for routing, admission, scoring or shedding.
+
+`inference.attempt_outcome{model,class}` counts dispatched attempts only.
+Queued exits carry the transient `QueueExit` marker and instead increment
+`inference.queue_outcome{model,class}`; queue deadline expiry uses
+`queue_deadline`, while a provider silent after dispatch uses
+`first_chunk_timeout`. Typed drain refusals count as capacity, never faults
+(`coordinator/api/attempt_outcome_metrics.go`, `emitAttemptOutcomeMetric`;
+`coordinator/api/dispatch.go`, `queuedExitOutcome`).
+
+`inference.cancel_sent{cause,model}` counts cancels accepted by the provider
+writer; a full/stopped writer increments `inference.cancel_send_failed{reason}`.
+`inference.cancel_to_terminal_ms{terminal,model,cause}` starts at the first
+successful enqueue, excluding failed-enqueue retry delay. It uses a terminal
+frame, or the last subsequent stray chunk for an expired entry. A cancel that
+was never accepted contributes only to `inference.cancel_unresolved` on expiry,
+even if stray chunks arrived. `inference.cancelled_terminal` includes
+`delivered:true|false` for correlated terminals. Successful enqueue marking and terminal resolution share the tracker lock,
+so an immediate terminal cannot observe an unmarked accepted cancel.
+Enqueue acceptance does not prove a frame reached the provider (`coordinator/api/cancel_lifecycle.go`,
+`sendRecordedCancel`, `resolveCancelledTerminal`, `emitExpiredCancelEntries`).
 
 ### Read surfaces
 

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-04 · commit `4e7a68739`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -436,12 +436,114 @@ outcome exactly once at first content or completion.
 
 Fault state keys by the provider's stable identity when one is bound, so it
 survives disconnect and reconnect (`Disconnect`, `coordinator/registry/registry.go`).
+Every tracker in this table and in [gray-box capacity signals](#gray-box-capacity-signals)
+stores its state in one `gateState` per identity
+([below](#concurrency-scan-commit-and-fault-state-gates)).
 
 **Fail-open.** If the scan produced no winner, at least one provider was
 rejected only by the breaker or ejection, and there were no capacity or TTFT
 rejections, `shouldBypassBreakerFailOpen` re-runs the scan with
 `ignoreProviderBreaker` so a degraded-but-only fleet still serves rather than
 returning `no_provider`.
+
+### Concurrency: scan, commit and fault-state gates
+
+`Registry.mu` is a writer-preferring `sync.RWMutex`: a pending writer blocks
+every new reader and drains the active batch of fleet scans first. Nothing on
+the request path takes it for writing.
+
+| Lock | Guards | Request-path holders |
+|---|---|---|
+| `Registry.mu` (`sync.RWMutex`, `coordinator/registry/registry.go`) | The provider map, catalog, aliases and routing configuration. | The scan and the commit, for READING (`scanProviderReservation`, `commitLock`). Writers are `Register`, `Disconnect`, `evictStale`, the swap planner and the config setters. |
+| `Provider.mu` | One provider's heartbeat state, pending set, attestation and cached gate pointer (`Provider.gate`). | The scan per provider (`snapshotProviderIntoLockedEx`); the commit's whole decide-and-debit section; the identity bind (`bindStableFaultKey`). |
+| `Registry.gatesMu` (`sync.RWMutex`) | The gate index: fault key → `gateState`, session → `Provider` (`coordinator/registry/gate_index.go`). | Recorders for READING (session → gate resolution), first insertion (`ensureGateLocked`), and the rare validated retry fallback (`lockGateWithIndex`). Also written by `attachSessionGate`, `detachSessionGate`, `bindStableFaultKey` and `sweepGates`. |
+| `gateState.mu` | One identity's fault trackers (`coordinator/registry/gate_state.go`). | Recorders (`lockGate`), the commit's probe claim (`tryClaimCapacityProbe`), the per-model gate reads. Microseconds, per identity. |
+
+Lock order: `r.mu → p.mu → gatesMu → gate.mu`. `r.mu` or `p.mu` is never
+acquired while `gatesMu` or a `gate.mu` is held, and there is no walk-wide
+gates lock on the scan (`gate_state.go` header).
+
+**Two-phase reservation** (`coordinator/registry/scheduler.go`).
+`scanProviderReservation` walks the fleet under `r.mu.RLock`; concurrent
+requests scan together and no capacity is consumed. `commitProviderReservation`
+holds `r.mu` for reading — the provider identity, catalog and cache-routing
+configuration must be stable, not the fleet frozen — and does everything that
+decides the reservation inside ONE `p.mu` section on the winner: the fresh
+snapshot (`snapshotProviderIntoPLockedEx`), the cost rebuild, the "winner
+unchanged since scan" compare (a change re-scans so the cohort does not herd
+onto the formerly cheapest provider), the admit re-check
+(`providerCanAdmitLockedEx`), the half-open capacity-probe claim
+(`tryClaimCapacityProbe`, check-and-claim under `gate.mu`) and the pending
+debit (`addPendingLocked`). `ReserveNextFromPlan`
+(`coordinator/registry/dispatch_plan.go`) commits each plan entry the same
+way. `commitLock` (`coordinator/registry/gate_commit_mode.go`) selects the
+mode: `reserveCommitShared` as described, or `reserveCommitGlobal`, which
+takes `r.mu.Lock()` for the commit — the previous fleet-wide serialization,
+kept as the kill switch behind
+[`EIGENINFERENCE_RESERVE_COMMIT_MODE`](../reference/configuration.md#routing-admission-and-ttft).
+
+**Per-identity gates.** Each fault tracker's state lives in a `gateState`
+keyed by fault key (serial → SE key → account → session id) with its own
+mutex; a connected provider caches its gate in `Provider.gate` (an atomic
+pointer). Recorders (`RecordProviderOutcome`, `RecordProviderServeOutcome`,
+`RecordProviderSessionServeOutcome`, `RecordInferenceError`,
+`RecordInferenceSuccess`, `RecordCapacityReject`, `RecordCapacityAcceptObserved`,
+`RecordCapacityAcceptOutcome`, `RecordDispatchLoadFailure`,
+`ClearDispatchLoadCooldown`) resolve the gate and take `gate.mu` through
+`lockGate` (`coordinator/registry/gate_lock.go`), never `r.mu`; `lockGate`
+re-validates under the lock that the gate is still the session's current one
+and not retired, and re-resolves otherwise. A missing identity makes a
+clear operation a no-op. After `gateRelockMaxRetries` optimistic retries,
+`lockGateWithIndex` holds `gatesMu` through resolution and gate acquisition
+so a recorder always writes to a validated identity. The scan reads the breaker and
+ejection verdicts from atomics (`breakerOpenAt`, `ejectedAt`) and takes
+`gate.mu` only for a provider whose flag word (`pairFlags`) says it holds
+per-model state, so a provider with no fault state costs a few atomic loads.
+
+Version-reset history and disconnect-flush tags live under the same identity
+mutex (`coordinator/registry/version_reset.go`). `disconnectSource` captures
+the session before acquiring the gate and compares its disconnect timestamp
+with `gateState.versionResetAt` while the mutation lock is held. This preserves
+the [restart behavior](scheduling.md#disconnect) without returning terminal
+recorders to the fleet lock. `RecordCapacityAcceptObserved` likewise replays
+only rejection strikes newer than the accepted observation, retaining a newer
+cooldown or clamp even when accept bookkeeping arrives late.
+
+**Identity rebinds** (`coordinator/registry/gate_migrate.go`). `bindStableFaultKey`
+runs at every (re-)attestation and at account linkage, under the session's
+`p.mu` and `gatesMu`. When the key changes it MOVES the identity's accumulated
+state to the refined identity (`migrateGateLocked`; merge policy
+`mergeLocked`: expiries and trip counts take the max, histories merge
+chronologically) and empties the source: an orphaned source is forwarded
+(`forwardTo`) so stale pointers land on the live state; a source still bound
+to a sibling session is reset and republished. Cached disconnected identities
+follow the refined identity without changing their disconnect timestamps.
+Their recorder references carry a `disconnectedGateBinding`
+(`coordinator/registry/gate_disconnected_binding.go`), updated under the source
+gate's mutex and validated on acquisition, so an in-flight late flush cannot
+recreate or write into the former identity after a shared-source migration.
+Because the bind holds
+`p.mu`, a section that reads `p.gate` under `p.mu` — the scan's gate chain,
+the commit through its debit, the alias resolver's `providerCanRouteBuildLocked`
+— never sees the identity change underneath it. The one dispatch-deciding
+read made without `p.mu`, the candidate's capacity-rate penalty
+(`capacityRatePenaltyFor`), confirms its verdict against `p.gate` afterwards
+and re-reads on a move (`gateView`, `coordinator/registry/gate_index.go`); the
+other gate reads confirm the same way as defence in depth.
+
+**Sweep** (`coordinator/registry/gate_sweep.go`). `sweepGates` runs from the
+eviction loop: it prunes per-model entries that can no longer gate routing
+and drops a gate with no live session once it has been idle for
+`gateIdleGrace = 10 * time.Minute`, marking it `retired` under `gate.mu`
+before the index delete so a recorder holding a stale pointer re-resolves.
+Version metadata additionally keeps its gate for `identityVersionRetention`
+after activity, disconnect or reset (`coordinator/registry/version_history.go`);
+see [disconnect and reconnect](scheduling.md#disconnect). Half-open trip memory
+of a live gate is never pruned.
+
+**Observability.** `registry.gate.wait_ms` (DogStatsD histogram tagged
+`site:`, via `SetGateWaitObserver`) records a recorder's `gate.mu`
+acquisition wait when it exceeds `gateWaitReportThreshold = time.Millisecond`.
 
 ### Reputation
 
@@ -543,7 +645,25 @@ must not run in parallel with other scheduler tests in the same process.
 9. **Exactly one attempt of a race commits; the other is cancelled** —
    `runRace` calls `cancelDispatch` on the loser before committing.
 10. **Fault memory survives reconnects** — `Disconnect` preserves breaker,
-    cooldown and ejection state keyed by stable identity.
+    cooldown and ejection state keyed by stable identity
+    (`detachSessionGate`, `coordinator/registry/gate_index.go`).
+11. **The admit re-check and the pending debit are atomic per provider, and
+    no request-path commit takes `r.mu` for writing** —
+    `commitProviderReservation` and `ReserveNextFromPlan` snapshot, compare,
+    admit (`providerCanAdmitLockedEx`), claim the probe
+    (`tryClaimCapacityProbe`) and debit (`addPendingLocked`) under one `p.mu`
+    hold; `commitLock` takes `r.mu` for reading unless the kill switch is set.
+12. **A dispatch decision never straddles an identity rebind** —
+    `bindStableFaultKey` runs under the session's `p.mu`, so a section that
+    read `p.gate` under `p.mu` acts on that same identity; a read made without
+    `p.mu` confirms against `p.gate` (`gateView.moved`).
+13. **Fault state moves with the identity and is never double-counted** —
+    `migrateGateLocked` merges the source into the destination (`mergeLocked`)
+    and empties the source; the state is not copied.
+14. **One capacity probe at a time per cooled (identity, model) pair** —
+    `tryClaimCapacityProbeLocked` is check-and-claim under `gate.mu`: a
+    second commit within `capacityProbeOutcomeWindow` of an outstanding claim
+    is rejected instead of leaking a second probe.
 
 ## Failure modes
 
@@ -565,6 +685,8 @@ must not run in parallel with other scheduler tests in the same process.
 | Shared gate primitives | `coordinator/registry/routing_eligibility.go` — `providerLivenessGateReasonLocked`, `providerServesRoutableModelLocked` |
 | Closed vocabularies | `coordinator/registry/gate_reason.go` — `GateReason`, `SelectionPath`, `SlotState` |
 | Trust floor, challenge failures, dispatch-load cooldown, `Disconnect` | `coordinator/registry/registry.go` — `MinTrustLevel`, `MaxFailedChallenges`, `RecordChallengeFailure`, `dispatchLoadCooldownTTL` |
+| Two-phase reservation (scan, commit, plan consumption) | `coordinator/registry/scheduler.go` — `scanProviderReservation`, `commitProviderReservation`, `providerCanAdmitLockedEx`; `coordinator/registry/dispatch_plan.go` — `ReserveNextFromPlan` |
+| Per-identity fault-state gates | `coordinator/registry/gate_state.go` — `gateState`, `publishLocked`, `breakerOpenAt`, `ejectedAt`; `coordinator/registry/gate_index.go` — `gateOf`, `gateView`, `attachSessionGate`, `detachSessionGate`; `coordinator/registry/gate_migrate.go` — `bindStableFaultKey`, `migrateGateLocked`, `mergeLocked`; `coordinator/registry/gate_lock.go` — `lockGate`, `gateRef`, `SetGateWaitObserver`; `coordinator/registry/gate_sweep.go` — `sweepGates`, `gateIdleGrace`; `coordinator/registry/gate_commit_mode.go` — `reserveCommitMode`, `commitLock` |
 | Bounded dispatch plan | `coordinator/registry/dispatch_plan.go` — `dispatchPlanMaxAlternates`, `PlanEntry` |
 | Servability predictor | `coordinator/registry/servability.go` — `PredictServable`, `coldTokenBudgetEstimate`, `servabilityActivationFloor` |
 | Budget clamp | `coordinator/registry/budget_clamp.go` — `recordBudgetClampLocked`, `releaseBudgetClampsOnHeartbeat` |

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `0be2aa074`
+> Last updated: 2026-09-04 · commit `6f364e64b`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -448,7 +448,10 @@ keeps `StatusUntrusted` instead. Eviction reaches `Disconnect` directly. It:
 On reconnect with a changed binary version, `Provider.SetVersion` removes the
 stable identity's disconnect-flush strikes and recomputes quarantine state,
 at most once per `identityVersionResetMinInterval = 10 * time.Minute`.
-Genuine 500/504 faults survive. Each tracker discards a late 502 from a session
+Genuine provider 500/502/504 faults survive. Only a 502 carrying the non-wire
+`CoordinatorCauseProviderDisconnected` marker is tagged as a disconnect flush;
+HTTP status alone does not establish that provenance. Each tracker discards a
+marked late disconnect flush from a session
 dropped before that reset while holding its mutation lock; request goroutines
 cannot reopen the new binary's quarantine after the reset. Same-version churn
 and a drop after a throttled reset keep their strikes

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `5d22be17a`
+> Last updated: 2026-09-04 · commit `a50f61560`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -86,6 +86,11 @@ the provider before removing its pending slot or draining queued demand.
 Consumer classification does not repeat the mutation, so a delayed error cannot
 overwrite a newer recovery heartbeat. Wire values are listed in
 [the protocol reference](../reference/protocol-messages.md).
+The Swift retirement reconnect keeps `refusingNewWork` raised through its
+late in-flight drain and clears that barrier on the new connection; another
+active update or shutdown barrier remains authoritative
+(`provider-swift/Sources/ProviderCore/ProviderLoop+DrainState.swift`,
+`setRetirementReconnectBarrier`).
 
 `PopNextFresh` skips stale entries as it pops; `RequeueFront` returns a
 waiter that could not be placed; `PreferWaiterOwners` lets a drain favour

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `c54b40e18`
+> Last updated: 2026-09-04 · commit `5d22be17a`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -80,7 +80,11 @@ is excluded as transient capacity until its next idle/serving heartbeat, or
 `drainStateTTL = 150 * time.Second` without a refresh. These rejections do not
 consume capacity retries or feed provider fault/capacity trackers
 (`coordinator/registry/drain_state.go`, `MarkDraining`;
-`coordinator/api/consumer.go`, `noteInferenceError`). Wire values are listed in
+`coordinator/api/provider.go`, `handleInferenceErrorOwned`;
+`coordinator/api/provider_drain.go`, `noteProviderDraining`). Error ingress marks
+the provider before removing its pending slot or draining queued demand.
+Consumer classification does not repeat the mutation, so a delayed error cannot
+overwrite a newer recovery heartbeat. Wire values are listed in
 [the protocol reference](../reference/protocol-messages.md).
 
 `PopNextFresh` skips stale entries as it pops; `RequeueFront` returns a

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `a50f61560`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -451,16 +451,18 @@ at most once per `identityVersionResetMinInterval = 10 * time.Minute`.
 Genuine 500/504 faults survive. Each tracker discards a late 502 from a session
 dropped before that reset while holding its mutation lock; request goroutines
 cannot reopen the new binary's quarantine after the reset. Same-version churn
-and a drop after a throttled reset keep their strikes. Cached disconnected
-identities follow identity enrichment without changing their original drop
-time, so a later weaker-identity reconnect cannot resurrect superseded faults
-(`coordinator/registry/version_reset.go`, `supersededDisconnectFlushLocked`;
-`coordinator/registry/health_ejection.go`, `migrateFaultStateLocked`).
-Version metadata for departed identities expires after
-`identityVersionRetention = 20 * time.Minute`; live identities, recent reset
-throttles, active fault windows and quarantines are retained. Disconnect
-starts a fresh reconnect grace window, and the eviction loop performs
-periodic cleanup (`coordinator/registry/version_history.go`).
+and a drop after a throttled reset keep their strikes
+(`coordinator/registry/version_reset.go`, `disconnectSource.supersededBy`).
+The reset and each fault mutation share the identity's `gateState.mu`; both
+live references and the disconnect cache use the same timestamp recorded by
+`detachSessionGate`. These request terminal paths never acquire `Registry.mu`.
+Cached disconnected identities follow enrichment without changing their drop
+times. Version metadata for departed identities remains for
+`identityVersionRetention = 20 * time.Minute` after the last activity or
+disconnect; live identities, recent resets and active fault state retain their
+gate. The existing eviction-loop gate sweep handles this cleanup
+(`coordinator/registry/version_history.go`, `versionHistoryActive`;
+`coordinator/registry/gate_sweep.go`, `sweepGates`).
 
 ## Invariants
 
@@ -487,6 +489,10 @@ periodic cleanup (`coordinator/registry/version_history.go`).
 9. **Control frames never wait behind queued data frames** — lane priority
    in `providerWriter`.
 10. **Disconnect preserves stable-identity fault state** — `Disconnect`.
+11. **A provider is never double-booked** — the admit re-check and the
+    pending debit run under one `p.mu` hold in `commitProviderReservation`
+    and `ReserveNextFromPlan`; the locking model is in
+    [`routing.md`](routing.md#concurrency-scan-commit-and-fault-state-gates).
 
 ## Failure modes
 

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-04 · commit `3f3fe7f00`
+> Last updated: 2026-09-04 · commit `c54b40e18`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -64,6 +64,24 @@ anything else to `unknown`):
 | `disconnect` | A provider left; queued requests it alone could have served fail fast (`Disconnect`). |
 | `kick` | Cold-dispatch kick from the API layer when a request is enqueued (`coordinator/api/cold_dispatch.go`). |
 | `unknown` | Any other caller of the public drain helpers (`coordinator/registry/scheduler.go`). |
+
+`drainModelQueue` (`coordinator/registry/scheduler.go`) serializes passes per
+model through `queueDrainCoalescer` (`coordinator/registry/queue_drain_coalesce.go`).
+A trigger arriving during a pass requests another pass after held waiters are
+requeued. Within a pass, `drainDominated` skips a scan only for a request with
+the same structural eligibility that is no smaller and has no looser TTFT
+ceiling than an earlier capacity rejection (`coordinator/registry/queue_drain_dominance.go`).
+Heartbeat-only triggers within `heartbeatDrainSuppressWindow = 20 * time.Millisecond`
+of a saturated pass coalesce into one trailing drain; other triggers run
+immediately (`coordinator/registry/queue_drain_suppress.go`).
+
+A provider reporting `status: draining` or a typed `error_reason: draining`
+is excluded as transient capacity until its next idle/serving heartbeat, or
+`drainStateTTL = 150 * time.Second` without a refresh. These rejections do not
+consume capacity retries or feed provider fault/capacity trackers
+(`coordinator/registry/drain_state.go`, `MarkDraining`;
+`coordinator/api/consumer.go`, `noteInferenceError`). Wire values are listed in
+[the protocol reference](../reference/protocol-messages.md).
 
 `PopNextFresh` skips stale entries as it pops; `RequeueFront` returns a
 waiter that could not be placed; `PreferWaiterOwners` lets a drain favour
@@ -246,8 +264,8 @@ model in rather than waiting out the queue. It has two entry points:
   heartbeat; the trailing plan claims the same gate, so the planner still
   runs at most once per window. If a delayed timer finds that a heartbeat
   opened a newer window, it rearms for that window to preserve any later
-  suppressed state change. The queue *drain* is per-heartbeat and is not
-  coalesced.
+  suppressed state change. The queue *drain* uses the per-model coalescing and
+  heartbeat suppression described above.
 - **Cold dispatch** ([`EIGENINFERENCE_COLD_DISPATCH`](../reference/configuration.md#routing-admission-and-ttft),
   `coordinator/api/cold_dispatch.go`) calls `TriggerModelSwaps` directly the
   moment a request is enqueued; that kick is immediate and not subject to
@@ -408,13 +426,32 @@ keeps `StatusUntrusted` instead. Eviction reaches `Disconnect` directly. It:
    its session-keyed residue deleted.
 3. Decrements the online and per-model provider counts.
 4. Fails every in-flight request on the provider with a `502`
-   `"provider disconnected"` error
-   (`CoordinatorCauseProviderDisconnected`) and closes its channels.
+   `"provider disconnected"` error and closes its channels. A peer close with
+   code 1000/1001 uses the health-neutral `CoordinatorCauseProviderRestart`;
+   abrupt drops retain `CoordinatorCauseProviderDisconnected`
+   (`coordinator/registry/disconnect_reason.go`, `ClassifyPeerClose`).
 5. Drains the provider's model queues with `DrainTriggerDisconnect` so
    waiters that only it could serve fail fast.
 6. Clears the provider's prefix-cache holders
    (`cacheHolderRemovalDisconnect`, [`cache-aware-routing.md`](cache-aware-routing.md))
    and resolves outstanding capacity-probe waiters as send-failed.
+
+On reconnect with a changed binary version, `Provider.SetVersion` removes the
+stable identity's disconnect-flush strikes and recomputes quarantine state,
+at most once per `identityVersionResetMinInterval = 10 * time.Minute`.
+Genuine 500/504 faults survive. Each tracker discards a late 502 from a session
+dropped before that reset while holding its mutation lock; request goroutines
+cannot reopen the new binary's quarantine after the reset. Same-version churn
+and a drop after a throttled reset keep their strikes. Cached disconnected
+identities follow identity enrichment without changing their original drop
+time, so a later weaker-identity reconnect cannot resurrect superseded faults
+(`coordinator/registry/version_reset.go`, `supersededDisconnectFlushLocked`;
+`coordinator/registry/health_ejection.go`, `migrateFaultStateLocked`).
+Version metadata for departed identities expires after
+`identityVersionRetention = 20 * time.Minute`; live identities, recent reset
+throttles, active fault windows and quarantines are retained. Disconnect
+starts a fresh reconnect grace window, and the eviction loop performs
+periodic cleanup (`coordinator/registry/version_history.go`).
 
 ## Invariants
 
@@ -460,7 +497,7 @@ keeps `StatusUntrusted` instead. Eviction reaches `Disconnect` directly. It:
 | Concern | File / symbol |
 |---|---|
 | Per-model queue, drain triggers, stale sweep | `coordinator/registry/queue.go` — `RequestQueue`, `Enqueue`, `WaitForProviderContext`, `PopNextFresh`, `cleanStaleLocked`, `DrainTrigger*` |
-| Drain orchestration | `coordinator/registry/registry.go` — `drainQueuedRequestsForModelsWithReason`, `SetProviderIdle`, `Heartbeat` |
+| Drain orchestration | `coordinator/registry/scheduler.go` — `drainQueuedRequestsForModelsWithReason`; `coordinator/registry/registry.go` — `SetProviderIdle`, `Heartbeat` |
 | Slot vocabulary | `coordinator/registry/gate_reason.go` — `SlotState`; `coordinator/registry/scheduler.go` — `slotStatePenalty`, `slotStateModelLoaded` |
 | Heartbeat payload | `coordinator/protocol/messages.go` — `BackendCapacity`, `BackendSlotCapacity` |
 | Token-budget and memory admission | `coordinator/registry/scheduler.go` — `freeMemoryAdmits`, `pooledBudgetAdmits`, `knownZeroTokenBudget`, `committedTokenBudget` |

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-04 · commit `aa87a0ebd`
 
 How operational data leaves a provider, what the coordinator does with it, and
 why nothing on that path can carry a prompt or slow a request. The heartbeat is
@@ -45,7 +45,7 @@ provider (every heartbeat_interval_secs, event heartbeats ≤ 2/s)
                                  drop stale capacity_seq (only LastHeartbeat advances); delta-merge stats
   → BackendCapacitySnapshot     the accepted, clamped copy
   → recordBackendWedgeTelemetry provider.first_token_wedge_suspected{model}, provider.eval_in_flight_long
-  → recordMLXCacheTelemetry     provider.mlx_memory.*{provider_id}, provider.mlx_cache.*{provider_id}
+  → recordMLXCacheTelemetry     provider.mlx_memory.*{chip_family,provider_version}, provider.mlx_cache.*{chip_family,provider_version}
   → PersistProviderThrottled    providers / provider_reputation rows, at most every 30 s
 ```
 
@@ -60,6 +60,23 @@ through the real routing gates; every 15 s `StartDDGaugeLoop` pushes the
 platform gauges (`providers.online`, `utilization.*`, `capacity.*`,
 `request_queue.depth`). How the scheduler reads the capacity fields:
 [`scheduling.md`](scheduling.md); the gate vocabulary: [`routing.md`](routing.md).
+
+`recordMLXCacheTelemetry` emits allocator snapshots as histograms with a
+DogStatsD-only client, or as latest-value gauges through HTTPS when
+`DD_API_KEY` is configured (`coordinator/datadog/metrics_snapshot.go`,
+`HistogramOrGauge`). HTTPS gauges preserve snapshot visibility without
+claiming fleet percentiles. It emits
+cumulative reclaimer counters as nonnegative deltas from the previous accepted
+heartbeat. The first observation has no counter baseline; a reset contributes
+no negative delta (`coordinator/api/provider_mlx_cache_telemetry.go`). Tags
+never include a provider session id. `sanitizeChipFamilyTag` uses the fixed
+M1–M5 family/tier vocabulary plus `unknown`/`other`; client-cancellation metrics
+use the same helper (`coordinator/api/chip_family_tags.go`).
+`sanitizeVersionTag` maps strict semver to `0.6.x`, `0.7.x`, `0.8.x`, `0.9.x`,
+`other_release`, or `prerelease`; missing values are `unknown`, invalid values
+are `other` (`coordinator/api/unknown_frame_metrics.go`). Arbitrary patch
+numbers and prerelease counters cannot create new series. Exact versions
+remain in provider metadata.
 
 ### Datadog transport
 

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-> Last updated: 2026-09-04 · commit `aa87a0ebd`
+> Last updated: 2026-09-04 · commit `a50f61560`
 
 How operational data leaves a provider, what the coordinator does with it, and
 why nothing on that path can carry a prompt or slow a request. The heartbeat is
@@ -68,7 +68,10 @@ DogStatsD-only client, or as latest-value gauges through HTTPS when
 claiming fleet percentiles. It emits
 cumulative reclaimer counters as nonnegative deltas from the previous accepted
 heartbeat. The first observation has no counter baseline; a reset contributes
-no negative delta (`coordinator/api/provider_mlx_cache_telemetry.go`). Tags
+no negative delta (`coordinator/api/provider_mlx_cache_telemetry.go`).
+`applyProviderHeartbeat` (`coordinator/api/provider_heartbeat.go`) emits only
+when `Registry.Heartbeat` accepts the snapshot; stale sequence-stamped frames
+still prove liveness but emit no repeated allocator or wedge samples. Tags
 never include a provider session id. `sanitizeChipFamilyTag` uses the fixed
 M1–M5 family/tier vocabulary plus `unknown`/`other`; client-cancellation metrics
 use the same helper (`coordinator/api/chip_family_tags.go`).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-04 · commit `4e7a68739`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -151,6 +151,12 @@ Capacity breakers:
 | `EIGENINFERENCE_CAPACITY_COOLDOWN_TTL_SECONDS` | seconds | `120` | `coordinator/registry/capacity_cooldown.go` | Initial cooldown; doubles on each failed probe. |
 | `EIGENINFERENCE_CAPACITY_COOLDOWN_MAX_TTL_SECONDS` | seconds | `600` | `coordinator/registry/capacity_cooldown.go` | Ceiling of the exponential cooldown. |
 | `EIGENINFERENCE_CAPACITY_RATE_PENALTY_MS` | milliseconds (≤ 0 disables) | `15000` | `coordinator/registry/capacity_rate.go` | Scores a penalty proportional to a provider's recent capacity-reject rate. |
+
+Reservation commit lock:
+
+| Variable | Values / type | Default | Read in | Effect |
+|---|---|---|---|---|
+| `EIGENINFERENCE_RESERVE_COMMIT_MODE` | `shared`, `global` (trimmed, case-insensitive; any other value is treated as `shared` and logged as unknown) | `shared` | `coordinator/registry/gate_commit_mode.go` (`loadReserveCommitMode`, `parseReserveCommitMode`); read once at `registry.New` | How the reservation commit (`commitProviderReservation`, `ReserveNextFromPlan`) holds the registry lock. `shared` commits under `r.mu.RLock` plus the winner's `p.mu`; `global` is the kill switch that restores the fleet-wide `r.mu.Lock()` commit serialization. The fault-tracker recorders stay on their per-identity gates in both modes; see [`../architecture/routing.md`](../architecture/routing.md). |
 
 Quality concurrency cap:
 

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -1,6 +1,6 @@
 # Provider ↔ coordinator protocol messages
 
-> Last updated: 2026-09-04 · commit `ac60c5ada`
+> Last updated: 2026-09-04 · commit `aa87a0ebd`
 
 Every JSON frame on the provider WebSocket (`GET /ws/provider`), with the Go
 type, the Swift type, and the presence rule for each field. Go is the canon
@@ -20,7 +20,7 @@ JSON keys are snake_case and identical in the Go tags and the Swift
 | Rule | Go | Swift |
 |---|---|---|
 | Discriminator | top-level `"type"` string | same |
-| Decode | `ProviderMessage.UnmarshalJSON` (`coordinator/protocol/messages.go`) reads `type` with `scanTopLevelString` (`coordinator/protocol/type_scan.go`), a byte walk over the top-level keys, then `json.Unmarshal`s the frame **once** into the concrete struct | `ProviderMessage.init(from:)` / `CoordinatorMessage.init(from:)` decode `TypeValue` then switch (`Messages.swift`) |
+| Decode | `DecodeProviderMessage` first tries the single-walk chunk scanner (`coordinator/protocol/chunk_scan.go`, `scanChunkFrame`); unsupported shapes fall back to `ProviderMessage.UnmarshalJSON` (`coordinator/protocol/messages.go`), which reads `type` with `scanTopLevelString` (`coordinator/protocol/type_scan.go`), a byte walk over the top-level keys, then `json.Unmarshal`s the frame **once** into the concrete struct | `ProviderMessage.init(from:)` / `CoordinatorMessage.init(from:)` decode `TypeValue` then switch (`Messages.swift`) |
 | Scanner fallback | escaped string, non-string value, malformed input or missing key → decode a `struct{ Type string }` envelope first (the historic double parse), so error behaviour is unchanged | — |
 | Unknown type | `protocol: unknown message type %q` | `DecodingError` — the decoder **throws**, so the coordinator version-gates `desired_models`, `prefetch_model`, `load_model` and `capacity_probe` sends |
 | Tests | `coordinator/protocol/type_scan_test.go` (`TestProviderMessageUnmarshalScanEquivalence`), `messages_envelope_test.go`, `messages_bench_test.go` | `provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift` |
@@ -154,7 +154,7 @@ the sinks of each field are in [`telemetry-inventory.md`](telemetry-inventory.md
 
 | JSON key | Go | Swift | Presence | Notes |
 |---|---|---|---|---|
-| `status` | `string` | `ProviderStatus` | req | `"idle"` or `"serving"` (`Protocol/Enums.swift`) |
+| `status` | `string` | `ProviderStatus` | req | `"idle"`, `"serving"` or `"draining"` (`Protocol/Enums.swift`, `ProviderStatus`; Go `HeartbeatStatusDraining`). A draining heartbeat excludes the provider from new routing; idle/serving clears the mark (`coordinator/registry/drain_state.go`, `applyHeartbeatDrainStateLocked`). |
 | `active_model` | `*string` (**no** `omitempty`) | `String?` (`encodeIfPresent`) | see note | **Intentional asymmetry.** Go always emits the key and writes `null` when nil; Swift omits the key when nil. Both decode to nil = no model is generating right now, and the coordinator treats `null` and absent identically |
 | `stats` | `HeartbeatStats` | `ProviderStats` | req | [`stats`](#stats) |
 | `warm_models` | `[]string` | `[String]` | opt | resident models; Swift omits when empty |
@@ -294,7 +294,7 @@ these fields: [`../architecture/request-outcome-observability.md`](../architectu
 | `request_id` | `string` | `String` | req | |
 | `error` | `string` | computed `String` (`failureCode.message`) | req | Swift never emits raw error text. The coordinator never reads the provider-authored value: `sanitizeProviderInferenceError` (`coordinator/api/inference_error_sanitize.go`) replaces it with the closed message for `failure_code` before anything downstream sees the frame |
 | `status_code` | `int` | `UInt16` | req | |
-| `error_reason` | `string` | `InferenceErrorReason?` | opt | closed, privacy-safe reason (`provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift`): `jinja_channel_tags`, `jinja_null_bridge`, `jinja_template`, `model_load`, `capacity_timeout`, `queue_full`, `token_budget_exhausted`, `request_exceeds_context`, `request_exceeds_node`, `request_exceeds_node_budget`, `request_exceeds_batch_token_budget`, `capacity_busy`, `deadline_unreachable`, `cancelled`, `client_error`, `tool_noncompliance`. The well-known string `"provider draining for update"` (`ProviderDrainingForUpdate`) marks a transient drain and earns a short backoff |
+| `error_reason` | `string` | `InferenceErrorReason?` | opt | closed, privacy-safe reason (`provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift`): `jinja_channel_tags`, `jinja_null_bridge`, `jinja_template`, `model_load`, `capacity_timeout`, `queue_full`, `token_budget_exhausted`, `request_exceeds_context`, `request_exceeds_node`, `request_exceeds_node_budget`, `request_exceeds_batch_token_budget`, `capacity_busy`, `deadline_unreachable`, `draining`, `cancelled`, `client_error`, `tool_noncompliance`. The typed `draining` reason on a 503 marks a transient update drain: no provider-health or capacity penalty, and no capacity retry charge (`coordinator/api/consumer.go`, `noteInferenceError`; `coordinator/api/dispatch.go`, `dispatchState.noteProviderError`). Swift emits it from `rejectIfDrainingForUpdate` (`provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift`). |
 | `failure_code` | `InferenceFailureCode` | `InferenceFailureCode?` | opt | closed enum (`coordinator/protocol/inference_failure.go`): `invalid_request`, `invalid_media`, `media_too_large`, `unsupported_media`, `template_render`, `model_unavailable`, `capacity`, `cancelled`, `encryption_failure`, `generation_failure`, `internal_failure` |
 | `terminal_cause` | `string` | `InferenceTerminalCause?` | opt | closed: `admission_timeout`, `prefill_stall`, `decode_stall`, `safety_deadline`, `backpressure_timeout`, `watchdog`, `cancelled`, `engine_error`. Unknown → treated as absent plus a drift metric (`coordinator/api/terminal_cause.go`); platform-policy terminals never strike health breakers |
 | `attempt_usage` | `*UsageInfo` | `UsageInfo?` | opt | engine-reconciled usage of the failed attempt; observability only, never billing |

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-04 · commit `b435e89ba`
+> Last updated: 2026-09-04 · commit `a50f61560`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -66,7 +66,7 @@ lists every name).
 | Metric | Type | Tags | Emitted |
 |---|---|---|---|
 | `provider.mlx_memory.active_gb`, `.peak_gb`, `.cache_gb` | histogram (DogStatsD-only) / latest-value gauge (HTTPS) | `chip_family`, `provider_version` | accepted heartbeat snapshot (`coordinator/api/provider_mlx_cache_telemetry.go`, `recordMLXCacheTelemetry`) |
-| `provider.mlx_cache.limit_bytes`, `.last_reclaimed_bytes`, `.last_reclaim_duration_ms` | histogram (DogStatsD-only) / latest-value gauge (HTTPS) | `chip_family`, `provider_version` | limit each heartbeat; last-reclaim samples only when reclaim count increases (`recordMLXCacheTelemetry`) |
+| `provider.mlx_cache.limit_bytes`, `.last_reclaimed_bytes`, `.last_reclaim_duration_ms` | histogram (DogStatsD-only) / latest-value gauge (HTTPS) | `chip_family`, `provider_version` | limit each accepted heartbeat; last-reclaim samples only when reclaim count increases (`recordMLXCacheTelemetry`) |
 | `provider.mlx_cache.sweep_signals`, `.reclaims`, `.reclaimed_bytes` | count | `chip_family`, `provider_version` | positive deltas from the previous accepted snapshot; first observation/reset contributes no delta (`ddCountDelta`) |
 | `provider.first_token_wedge_suspected` | count | `model` | per slot with `wedge_suspected` true, per heartbeat |
 | `provider.eval_in_flight_long` | count | — | at most once per heartbeat when any slot's `eval_in_flight_ms ≥ evalInFlightLongMs = 2000` |
@@ -122,6 +122,7 @@ lists every name).
 | `profiler.fleet_snapshot` | count | `status:written`, `write_failed` | each fleet sample |
 | `profiler.pruned_rows` | count | — | each hourly retention sweep |
 | `providers.online`, `providers.per_model{model}`, `providers.per_version{version}`, `providers.by_trust_status{…}`, `providers.by_mdm_failure{reason}`, `attestation.code_attested`, `attestation.code_enforced`, `coordinator.min_provider_version_set{min_version}`, `request_queue.depth`, `utilization.network`, `utilization.warm`, `utilization.token_budget`, `utilization.bottleneck`, `utilization.model{model}`, `capacity.tps`, `capacity.demand_concurrency`, `capacity.serving_capacity`, `capacity.spill_arrival_rate` | gauge | as listed | every 15 s from `StartDDGaugeLoop` (`coordinator/api/server.go`), which also pushes the `exact_cache.*` gauges (`emitExactCacheDDGauges`, `coordinator/api/exact_cache_metrics.go`); the loop returns immediately when no Datadog client is configured |
+| `request_queue.depth_by_model`, `request_queue.oldest_age_ms` | gauge | `model` | every gauge-loop tick for served or queued models; a disappearing model gets one final zero for both series and is then forgotten (`coordinator/api/fleet_gauges.go`, `emitPerModelQueueGauges`) |
 
 ### In-process registry (not Datadog)
 

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-04 · commit `a50f61560`
+> Last updated: 2026-09-04 · commit `6f364e64b`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -42,7 +42,7 @@ Producer: the Swift provider over the `GET /ws/provider` WebSocket. Consumer:
 | `profile` (on both terminals) | `inference_complete`, `inference_error` | per attempt, ≤ `MaxInferenceProfileBytes` ([`protocol-messages.md#inference_complete`](protocol-messages.md#inference_complete)) | raw bytes retained on the attempt, decoded on the profile-sink worker → `request_profiles`; `profiler.provider_profile{valid, reason}` | `request_profiles` retention ([below](#coordinator-per-request-records-postgres)) |
 | `cache_stage_ms` and prefix-cache receipts | `inference_complete.usage`, `prefix_cache_lookup*`, `prefix_cache_ready*` | per attempt | `routing.cache_stage_ms`, `routing.cache_lookup_receipt`, `routing.cache_ready_receipt`, `routing.cache_receipt_rejected`, `exact_cache.*` | Datadog |
 | `capacity_quote` | reply to `capacity_probe` | per probed request, within `capacityProbeWindow` ([`../architecture/routing.md#entry-points`](../architecture/routing.md#entry-points)) | `Registry.HandleCapacityQuote` — ledger drift correction | memory |
-| Disconnect | WebSocket close / read error | per session | `ws.disconnects{reason:peer_close, code}` or `{reason:read_error}`; `provider.oom_suspected` when `ClassifyDisconnectReason` (`coordinator/registry/disconnect_classify.go`) sees `memory_pressure ≥ 0.90`, or `≥ 0.80` with in-flight work; `provider_sessions.disconnect_reason` via `CloseProviderSession` (`oom_suspected`, `ws_close_<code>`, `read_error`, sweep default `disconnect`) | `provider_sessions` unbounded |
+| Disconnect | WebSocket close / read error | per session | `ws.disconnects{reason:peer_close, code}` or `{reason:read_error|read_error_control_frame}`; `provider.oom_suspected` when `ClassifyDisconnectReason` (`coordinator/registry/disconnect_classify.go`) sees `memory_pressure ≥ 0.90`, or `≥ 0.80` with in-flight work; `provider_sessions.disconnect_reason` via `CloseProviderSession` (`oom_suspected`, `ws_close_<code>`, `read_error`, `read_error_control_frame`, sweep default `disconnect`) | `provider_sessions` unbounded |
 | `darkbloom report` log bundle | `POST /v1/provider/log-report` (`handleUploadLogReport`, `coordinator/api/log_report_handlers.go`) | operator-initiated | `provider_log_reports`, ≤ 10 MiB (`maxLogReportBodySize`); `?serial` → `426` | unbounded |
 
 Fields the v0.8.16 provider declares but never populates: `register.prefill_tps`
@@ -73,7 +73,7 @@ lists every name).
 | `provider.oom_suspected` | count | — | abrupt disconnect classified as OOM |
 | `provider.enqueue_failed` | count | `msg:runtime_status`, `msg:trust_status` | outbound frame could not be queued |
 | `providers.registrations` | count | `trust_level` | each `register` |
-| `ws.disconnects` | count | `reason:peer_close` + `code:<n>`, or `reason:read_error` | each session end |
+| `ws.disconnects` | count | `reason:peer_close` + `code:<n>`, or `reason:read_error|read_error_control_frame` | each session end (`coordinator/api/provider.go`, `readErrorDisconnectReason`); mirrored by `ws_disconnects_total` |
 | `routing.cache_telemetry_rejected`, `routing.cache_capability_rejected` | count | `source:heartbeat` | heartbeat prefix-cache payload failed validation |
 | `inference.unknown_request_frames` | count | `kind:chunk`, `complete`, `duplicate_complete`, `error`, `duplicate_error` | frame for an unknown or already-closed request |
 | `routing.throughput_anomaly` | count | `model`, `chip_family` | observed vs advertised throughput divergence (`coordinator/api/throughput_anomaly.go`); mirrored to the in-process registry |
@@ -86,6 +86,9 @@ lists every name).
 | Metric | Type | Tags | Emitted |
 |---|---|---|---|
 | `inference.request_outcome` | count | `model`, `class` (`success`, `provider_5xx`, `timeout`, `rate_limited`, `client_error`; `mid_stream` declared, never produced), `kv_backend`, `kv_backend_fallback` | once per chat/responses request (`coordinator/api/or_uptime.go`); `/v1/completions` and `/v1/messages` dispatches excluded, their pre-dispatch rejections included |
+| `inference.request_outcome_or_view` | count | `model`, `class` (`success`, `provider_5xx`, `timeout`, `mid_stream`, `rate_limited`, `client_error`, `client_gone`) | request-level terminal view: pre-dispatch rejection, dispatch terminal (including attempt-zero TTFT rejection), client departure, or committed route outcome; `client_gone` excludes early/post-commit client aborts while pre-content aborts at the deadline count as `timeout` (`coordinator/api/attempt_outcome_metrics.go`, `recordRequestOutcomeORView`) |
+| `routing.route_latency_ms` | histogram (DogStatsD only) | `model` | attempt-zero non-queued provider selection: `RoutedAt` minus `MediaFetchedAt` when set, otherwise `ReservedAt`; requires valid timing anchors (`coordinator/api/attempt_outcome_metrics.go`, `emitRouteLatency`). No in-process mirror. |
+| `routing.provider_draining` | count | `model` | transition into draining announced by a validated error terminal, before releasing pending capacity (`coordinator/api/provider_drain.go`, `noteProviderDraining`). No in-process mirror. |
 | `inference.completions` | count | `model` | each `inference_complete` |
 | `inference.dispatches` | count | `status:success`, `failure`, `timeout`, `retry`, `retry_precontent` | each attempt |
 | `inference.ttft_ms`, `inference.decode_tps` | histogram | `model`, `kv_backend`, `kv_backend_fallback` | Measured on the coordinator's clock, not reported by the provider: TTFT is dispatch → first content chunk, the same value `handleComplete` persists as `inference_routes.actual_ttft_ms`; decode TPS is the outcome row's `actual_decode_tps`. Emitted once per completion with a positive finite value (`coordinator/api/kv_backend_metrics.go`) |
@@ -97,6 +100,7 @@ lists every name).
 | `inference.invalid_failure_code`, `inference.in_band_error`, `inference.first_content_after_deadline`, `inference.speculative_dispatch`, `inference.speculative_win`, `inference.zombie_stream_cancel`, `inference.chunk_overflow_abort` | count | various | dispatch edge cases (`coordinator/api/dispatch.go`, `provider.go`) |
 | `inference.prompt_tokens`, `inference.completion_tokens` (histogram); `inference.prompt_tokens_total`, `inference.completion_tokens_total` (count) | — | `model` | each completion |
 | `registry.mu.write_wait_ms` | histogram | `site` | Registry write-lock acquisition wait, emitted after unlock (`coordinator/registry/lock_wait.go`, `lockWrite`); dispatch-load failure and recovery are separate sites. |
+| `registry.gate.wait_ms` | histogram (DogStatsD only) | `site` | per-identity recorder gate waits over `gateWaitReportThreshold`, emitted after release (`coordinator/registry/gate_lock.go`, `SetGateWaitObserver`; `coordinator/api/server.go`). No in-process mirror. |
 | `routing.scans` | count | `model`, `outcome` | Full reservation scans including retries (`coordinator/api/dispatch.go`, `recordRoutingDecisionFor`). |
 | `routing.decisions` | count | `model`, `model_type`, `outcome` (`selected`, `queued`, `model_shed`, `ttft_429`, `model_too_large`, `over_capacity`, `routing_saturated`, `capacity_queue_spill`, `capacity_429`, `cold_dispatch_spill`, `dedicated_capacity_429`, `no_eligible_provider`, `ttft_soft_served`, `unservable_429`) | each admission decision |
 | `inference.attempt_outcome`, `inference.queue_outcome` | count | `model`, `class` | dispatched-attempt and queue-only outcomes kept separate (`coordinator/api/attempt_outcome_metrics.go`, `emitAttemptOutcomeMetric`) |
@@ -131,6 +135,15 @@ lists every name).
 and computed gauges in memory; `GET /v1/admin/metrics` returns them as JSON or
 Prometheus text (`?format=prom`). Reset on restart.
 
+| In-process counter | Labels | Source / Datadog counterpart |
+|---|---|---|
+| `inference_attempt_outcome_total` | `model`, `class` | `inference.attempt_outcome`; terminal dispatched-attempt outcomes (`coordinator/api/attempt_outcome_metrics.go`, `emitAttemptOutcomeMetric`) |
+| `inference_queue_outcome_total` | `model`, `class` | `inference.queue_outcome`; queue exits that dispatched no attempt (`coordinator/api/attempt_outcome_metrics.go`, `emitQueueOutcomeMetric`) |
+| `inference_request_outcome_or_view_total` | `model`, `class` | `inference.request_outcome_or_view`; the same request-terminal classes and counting boundaries (`coordinator/api/attempt_outcome_metrics.go`, `recordRequestOutcomeORView`) |
+| `inference_unknown_frames_total` | `kind`, `provider_version` | `inference.unknown_frames`; unrecognized chunk/complete/error frames (`coordinator/api/unknown_frame_metrics.go`, `emitUnknownFrame`) |
+| `ws_disconnects_total` | `reason`, plus `code` for `peer_close` | `ws.disconnects`; `reason` is `peer_close`, `read_error`, or `read_error_control_frame` (`coordinator/api/provider.go`, `providerReadLoop`) |
+
+
 ## Coordinator-emitted events
 
 Producer: `Emitter.Emit` (`coordinator/telemetry/emitter.go`) via `s.emit`,
@@ -142,7 +155,7 @@ Datadog's; nothing is stored locally.
 | Message | Severity · kind | Fields | Site |
 |---|---|---|---|
 | `provider registered` | info · `log` | `provider_id`, `trust_level`, `hardware_chip`, `memory_gb` | `coordinator/api/provider.go` |
-| `provider websocket read error` | warn · `connectivity` | `provider_id`, `ws_state:read_error`, `last_error` | `provider.go` |
+| `provider websocket read error` | warn · `connectivity` | `provider_id`, `ws_state:read_error`, `reason:read_error|read_error_control_frame`, `last_error` | `provider.go` |
 | `provider disconnected under memory pressure (suspected OOM)` | error · `oom` | `provider_id`, `memory_pressure`, `in_flight` | `provider.go` |
 | `attestation challenge failed` | warn or error · `attestation_failure` | `provider_id`, `reason`, `reconnect_count` | `provider.go` |
 | `provider failed, retrying` / `provider failed after accepting request, retrying` | warn · `inference_error` | `provider_id`, `attempt`, `reason:provider_error`, `status_code` (+ `request_id`) | `coordinator/api/dispatch.go` |

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-04 · commit `fcecc3675`
+> Last updated: 2026-09-04 · commit `b435e89ba`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -34,7 +34,7 @@ Producer: the Swift provider over the `GET /ws/provider` WebSocket. Consumer:
 | `backend_capacity` (`slots[]`, GPU memory, `free_for_load_gb`, `capacity_seq`, `mlx_cache_reclaimer`) | `heartbeat` | same; the provider recomputes capacity every `max(1, heartbeat_interval_secs / 2)` s, integer division (`capacityRefreshTick`, `provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift`) | `canonicalHeartbeatModelState` clones then `clampBackendCapacity` (`coordinator/registry/registry.go`); stale `capacity_seq` frames update only `LastHeartbeat` | memory; sampled into `fleet_snapshots` |
 | `slots[].telemetry`, `backend_capacity.telemetry` | `heartbeat` | same | clamped by `clampBackendCapacity`; sampled into `fleet_snapshots` | `fleet_snapshots` retention ([below](#coordinator-per-request-records-postgres)) |
 | `slots[]` engine-health fields (`steps_executed`, `admits`, `wedge_suspected`, `eval_in_flight_ms`, …) | `heartbeat` | same | `recordBackendWedgeTelemetry` (`coordinator/api/provider_wedge_telemetry.go`) → Datadog counters; measurement only, never a gate | Datadog |
-| GPU memory and `mlx_cache_reclaimer` | `heartbeat` | same | `recordMLXCacheTelemetry` (`coordinator/api/provider_mlx_cache_telemetry.go`) → gauges tagged `provider_id` | Datadog |
+| GPU memory and `mlx_cache_reclaimer` | `heartbeat` | same | `recordMLXCacheTelemetry` (`coordinator/api/provider_mlx_cache_telemetry.go`) → histograms (DogStatsD-only) or latest-value gauges (HTTPS), and counter deltas tagged `chip_family`, `provider_version` | Datadog |
 | `prefix_cache_statuses`, `prefix_cache_donation_outcomes`, `prefix_cache_v2_models` | `register`, `heartbeat` | same | registry exact-cache state; `exact_cache.*` gauges; `routing.cache_telemetry_rejected{source:heartbeat}` on validation failure | memory |
 | `apns_device_token`, `apns_environment` | `register`, `heartbeat` | when changed | code-attestation re-arm (`maybeRearmCodeAttest`) | memory |
 | `usage`, `stop_sequence`, `response_hash`, `se_signature` | `inference_complete` | per attempt | `handleComplete` → `inference_routes` outcome columns, `usage` row, billing; `inference.completions`, `inference.ttft_ms`, `inference.decode_tps` | `inference_routes`/`usage` unbounded |
@@ -65,8 +65,9 @@ lists every name).
 
 | Metric | Type | Tags | Emitted |
 |---|---|---|---|
-| `provider.mlx_memory.active_gb`, `.peak_gb`, `.cache_gb` | gauge | `provider_id` | every accepted heartbeat with `backend_capacity` |
-| `provider.mlx_cache.limit_bytes`, `.sweep_signals_total`, `.reclaims_total`, `.reclaimed_bytes_total`, `.last_reclaimed_bytes`, `.last_reclaim_duration_ms` | gauge (cumulative, resets on provider restart) | `provider_id` | every heartbeat carrying `mlx_cache_reclaimer` |
+| `provider.mlx_memory.active_gb`, `.peak_gb`, `.cache_gb` | histogram (DogStatsD-only) / latest-value gauge (HTTPS) | `chip_family`, `provider_version` | accepted heartbeat snapshot (`coordinator/api/provider_mlx_cache_telemetry.go`, `recordMLXCacheTelemetry`) |
+| `provider.mlx_cache.limit_bytes`, `.last_reclaimed_bytes`, `.last_reclaim_duration_ms` | histogram (DogStatsD-only) / latest-value gauge (HTTPS) | `chip_family`, `provider_version` | limit each heartbeat; last-reclaim samples only when reclaim count increases (`recordMLXCacheTelemetry`) |
+| `provider.mlx_cache.sweep_signals`, `.reclaims`, `.reclaimed_bytes` | count | `chip_family`, `provider_version` | positive deltas from the previous accepted snapshot; first observation/reset contributes no delta (`ddCountDelta`) |
 | `provider.first_token_wedge_suspected` | count | `model` | per slot with `wedge_suspected` true, per heartbeat |
 | `provider.eval_in_flight_long` | count | — | at most once per heartbeat when any slot's `eval_in_flight_ms ≥ evalInFlightLongMs = 2000` |
 | `provider.oom_suspected` | count | — | abrupt disconnect classified as OOM |
@@ -98,7 +99,13 @@ lists every name).
 | `registry.mu.write_wait_ms` | histogram | `site` | Registry write-lock acquisition wait, emitted after unlock (`coordinator/registry/lock_wait.go`, `lockWrite`); dispatch-load failure and recovery are separate sites. |
 | `routing.scans` | count | `model`, `outcome` | Full reservation scans including retries (`coordinator/api/dispatch.go`, `recordRoutingDecisionFor`). |
 | `routing.decisions` | count | `model`, `model_type`, `outcome` (`selected`, `queued`, `model_shed`, `ttft_429`, `model_too_large`, `over_capacity`, `routing_saturated`, `capacity_queue_spill`, `capacity_429`, `cold_dispatch_spill`, `dedicated_capacity_429`, `no_eligible_provider`, `ttft_soft_served`, `unservable_429`) | each admission decision |
-| `routing.client_gone` | count | `model`, `prompt_bucket`, `chip_family`, `phase` (`before_first_token`, `after_commit`) | consumer disconnect |
+| `inference.attempt_outcome`, `inference.queue_outcome` | count | `model`, `class` | dispatched-attempt and queue-only outcomes kept separate (`coordinator/api/attempt_outcome_metrics.go`, `emitAttemptOutcomeMetric`) |
+| `inference.unknown_frames` | count | `kind`, `provider_version` | unrecognized chunk/complete/error frames (`coordinator/api/unknown_frame_metrics.go`, `emitUnknownFrame`) |
+| `inference.cancel_sent`, `inference.cancel_unresolved` | count | `cause`, `model` | enqueue accepted / tracker expiry without a terminal or post-send stray chunk (`coordinator/api/cancel_lifecycle.go`) |
+| `inference.cancel_send_failed` | count | `reason` | enqueue rejected (`sendProviderCancel`) |
+| `inference.cancelled_terminal` | count | `outcome`, `cause`, `delivered` | terminal correlation; `delivered` means enqueue accepted (`resolveCancelledTerminal`) |
+| `inference.cancel_to_terminal_ms` | histogram | `terminal`, `model`, `cause` | first successful enqueue to terminal or last later stray chunk; no sample for an unsent cancel (`emitExpiredCancelEntries`) |
+| `routing.client_gone` | count | `model`, `prompt_bucket`, `chip_family`, `phase` (`before_first_token`, `after_commit`), `deadline_bucket` | consumer disconnect (`coordinator/api/prompt_buckets.go`, `emitClientGoneBucketed`) |
 | `routing.provider_breaker_open` / `_closed`, `routing.provider_ejected` / `routing.provider_ejection_recovered`, `routing.cooldown_entered`, `routing.capacity_cooldown_tripped`, `routing.load_failure_cooldowns` | count | `model` (+ `provider_id` for capacity cooldown) | fault-tracker transitions (`coordinator/api/consumer.go`, `provider.go`) |
 | `routing.ttft_calibration_ratio` | gauge | `model` | each TTFT observation (`coordinator/api/settlement.go`) |
 | `routing.unservable_reclassified`, `routing.first_chunk_timeout_reclassified`, `routing.client_error_passthrough`, `routing.oversized_request_rejected`, `routing.deadline_unreachable_rejected`, `routing.invalid_ttft`, `routing.dispatch_client_error_stop`, `routing.first_chunk_timeout_ladder_capped`, `routing.hedge_governor_suppressed`, `routing.pending_load_backoff`, `routing.scan_admission_timeout`, `routing.ttft_admission`, `routing.ttft_spread`, `routing.provider_selected`, `routing.load_model_rejects` | count | mostly `model` | routing edge cases |

--- a/docs/reports/2026-09-03-perf-pr-c-tier3-body.md
+++ b/docs/reports/2026-09-03-perf-pr-c-tier3-body.md
@@ -1,0 +1,347 @@
+# perf(registry): take the global write lock off the per-request path (Tier 3)
+
+> Last updated: 2026-09-04 · commit `6a1d1eb27`
+
+Stacks on `perf/coordinator-registry-scan-2026-09-03` (PR B: per-model index, arena snapshots,
+cached medians). **Merge after it and after PR #818** (`perf/coordinator-tier1-2026-09-03`, the
+`lockWrite(site)` observer and `ScanCount` stamp); this branch is rebased onto #818 once it lands —
+the six recorder bodies #818 instruments are rewritten wholesale here, so the conflicts resolve
+to this branch. Two things to do **at that rebase**:
+
+- #818's `TestRegistryLockWaitHistogramTaggedBySite` (api) drives a `registry.mu.write_wait_ms`
+  sample through `reg.ClearDispatchLoadCooldown` behind `HoldWriteLockForTest`. On this branch that
+  recorder never touches `r.mu`, so the test must be retargeted at a remaining `r.mu` writer (a
+  config setter, or the commit in `global` mode) or it hangs.
+- Route `commitLock.lock()` in `global` mode through `r.lockWrite("commit")` /
+  `("commit_plan")` so the kill switch keeps its write-wait histogram; in `shared` mode the commit
+  takes `r.mu.RLock` and has no write wait to report.
+
+Design and evidence: `docs/reports/2026-09-03-coordinator-perf-proposal/01-registry-lock.md`
+(E1–E4), README §3 Tier 3 and §6.
+
+## What was wrong
+
+`Registry.mu` is a writer-preferring `sync.RWMutex`. Every served request took it for **writing six
+times** — the reservation commit, the first-content capacity accept, and at completion
+`RecordInferenceSuccess`, `RecordProviderOutcome`, `RecordProviderServeOutcome`,
+`ClearDispatchLoadCooldown` — plus `ReserveNextFromPlan` held it across its whole loop. Each
+holder ran for microseconds (0.007 core in total), but a pending writer blocks every new reader
+and must drain the active batch of fleet scans first: **≈190 ms per acquisition in prod**, 152
+writers queued behind one scanning reader, two of the six acquisitions before the first byte.
+Commits that lost the race rescanned the fleet (10–14 iterations per reservation). Coordinator-caused
+TTFB at the median: ≈2.4 s.
+
+## What changed
+
+Two halves, shipped together (neither helps alone — see 01 "Why not (a) alone"):
+
+**(a) Per-identity gate state.** The node-health breaker, stable-identity health ejection, the
+shape-keyed inference-error cooldown, the capacity cooldown / rate window / budget clamp and the
+dispatch-load cooldown moved out of the global maps into one `gateState` per fault key
+(`registry/gate_state.go` — the struct and its lock-free view; the index, migration, sweep, recorder lock
+and commit-mode switch live in `gate_index.go`, `gate_migrate.go`, `gate_sweep.go`, `gate_lock.go`,
+`gate_commit_mode.go`), each with its own `sync.Mutex`. Recorders resolve the gate, take
+`gate.mu`, mutate, release — **they never touch `r.mu`**. Connected providers cache their gate
+(`p.gate`, atomic); the disconnected trailing-flush path does one `gatesMu.RLock` lookup. The scan
+reads the two hot booleans (breaker open, ejected) from atomics and a per-gate flag word says which
+per-model trackers hold state, so a provider with no fault state costs the scan a few atomic loads and
+no lock section. The size-triggered map sweeps (>1024 / >2048 walks under the write lock) became a
+periodic per-gate sweep from the eviction loop. Identity rebinds migrate a gate's state and forward the
+orphan, so a recorder holding a stale pointer still lands on the live state; and because a recorder
+resolves its gate under `gatesMu.RLock` but locks it only after letting go of `gatesMu`, it re-validates
+the gate under `gate.mu` once acquired (not retired by the sweep, still the session's cached gate) and
+re-resolves through the index otherwise. The routing READS are covered two ways: the identity bind runs under the session's `p.mu`
+(third review pass), so the scan's gate chain, the commit through its debit and the alias resolver — all under
+`p.mu` — never see `p.gate` move mid-section; and every read that feeds a dispatch decision also confirms its
+verdict against `p.gate` afterwards and re-reads from the session's new gate when it moved (`gateView`; see
+"Review follow-ups"), which is what covers the candidate cost read the scan makes after releasing `p.mu`.
+
+**(a′) Commit without the global write lock.** `commitProviderReservation` and
+`ReserveNextFromPlan` hold `r.mu` for **reading** (identity, catalog and cache-routing config only)
+and do everything that decides the reservation — fresh snapshot, cost rebuild, the "winner unchanged
+since scan" compare, admit re-check, probe claim, pending debit — inside **one `p.mu` section** on the
+winner. The half-open capacity probe is check-and-claim under `gate.mu`. The breaker-bypass re-scan is
+a read.
+
+Lock order: `r.mu → p.mu → gatesMu → gate.mu`. Never `r.mu` or `p.mu` while holding `gatesMu` or a
+`gate.mu`. There is deliberately **no walk-wide gates lock** on the scan; the parallel speed-up guard
+below is what keeps it out.
+
+## Before / after
+
+### Behaviour
+
+```mermaid
+flowchart LR
+  subgraph Before["Before (master / PR B)"]
+    A1[attempt] --> S1["scan under r.mu.RLock<br/>(whole fleet)"]
+    S1 --> W1["wait for r.mu.Lock<br/>≈190 ms: drain the reader batch"]
+    W1 --> C1["commit: re-snapshot + compare"]
+    C1 -->|winner changed| S1
+    C1 -->|ok| D1[dispatch]
+    D1 --> F1["first content:<br/>RecordCapacityAccept → r.mu.Lock (≈190 ms)"]
+    F1 --> B1[first byte to client]
+    B1 --> E1["completion: 4 × r.mu.Lock<br/>(success, outcome, serve outcome, cooldown clear)"]
+  end
+  subgraph After["After (this branch, shared mode)"]
+    A2[attempt] --> S2["scan under r.mu.RLock<br/>(gate reads: atomics + flag word)"]
+    S2 --> C2["commit under r.mu.RLock + p.mu:<br/>snapshot · cost · compare · admit · probe claim (gate.mu) · debit"]
+    C2 -->|winner changed on this provider| S2
+    C2 -->|ok| D2[dispatch]
+    D2 --> F2["first content:<br/>RecordCapacityAccept → gate.mu (µs)"]
+    F2 --> B2[first byte to client]
+    B2 --> E2["completion: 4 recorders → gate.mu (µs each)<br/>r.mu never taken"]
+  end
+```
+
+### Code
+
+```mermaid
+flowchart TB
+  subgraph Before["Before"]
+    direction TB
+    RB["Registry.mu (RWMutex)"]
+    RB --- M1["providerOutcomes / providerBreakerOpenUntil / providerBreakerTrips"]
+    RB --- M2["healthEjection* (5 maps)"]
+    RB --- M3["inferenceErrorStrikes / inferenceErrorCooldowns"]
+    RB --- M4["capacityRejectStrikes / capacityCooldowns / capacityCooldownTrips"]
+    RB --- M5["budgetClamps · capacityRateRejects / Accepts"]
+    RB --- M6["dispatchLoadCooldowns · faultKeyBySession · disconnectedStableIDs"]
+    RecB["RecordProviderOutcome · RecordProviderServeOutcome · RecordInferenceError/Success<br/>recordCapacityReject · RecordCapacityAcceptOutcome · RecordDispatchLoadFailure · ClearDispatchLoadCooldown"] -- "r.mu.Lock()" --> RB
+    ComB["commitProviderReservation · ReserveNextFromPlan"] -- "r.mu.Lock()" --> RB
+    ScanB["providerRoutingGateReasonLockedEx · snapshot · buildCandidateInto"] -- "r.mu.RLock() + map reads" --> RB
+  end
+  subgraph After["After"]
+    direction TB
+    RA["Registry.mu (RWMutex)<br/>writers: Register · Disconnect · evictStale · swap planner · config"]
+    GI["gatesMu (RWMutex, insert-only)<br/>gates map[faultKey]*gateState · sessions · disconnectedStableIDs"]
+    G["gateState (one per identity, own mutex)<br/>breaker · ejection · error cooldown · capacity cooldown/rate/clamp · dispatch-load<br/>atomics: breakerOpenUntilNS · ejectionUntilNS · pairFlags · newestRateRejectNS"]
+    GI --> G
+    P["Provider.gate (atomic.Pointer)"] --> G
+    RecA["same 8 recorders"] -- "gateForSession → lockGate(site) → gate.mu" --> G
+    ComA["commitProviderReservation · ReserveNextFromPlan<br/>(commitLock: RLock in shared, Lock in global)"] -- "r.mu.RLock()" --> RA
+    ComA -- "p.mu: snapshotProviderIntoPLockedEx · buildCandidate · compare · canAdmit · tryClaimCapacityProbe · addPendingLocked" --> P
+    ScanA["providerRoutingGateReasonLockedEx · snapshotProviderIntoLockedEx · buildCandidateInto"] -- "gateOf(p): atomic loads; gate.mu only for pairs with state" --> P
+    Sweep["evictStale → sweepGates"] -- "gatesMu.Lock (periodic, off the request path)" --> GI
+  end
+```
+
+## Invariants (from 01, with how each is protected now)
+
+| Invariant `r.mu.Lock()` protected before | Now |
+|---|---|
+| No double-booking of a provider | `providerCanAdmitLockedEx` + `addPendingLocked` under **`p.mu`** — unchanged, and now in the same `p.mu` section as the fresh snapshot (`snapshotProviderIntoPLockedEx`), so nothing on the provider changes between the check and the debit. Test: N goroutines vs one capped provider admit exactly the serial capacity, both modes, `-race`. |
+| Probe claim atomic w.r.t. other commits | `gateState.tryClaimCapacityProbe`: check **and** claim in one `gate.mu` section, per identity; a closed gate rejects the reservation instead of leaking a second probe. Test: two sessions of one identity racing → exactly one claim. |
+| Fleet-wide serialization makes the "unchanged since scan" compare exact (herd avoidance) | The four-field compare runs against a snapshot taken under the **same `p.mu` hold that debits**; only the winner's own counters are compared, so `p.mu` suffices. A concurrent commit on the same provider is either fully before (visible → rescan) or fully after. |
+| Stale gate state seen by a scan | Already tolerated between scan RUnlock and commit; the commit re-checks under `p.mu`/`gate.mu`. A gate being migrated is read two ways. An ORPHANED source (its last session left) is forwarded before it is reset and never republished, so lock-free readers see its intact pre-merge view or the forward, never zeros. A SHARED source (a sibling session still bound to it) IS reset and republished — the state moved with the rebinding session — so every read that feeds a dispatch decision (the five routing gates in `gateStateReasonLocked`: scan, commit admit re-check and preflight; the snapshot's budget clamp on both snapshot paths; the candidate's capacity-rate penalty) confirms its verdict against `p.gate` after the read and re-reads from the session's new gate when it moved (`gateView`, bounded like `lockGate`'s re-resolve). Sound without a lock because the migration repoints `p.gate` BEFORE it resets and republishes the source, and Go's atomics are sequentially consistent. Tallies, classification counts, fleet_sample rows and warm-pool planning read unconfirmed: a stale sample there miscounts once and dispatches nothing. Test: a scan that loaded the shared gate before the rebind is gated on the new gate (breaker — atomic path — and dispatch-load cooldown — locked per-model path; both modes), an unconfirmed read of the stale gate says clean, the sibling's view reads not gated, and the end-to-end reservation never lands on the rebound session; a `-race` stress variant with a flapping session carrying a permanent cooldown. |
+| Identity rebind moves accumulated fault state | `bindStableFaultKey` migrates `gateState` → `gateState` under the session's `p.mu` and `gatesMu.Lock` (the only place two gate locks nest); stale pointers follow `forwardTo`; a recorder holding a stale pointer re-validates under `gate.mu` (not retired, still the session's cached gate) and re-resolves through the index otherwise; the session is repointed inside the migration's two-gate locked section, so a recorder holding the source either wrote before the merge (its outcome travels) or sees the pointer moved. A shared identity gate with other live sessions is emptied, not orphaned — the repointed `p.gate` is what tells a stale holder its outcome now belongs to the new gate. The lock-free "no per-model state" fast paths (probe claim, the clear recorders) trust a cleared flag only while `p.gate` still points at the gate it was read from (`refHasPairState`). **Semantics (written down in `gate_migrate.go`): the state MOVES, it is not copied.** The source identity — and a sibling session still bound to it (the same machine connected twice: one SE key, two sessions) — starts from nothing, exactly as the map-keyed `migrateFaultStateLocked` left the old key; the sibling lands on the moved state at its own enrichment. A copy was rejected: the merge does not deduplicate histories, so it would double-count every fault (strike lists, health rings, consecutive-fault streaks) the moment the sibling enriches to the same serial. |
+| Fault state survives Disconnect; identity-less residue is dropped | `detachSessionGate`: caches the stable id for the trailing flush and keeps the identity's gate; a session-keyed gate (no identity) is dropped at Disconnect. |
+| Bounded maps | Periodic `sweepGates` from the eviction loop (plus a rate-limited inline sweep past 4096 gates): prunes dead per-model entries; drops gates with no live session once idle for 10 min, marking them `retired` under `gate.mu` before the index delete so a recorder that resolved the gate before the walk re-resolves instead of writing into it. A gate's **creation counts as activity** for the idle grace, so a gate filed for a disconnected identity (the trailing flush's first fault, a serve outcome by stable id) cannot be swept before the recorder that created it takes the lock — an untouched disconnected identity therefore lingers ≤ 10 min instead of dropping on the first sweep (negligible: one empty `gateState`). Half-open trip memory of a **live** gate is never pruned (the old size-triggered sweeps only ran past 1024 entries). |
+
+## Mode flag
+
+`EIGENINFERENCE_RESERVE_COMMIT_MODE` = `shared` (default) | `global`, read once at construction.
+
+- `shared`: commit and plan consumption hold `r.mu.RLock` + `p.mu` (this change).
+- `global`: they take `r.mu.Lock()` — the previous fleet-wide serialization, kept as the **kill
+  switch** for (a′). The recorders stay on their per-identity gates in **both** modes: that half is
+  safe on its own, and the flag exists for a defect in the shared commit.
+
+The request-path suites run in both modes (`forEachCommitMode`).
+
+## Observability
+
+- `registry.gate.wait_ms` — DogStatsD histogram tagged `site:` (`breaker`, `health_ejection`,
+  `inference_error`, `inference_success`, `capacity_reject`, `capacity_accept`,
+  `dispatch_load_failure`, `dispatch_load_clear`, `clamp_heartbeat`), emitted only when a `gate.mu`
+  wait exceeds 1 ms (uncontended path: one `TryLock`, no clock reads). Distinct from #818's
+  `registry.mu.write_wait_ms`. The commit-path probe claim (`capacity_probe` site) takes the same
+  gate lock but does not report its wait: it runs under `p.mu` (and `r.mu` in `global` mode), where the
+  emit must not happen; the recorders' waits on the same gates cover it.
+- The #809 per-attempt stamps (`lock_wait_us`, `scan_us`, `admit_us`) are the acceptance metric.
+
+## Bench (this box: M-series, 16 threads, `-benchtime 2s -count 2`; load average 330–380 on 16 cores during both runs — treat absolute numbers as ±30%, ratios within a run as the signal)
+
+| Benchmark | PR B (base) | this branch |
+|---|---:|---:|
+| RequestPathWalkParallel-16 (RLock-only fleet walk) | 158–176 µs/op | 100–109 µs/op |
+| RequestPathWalkParallelWithWriter-16 — one recorder at 500/s under 16 walkers: **writer wait mean** | **1.7–2.6 ms** | **39–72 µs** |
+| … writer wait max | 18–100 ms | 31–68 ms (scheduler noise at this load) |
+| RequestPathSerial (scan+commit+5 recorders+release) | 424–537 µs/op | 346–351 µs/op |
+| RequestPathParallel-16 (same, 16 threads) | 353–386 µs/op | 145–157 µs/op |
+| **parallel speed-up (serial ÷ parallel)** | **≈1.2×** | **≈2.3×** (read-only walk ceiling on this box at that moment: 2.6×) |
+| FleetReserveProviderExParallel-16 | 311–351 µs/op | 312 µs/op (fixture herds every goroutine onto model 0 with colliding request ids → rescans dominate; not a lock signal) |
+
+`TestRequestPathParallelSpeedup` pins the guard. **Deviation from the proposal's "asserts ≥ 4× at
+16 threads":** the absolute 4× is asserted only when the box's own read-only fleet walk (RLock, no
+writers) reaches 4× — an unloaded machine; on a busy box it asserts the relative property instead
+(request path ≥ 60% of the read-only walk's speed-up; the base branch sits at ≈45%), and above a
+1-minute load of 2×GOMAXPROCS it skips with the numbers logged, because lock-holder preemption
+defeats every locking scheme there. Each quantity is the best of three interleaved fixed-work runs.
+On the development box (load 449–459 on 16 cores) it therefore **skipped**, measuring read-only
+4.75× vs request path 3.50× (74%). The request path's ceiling sits below the read-only walk's
+because of three pre-existing global write locks the read walk does not pay: `ttftCalibration.
+notePrediction` per warm commit, the warm-pool `recordEvent` per cold dispatch, and the cache
+tracker on `RemovePending`. None of them is `r.mu`.
+
+## Acceptance metrics (prod, via #809 stamps)
+
+- `admit_us` p99 < 10 ms; attempt-start → first-lock p90 < 50 ms, for 24 h.
+- `registry.mu.write_wait_ms` (#818) collapses to the non-request writers (Register/Disconnect/
+  evictStale/swap planner/config: tens per second); `registry.gate.wait_ms` stays empty or
+  single-digit ms.
+- Rescans per attempt (`ScanCount`, #818) → ~1.
+
+## Rollout
+
+1. Deploy with the default (`shared`). Kill switch: `EIGENINFERENCE_RESERVE_COMMIT_MODE=global`
+   restores the fleet-wide commit serialization without touching the recorders.
+2. **Not in this branch (deploy knob):** the #799 routing semaphore is still sized to host
+   `runtime.NumCPU()` and its slots were held across the write-lock wait. With the wait gone, re-size
+   `EIGENINFERENCE_ROUTING_CONCURRENCY` to the container's CPU quota so it bounds scan CPU as
+   designed.
+3. Re-profile 30 s after landing and diff against 00.
+
+## Behaviour-neutral changes worth knowing about
+
+- `ClearDispatchLoadCooldown` returns without taking any lock when the identity has no dispatch-load
+  state (one flag load) — the common completion case.
+- `RecordCapacityAcceptOutcome(_, _, false)` lost its read-only no-state probe; every accept now takes
+  one uncontended `gate.mu` (microseconds, per identity) instead of an `r.mu.RLock` probe.
+- `Disconnect` of an identity-less session drops **all** of that session's fault residue (capacity
+  trackers included); before, only breaker / inference-error / dispatch-load residue was dropped.
+- `TestReserveProviderWithPlanPrimarySelectionUnchanged` compared candidate summaries including
+  their wall-clock `HBAgeMs`; it flaked 4/40 under `-race` on the loaded box (0/40 on base at that
+  moment). The summaries' heartbeat ages are now zeroed like the decision's own `SnapshotAgeMs`.
+  Test-only; revert if preferred.
+- `ReserveNextFromPlan` is exercised concurrently with one plan per goroutine (the plan itself is
+  single-consumer); the existing sequential plan suite covers the rest under `-race`.
+
+## Remaining `r.mu` writers
+
+Register, Disconnect, `evictStale` (strike map install), the swap planner
+(`expirePendingModelLoads`/`reservePendingModelLoads`), `markUntrusted`, config setters, hook
+setters. **No `r.mu.Lock()` remains on any request path.** The recorders take `r.mu` in no mode; the
+only read-side touch left near a recorder is the budget snapshot for the clamp
+(`providerReportsTokenBudget`/`providerBudgetSnapshot`), which reads `p.BackendCapacity` under
+`p.mu` via the `sessions` index — no `r.mu` at all.
+
+## Review follow-ups
+
+### Third pass
+
+Codex's third review left five findings; all legitimate.
+
+- **F1 [P1] — a landed report was edited.** The "Follow-on" cross-link added to the PR-B body (landed on
+  the parent branch; reports are frozen) is removed; the Tier 3 body is indexed in `docs/reports/README.md`
+  instead. Commit `6a64f71a8`.
+- **F2 [P1] — `EIGENINFERENCE_RESERVE_COMMIT_MODE` documented only here.** Row added to
+  `docs/reference/configuration.md` (values, default, read-once at construction, what each mode holds).
+  Commit `9d2138db3`.
+- **F3 [P2] — a rebind could land between the commit's final gate check and its debit.**
+  `bindStableFaultKey` ran after `SetAttestationResult` / `RebindStableFaultKey` had released `p.mu`, while
+  the commit reads `p.gate` (the admit re-check) and debits inside one `p.mu` section in both modes;
+  `gateView` closes a rebind that lands during the reads, not one after `moved()` has confirmed them, so a
+  commit could accept a clean source gate and dispatch to a session whose destination identity already
+  carried a breaker or cooldown. The map-keyed code had no window (bind and commit shared `r.mu.Lock`).
+  Both entry points now derive the identity and bind while `p.mu` is still held; lock order unchanged
+  (`r.mu → p.mu → gatesMu → gate.mu` — the bind takes the last two, and no recorder takes `p.mu` under a
+  gate lock). `gateView` stays for the capacity-rate read the scan makes after releasing `p.mu`. Test:
+  `p.gate` never changes under a `p.mu` holder while the session flaps identities through either entry
+  point (`-race`; 2000+ moves per run without the fix, zero with it). Commit `dd936c097`.
+- **F4 [P2] — the alias resolver's cooldown read was unconfirmed.** `providerCanRouteBuildLocked`
+  (`ResolveModel` → `anyProviderCanRouteBuildLocked`) read `gateOf(p).dispatchLoadCooled` with no
+  confirmation, so a shared source reset by this session's own rebind could read "not cooled" and resolve
+  the alias to a Desired build whose only provider was cooled. Closed by F3: the read runs under `p.mu`,
+  which the bind now holds; said so at the read site. Test: a Desired-only session flapping identities with
+  a travelling cooldown while every concurrent `ResolveModel` must pick Previous (`-race`; ~2400 wrong
+  resolutions per run without the fix, zero with it). Commit `d789d1723`.
+- **F5 [P1] — the locking model was documented only here.** `docs/architecture/routing.md` gains
+  "Concurrency: scan, commit and fault-state gates" (lock table and order, two-phase reservation, the
+  per-identity gates and recorders, rebinds, sweep, observability), four invariants and the code-map rows
+  for the `gate_*.go` files; `scheduling.md` carries the double-booking invariant with a link. This commit.
+
+### Second pass
+
+Codex's second review left two findings; both legitimate.
+
+- **F1 [P1] — split the gate implementation** (`gate_state.go` had grown to 1,013 lines across six
+  concerns; repo policy asks for small single-responsibility files and a modular pass after large work).
+  Split by concern: `gate_state.go` (design header with lock order and file map, the `gateState` struct,
+  `publishLocked` and the atomic readers), `gate_index.go` (`r.gates` / `r.sessions` under `gatesMu`,
+  `gateRef` resolution, `gateOf`, attach/detach), `gate_migrate.go` (`resolve`, merge and reset policy,
+  `bindStableFaultKey`, `migrateGateLocked`), `gate_sweep.go` (`pruneLocked`, `sweepGates`),
+  `gate_lock.go` (`lockResolved`, `lockGate`, `refHasPairState`, the wait observer),
+  `gate_commit_mode.go` (the kill switch). Tests split the same way (`gate_index_test.go`,
+  `gate_migrate_test.go`, `gate_sweep_test.go`, `gate_lock_test.go`, `gate_stress_test.go`). Pure
+  moves — verified by a sorted-line diff of the old file against the concatenated new ones (only each
+  file's header and the file map are new). Commit `829849ee9`.
+- **F2 [P2] — the routing read path trusted an emptied shared source** (the residual the first pass
+  documented). The scan loads `p.gate` and reads it holding no lock a rebind respects; a rebind landing
+  in between moves the session's state and, for a SHARED source, resets and republishes it as zeros, so
+  the scan — and the commit's admit re-check, which reads the same way — admitted a session whose
+  breaker or cooldown had just moved. Closed by confirming every dispatch-deciding read against `p.gate`
+  after the read (`gateView`, details in the invariants table). Also settled the semantics question the
+  reset raised — move, not copy — and wrote it into `gate_migrate.go`. Commit `4001286bf`.
+
+### First pass
+
+Codex left two P2 findings on the gate index; both were legitimate and share one root cause — a
+recorder resolves its gate under `gatesMu.RLock` but locks it only after releasing `gatesMu`, a
+window the map-keyed code never had (key resolution and the write shared one `r.mu.Lock` section
+with the bind). Fixed by re-validating the gate under `gate.mu` after acquiring it and re-resolving
+through the index otherwise (`gateRef` / `lockGate`, `retired`, the repoint inside the migration's
+locked section, creation-counts-as-touched):
+
+- **F1 — recorders racing a shared-identity rebind** (`migrateGateLocked(..., false)` reset the shared
+  gate without a forward; a recorder holding the old pointer wrote into the emptied gate that now
+  belonged to the other session — a success left the migrated clamp/cooldown unreleased, a fault
+  poisoned the other identity's breaker). The removed comment claiming parity with the map-keyed
+  implementation was wrong. Commit `d21e0d48f`.
+- **F2 — the sweep dropping in-flight recorder updates** (the sweep decided under `gate.mu`, unlocked,
+  deleted; a trailing-flush recorder that had already resolved the pointer wrote the disconnect 502
+  into a gate no lookup would find — `evictStale` runs `Disconnect` then `sweepGates` in the same
+  pass, and a gate created for a disconnected identity had `touched == 0`). Commit `d21e0d48f`.
+- **Adjacent gap found while fixing F1 — the commit-path probe claim** (`tryClaimCapacityProbe` via
+  `gateOf(p).lockResolved()` mutated `probeAt` with no session check, so a rebind racing a commit could
+  leak one probe through a cooled pair; the lock-free "no state" fast path had the same hole one layer
+  up — an emptied source gate's flag says "nothing" because the state moved). Now claimed through the
+  same validated lock, both commit modes, with `refHasPairState` confirming a cleared flag against
+  `p.gate`. Commit `020fac64f`.
+
+Deliberately unchanged: `detachSessionGate` does not retire the session-keyed gate it drops at
+Disconnect — a recorder racing it writes into residue that is dropped by design (see "Disconnect of
+an identity-less session drops all of that session's fault residue" above).
+
+## Tests
+
+- `reserve_commit_test.go`: exact-capacity concurrent commit through `ReserveProviderEx` AND through
+  `ReserveNextFromPlan` (both modes, `-race`); the half-open probe race end to end — two sessions of
+  one identity, N concurrent reservations, exactly one admitted (both modes); identical routing walks
+  and per-provider gate outcomes across modes before/after concurrent scans + recorders over the
+  fault-state fixture (breaker-open, ejected, capacity-cooled, dispatch-load-cooled, error-cooled,
+  budget-clamped — the recorders in the concurrent phase target healthy providers, so this is
+  `-race` interleaving coverage plus "faulted stay excluded", not a decision-changing script); the
+  parallel speed-up guard; the mode-flag parser (unknown values fall back to `shared` and are logged).
+- `gate_migrate_test.go` / `gate_sweep_test.go` / `gate_index_test.go` / `gate_lock_test.go` /
+  `gate_stress_test.go` (split from `gate_state_test.go`): stale-pointer migration, no empty-gate
+  window for lock-free readers during a live re-attestation, shared-identity rebind, sweep liveness
+  rule, trailing-flush resolution, exclusive probe claim, nil-safety, wait observer, recorders never
+  block behind `r.mu.Lock`; from the first review pass: a stale ref across a shared-identity rebind
+  lands on the session's new gate and leaves the other identity untouched; a stale ref across a sweep
+  of a disconnected gate lands on the gate a fresh lookup finds (by session and by stable id); a clear
+  keeps the retired gate and files nothing; a fresh gate survives the first sweep; a rebind between
+  the probe's resolution and its claim lands the claim on the new gate in both commit modes; the
+  lock-free fast path follows the rebind; from the second pass:
+  `TestScanRevalidatesGateAcrossSharedRebind` (a scan that loaded the shared gate before the rebind is
+  gated on the session's new gate — breaker and dispatch-load cooldown, both commit modes — while an
+  unconfirmed read of the stale gate says clean, the sibling's view reads not gated, and the
+  end-to-end reservation never lands on the rebound session; fails with the confirmation stubbed out);
+  `TestGateRecordersRaceRebindsAndSweeps` now also runs routing reads against a session flapping
+  between a shared and an enriched identity with a permanent dispatch-load cooldown and asserts no read
+  ever admits it, alongside the recorders and probe claims racing rebinds and sweeps under `-race`.
+- `request_path_probe_test.go`: the probe benches from 01.
+- Existing tracker suites adapted to the gate API (helpers only; assertions unchanged); index ==
+  brute-force, routing_context, fleet_sample and gate-tally suites untouched and green.
+- `api`: `TestRegistryGateWaitHistogramTaggedBySite`; full `go test ./api/` green against the new
+  registry.

--- a/docs/reports/2026-09-03-perf-pr-cd-body.md
+++ b/docs/reports/2026-09-03-perf-pr-cd-body.md
@@ -1,0 +1,164 @@
+# PR body — coordinator performance program, PR C/D: 2026-09-02 wave fixes (2026-09-03)
+
+> Last updated: 2026-09-04 · commit `637cf48ea`
+
+Branch `perf/coordinator-wave-fixes-2026-09-03`.
+**Base: `perf/coordinator-tier2-base-2026-09-03` (PR A + PR B); retarget to master after PR #820 and PR #819 merge; Retry-After policy left for the owner.**
+
+Source: the two coordinator commits of the 2026-09-02 provider/system optimization pass —
+`773bee1b3` (wave 1) and `58d7792da` (wave 2) on `worktree-bridge-cse_01SAkmgZHFsFMVXijYt6Czjp`
+— ported hunk by hunk onto the Tier 2 base (never cherry-picked whole: the source commits carry
+the Tier 5.1 calibration slices, a second Retry-After policy and duplicates of PR A/PR B).
+Seven commits, one per item, each with its tests.
+
+## Summary
+
+| Commit | Item | Effect |
+|---|---|---|
+| `12cfe68b9` | Provider WS write fragmentation (> 256 KiB) | A 20 MiB vision frame no longer holds nhooyr's frame lock for 10–30 s; the provider's ping is answered between continuation frames instead of killing the whole provider session (and 502-ing every request on it). Read errors of that class are tagged `read_error_control_frame`. |
+| `eef41426b` | Queue-drain cost bound | One fleet scan per distinct rejected request shape per pass (dominance skip) + 20 ms heartbeat suppression with one trailing pass. Measured on this base at 1,300 providers × 32 queued: heartbeat 44.7 ms → 12 µs amortised (≈1.3 ms per real pass), `SetProviderIdle` 35.7 ms → 1.39 ms. |
+| `2dc6ddc91` | Drain-neutral faults + disconnect reasons | Graceful 1000/1001 closes flush pending requests with the health-neutral `provider_restart` cause; a reconnect on a changed binary version clears exactly the disconnect-flush (502) strikes (rate-limited 1/identity/10 min); heartbeat `status:"draining"` / typed `error_reason:"draining"` skip the provider in routing as transient capacity without derating it or charging the request's capacity retries. |
+| `4f13be2ad` | Failure classification + cascade metrics | `inference.attempt_outcome{model,class}`, `inference.request_outcome_or_view{model,class}`, `inference.unknown_frames{kind,provider_version}`, `routing.route_latency_ms{model}`, `request_queue.depth_by_model` / `oldest_age_ms{model}`, `deadline_bucket` on `routing.client_gone`; a client leaving between ladder attempts is `client_gone`; a queue-wait first-content expiry is `queue_deadline`, not `first_chunk_timeout`. |
+| `359921252` | Cancel hygiene | A cancel frame is sent only when the abandoning path removed a LIVE pending record with no completion ingressed (~140K phantom cancels/h at baseline); cancels are recorded by cause and correlated with the provider's terminal; zombies are re-cancelled on an escalating schedule (+1 s, +3 s, +10 s, then 30 s); control lane 64 → 256. |
+| `dccc704f9` | Relay decode | Single-pass hand decoder for `inference_response_chunk` with generic fallback on any shape it is not certain about; `DecodeProviderMessage` skips encoding/json's redundant outer validation. Measured: decode 27.7 µs / 6 allocs → 3.2 µs / 2; read loop per frame 32.3 µs / 15 allocs → 6.3 µs / 5. |
+| `74c8bc31d` | MLX cache telemetry re-key | Session-UUID-tagged gauges (~11K churning series) → `{chip_family, provider_version}` histograms and per-heartbeat counter deltas. |
+
+## Before / After — behaviour
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A1["20 MiB vision frame: one WS frame, write lock held 10–30 s"] --> B1["provider ping lands mid-frame → pong cannot take lock in 5 s"]
+    B1 --> C1["nhooyr READ error → Disconnect → 502 for every pending request on the box"]
+    D1["heartbeat (~260/s fleet)"] --> E1["drain: one full fleet scan PER queued request (32× on a saturated queue)"]
+    F1["provider stop/restart/update: graceful close or version bump"] --> G1["502 flush strikes stable identity → breakers/cooldowns/ejection for up to 5 min"]
+    H1["draining box keeps heartbeating idle"] --> I1["selected, bounces, burns a capacity retry, derates the pair"]
+    J1["every dispatch ends"] --> K1["cancel frame to provider, even after clean completion"]
+    L1["chunk for abandoned stream"] --> M1["re-cancel at most once per 10 s"]
+    N1["per-token chunk frame"] --> O1["encoding/json: validate + type scan + reflective decode"]
+  end
+  subgraph After
+    A2["> 256 KiB → continuation frames, lock held per fragment"] --> B2["pong interleaves; read loop survives"]
+    C2["read_error_control_frame tagged when it does happen"]
+    D2["heartbeat"] --> E2["dominance skip: one scan per rejected shape; 20 ms suppression + one trailing pass"]
+    F2["graceful close → provider_restart (health-neutral); new version → flush strikes cleared"]
+    H2["status:draining / error_reason:draining"] --> I2["skipped as transient capacity; no derate, no retry charge"]
+    J2["abandon with live pending record"] --> K2["cancel sent + recorded by cause; terminal correlated"]
+    L2["stray chunk"] --> M2["re-cancel +1 s / +3 s / +10 s / 30 s; per-provider log rate limit"]
+    N2["chunk frame"] --> O2["scanChunkFrame: one byte walk, 2 allocs; generic fallback"]
+  end
+```
+
+## Before / After — code
+
+```mermaid
+flowchart LR
+  subgraph Before
+    W1["providerWriter.writeFrame → conn.Write (one frame)"]
+    Q1["drainQueuedRequestsForModelsWithReason: ReserveProviderEx per waiter"]
+    X1["Registry.Disconnect (one cause)"] --> Y1["flush: CoordinatorCauseProviderDisconnected"]
+    Z1["providerPassesRoutingGatesLockedEx: capacityCooldownActiveLocked"]
+    S1["sendProviderCancel everywhere (cancelDispatch, post-commit defer)"] --> T1["zombieStreamCanceller.shouldCancel (10 s throttle)"]
+    U1["providerReadLoop: json.Unmarshal(ProviderMessage)"]
+    V1["recordMLXCacheTelemetry(providerID, capacity): gauges tagged provider_id"]
+  end
+  subgraph After
+    W2["writeFrame → writeFragmented → conn.Writer, 256 KiB fragments"]
+    Q2["drainDominated / drainRejectionRecordFor / drainSuppress + drainQueuedRequestsForHeartbeat (DrainTriggerHeartbeat kept)"]
+    X2["Disconnect → disconnectWithCause; DisconnectWithReason(ClassifyPeerClose)"] --> Y2["flush: cause + disconnectFlushErrorReason; version_reset.go clears flush strikes"]
+    Z2["… || providerDrainingLocked (drain_state.go: applyHeartbeatDrainStateLocked, MarkDraining)"]
+    S2["cancelDispatch(cause) / cancelDispatchAfterTerminal / sendAbandonCancel / sendRecordedCancel"] --> T2["zombieStreamCanceller.record / strayChunk / terminal (cancel_lifecycle.go)"]
+    U2["protocol.DecodeProviderMessage → scanChunkFrame fast path"]
+    V2["recordMLXCacheTelemetry(provider, prev, capacity): histograms + ddCountDelta, tags chip_family/provider_version"]
+  end
+```
+
+## Included / excluded
+
+| Slice (source commit) | Decision | Reason |
+|---|---|---|
+| `registry/provider_writer.go` fragmentation + `provider_writer_fragment_test.go`; `api/provider.go` `readErrorDisconnectReason` (773bee1b3) | **Included** (`12cfe68b9`) | Root cause of self-inflicted provider disconnects. |
+| `registry/queue_drain_dominance.go`, `queue_drain_suppress.go` (w2 state, trailing pass), drain hunks in `scheduler.go` / `registry.go`, `queue_drain_test.go`, `queue_drain_bench_test.go` | **Included** (`eef41426b`) | Runs on the provider read loop, outside #799's routing semaphore. Both the heartbeat path and the trailing pass call `drainQueuedRequestsForModelsWithReason(…, DrainTriggerHeartbeat)` so #809's drain-trigger vocabulary is kept. |
+| `registry/queue_depth.go`, `queue.go` `DepthFor` / `MaxSizeFor` / `depthCeiling`, `queue_depth_test.go` | Excluded | Capacity-derived queue depth is half of the Retry-After policy (H6) — owner decision. |
+| `protocol/messages.go` `HeartbeatStatusDraining` / `InferenceErrorReasonDraining`; `protocol/inference_failure.go` `CoordinatorCauseProviderRestart`, `InferenceErrorReasonProviderRestart`, `IsProviderDisconnect`; `registry/drain_state.go` (w2), `disconnect_reason.go`, `version_reset.go` (w2 rate limit, minus the pooled-budget memo refresh PR B has no equivalent of); `error_cooldown.go` / `health_ejection.go` / `provider_breaker.go` w1 flush-tag hunks; api `provider.go` (`peerCloseStatus`, `DisconnectWithReason`, `SetVersion`), `consumer.go` (`MarkDraining`), `dispatch.go` (draining does not charge a capacity retry; `IsProviderDisconnect`), `route_outcome.go`, `inference_error_sanitize.go`, `inference_failure_class.go`; tests incl. `drain_integration_test.go`, `restart_disconnect_integration_test.go` | **Included** (`2dc6ddc91`) | Behaviour-only edits to the fault trackers (Tier 3 is re-locking them). |
+| `registry/warm_pool_controller.go` — w1 `LatestWarmPoolSnapshotFor`, w2 "exclude draining from warm count"; `warm_pool_draining_test.go` | Excluded | Consumers are the excluded Retry-After / queue-depth estimators; changing the warm-pool planner's count is a separate decision. |
+| `api/attempt_outcome_metrics.go` (w2), `unknown_frame_metrics.go`, `fleet_gauges.go` (queue gauges only), `prompt_buckets.go`, `route_outcome.go` funnel, `rejection_telemetry.go` OR-view mirror, `server.go` gauge-loop wiring, `dispatch.go` (deadline bucket, OR view, `queue_deadline`, client-gone-between-attempts, `emitRouteLatency`, reclassified reason tag); `attempt_outcome_metrics_test.go`, `queue_deadline_test.go` (with the queued-fleet harness helpers moved in from the excluded `retry_after_test.go`) | **Included** (`4f13be2ad`) | Additive telemetry + two classification fixes. |
+| `routing.provider_eligibility{model,state}` (`emitProviderEligibilityGauges`) | Excluded | Needs `registry/eligibility_snapshot.go` (Tier 5.1 slice). |
+| `api/retry_after.go`, `retry_after_metrics.go` (`routing.retry_after_seconds`), `retry_after_test.go`, the `retryAfterSeconds` call sites, `estimateTTFTRetryAfter` request-id jitter, `consumer_ttft_test.go` edits | Excluded | Second Retry-After policy vs #799's `estimateRetryAfter` (H6). The base's `estimateRetryAfter` is untouched. |
+| `api/routing_estimates.go`, `registry/completion_calibration.go`, `prompt_calibration.go`, `sample_window.go`, `eligibility_snapshot.go`, `api/settlement.go` `observeTokenCalibration`, `servability_gate.go`, `inference_admission.go`, `request_introspection.go`, `dispatch_plan_wiring.go` hunks, `ExpectedCompletionTokens` / `RawPromptTokens` plumbing, `thisReqDecodeTokens`, and their tests (`dispatch_spread_test.go`, `*_calibration_test.go`, `servability_gate_calibration_test.go`, `token_calibration_hook_test.go`, `routing_estimates_test.go`, `deadline_unreachable_integration_test.go` arg) | Excluded | Tier 5.1 — ships later behind shadow logging. |
+| `api/cancel_lifecycle.go`, `zombie_stream.go` rewrite, `registry/pending_terminal.go`, `provider_writer.go` control lane 256 + exported errors, `consumer.go` / `dispatch.go` / `provider.go` cancel hunks; `cancel_lifecycle_test.go`, `cancellation_integration_test.go`, `zombie_stream_test.go`, `provider_writer_control_lane_test.go`, `first_token_clock_test.go` | **Included** (`359921252`) | Adapted around #809's terminal-claim logic (see deltas below). |
+| `protocol/chunk_scan.go`, `DecodeProviderMessage` + fast path, `api/provider.go` decode switch; `chunk_scan_test.go`, `chunk_decode_bench_test.go`, `api/relay_bench_test.go` | **Included** (`dccc704f9`) | Decode-only; PR A's `chatStreamRelay` / `stream_coalesce` / `generic_endpoint_stream` untouched. |
+| `api/provider_mlx_cache_telemetry.go` + test; `provider.go` heartbeat site | **Included** (`74c8bc31d`) | PR B's `provider_heartbeat_bench_test.go` helper adapted to the new signature. |
+| `registry/scan_arena.go`, `model_index.go`, `tps_registry.go`, `solo_tps.go`, `pooled_budget_memo.go`, `ttft_shadow.go` scan hunks, `scan_bench_test.go`, `tps_registry_memo_test.go`, `pooled_budget_memo_test.go`, `scan_arena_test.go`, `model_index_test.go`; all `*KeyLocked` fault-map variants; `dispatchLoadCooldowns` struct-key change; w2 test edits to `alias_test.go`, `helpers_shared_test.go`, `provider_capabilities_test.go`, `scheduler_queue_drain_test.go`, `stable_fault_key_test.go` | Excluded | Duplicates of PR B (one implementation lands). |
+| `api/telemetry_sink.go` four-lane rewrite, keyed `submitTelemetry`, `telemetry_sink_test.go` | Excluded | Duplicate of PR A's batched route sink. |
+| `registry/budget_clamp.go`, `capacity_cooldown.go`, `capacity_rate.go`, `dispatch_plan.go`, `servability_gate.go`, `settlement.go`, `route_outcome.go` (beyond the drain/metric hunks above), `request_introspection.go`, `server.go` (beyond the gauge wiring) | Excluded | Not needed by any ported item. |
+| `deploy/datadog/dev-network-dashboard.json`, `docs/architecture/operations/scheduling.md`, `docs/architecture/request-outcome-observability.md` | Excluded | The dashboard widgets reference unported series (eligibility, Retry-After); the excluded dashboard and broad observability doc changes reference unported series. The canonical protocol reference is updated with the shipped drain markers. |
+
+## Semantics deltas against #809 / PR A (intentional, documented here)
+
+1. `request_profiles.error_reason` and the `inference_routes` `error_class` for a request whose first-content clock expires while QUEUED are `queue_deadline`, not `first_chunk_timeout`. `TestQueuedAttemptExitsCarryRouteOutcome` (#809) is updated accordingly. Queue-wait exits dispatch no provider attempt, so they are excluded from `inference.attempt_outcome` and counted on `inference.queue_outcome{model,class}` (`queue_deadline`, `queue_timeout`, `ttft_too_slow`, `client_gone`, `model_capability_unsupported`) instead; the amplification denominator counts dispatched attempts only.
+2. `StampCancelSent` is stamped only where a cancel frame is actually sent (`cancelDispatch` send branch, `cancelDispatchForFirstContentTimeout`, the post-commit defer's `sendRecordedCancel`, and the two write-error paths). `cancelDispatchAfterTerminal` never stamps — nothing was sent. The stamp set is otherwise #809's: the two `handleChunk` abort cancels (late content, chunk overflow) send via `sendAbandonCancel` and are not stamped, exactly as on the base.
+3. A draining provider fails the routing gate on the capacity-cooldown branch, so #809's routing record tallies it under `GateCapacityCooldown`; no new `GateReason` is introduced.
+4. `inference.unknown_frames{kind,provider_version}` (new) counts frames whose id matched no recorded cancel; #809's `inference.unknown_request_frames{kind}` and the in-process `unknownRequestFrames` counter keep counting EVERY frame without a live pending record. The denominators differ by design; the owner can retire one.
+
+## Protocol symmetry
+
+- `HeartbeatStatusDraining = "draining"` and `InferenceErrorReasonDraining = "draining"` are the Go side of wire strings the Swift provider emits from `bcafa19e0` on this branch (`ProviderStatus.draining` in `Protocol/Enums.swift`; `InferenceFailure(code: .capacity, statusCode: 503, errorReason: .draining)` in `Inference/InferenceFailure.swift`; a port of `eb2f84bb3` from the bridge-cse worktree branch, which is not an ancestor of this branch). Both markers ship in the same provider commit and no tagged release carries either — `v0.8.16` sends neither — so a provider that types the reason also reports the status. Additive; legacy providers send neither.
+- `CoordinatorCauseProviderRestart` / `InferenceErrorReasonProviderRestart` are coordinator-internal and never on the wire (the ingress sanitizer's allowlists do not emit them).
+- `DecodeProviderMessage` / `scanChunkFrame` change no wire type; `58d7792da` has no Swift side for it (its Swift companion `e5461b53d` is the think-probe fix). `TestScanChunkFrameSwiftShapeTakesFastPath` pins the Swift sorted-key wire order.
+- `provider-swift/` changes on this branch are the drain-awareness emitter (`bcafa19e0`: `ProviderStatus.draining` in the heartbeat while refusing new work, `error_reason: draining` on the drain rejection) and the heartbeat encode-failure fallback keeping the computed status.
+
+## Measurements (this base, M-series laptop with other load)
+
+| Benchmark | Base | This branch |
+|---|---|---|
+| `BenchmarkDrain_Heartbeat_1300_SaturatedQueue_Depth32` | 44.7 ms / 1.49 MB / 178 allocs | 12 µs amortised, 1.19 KB, 11 allocs (≈1.3 ms per un-suppressed pass) |
+| `BenchmarkDrain_SetProviderIdle_1300_SaturatedQueue_Depth32` | 35.7 ms / 1.49 MB / 165 allocs | 1.39 ms / 52 KB / 75 allocs |
+| `BenchmarkChunkFrame_ProviderMessage_Unmarshal` → `_DecodeProviderMessage` | 27.7 µs / 6 allocs | 3.2 µs / 2 allocs |
+| `BenchmarkRelay_ReadLoopPerFrame_GenericDecode` → `_ReadLoopPerFrame` | 32.3 µs / 15 allocs | 6.3 µs / 5 allocs |
+| `BenchmarkHeartbeatBranchTelemetryOnly[Statsd]` | — | 0.97 µs / 8 allocs (1.9 µs / 11 with statsd) |
+
+`FuzzChunkFrameDecode`: 530K execs in a 10 s smoke, no findings.
+
+## Gates run
+
+Per commit: `gofmt -l .`, `go build ./...`, `go vet ./...`, `golangci-lint v2.1.6 run ./...` (0 issues), then `go test ./registry/... ./protocol/ ./api/` in the foreground. Final tree: all three packages green. One full-`./api/` run mid-port surfaced `TestConstrainedExactNonnegativeIntBoundsAdversarialLiterals` ("parse took 291 ms — superlinear parse regression") in an untouched file; it passes 3/3 in isolation (CPU-load flake, not on the known-flake list).
+
+## Follow-ups noted by the independent review (not in this PR)
+
+- `api/consumer.go` / `api/dispatch.go` write-error paths still cancel through the raw `sendProviderCancel`: the cancel is neither recorded in the zombie tracker nor counted in `inference.cancel_sent{cause}`, so a later terminal for that id classifies as stray/unknown. The source commit left them raw too; routing them through `sendAbandonCancel` with a `write_error` cause is a small follow-up.
+- `ClassifyPeerClose(peerCloseStatus, false)` hardcodes `oomSuspected=false` at its only call site (same as the source; outcome-neutral since OOM and read_error both take the abrupt cause).
+- The candidate-scan drop path now takes `p.mu` once per dropped provider to read the draining mark (previously only when a capacity cooldown was active) — one uncontended lock per dropped candidate.
+- `queue_deadline` is a new value in the rejection-ledger `reason_code`, `inference_routes.error_class` and `routing.first_chunk_timeout_reclassified{reason}` vocabularies; dashboards keyed on `first_chunk_timeout` shift accordingly.
+
+### Addressed from the second review pass (in this PR)
+
+- Queue drain: one pass runs per model at a time (`registry/queue_drain_coalesce.go`). A trigger that lands while a pass holds popped waiters — heartbeat, `SetProviderIdle`, challenge recovery, disconnect — no longer scans an empty queue; it makes the running pass go around once more with fresh fleet state and empty dominance records, attributed to that trigger. Closes the interleaving where a mid-pass capacity change left dominance-skipped waiters requeued on a stale verdict until the next trigger. Pinned by `TestDrainTriggerMidPassRerunsHeldWaiters` through a nil-in-production `drainBeforePop` seam.
+- Drain mark ownership removed: a provider's idle/serving heartbeat clears a typed-rejection-set mark too. The typed reason and the heartbeat status ship in the same provider binary (released 0.8.16 sends neither), so no provider types the reason without reporting the status, while the rejection-first ordering is real (the drain announcement is a detached task, dropped while the session is not registered). An aborted update drain is back in routing on its next heartbeat instead of after the 150 s TTL, which stays as the heartbeat-loss fallback. `TestMarkDraining_ClearedByIdleHeartbeat_OrTTL`, `TestDrain_TypedRejectionClearedByIdleHeartbeat` (inverted from the previous round).
+- Version-reset throttle follows an identity rebind: `migrateFaultStateLocked` now moves `identityVersionResetAt` with `identityVersions` (later timestamp wins), so a `sekey:` → `serial:` rebind cannot hand the identity a second flush-strike reset inside the 10-minute interval. `TestVersionResetThrottle_FollowsIdentityRebind`, `TestMigrateFaultState_ResetTimestampKeepsLater`.
+- `provider_version` tag cardinality: `sanitizeVersionTag` validates strict semver and maps it to the fixed vocabulary `0.6.x`, `0.7.x`, `0.8.x`, `0.9.x`, `other_release`, `prerelease`, `unknown`, or `other`. Exact versions remain in provider metadata; arbitrary patch numbers and prerelease counters do not create new series. Covers `inference.unknown_frames` and the MLX cache histograms.
+- Swift heartbeat encode-failure fallback carries the computed status (`draining`/`serving`/`idle`) instead of a literal `idle`; `UpdateDrainAwarenessTests` forces the path with a NaN capacity payload.
+- `inference.attempt_outcome`: a typed `draining` refusal (chat `provider_error`, generic `provider_error_before_response`) is `class:capacity`, not `fault` — `isCapacityClassErrorReason` now lists `draining`, matching the health-neutral treatment the same terminal already gets everywhere else. Mapping cases added.
+- Cancel lifecycle telemetry counts delivery, not intent: `sendRecordedCancel` and the stray-chunk re-send hand the frame to the provider writer first and mark/count `inference.cancel_sent` only when the enqueue succeeded; a refused enqueue (control lane full, writer stopped) keeps the entry unsent for the next stray-chunk retry, and the first cancel that reaches a writer counts once under the abandon cause. `inference.cancelled_terminal` gains a bounded `delivered:true|false` tag and `inference.cancel_to_terminal_ms` is sampled only for delivered cancels. `TestCancelSendCountsOnlyDeliveredFrames`; the socketless racer fixture now expects no `cancel_sent`.
+- CI `Provider Tests` run 33904439872 (`MTPPostureTelemetryTests` ×2, `postureCount() → 1 >= 2`): not caused by the emitter port. The sampler is a self-contained `Task` loop on `EngineV2Bridge` over a plain `Task.sleep` wrapper and the test builds the bridge directly (no `ProviderLoop`, no `CoordinatorClient`); nothing on this branch touches `EngineV2Bridge*`, `TaskSleep.swift`, telemetry, or the test. The failing run shows a process-wide ~5.8 s startup stall (213 of 243 suites "passed after 5.5–6.6 s", including pure tests such as `storeRoundtripsSingleChunk()`), and the two posture tests are the only ones with a hard 5 s deadline. The passing master run f127f43a2 has the same stall (245/253 suites ≥5.5 s) with the posture tests passing at 5.58 s and 5.90 s — no margin. Locally: filter 6/6, full suite 3/3 green for these tests (one unrelated load-sensitive compile-duration guard flaked once). Left as is; the test deadline, not the emitter, is the follow-up.
+
+## Notes for reviewers
+
+- `store/interface.go` adds the transient, non-persisted `InferenceRouteOutcome.QueueExit` marker to keep queued exits out of dispatched-attempt metrics. No store schema or persistence behavior changes. Nothing under `chat_stream_relay.go`, `stream_coalesce.go`, `generic_endpoint_stream.go`, `telemetry_sink.go`, `model_index.go`, `tps_registry.go` or `solo_tps.go` changes.
+- The fault-tracker files Tier 3 is restructuring (`capacity_cooldown.go` untouched; `error_cooldown.go` +5, `health_ejection.go` +27/−3, `provider_breaker.go` +11/−1) carry behaviour-only hunks: a flush flag on the health-window outcome and the flush-strike tag on the inference-error strike.
+- Retry-After is deliberately untouched everywhere (#799's `estimateRetryAfter` / `estimateTTFTRetryAfter` stay).
+
+## Final review corrections (2026-09-04)
+
+- Late disconnect-flush suppression is checked inside each tracker mutation lock.
+  The session-aware health-ejection entrypoint preserves source identity through
+  the write, so a reconnect reset cannot race an API-side precheck and reopen
+  quarantine. Regression coverage inserts the reset before or between all three
+  tracker updates, alongside same-version and throttled-reset controls.
+- Both MLX and client-gone chip tags use one fixed vocabulary. Version tags use
+  fixed release-family buckets; patch and prerelease rotation cannot create series.
+- Cancel latency begins at the first successful enqueue, never at a failed
+  initial attempt. An expired unsent cancel is unresolved even when stray chunks
+  arrived; only chunks at or after the first successful send contribute latency.
+- Canonical protocol, scheduling, telemetry and outcome references now describe
+  the wire markers, queue coalescing, reset ordering and metric semantics.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-04 · commit `fd2f0be2c`
+> Last updated: 2026-09-04 · commit `c54b40e18`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -63,6 +63,7 @@ Plans and decision memos live in [`../design/`](../design/README.md).
 | 2026-09-02 | [coordinator-performance-pr-body](2026-09-02-coordinator-performance-pr-body.md) | Original PR body of the 75-commit program branch, kept as the record |
 | 2026-09-03 | [perf-pr-a-body](2026-09-03-perf-pr-a-body.md) | Landing the store/api half of the program on master (read-through cache, batched route sink, parse-once bodies, relay coalescing) |
 | 2026-09-03 | [perf-pr-b-body](2026-09-03-perf-pr-b-body.md) | PR description for the routing-scan landing (PR B): per-model provider index, in-place snapshots, TPS median caches, version memos, heartbeat swap-plan coalescing; before/after benchmarks and the `scanned` semantics change |
+| 2026-09-03 | [perf-pr-cd-body](2026-09-03-perf-pr-cd-body.md) | Wave fixes following the A+B base: WebSocket fragmentation, bounded queue drains, restart/drain/cancel lifecycle and telemetry |
 
 ## Raw benchmark outputs
 

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-04 · commit `c54b40e18`
+> Last updated: 2026-09-04 · commit `0be2aa074`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -63,6 +63,7 @@ Plans and decision memos live in [`../design/`](../design/README.md).
 | 2026-09-02 | [coordinator-performance-pr-body](2026-09-02-coordinator-performance-pr-body.md) | Original PR body of the 75-commit program branch, kept as the record |
 | 2026-09-03 | [perf-pr-a-body](2026-09-03-perf-pr-a-body.md) | Landing the store/api half of the program on master (read-through cache, batched route sink, parse-once bodies, relay coalescing) |
 | 2026-09-03 | [perf-pr-b-body](2026-09-03-perf-pr-b-body.md) | PR description for the routing-scan landing (PR B): per-model provider index, in-place snapshots, TPS median caches, version memos, heartbeat swap-plan coalescing; before/after benchmarks and the `scanned` semantics change |
+| 2026-09-03 | [perf-pr-c-tier3-body](2026-09-03-perf-pr-c-tier3-body.md) | PR description for the Tier 3 lock restructure (PR C, stacked on PR B): per-identity `gateState` fault trackers off the global write lock, the reservation commit under `r.mu.RLock` + `p.mu`, the `EIGENINFERENCE_RESERVE_COMMIT_MODE` kill switch; invariants, benchmarks and the review follow-ups |
 | 2026-09-03 | [perf-pr-cd-body](2026-09-03-perf-pr-cd-body.md) | Wave fixes following the A+B base: WebSocket fragmentation, bounded queue drains, restart/drain/cancel lifecycle and telemetry |
 
 ## Raw benchmark outputs

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -98,8 +98,14 @@ extension CoordinatorClient {
             ? (config.apnsEnvironment ?? "production")
             : config.apnsEnvironment
 
+        // A drain (update / shutdown) outranks serving/idle: the box may still
+        // be decoding in-flight work, but it refuses new work, and the
+        // coordinator must stop selecting it now rather than after enough
+        // 503 bounces trip a cooldown.
+        let status: ProviderStatus = state.refusingNewWork
+            ? .draining : (isActive ? .serving : .idle)
         let message = CoordinatorClientCodec.heartbeatMessage(
-            status: isActive ? .serving : .idle,
+            status: status,
             activeModel: activeModel,
             warmModels: warmModels,
             stats: stats.snapshot(),
@@ -123,9 +129,12 @@ extension CoordinatorClient {
             return json
         } catch {
             recordEncodeFailure("heartbeat", error)
-            // Last resort: a valid idle heartbeat keeps the connection alive
+            // Last resort: a minimal valid heartbeat keeps the connection alive
             // rather than shipping malformed bytes the coordinator would drop.
-            return "{\"type\":\"heartbeat\",\"status\":\"idle\",\"stats\":{\"requests_served\":0,\"tokens_generated\":0},\"system_metrics\":{\"memory_pressure\":0,\"cpu_usage\":0,\"thermal_state\":\"nominal\"}}"
+            // It carries the status computed above — a draining box must not
+            // announce itself idle just because its capacity payload failed to
+            // encode, or the coordinator keeps routing to it.
+            return "{\"type\":\"heartbeat\",\"status\":\"\(status.rawValue)\",\"stats\":{\"requests_served\":0,\"tokens_generated\":0},\"system_metrics\":{\"memory_pressure\":0,\"cpu_usage\":0,\"thermal_state\":\"nominal\"}}"
         }
     }
 

--- a/provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/InferenceFailure.swift
@@ -66,6 +66,11 @@ public enum InferenceErrorReason: String, Codable, Sendable, Equatable, CaseIter
     case cancelled
     case clientError = "client_error"
     case toolNoncompliance = "tool_noncompliance"
+    /// The provider is refusing new work for an update drain / shutdown.
+    /// Distinct from `capacityBusy` so the coordinator can skip the box
+    /// without derating the (provider, model) pair or spending the request's
+    /// capacity retries. Wire string mirrors coordinator/protocol/messages.go.
+    case draining
 }
 
 /// The only value accepted by provider-to-coordinator inference error sinks.

--- a/provider-swift/Sources/ProviderCore/Protocol/CapacityQuotes.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/CapacityQuotes.swift
@@ -65,6 +65,8 @@ extension CapacityRejectionReason {
             self = .kvHeadroom
         case .modelLoad:
             self = .memoryCap
+        case .draining:
+            self = .slotState
         case .deadlineUnreachable:
             self = .deadline
         case .jinjaChannelTags, .jinjaNullBridge, .jinjaTemplate:

--- a/provider-swift/Sources/ProviderCore/Protocol/Enums.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Enums.swift
@@ -3,6 +3,11 @@ import Foundation
 public enum ProviderStatus: String, Codable, Sendable {
     case idle
     case serving
+    /// Refusing new work (update drain / shutdown) while in-flight requests
+    /// finish. Mirrors `HeartbeatStatusDraining` in coordinator/protocol/messages.go;
+    /// the coordinator stops routing to a draining provider on its next
+    /// heartbeat instead of learning by dispatching into 503s.
+    case draining
 }
 
 public enum ChipFamily: String, Codable, Sendable {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -184,10 +184,16 @@ extension ProviderLoop {
     /// admission, drop any staged-but-uncommitted bundle, and replay the
     /// desired-models state that was deferred during the drain so the
     /// provider converges back onto the coordinator's current desired set.
-    private func resumeServingAfterUpdate() async {
+    internal func resumeServingAfterUpdate() async {
         updatePhase = .idle
         // Quote path mirror (routing v2): quotes may admit again.
         state.refusingNewWork = false
+        // Announce the un-drain NOW: the coordinator ages its drain mark on a
+        // TTL, so a prompt `serving`/`idle` heartbeat ends the routing
+        // blackout instead of leaving it to the next 5 s baseline tick.
+        if let client = coordinatorClient {
+            Task { await client.sendEventHeartbeat() }
+        }
 
         if let staged = stagedUpdateBundle {
             stagedUpdateBundle = nil
@@ -208,11 +214,18 @@ extension ProviderLoop {
     /// Enter the `.draining` phase: new requests are refused (503 reroute /
     /// local queue-full) while in-flight work finishes ahead of the commit +
     /// hot-swap.
-    private func beginUpdateDraining() {
+    internal func beginUpdateDraining() {
         updatePhase = .draining
         // Quote path mirror (routing v2): while draining, capacity quotes
         // refuse with `slot_state` exactly like the live admission gate.
         state.refusingNewWork = true
+        // Tell the coordinator NOW (heartbeat `status: draining`) instead of
+        // letting it discover the drain one 503 bounce at a time until the
+        // next baseline heartbeat. The flag above is set before the send, so
+        // the frame carries the draining status.
+        if let client = coordinatorClient {
+            Task { await client.sendEventHeartbeat() }
+        }
     }
 
     /// Download, verify, and stage the release bundle while still serving.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -187,7 +187,7 @@ extension ProviderLoop {
     internal func resumeServingAfterUpdate() async {
         updatePhase = .idle
         // Quote path mirror (routing v2): quotes may admit again.
-        state.refusingNewWork = false
+        state.refusingNewWork = isReconnectingAfterRetirement || isShuttingDown
         // Announce the un-drain NOW: the coordinator ages its drain mark on a
         // TTL, so a prompt `serving`/`idle` heartbeat ends the routing
         // blackout instead of leaving it to the next 5 s baseline tick.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+DrainState.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+DrainState.swift
@@ -1,0 +1,11 @@
+extension ProviderLoop {
+    /// Keep the heartbeat/quote admission mirror raised for the whole
+    /// retirement reconnect barrier, including the late in-flight drain.
+    internal func setRetirementReconnectBarrier(_ active: Bool) {
+        isReconnectingAfterRetirement = active
+        state.refusingNewWork = active || isDrainingForUpdate || isShuttingDown
+        if let client = coordinatorClient {
+            Task { await client.sendEventHeartbeat() }
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -37,7 +37,7 @@ extension ProviderLoop {
     /// hot-swap, or across the post-retirement reconnect (the socket is
     /// about to close; admitting now would only hand the request to the
     /// `.disconnected` cancel).
-    private func rejectIfDrainingForUpdate(
+    internal func rejectIfDrainingForUpdate(
         requestId: String,
         send: SendHandle,
         lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer
@@ -47,7 +47,7 @@ extension ProviderLoop {
             .inferenceError(
                 requestId: requestId,
                 failure: CapacityRejectionEnrichment.enrich(
-                    InferenceFailure(code: .capacity, statusCode: 503),
+                    InferenceFailure(code: .capacity, statusCode: 503, errorReason: .draining),
                     modelId: nil,
                     published: state.publishedCapacity,
                     fallbackReason: .slotState),

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -234,7 +234,7 @@ extension ProviderLoop {
                     // (see `fireRetirementReconnect`) lifts with the new
                     // session: the register it carried excluded every
                     // retired id, so routed work is safe to admit again.
-                    isReconnectingAfterRetirement = false
+                    setRetirementReconnectBarrier(false)
 
                 case .disconnected:
                     logger.warning(.coordinatorDisconnected)

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+StartupPreload.swift
@@ -416,14 +416,14 @@ extension ProviderLoop {
         // routed request admitted in it would only be cancelled by the
         // `.disconnected` handler. Raised here, actor-isolated, before any
         // suspension; lifted by the `.connected` event of the new session.
-        isReconnectingAfterRetirement = true
+        setRetirementReconnectBarrier(true)
         if hasInflightWork {
             // Work landed in the hop after the drain observed empty: let it
             // ride out under the barrier (nothing new is admitted), then close.
             _ = await waitForInflightDrain(
                 timeout: Self.shutdownDrainTimeout, reason: "retirement reconnect")
             if isShuttingDown || Task.isCancelled {
-                isReconnectingAfterRetirement = false
+                setRetirementReconnectBarrier(false)
                 return
             }
         }

--- a/provider-swift/Tests/ProviderCoreTests/UpdateDrainAwarenessTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateDrainAwarenessTests.swift
@@ -1,0 +1,272 @@
+/// Drain awareness (provider half). While the provider refuses new work
+/// (update drain / shutdown) its heartbeat reports `status: "draining"` and
+/// its admission rejection carries `error_reason: "draining"`, so the
+/// coordinator can stop routing to the box immediately instead of discovering
+/// the drain one 503 bounce at a time — and without derating the
+/// (provider, model) pair as if it were merely busy. Both wire strings are
+/// mirrored in coordinator/protocol/messages.go.
+
+import Foundation
+import Testing
+@testable import ProviderCore
+
+// MARK: - Fixtures
+
+private func drainTestHardware() -> HardwareInfo {
+    HardwareInfo(
+        machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+        memoryGb: 128, memoryAvailableGb: 124,
+        cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+        gpuCores: 40, memoryBandwidthGbs: 546
+    )
+}
+
+private func drainTestModel() -> ModelInfo {
+    ModelInfo(id: "org/model-a", modelType: "gpt_oss", sizeBytes: 1, estimatedMemoryGb: 1)
+}
+
+/// A real `ProviderLoop` (no coordinator connection, no model on disk): the
+/// drain transitions and the admission gate are actor-isolated plain state.
+private func makeDrainTestLoop() throws -> ProviderLoop {
+    let config = ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/ignored",
+        hardware: drainTestHardware(),
+        models: [drainTestModel()],
+        config: ProviderConfig(
+            provider: ProviderSettings(name: "drain-awareness-test", memoryReserveGB: 1),
+            backend: BackendSettings(
+                model: nil, enabledModels: ["org/model-a"], idleTimeoutMins: 0, preloadModels: []),
+            coordinator: CoordinatorSettings(heartbeatIntervalSecs: 60)
+        )
+    )
+    return try ProviderLoop(config: config, purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+/// A `CoordinatorClient` sharing `state` with the loop — exactly how the
+/// production heartbeat reads the loop's refuse-new-work window.
+private func makeHeartbeatClient(
+    state: ProviderState,
+    url: String = "ws://127.0.0.1:0/ignored",
+    heartbeatInterval: TimeInterval = 0.5
+) -> CoordinatorClient {
+    CoordinatorClient(
+        config: CoordinatorClientConfig(
+            url: url,
+            hardware: drainTestHardware(),
+            models: [drainTestModel()],
+            backendName: "mlx-swift",
+            heartbeatInterval: heartbeatInterval,
+            publicKey: "cHVibGlj"
+        ),
+        stats: AtomicProviderStats(),
+        state: state,
+        liveAPNsToken: { nil }
+    )
+}
+
+private func jsonObject(_ data: Data) throws -> [String: Any] {
+    try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func heartbeatObject(_ client: CoordinatorClient) async throws -> [String: Any] {
+    try jsonObject(Data(await client.buildHeartbeatJSON().utf8))
+}
+
+private final class OutboundCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [OutboundMessage] = []
+    func append(_ message: OutboundMessage) { lock.withLock { messages.append(message) } }
+    var all: [OutboundMessage] { lock.withLock { messages } }
+}
+
+@Suite("Update drain awareness")
+struct UpdateDrainAwarenessTests {
+
+    // MARK: Heartbeat status
+
+    @Test("heartbeat reports draining whenever the provider refuses new work, even mid-decode")
+    func heartbeatReportsDrainingWhileRefusingNewWork() async throws {
+        let state = ProviderState()
+        let client = makeHeartbeatClient(state: state)
+
+        state.inferenceActive = true
+        #expect(try await heartbeatObject(client)["status"] as? String == "serving")
+
+        // Drain outranks serving: in-flight decodes may still be running, but
+        // the box must not be selected for new work.
+        state.refusingNewWork = true
+        #expect(try await heartbeatObject(client)["status"] as? String == "draining")
+
+        // Non-draining heartbeats are unchanged.
+        state.refusingNewWork = false
+        state.inferenceActive = false
+        #expect(try await heartbeatObject(client)["status"] as? String == "idle")
+    }
+
+    @Test("the encode-failure fallback heartbeat carries the computed status, not a literal idle")
+    func encodeFailureFallbackKeepsComputedStatus() async throws {
+        let state = ProviderState()
+        let client = makeHeartbeatClient(state: state)
+        // JSONEncoder's default non-conforming-float strategy is .throw, so a
+        // NaN in the capacity payload forces the catch branch deterministically;
+        // the fallback must be the minimal frame (no backend_capacity) but with
+        // the status the drain/serving logic computed.
+        state.backendCapacity = BackendCapacity(
+            slots: [], gpuMemoryActiveGb: .nan, gpuMemoryPeakGb: 0, gpuMemoryCacheGb: 0,
+            totalMemoryGb: 128)
+
+        state.refusingNewWork = true
+        var fallback = try await heartbeatObject(client)
+        #expect(fallback["backend_capacity"] == nil)
+        #expect(fallback["type"] as? String == "heartbeat")
+        #expect(fallback["status"] as? String == "draining")
+
+        state.refusingNewWork = false
+        state.inferenceActive = true
+        fallback = try await heartbeatObject(client)
+        #expect(fallback["backend_capacity"] == nil)
+        #expect(fallback["status"] as? String == "serving")
+
+        state.inferenceActive = false
+        fallback = try await heartbeatObject(client)
+        #expect(fallback["backend_capacity"] == nil)
+        #expect(fallback["status"] as? String == "idle")
+
+        // A finite payload encodes normally again.
+        state.backendCapacity = BackendCapacity(
+            slots: [], gpuMemoryActiveGb: 1, gpuMemoryPeakGb: 1, gpuMemoryCacheGb: 0,
+            totalMemoryGb: 128)
+        let normal = try await heartbeatObject(client)
+        #expect(normal["backend_capacity"] != nil)
+        #expect(normal["status"] as? String == "idle")
+    }
+
+    @Test("beginUpdateDraining flips the phase and the shared flag the heartbeat reads")
+    func beginUpdateDrainingFlipsHeartbeatStatus() async throws {
+        let loop = try makeDrainTestLoop()
+        let state = await loop.state
+        let client = makeHeartbeatClient(state: state)
+
+        #expect(try await heartbeatObject(client)["status"] as? String == "idle")
+        #expect(await loop.updatePhase == .idle)
+
+        await loop.beginUpdateDraining()
+
+        #expect(await loop.updatePhase == .draining)
+        #expect(state.refusingNewWork)
+        #expect(try await heartbeatObject(client)["status"] as? String == "draining")
+    }
+
+    // MARK: Drain / un-drain announcements
+
+    @Test("drain and un-drain transitions each push an event heartbeat the coordinator can act on immediately")
+    func drainAndResumeAnnounceThemselvesOnTheWire() async throws {
+        let mock = MockCoordinator()
+        let baseURL = try await mock.start()
+        defer { Task { await mock.shutdown() } }
+
+        let loop = try makeDrainTestLoop()
+        let state = await loop.state
+        // 60 s baseline: every heartbeat the mock sees is event-triggered.
+        let client = makeHeartbeatClient(
+            state: state, url: baseURL.mockProviderWebSocketURL(), heartbeatInterval: 60)
+        let (events, _) = await client.start()
+        defer { Task { await client.shutdown() } }
+
+        // `.connected` is announced only once the session is registered, i.e.
+        // once event heartbeats are permitted on it.
+        var connected = false
+        for await event in events {
+            if case .connected = event { connected = true; break }
+        }
+        try #require(connected)
+        await loop.setCoordinatorClientForTesting(client)
+
+        // Drain: the coordinator learns `draining` from an out-of-band
+        // heartbeat, not from the next 503 bounce or baseline tick.
+        await loop.beginUpdateDraining()
+        let drained = try await mock.waitForSnapshot(timeout: .seconds(5)) { $0.heartbeats.count >= 1 }
+        #expect(try #require(drained).heartbeats.last?.status == .draining)
+
+        // A failed commit/restart resumes serving: the flag clears, the next
+        // heartbeat reports idle again, and the un-drain is announced right
+        // away so the coordinator's TTL-aged drain mark is lifted now rather
+        // than on the next 5 s baseline tick.
+        await loop.resumeServingAfterUpdate()
+        #expect(await loop.updatePhase == .idle)
+        #expect(!state.refusingNewWork)
+        #expect(try await heartbeatObject(client)["status"] as? String == "idle")
+        let resumed = try await mock.waitForSnapshot(timeout: .seconds(5)) { $0.heartbeats.count >= 2 }
+        #expect(try #require(resumed).heartbeats.last?.status == .idle)
+    }
+
+    // MARK: Drain rejection reason
+
+    @Test("the drain rejection frame carries error_reason=draining alongside the slot_state enrichment")
+    func drainRejectionCarriesTypedReason() async throws {
+        let loop = try makeDrainTestLoop()
+        let captured = OutboundCapture()
+        let send = SendHandle { captured.append($0) }
+
+        // Not draining: the gate admits (returns false, sends nothing).
+        let admitted = await loop.rejectIfDrainingForUpdate(
+            requestId: "req-admit", send: send,
+            lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer(callback: nil))
+        #expect(admitted == false)
+        #expect(captured.all.isEmpty)
+
+        await loop.beginUpdateDraining()
+        let rejected = await loop.rejectIfDrainingForUpdate(
+            requestId: "req-drain", send: send,
+            lookupReceiptFinalizer: PrefixCacheLookupReceiptFinalizer(callback: nil))
+        #expect(rejected)
+
+        let message = try #require(captured.all.first)
+        let frame = try jsonObject(try CoordinatorClientCodec.encodeOutboundMessage(message))
+        #expect(frame["type"] as? String == "inference_error")
+        #expect(frame["request_id"] as? String == "req-drain")
+        #expect(frame["status_code"] as? Int == 503)
+        #expect(frame["error_reason"] as? String == "draining")
+        // Enrichment is unchanged: the typed reason maps onto the same
+        // slot_state the bare 503 used to fall back to.
+        #expect(frame["rejection_reason"] as? String == "slot_state")
+    }
+
+    // MARK: Protocol symmetry
+
+    @Test("ProviderStatus.draining and InferenceErrorReason.draining round-trip with the Go wire strings")
+    func drainingWireStringsRoundTrip() throws {
+        #expect(ProviderStatus.draining.rawValue == "draining")
+        #expect(ProviderStatus(rawValue: "draining") == .draining)
+        #expect(InferenceErrorReason.draining.rawValue == "draining")
+        #expect(InferenceErrorReason(rawValue: "draining") == .draining)
+        #expect(CapacityRejectionReason(errorReason: .draining) == .slotState)
+
+        let heartbeat = ProviderMessage.heartbeat(ProviderMessage.Heartbeat(
+            status: .draining,
+            stats: ProviderStats(),
+            systemMetrics: SystemMetrics(memoryPressure: 0, cpuUsage: 0, thermalState: .nominal)))
+        let heartbeatData = try ProviderProtocolCodec.encodeProviderMessage(heartbeat)
+        #expect(try jsonObject(heartbeatData)["status"] as? String == "draining")
+        guard case .heartbeat(let decodedHeartbeat) =
+            try ProviderProtocolCodec.decodeProviderMessage(from: heartbeatData)
+        else {
+            Issue.record("expected a heartbeat")
+            return
+        }
+        #expect(decodedHeartbeat.status == .draining)
+
+        let error = ProviderMessage.inferenceError(ProviderMessage.InferenceError(
+            requestId: "r",
+            failure: InferenceFailure(code: .capacity, statusCode: 503, errorReason: .draining)))
+        let errorData = try ProviderProtocolCodec.encodeProviderMessage(error)
+        #expect(try jsonObject(errorData)["error_reason"] as? String == "draining")
+        guard case .inferenceError(let decodedError) =
+            try ProviderProtocolCodec.decodeProviderMessage(from: errorData)
+        else {
+            Issue.record("expected an inference_error")
+            return
+        }
+        #expect(decodedError.errorReason == .draining)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/UpdateDrainAwarenessTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/UpdateDrainAwarenessTests.swift
@@ -269,4 +269,30 @@ struct UpdateDrainAwarenessTests {
         }
         #expect(decodedError.errorReason == .draining)
     }
+
+    @Test("retirement reconnect remains draining until the new connection lifts its barrier")
+    func retirementReconnectPreservesHeartbeatDrainState() async throws {
+        let loop = try makeDrainTestLoop()
+        let state = await loop.state
+        let client = makeHeartbeatClient(state: state)
+
+        await loop.setRetirementReconnectBarrier(true)
+        #expect(await loop.isReconnectingAfterRetirement)
+        #expect(try await heartbeatObject(client)["status"] as? String == "draining")
+        await loop.resumeServingAfterUpdate()
+        #expect(state.refusingNewWork)
+        #expect(try await heartbeatObject(client)["status"] as? String == "draining")
+
+        await loop.setRetirementReconnectBarrier(false)
+        #expect(!state.refusingNewWork)
+        #expect(try await heartbeatObject(client)["status"] as? String == "idle")
+
+        await loop.beginUpdateDraining()
+        await loop.setRetirementReconnectBarrier(true)
+        await loop.setRetirementReconnectBarrier(false)
+        #expect(state.refusingNewWork)
+        #expect(try await heartbeatObject(client)["status"] as? String == "draining")
+        await loop.resumeServingAfterUpdate()
+        #expect(!state.refusingNewWork)
+    }
 }


### PR DESCRIPTION
This completes the provider lifecycle work and includes the Tier 3 reservation-gate implementation merged from #822, following the store/API and routing-scan changes. It keeps large writes and queue draining bounded, treats drain/restart behavior correctly, and makes operational telemetry reflect actual sends and accepted snapshots.

- Fragment provider WebSocket messages over 256 KiB so ping/pong replies can interleave between continuation frames. Application control messages retain non-preemptive lane priority. Coalesce queue drains and avoid repeated dominated scans.
- Mark sanitized draining refusals at ingress before releasing the pending slot or draining queued demand. Delayed consumer classification cannot overwrite a newer recovery heartbeat.
- Swift update, shutdown, and retirement reconnect barriers advertise draining consistently. Recovery clears only the barrier that ended.
- Graceful restarts are health-neutral. Version changes remove only explicitly coordinator-marked disconnect-flush faults; genuine provider 502s, other faults, and reset throttling are retained, and departed version history is bounded. Cached disconnected identities follow enrichment.
- Bound zombie tracking with constant-time least-recently-active eviction at capacity, retaining rate-limited TTL cleanup.
- Serialize successful cancel enqueue and tracking so terminals cannot observe an accepted-but-unmarked cancel; count failures/resends accurately and anchor latency to successful sends.
- Use one chunk decode, bounded chip/version tags, HTTP-capable MLX snapshot metrics, and positive counter deltas. Rejected stale heartbeats emit no duplicate allocator samples. Departing queue models receive a final zero depth/age sample and are forgotten.

- Commit reservations under the registry read lock and selected provider mutex, with fault state held per identity. Rebind, sweep, and disconnected-session reference validation preserve the check-through-debit invariant; `EIGENINFERENCE_RESERVE_COMMIT_MODE=global` retains the reservation rollback mode.
- Count first-reservation TTFT rejections in the request-level OR view, independently of retry-only ledger writes. Document the emitted metrics, labels, in-process mirrors, and disconnect reasons.

## Before
```mermaid
flowchart LR
  L[Large provider write] --> B[Ping replies wait for the entire frame]
  E[Draining error ingress] --> I[Release slot and drain queue]
  I --> R[Queued work reassigned to draining provider]
  E --> C[Consumer later marks draining]
  X[Cancel enqueue] --> U[Terminal can remove entry before send is marked]
  H[Stale heartbeat] --> M[Repeated allocator sample]
  C1[Capped tracker insertion] --> W[Full-map sweeps under tracker mutex]
  E1[Any provider 502] --> F1[Tagged as flush and removed on version change]
  R1[Reservation and terminal recorders] --> G1[Global registry write lock]
```

## After
```mermaid
flowchart LR
  L[Large provider write] --> F[Continuation frames permit pong replies]
  E[Sanitized draining error] --> D[noteProviderDraining before RemovePending]
  D --> Q[SetProviderIdle drains only eligible providers]
  S[Swift retirement or update barrier] --> H[Heartbeat reports draining until recovery]
  X[Cancel enqueue] --> A[Atomic tracker enqueue and send mark]
  A --> T[Terminal sees correct delivery state]
  V[Registry.Heartbeat acceptance result] -->|accepted| M[Allocator telemetry]
  V -->|stale| N[Liveness only]
  C2[Capped tracker insertion] --> L2[Constant-time recency eviction]
  E2[Non-wire coordinator cause] --> F2[Only true disconnect flushes can reset]
  R2[Reservation] --> G2[Registry read lock and selected provider mutex]
  T2[Fault recorders] --> I2[Validated per-identity gates]
  Z[First reservation TTFT rejection] --> O[One OR-view rate_limited outcome]
```

Validation: full coordinator tests, focused lifecycle/queue/telemetry/eviction race suites, Datadog transport wire tests, build/vet/lint/docs checks, and seven Swift drain-awareness tests passed. The drain-ingress regression failed before the fix and now proves queued demand stays fenced without a consumer reading ErrorCh.

#821 has landed; #822 is already merged into this branch. Remaining parent order: #820 → #819 → #823. Retarget each child to master after its parent lands.

The maintainer has deferred the known Threat Model Review credential failure. The benchmark environment remains subject to its existing manual approval gate.

Current review follow-up validation: targeted race regressions cover capped eviction and cleanup, genuine encryption 502s across version reset, true/late disconnect flushes, and attempt-zero TTFT counting. Build, vet, lint, and docs checks pass.
