### PR TITLE
fix(provider): canonicalize mixed-case status maps

### DIFF
--- a/coordinator/attestation/status_canonical_test.go
+++ b/coordinator/attestation/status_canonical_test.go
@@ -59,6 +59,29 @@ func TestBuildStatusCanonicalGoldenBytes(t *testing.T) {
 	}
 }
 
+// TestBuildStatusCanonicalMixedCaseModelIDs pins the bytewise ordering used by
+// Go's encoding/json. The matching Swift test includes the same production
+// model IDs so a case-sensitive ordering drift cannot break status signatures.
+func TestBuildStatusCanonicalMixedCaseModelIDs(t *testing.T) {
+	got, err := BuildStatusCanonical(StatusCanonicalInput{
+		Nonce:     "n",
+		Timestamp: "t",
+		ModelHashes: map[string]string{
+			"Qwen3.5-9B":                   "127de76b4ef82b7a",
+			"gemma-4-26b-qat-4bit":         "2468a0cb3049a871",
+			"qwen3.6-35b-a3b-vl-mtp-mxfp8": "d932e96b00404b05",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildStatusCanonical: %v", err)
+	}
+
+	expected := []byte(`{"model_hashes":{"Qwen3.5-9B":"127de76b4ef82b7a","gemma-4-26b-qat-4bit":"2468a0cb3049a871","qwen3.6-35b-a3b-vl-mtp-mxfp8":"d932e96b00404b05"},"nonce":"n","timestamp":"t"}`)
+	if !bytes.Equal(got, expected) {
+		t.Fatalf("mixed-case canonical bytes drifted from Swift golden\nwant: %s\ngot:  %s", expected, got)
+	}
+}
+
 // TestBuildStatusCanonicalGoldenBytesLegacyHypervisor pins the OLD-fleet
 // canonical bytes. Legacy fleet compat only: providers < v0.6.31 sign
 // hypervisor_active into the canonical status, so when a challenge

--- a/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
+++ b/provider-swift/Sources/ProviderCore/Security/AttestationBuilder.swift
@@ -118,26 +118,55 @@ public struct StatusCanonicalInput: Sendable, Equatable {
     }
 }
 
+private struct StatusCanonicalPayload: Encodable {
+    let nonce: String
+    let timestamp: String
+    let rdmaDisabled: Bool?
+    let sipEnabled: Bool?
+    let secureBootEnabled: Bool?
+    let binaryHash: String?
+    let activeModelHash: String?
+    let pythonHash: String?
+    let runtimeHash: String?
+    let templateHashes: [String: String]?
+    let modelHashes: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case nonce
+        case timestamp
+        case rdmaDisabled = "rdma_disabled"
+        case sipEnabled = "sip_enabled"
+        case secureBootEnabled = "secure_boot_enabled"
+        case binaryHash = "binary_hash"
+        case activeModelHash = "active_model_hash"
+        case pythonHash = "python_hash"
+        case runtimeHash = "runtime_hash"
+        case templateHashes = "template_hashes"
+        case modelHashes = "model_hashes"
+    }
+}
+
 public enum StatusCanonical {
     public static func build(_ input: StatusCanonicalInput) throws -> Data {
-        var object: [String: Any] = [
-            "nonce": input.nonce,
-            "timestamp": input.timestamp,
-        ]
-        if let value = input.rdmaDisabled { object["rdma_disabled"] = value }
-        if let value = input.sipEnabled { object["sip_enabled"] = value }
-        if let value = input.secureBootEnabled { object["secure_boot_enabled"] = value }
-        if let value = nonEmpty(input.binaryHash) { object["binary_hash"] = value }
-        if let value = nonEmpty(input.activeModelHash) { object["active_model_hash"] = value }
-        if let value = nonEmpty(input.pythonHash) { object["python_hash"] = value }
-        if let value = nonEmpty(input.runtimeHash) { object["runtime_hash"] = value }
-        if !input.templateHashes.isEmpty { object["template_hashes"] = input.templateHashes }
-        if !input.modelHashes.isEmpty { object["model_hashes"] = input.modelHashes }
-
-        return try JSONSerialization.data(
-            withJSONObject: object,
-            options: [.sortedKeys, .withoutEscapingSlashes]
+        let payload = StatusCanonicalPayload(
+            nonce: input.nonce,
+            timestamp: input.timestamp,
+            rdmaDisabled: input.rdmaDisabled,
+            sipEnabled: input.sipEnabled,
+            secureBootEnabled: input.secureBootEnabled,
+            binaryHash: nonEmpty(input.binaryHash),
+            activeModelHash: nonEmpty(input.activeModelHash),
+            pythonHash: nonEmpty(input.pythonHash),
+            runtimeHash: nonEmpty(input.runtimeHash),
+            templateHashes: input.templateHashes.isEmpty ? nil : input.templateHashes,
+            modelHashes: input.modelHashes.isEmpty ? nil : input.modelHashes
         )
+
+        // JSONEncoder's sortedKeys ordering matches Go's encoding/json bytewise
+        // string-key ordering, including for mixed-case keys in nested maps.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try encoder.encode(payload)
     }
 
     private static func nonEmpty(_ value: String?) -> String? {

--- a/provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SecurityTests.swift
@@ -183,6 +183,20 @@ import Testing
     #expect(String(data: data, encoding: .utf8) == expected)
 }
 
+@Test func statusCanonicalMatchesCoordinatorForMixedCaseModelIDs() throws {
+    let data = try StatusCanonical.build(StatusCanonicalInput(
+        nonce: "n",
+        timestamp: "t",
+        modelHashes: [
+            "Qwen3.5-9B": "127de76b4ef82b7a",
+            "gemma-4-26b-qat-4bit": "2468a0cb3049a871",
+            "qwen3.6-35b-a3b-vl-mtp-mxfp8": "d932e96b00404b05",
+        ]
+    ))
+    let expected = #"{"model_hashes":{"Qwen3.5-9B":"127de76b4ef82b7a","gemma-4-26b-qat-4bit":"2468a0cb3049a871","qwen3.6-35b-a3b-vl-mtp-mxfp8":"d932e96b00404b05"},"nonce":"n","timestamp":"t"}"#
+    #expect(String(data: data, encoding: .utf8) == expected)
+}
+
 @Test func registrationAttestationBlobJSONOmitsHypervisorKeys() throws {
     // The registration attestation blob is signed over its exact serialized
     // bytes (sorted keys, ISO-8601 dates -- the same encoder settings


### PR DESCRIPTION
## Summary

Use a typed `Encodable` status payload with `JSONEncoder.sortedKeys` so Swift orders mixed-case keys in nested model-hash maps the same way as Go's `encoding/json`.

This prevents valid Secure Enclave status signatures from being rejected when a provider advertises model IDs such as `Qwen3.5-9B` alongside lowercase IDs. Matching Swift and Go golden vectors pin the production three-model payload that exposed the mismatch.

## Linked issue

Closes #825

## Before

```mermaid
flowchart LR
  A[Attestation challenge] --> B[StatusCanonical.build]
  B --> C[JSONSerialization sortedKeys]
  C --> D[Foundation orders nested keys: gemma before Qwen]
  D --> E[Provider signs Swift bytes]
  E --> F[Coordinator rebuilds bytes with Go encoding/json]
  F --> G[Byte order differs]
  G --> H[ECDSA verification fails]
  H --> I[Provider becomes untrusted]
```

## After

```mermaid
flowchart LR
  A[Attestation challenge] --> B[StatusCanonical.build]
  B --> C[Typed StatusCanonicalPayload]
  C --> D[JSONEncoder sortedKeys]
  D --> E[Mixed-case nested keys use Go-compatible bytewise order]
  E --> F[Provider signs canonical bytes]
  F --> G[Coordinator rebuilds identical bytes]
  G --> H[ECDSA verification succeeds]
  H --> I[Provider retains hardware trust]
```

## Test plan

- [x] `cd provider-swift && swift build --build-tests`
- [x] `cd provider-swift && swift test --skip-build --filter statusCanonical`
- [x] `make coordinator-test`
- [x] Verified the new Swift mixed-case golden test fails before the implementation and passes afterward.
- [ ] `make provider-test` requires the optional Xcode Metal Toolchain on this host; it stops while building `mlx.metallib` before executing the suite.

## Components touched

- [x] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

The wire shape and omission rules are unchanged: nil booleans, empty strings, and empty maps remain omitted, while explicit `false` values remain signed. The coordinator production path is unchanged; its added test mirrors the Swift production-ID vector and guards the cross-language byte contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791122098&installation_model_id=21733&pr_number=826&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F826&signature=159b3a74db9e56ec5f7a13b6bb96b5c146db997f1bf561a8cab682361c4dfb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->