### PR TITLE
fix(earn): add missing Mac mini M5 Pro and Mac Studio M5 Max configs

### DIFF
--- a/console-ui/src/app/earn/calc.ts
+++ b/console-ui/src/app/earn/calc.ts
@@ -39,6 +39,7 @@ export const MAC_CONFIGS: MacConfig[] = [
   { macType: MAC_MINI, chip: "M2 Pro", ramOptions: [16, 32], bandwidthGBs: 200 },
   { macType: MAC_MINI, chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120 },
   { macType: MAC_MINI, chip: "M4 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 273 },
+  { macType: MAC_MINI, chip: "M5 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 307 },
   { macType: MAC_MINI, chip: "M6", ramOptions: [16, 24, 32], bandwidthGBs: 170 },
   { macType: MAC_STUDIO, chip: "M1 Max", ramOptions: [32, 64], bandwidthGBs: 400 },
   { macType: MAC_STUDIO, chip: "M1 Ultra", ramOptions: [64, 128], bandwidthGBs: 800 },
@@ -48,6 +49,8 @@ export const MAC_CONFIGS: MacConfig[] = [
   { macType: MAC_STUDIO, chip: "M5 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 1200 },
   { macType: MAC_STUDIO, chip: M4_MAX_14_CORE, ramOptions: [36], bandwidthGBs: 410 },
   { macType: MAC_STUDIO, chip: M4_MAX_16_CORE, ramOptions: [48, 64, 128], bandwidthGBs: 546 },
+  { macType: MAC_STUDIO, chip: "M5 Max (32-core GPU)", ramOptions: [36], bandwidthGBs: 460 },
+  { macType: MAC_STUDIO, chip: "M5 Max (40-core GPU)", ramOptions: [48, 64, 128], bandwidthGBs: 614 },
   { macType: MAC_PRO, chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800 },
 ];
 

--- a/landing/earn-calculator-core.js
+++ b/landing/earn-calculator-core.js
@@ -34,6 +34,7 @@
     { macType: "Mac Mini", chip: "M2 Pro", ramOptions: [16, 32], bandwidthGBs: 200 },
     { macType: "Mac Mini", chip: "M4", ramOptions: [16, 24, 32], bandwidthGBs: 120 },
     { macType: "Mac Mini", chip: "M4 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 273 },
+    { macType: "Mac Mini", chip: "M5 Pro", ramOptions: [24, 48, 64], bandwidthGBs: 307 },
     { macType: "Mac Mini", chip: "M6", ramOptions: [16, 24, 32], bandwidthGBs: 170 },
     { macType: "Mac Studio", chip: "M1 Max", ramOptions: [32, 64], bandwidthGBs: 400 },
     { macType: "Mac Studio", chip: "M1 Ultra", ramOptions: [64, 128], bandwidthGBs: 800 },
@@ -43,6 +44,8 @@
     { macType: "Mac Studio", chip: "M5 Ultra", ramOptions: [96, 256, 512], bandwidthGBs: 1200 },
     { macType: "Mac Studio", chip: "M4 Max (14-core CPU)", ramOptions: [36], bandwidthGBs: 410 },
     { macType: "Mac Studio", chip: "M4 Max (16-core CPU)", ramOptions: [48, 64, 128], bandwidthGBs: 546 },
+    { macType: "Mac Studio", chip: "M5 Max (32-core GPU)", ramOptions: [36], bandwidthGBs: 460 },
+    { macType: "Mac Studio", chip: "M5 Max (40-core GPU)", ramOptions: [48, 64, 128], bandwidthGBs: 614 },
     { macType: "Mac Pro", chip: "M2 Ultra", ramOptions: [64, 128, 192], bandwidthGBs: 800 },
   ];
   const CHIP_ORDER = [


### PR DESCRIPTION
## What happened

Apple's Aug 25, 2026 refresh added the M5 Pro chip to Mac mini and the M5 Max chip to Mac Studio, alongside M6 (mini) and M5 Ultra (Studio), which are already in the calculator. That refresh landed the same day as #728's calculator rewrite, so these two chip tiers got missed in both copies of the hardware table (`console-ui/src/app/earn/calc.ts` and `landing/earn-calculator-core.js`).

## Why

Without these entries, anyone with an M5 Pro Mac mini or M5 Max Mac Studio can't get an earnings estimate at all, since the calculator has no matching config to look up.

## What changed

Added two rows to `MAC_CONFIGS` in both files:
- Mac mini M5 Pro: 24 / 48 / 64 GB, 307 GB/s
- Mac Studio M5 Max (32-core GPU): 36 GB, 460 GB/s
- Mac Studio M5 Max (40-core GPU): 48 / 64 / 128 GB, 614 GB/s

Verified against Apple's official tech specs. Data-only change, no logic touched.

## Test plan

- [x] `node --test landing/earn-calculator-core.test.js` — all 5 existing tests pass
- [x] `tsc --noEmit` on console-ui — no new errors