### PR TITLE
fix(stats): avoid full-row sorts in location refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — stats location refresh
+
+- Restore public stats refreshes on large usage tables by aggregating locations per provider before combining location totals. Preserve distinct-provider and token counts and request-weighted coordinates without sorting every usage row. Keep the selective cutoff's query plan local to the analytics transaction.
+
 ## Unreleased — coordinator performance Tiers 2 and 3
 
 - Cache repeated user and model lookups, batch route telemetry writes, and credit balances in one database statement. Invalidate model caches without allowing older in-flight reads to republish stale entries.

--- a/coordinator/store/analytics_locations_test.go
+++ b/coordinator/store/analytics_locations_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Keep the pre-fix query as an independent semantics oracle. Unequal per-provider
+// sample counts and missing coordinates make unweighted averages incorrect.
+const originalLocationAggregateSQL = `SELECT
+				COALESCE(request_location->>'city', '') AS city,
+				COALESCE(request_location->>'region', '') AS region,
+				COALESCE(request_location->>'region_code', '') AS region_code,
+				COALESCE(request_location->>'country', '') AS country,
+				COALESCE(request_location->>'country_code', '') AS country_code,
+				COALESCE(AVG(NULLIF(request_location->>'latitude', '')::double precision), 0),
+				COALESCE(AVG(NULLIF(request_location->>'longitude', '')::double precision), 0),
+				COUNT(*),
+				COALESCE(SUM(prompt_tokens), 0),
+				COALESCE(SUM(completion_tokens), 0),
+				COUNT(DISTINCT provider_id)
+			 FROM usage
+			 WHERE request_location IS NOT NULL
+			   AND created_at >= $1
+			 GROUP BY city, region, region_code, country, country_code
+			 ORDER BY COUNT(*) DESC`
+
+func TestUsageLocationBucketsMatchesOriginalAggregate(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	since := time.Date(2026, 9, 4, 0, 0, 0, 0, time.UTC)
+	normal := `{"city":"North","region":"Region","region_code":"R","country":"United States","country_code":"US","latitude":"10","longitude":"20"}`
+	later := `{"city":"North","region":"Region","region_code":"R","country":"United States","country_code":"US","latitude":"30","longitude":"40"}`
+	missing := `{"city":"North","region":"Region","region_code":"R","country":"United States","country_code":"US","latitude":"","longitude":""}`
+	partial := `{"city":"North","region":"Region","region_code":"R","country":"United States","country_code":"US","latitude":null,"longitude":"50"}`
+	insert := func(provider string, location any, prompt, completion int, at time.Time) {
+		t.Helper()
+		_, err := s.pool.Exec(ctx, `INSERT INTO usage
+   (provider_id, consumer_key_hash, model, prompt_tokens, completion_tokens, created_at, request_location)
+   VALUES ($1, 'aggregate-consumer', 'aggregate-model', $2, $3, $4, $5::jsonb)`, provider, prompt, completion, at, location)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		insert("p1", normal, 10, 20, since.Add(time.Hour))
+	}
+	insert("p2", later, 7, 9, since.Add(time.Hour))
+	insert("p2", missing, 0, 1, since.Add(time.Hour))
+	insert("", partial, 5, 6, since) // inclusive cutoff; empty ID is still distinct
+	insert("p3", `{}`, 2, 3, since.Add(time.Hour))
+	insert("p4", `null`, 4, 5, since.Add(time.Hour)) // JSON null is not SQL NULL
+	insert("p1", strings.Replace(normal, `"R"`, `"S"`, 1), 6, 7, since.Add(time.Hour))
+	insert("p1", strings.Replace(normal, `"US"`, `"CA"`, 1), 8, 9, since.Add(time.Hour))
+	insert("expired", normal, 9999, 9999, since.Add(-time.Second))
+	insert("unlocated", nil, 9999, 9999, since.Add(time.Hour))
+
+	got, err := s.UsageLocationBuckets(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := s.pool.Query(ctx, originalLocationAggregateSQL, since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var want []UsageLocationBucket
+	for rows.Next() {
+		var b UsageLocationBucket
+		if err := rows.Scan(&b.City, &b.Region, &b.RegionCode, &b.Country, &b.CountryCode,
+			&b.Latitude, &b.Longitude, &b.Requests, &b.PromptTokens, &b.CompletionTokens, &b.Providers); err != nil {
+			t.Fatal(err)
+		}
+		want = append(want, b)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) || len(got) != 4 {
+		t.Fatalf("buckets: got %d, want %d (four fixture locations)", len(got), len(want))
+	}
+	key := func(b UsageLocationBucket) string {
+		return strings.Join([]string{b.City, b.Region, b.RegionCode, b.Country, b.CountryCode}, "\x00")
+	}
+	indexed := make(map[string]UsageLocationBucket, len(want))
+	for _, b := range want {
+		indexed[key(b)] = b
+	}
+	for i, b := range got {
+		expected, ok := indexed[key(b)]
+		if !ok {
+			t.Fatalf("unexpected location: %+v", b)
+		}
+		if math.Abs(b.Latitude-expected.Latitude) > 1e-10 || math.Abs(b.Longitude-expected.Longitude) > 1e-10 {
+			t.Fatalf("coordinate averages differ: got %+v, want %+v", b, expected)
+		}
+		b.Latitude, b.Longitude = expected.Latitude, expected.Longitude
+		if !reflect.DeepEqual(b, expected) {
+			t.Fatalf("aggregate differs: got %+v, want %+v", b, expected)
+		}
+		if i > 0 && got[i-1].Requests < b.Requests {
+			t.Fatal("buckets are not ordered by descending request count")
+		}
+	}
+	if b := got[0]; b.Requests != 6 || b.Providers != 3 || b.PromptTokens != 42 || b.CompletionTokens != 76 || b.Latitude != 15 || b.Longitude != 30 {
+		t.Fatalf("weighted fixture result: %+v", b)
+	}
+}
+
+func TestUsageLocationPlanChoiceDoesNotLeakToPool(t *testing.T) {
+	s, tracer := testPostgresStoreWithTracer(t, func(cfg *pgxpool.Config) {
+		cfg.MaxConns = 1 // SHOW below must inspect the query's original connection.
+		cfg.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_generic_plan"
+	})
+	tracer.reset()
+	if _, err := s.UsageLocationBuckets(time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	events := tracer.snapshot()
+	assertAnalyticsTx(t, events, "FROM usage")
+	custom := -1
+	for i, event := range events {
+		if event.sql == "SET LOCAL plan_cache_mode = force_custom_plan" {
+			custom = i
+		}
+		if strings.Contains(event.sql, "FROM usage") && (custom < 0 || events[custom].pid != event.pid) {
+			t.Fatal("location query did not select a custom plan on its transaction connection")
+		}
+	}
+	var mode string
+	if err := s.pool.QueryRow(context.Background(), "SHOW plan_cache_mode").Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "force_generic_plan" {
+		t.Fatalf("location query leaked plan_cache_mode=%q into the pool", mode)
+	}
+}

--- a/coordinator/store/analytics_workmem_test.go
+++ b/coordinator/store/analytics_workmem_test.go
@@ -48,7 +48,7 @@ func (t *statementTracer) snapshot() []tracedStatement {
 
 // testPostgresStoreWithTracer is testPostgresStore with a statement tracer on
 // every pooled connection. Only the tables this file touches are truncated.
-func testPostgresStoreWithTracer(t *testing.T) (*PostgresStore, *statementTracer) {
+func testPostgresStoreWithTracer(t *testing.T, configure ...func(*pgxpool.Config)) (*PostgresStore, *statementTracer) {
 	t.Helper()
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
@@ -59,6 +59,9 @@ func testPostgresStoreWithTracer(t *testing.T) (*PostgresStore, *statementTracer
 	tracer := &statementTracer{}
 	s, err := newPostgresWithPoolConfig(ctx, Config{DatabaseURL: dbURL}, func(cfg *pgxpool.Config) {
 		cfg.ConnConfig.Tracer = tracer
+		for _, configurePool := range configure {
+			configurePool(cfg)
+		}
 	})
 	if err != nil {
 		t.Fatalf("NewPostgres: %v", err)
@@ -185,7 +188,7 @@ func TestUsageAnalyticsRunInWorkMemTransaction(t *testing.T) {
 	if len(locations) != 1 || locations[0].Requests != 3 || locations[0].Providers != 1 {
 		t.Fatalf("location buckets = %+v, want one NY bucket with 3 requests from 1 provider", locations)
 	}
-	assertAnalyticsTx(t, tracer.snapshot(), "COUNT(DISTINCT provider_id)")
+	assertAnalyticsTx(t, tracer.snapshot(), "FROM usage")
 
 	tracer.reset()
 	flows, err := s.UsageFlowBuckets(since, nil)

--- a/coordinator/store/postgres_analytics.go
+++ b/coordinator/store/postgres_analytics.go
@@ -51,26 +51,13 @@ func (s *PostgresStore) UsageLocationBuckets(since time.Time) ([]UsageLocationBu
 
 	var buckets []UsageLocationBucket
 	err := s.withAnalyticsTx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx,
-			`SELECT
-				COALESCE(request_location->>'city', '') AS city,
-				COALESCE(request_location->>'region', '') AS region,
-				COALESCE(request_location->>'region_code', '') AS region_code,
-				COALESCE(request_location->>'country', '') AS country,
-				COALESCE(request_location->>'country_code', '') AS country_code,
-				COALESCE(AVG(NULLIF(request_location->>'latitude', '')::double precision), 0),
-				COALESCE(AVG(NULLIF(request_location->>'longitude', '')::double precision), 0),
-				COUNT(*),
-				COALESCE(SUM(prompt_tokens), 0),
-				COALESCE(SUM(completion_tokens), 0),
-				COUNT(DISTINCT provider_id)
-			 FROM usage
-			 WHERE request_location IS NOT NULL
-			   AND created_at >= $1
-			 GROUP BY city, region, region_code, country, country_code
-			 ORDER BY COUNT(*) DESC`,
-			since,
-		)
+		// The rolling cutoff is selective, while a generic parameter plan can
+		// estimate tens of millions of groups and choose another full sort.
+		// Keep this choice local to this read-only transaction.
+		if _, err := tx.Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan"); err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx, usageLocationBucketsSQL, since)
 		if err != nil {
 			return err
 		}

--- a/coordinator/store/postgres_analytics_locations.go
+++ b/coordinator/store/postgres_analytics_locations.go
@@ -1,0 +1,39 @@
+package store
+
+// Group by location and provider before rolling up the public location bucket.
+// COUNT(DISTINCT provider_id) in the former single-level aggregate forced a
+// sorted aggregate over every usage row: the production 24-hour window spilled
+// to disk and exceeded the refresh deadline. Both levels here can use hash
+// aggregation, reducing the intermediate rows before the final count sort.
+//
+// Coordinate sums carry their non-null sample counts so providers with unequal
+// request counts do not receive equal weight. COUNT(provider_id) ignores the
+// null-provider group, matching COUNT(DISTINCT provider_id); an empty ID still
+// counts as one provider. The query and its timeout remain read-only.
+const usageLocationBucketsSQL = `SELECT city, region, region_code, country, country_code,
+       COALESCE(SUM(latitude_sum) / NULLIF(SUM(latitude_count), 0), 0),
+       COALESCE(SUM(longitude_sum) / NULLIF(SUM(longitude_count), 0), 0),
+       SUM(requests)::bigint,
+       COALESCE(SUM(prompt_tokens), 0),
+       COALESCE(SUM(completion_tokens), 0),
+       COUNT(provider_id)
+FROM (
+    SELECT COALESCE(request_location->>'city', '') AS city,
+           COALESCE(request_location->>'region', '') AS region,
+           COALESCE(request_location->>'region_code', '') AS region_code,
+           COALESCE(request_location->>'country', '') AS country,
+           COALESCE(request_location->>'country_code', '') AS country_code,
+           provider_id,
+           SUM(NULLIF(request_location->>'latitude', '')::double precision) AS latitude_sum,
+           COUNT(NULLIF(request_location->>'latitude', '')::double precision) AS latitude_count,
+           SUM(NULLIF(request_location->>'longitude', '')::double precision) AS longitude_sum,
+           COUNT(NULLIF(request_location->>'longitude', '')::double precision) AS longitude_count,
+           COUNT(*) AS requests,
+           SUM(prompt_tokens) AS prompt_tokens,
+           SUM(completion_tokens) AS completion_tokens
+    FROM usage
+    WHERE request_location IS NOT NULL AND created_at >= $1
+    GROUP BY city, region, region_code, country, country_code, provider_id
+) AS location_usage_by_provider
+GROUP BY city, region, region_code, country, country_code
+ORDER BY SUM(requests) DESC`


### PR DESCRIPTION
After the coordinator upgrade, `/v1/stats` cannot populate its cache: `UsageLocationBuckets` repeatedly exceeds its 10-second query deadline. The production query sorts about 3.2 million usage rows for `COUNT(DISTINCT provider_id)` and spills to disk, so cold requests receive 503.

Group usage by location and provider first, then combine location totals. Both aggregation levels can use hash aggregation; only the final location buckets need sorting. Carry coordinate sums and non-null sample counts to retain request-weighted averages. Select a custom parameter plan within this read-only transaction so the rolling cutoff's selectivity is used; the setting does not leak into the connection pool. The existing timeout and memory budget remain unchanged.

## Before

```mermaid
flowchart LR
  R[GET /v1/stats or background refresh] --> C[computeStats]
  C --> U[UsageLocationBuckets]
  U --> S[Sort every located usage row for COUNT DISTINCT]
  S --> D[Disk spill exceeds 10-second deadline]
  D --> E[No cached snapshot; return 503]
```

## After

```mermaid
flowchart LR
  R[GET /v1/stats or background refresh] --> C[computeStats]
  C --> P[Transaction-local custom plan]
  P --> H[usageLocationBucketsSQL groups location and provider]
  H --> L[Combine counts, tokens and weighted coordinate sums]
  L --> S[Sort final location buckets]
  S --> V[Publish cached stats snapshot; return 200]
```

## Validation

- Read-only production PostgreSQL 17.10 trial of the exact parameterized query: **5.03 seconds**, 3,216,186 input rows → 53,463 provider/location groups → 192 location buckets; **zero temporary reads/writes**, largest hash node about 28 MiB.
- One-snapshot comparison with the original SQL: no missing buckets and exact request/provider/token counts. Floating-point coordinate differences were below 1.8e-9 degrees.
- The other required stats aggregate (flows) completed in 7.46 seconds without spilling, within its existing deadline.
- A forced generic plan estimated 23.6 million intermediate groups and chose sorts. The transaction-local custom plan keeps the tested selective plan; a regression test proves that even a pool configured for generic plans regains its original setting afterward.
- Full store race suite against local PostgreSQL 16.14 passed, including the original-query equivalence fixture with repeated providers, unequal weights, missing coordinates, empty provider IDs, JSON null versus SQL NULL, grouping-key separation, and the inclusive cutoff.
- Focused API stats/cache tests, coordinator build, formatting, and golangci-lint passed.

This is the stats follow-up to #829. No schema migration, global database tuning, provider change, or new environment setting is required. The read-only SQL trials are production-size evidence, not an assertion that this binary is already deployed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791163264&installation_model_id=21733&pr_number=830&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F830&signature=de29baae75fa6b0a71c4bed50d5c8385d6e2e82adeedb62e9e74742c8508bc1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->