### PR TITLE
docs: sync the three CLI tables with Darkbloom.configuration.subcommands (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,17 @@ darkbloom doctor             # local diagnostics + coordinator's trust view
 | `status` | Hardware, config, schedule, and live daemon/trust state |
 | `doctor` / `verify` | Diagnostics (`verify` = strict, non-zero on any warning) |
 | `models` | `catalog`, `list`, `download`, `remove` cached models |
+| `local` | Show the local (direct-mode) OpenAI endpoint and API key |
 | `login` / `logout` | Link / unlink the provider to a Darkbloom account |
 | `enroll` / `unenroll` | MDM enrollment for hardware-trust attestation |
 | `benchmark` | Local tokens/sec benchmark |
 | `update` | Check for and apply provider updates |
 | `logs` | Tail provider logs |
+| `report` | Upload recent unified logs to the coordinator |
+| `autoupdate` | `enable` / `disable` / `status` automatic provider updates |
+| `beta` | `list` / `status` / `enable` / `disable` beta features |
+| `idle` | Idle-memory policy: `status`, `keep-loaded`, `unload-after <mins>` |
+| `fan` | Experimental temperature-based fan control |
 
 There is **no** `serve` or `earnings` command — use `start`, and view earnings in the [console](https://console.darkbloom.dev). Full flags: [`docs/provider/cli-reference.md`](docs/provider/cli-reference.md).
 

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -1,6 +1,6 @@
 # Provider CLI reference
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-04 · commit `ccb3d23fe`
 
 Reference for the `darkbloom` command-line tool: every subcommand and flag, the
 files and identifiers it creates, the `provider.toml` keys it reads with their
@@ -26,7 +26,7 @@ set to any value skips it. Logging goes to stderr so launchd captures it in
 
 ## Subcommands
 
-Declaration order of `Darkbloom.configuration.subcommands` (21):
+Declaration order of `Darkbloom.configuration.subcommands` (22):
 
 | Command | Purpose | `--config` | Source (`provider-swift/Sources/darkbloom/…`) |
 |---|---|---|---|
@@ -48,6 +48,7 @@ Declaration order of `Darkbloom.configuration.subcommands` (21):
 | `report` | Upload recent unified logs to the coordinator | ✓ | `ReportCommand.swift` (`Report`) |
 | `autoupdate` | Toggle `provider.auto_update` | ✓ | `AutoUpdateCommand.swift` (`AutoUpdate`) |
 | `beta` | `list`, `status`, `enable`, `disable` beta features | ✓ | `BetaCommand.swift` (`Beta`) |
+| `idle` | Idle-memory policy: `status`, `keep-loaded`, `unload-after <minutes>` (see [`darkbloom idle`](#darkbloom-idle)) | ✓ | `IdleCommand.swift` (`Idle`) |
 | `fan` | Experimental fan control (`status`, `diagnose`, `enable`, `configure`, `disable`, `uninstall`) | | `Fan/FanCommand.swift` (`Fan`) |
 | `watchdog` | Internal, hidden: crash-recovery watchdog process | ✓ | `WatchdogCommand.swift` (`Watchdog`) |
 | `runtime-smoke` | Internal, hidden: load packaged Metal runtime and exit | | `RuntimeSmokeCommand.swift` (`RuntimeSmoke`) |

--- a/provider-swift/README.md
+++ b/provider-swift/README.md
@@ -4,7 +4,7 @@ CLI provider for Apple Silicon Macs. Builds two executables:
 
 | Binary | Purpose |
 |---|---|
-| `darkbloom` | Provider CLI: `serve`, `start`, `stop`, `status`, `doctor`, `models`, `login`, `logout`, `benchmark`, `update`, `verify` |
+| `darkbloom` | Provider CLI: `start`, `stop`, `restart`, `status`, `doctor`, `models`, `local`, `login`, `logout`, `benchmark`, `update`, `verify`, `enroll`, `unenroll`, `logs`, `report`, `autoupdate`, `beta`, `idle`, `fan` |
 | `darkbloom-enclave` | Stateless Secure Enclave helper: `attest`, `sign`, `info`, `wallet-address`. Installed as both `darkbloom-enclave` (canonical) and `eigeninference-enclave` (legacy symlink). |
 
 This package is **CLI-only**: no SwiftUI app, no `.app` bundle, no DMG.
@@ -44,7 +44,7 @@ Python wheel:
 ./scripts/fetch-metallib.sh debug
 ./scripts/fetch-metallib.sh release
 
-provider-swift/.build/release/darkbloom serve --foreground
+provider-swift/.build/release/darkbloom start --foreground
 ```
 
 The helper also accepts an absolute destination directory and
@@ -83,7 +83,7 @@ Tests/
 ## CLI surface
 
 ```
-darkbloom serve / start / stop      lifecycle
+darkbloom start / stop              lifecycle
 darkbloom status / doctor           read-only diagnostics (with update banner)
 darkbloom models list / catalog / download <id> / remove <id>
 darkbloom enroll / unenroll         MDM device-attestation profile


### PR DESCRIPTION
Fixes item 3 of #256.

## Problem

`README.md`, `docs/provider/cli-reference.md`, and `provider-swift/README.md`
each hand-list the `darkbloom` CLI's subcommands, and all three have drifted
from the actual list in `Darkbloom.configuration.subcommands`
(`provider-swift/Sources/darkbloom/Darkbloom.swift:29-52`, 22 subcommands, 20
visible). Nothing in CI compares them to code.

- `README.md:245-254` names only 14 of 22 commands — missing `local`, `idle`,
  `beta`, `fan`, `autoupdate`. It already contradicts itself: `README.md:233`
  tells the operator to run `darkbloom idle keep-loaded`, a command its own
  table doesn't list.
- `docs/provider/cli-reference.md:29` claims "(21)" commands and its table has
  no `idle` row, even though `:271` has a full `## darkbloom idle` section.
- `provider-swift/README.md:7` lists a `serve` command that doesn't exist
  (`git grep -n 'Serve.self\|commandName: "serve"'` over `provider-swift/`
  returns nothing), also at `:47` and `:86`.

## Fix

Docs only, no Swift source touched:

- `README.md` — add the 6 missing rows in declaration order.
- `docs/provider/cli-reference.md` — `(21)` → `(22)`, add the missing `idle`
  row, refresh the freshness stamp per `docs/AGENTS.md:131`.
- `provider-swift/README.md` — replace the command list with the real one;
  `darkbloom serve --foreground` → `darkbloom start --foreground`
  (`StartCommand.swift:32`); drop `serve /` from the lifecycle line.

Two corrections to the issue text: the command is `autoupdate`, not
`auto-update` (`AutoUpdateCommand.swift:7`). And `report`: `Report.self` is
still registered in `Darkbloom.swift` today, so all three tables document it
as it exists in the shipped code — `README.md` and `provider-swift/README.md`
now carry the same `report` row `docs/provider/cli-reference.md` already had.
Open PR **#748** ("chore: remove provider log report endpoint group") would
delete `ReportCommand.swift`; when it lands, the `report` row needs removing
from all three tables (and the "(22)" count in `cli-reference.md` drops to
21).

## Evidence

`./scripts/docs-check.sh` passes before and after (119 files OK — it doesn't
check command-table content, only stamps/links/paths). Diffed the declared
subcommand names (`Darkbloom.configuration.subcommands`) against each
table's rendered names: all three now agree on the full set (22, including
the two hidden internal commands `watchdog`/`runtime-smoke` in
`cli-reference.md`) or the 20-command visible subset (`README.md`,
`provider-swift/README.md`). Full commands and output in `qa-report.md`.

## Limitations

- No automated parity check exists in this repo to prevent the next drift;
  building one needs to handle the `#if DEBUG` command lists in
  `Fan/FanCommand.swift` and is better scoped as its own follow-up.
- `ProcessLifecycle.swift:5`'s doc comment still says `darkbloom serve` — same
  defect, left alone since this PR touches no Swift source.
- The `report` row in all three tables will need removing once `#748` lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791176056&installation_model_id=21733&pr_number=832&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F832&signature=773e37abc6429ab6ed65b4cd8491e0b1158acbf66c5913eeed302162169c97b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->