### PR TITLE
fix(provider): keep whole seconds in benchmark iteration timings (#770)

### DIFF
--- a/provider-swift/Sources/ProviderBenchmark/ModelBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ModelBenchmark.swift
@@ -203,7 +203,7 @@ public struct ModelBenchmark: Sendable {
 
         var promptTokens = 0
         var completionTokens = 0
-        var prefillLatencyMs: Double = 0
+        var infoPromptTimeSeconds: Double = 0
         var firstTokenTime: ContinuousClock.Instant?
 
         for await generation in generationStream {
@@ -211,17 +211,12 @@ public struct ModelBenchmark: Sendable {
             case .chunk:
                 if firstTokenTime == nil {
                     firstTokenTime = .now
-                    let elapsed = firstTokenTime! - iterationStart
-                    prefillLatencyMs = Double(elapsed.components.attoseconds) / 1e15
                 }
 
             case .info(let info):
                 promptTokens = info.promptTokenCount
                 completionTokens = info.generationTokenCount
-                // Use the info's own timing if we didn't capture first token
-                if prefillLatencyMs == 0 {
-                    prefillLatencyMs = info.promptTime * 1000
-                }
+                infoPromptTimeSeconds = info.promptTime
 
             case .toolCall:
                 break
@@ -229,10 +224,36 @@ public struct ModelBenchmark: Sendable {
         }
 
         let totalElapsed = ContinuousClock.now - iterationStart
-        let totalTimeMs = Double(totalElapsed.components.attoseconds) / 1e15
 
-        // Calculate decode TPS from the generation info's timing when available,
-        // otherwise approximate from wall-clock
+        return iterationResult(
+            iteration: iteration,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            prefillElapsed: firstTokenTime.map { $0 - iterationStart },
+            infoPromptTimeSeconds: infoPromptTimeSeconds,
+            totalElapsed: totalElapsed
+        )
+    }
+
+    /// Derive an iteration's reported timings from its raw clock measurements.
+    ///
+    /// Split out of `runIteration` so the arithmetic is reachable in tests
+    /// without a live MLX `ModelContainer`.
+    static func iterationResult(
+        iteration: Int,
+        promptTokens: Int,
+        completionTokens: Int,
+        prefillElapsed: Duration?,
+        infoPromptTimeSeconds: Double,
+        totalElapsed: Duration
+    ) -> BenchmarkIterationResult {
+        // Fall back to the generation info's own prompt timing only when no
+        // chunk ever arrived to time.
+        let prefillLatencyMs =
+            prefillElapsed.map { MTPBenchmarkRunner.milliseconds($0) }
+            ?? infoPromptTimeSeconds * 1000
+        let totalTimeMs = MTPBenchmarkRunner.milliseconds(totalElapsed)
+
         let decodeTimeMs = totalTimeMs - prefillLatencyMs
         let decodeTokensPerSecond: Double
         if completionTokens > 0 && decodeTimeMs > 0 {

--- a/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MTPBenchmarkTests.swift
@@ -1303,6 +1303,54 @@ struct MTPBenchmarkTests {
             Issue.record("unexpected deadline error: \(error)")
         }
     }
+
+    // Regression for #770: `Duration.components` is a (seconds, attoseconds)
+    // quotient/remainder pair, so reading only `attoseconds` throws away every
+    // whole second — a 2.168 s phase reported 168 ms, and the derived decode
+    // window went negative, printing a flat 0 tok/s.
+    @Test(
+        "iteration timings keep whole seconds",
+        arguments: [
+            (Duration.milliseconds(900), Duration.seconds(2) + .milliseconds(100), 900.0, 2100.0, 213.333),
+            (Duration.seconds(2) + .milliseconds(168), Duration.seconds(4), 2168.0, 4000.0, 139.738),
+            (Duration.milliseconds(168), Duration.milliseconds(900), 168.0, 900.0, 349.727),
+        ] as [(Duration, Duration, Double, Double, Double)]
+    )
+    func iterationTimingsKeepWholeSeconds(
+        prefill: Duration,
+        total: Duration,
+        wantPrefillMs: Double,
+        wantTotalMs: Double,
+        wantTps: Double
+    ) {
+        let result = ModelBenchmark.iterationResult(
+            iteration: 1,
+            promptTokens: 12,
+            completionTokens: 256,
+            prefillElapsed: prefill,
+            infoPromptTimeSeconds: 0,
+            totalElapsed: total)
+
+        #expect(abs(result.prefillLatencyMs - wantPrefillMs) < 1e-6)
+        #expect(abs(result.totalTimeMs - wantTotalMs) < 1e-6)
+        #expect(abs(result.decodeTokensPerSecond - wantTps) < 1e-3)
+    }
+
+    @Test("iteration falls back to info prompt time when no chunk arrived")
+    func iterationFallsBackToInfoPromptTime() {
+        let result = ModelBenchmark.iterationResult(
+            iteration: 2,
+            promptTokens: 12,
+            completionTokens: 0,
+            prefillElapsed: nil,
+            infoPromptTimeSeconds: 1.25,
+            totalElapsed: .seconds(3))
+
+        #expect(abs(result.prefillLatencyMs - 1250.0) < 1e-6)
+        #expect(abs(result.totalTimeMs - 3000.0) < 1e-6)
+        #expect(result.decodeTokensPerSecond == 0)
+    }
+
 }
 
 private final class TerminalErrorEngine: CBv2Engine, @unchecked Sendable {


### PR DESCRIPTION
## Summary

`darkbloom benchmark` reported invalid latency and TPS because `ModelBenchmark.runIteration`
converted its `ContinuousClock` measurements by reading only the sub-second remainder of
`Duration.components`, discarding every whole second (a 2.168 s prefill printed as 168 ms).
Both conversions now go through `MTPBenchmarkRunner.milliseconds`, an existing converter in
the same target that already handles this correctly.

## Linked issue

Closes #770

## Test plan

- [x] Added a parameterized regression test (`MTPBenchmarkTests.swift`) covering the exact
      timings from the issue plus a no-chunk fallback case. Red against the old
      attoseconds-only arithmetic, green with the fix.
- [x] `provider-swift` needs macOS + MLX and can't build on Linux, so the arithmetic was
      additionally verified by slicing the exact function text (unmodified) into a minimal
      package and running it under `swift:6.1` on Linux — full commands and output in
      `qa-report.md`.
- [x] `swiftc -parse` on both edited files (syntax only, doesn't typecheck against MLX): exit 0.
- [x] `./scripts/docs-check.sh`: 119 files OK.
- [ ] Not run: `swift build --build-tests && swift test` on `provider-swift` itself — needs
      Apple Silicon. CI's `Provider Tests` job is the real gate for this change; please check
      it on this PR.
- [ ] Not run: end-to-end `darkbloom benchmark` — needs a Mac and a downloaded model. Expected
      result: an iteration over 1 s prints `totalTimeMs` ≥ 1000 and a decode TPS in the tens,
      not 2502 or 0.

## Components touched

- [x] provider-swift (Swift CLI)

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

Two side effects of moving the arithmetic into a testable seam, both deliberate:

- The `info.promptTime` fallback now fires only when no chunk ever arrived. The old
  `prefillLatencyMs == 0` sentinel also fired when a genuine whole-second prefill truncated to
  0 — that was the same bug wearing a different hat.
- A comment claiming decode TPS came "from the generation info's timing when available" is
  removed rather than carried along; the code below it only ever used wall-clock.

Every other `Duration.components.attoseconds` conversion in `provider-swift` (15 sites)
already carries the seconds term — these two were the only truncating pair in the tree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175851&installation_model_id=21733&pr_number=831&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F831&signature=d8b4cf9f638b68ef948e263387d39b891d74abca3ce11ddc34f6dc8810ad0289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->