### PR TITLE
fix(provider): stream Qwen answers when thinking is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — Qwen non-thinking streaming
+
+- Stream Qwen answers as they are generated when the rendered prompt already closes its thinking block, including image and video requests that default thinking off. Preserve incremental reasoning, explicit parser overrides, and token usage.
+
 ## Unreleased — stats location refresh
 
 - Restore public stats refreshes on large usage tables by aggregating locations per provider before combining location totals. Preserve distinct-provider and token counts and request-weighted coordinates without sorting every usage row. Keep the selective cutoff's query plan local to the analytics transaction.

--- a/docs/architecture/inference.md
+++ b/docs/architecture/inference.md
@@ -1,6 +1,6 @@
 # Provider inference engine
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 How a chat-completion request is served inside the `darkbloom` provider
 process in v0.8.16: one in-process engine (`mlx-swift-lm`
@@ -159,6 +159,25 @@ see [`../reference/configuration.md`](../reference/configuration.md)).
 | `stop` | `stopStrings`, matched on held-back detokenised text (`EngineV2Bridge+StopSequence.swift`) | `[]` |
 | `min_p`, `priority` | **Ignored**: always `0` | — |
 | `n`, `best_of` | **Not represented**: one alternative | — |
+
+### Streaming reasoning state
+
+`ReasoningPromptProbe.streamingPrefix` in
+`provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift`
+decodes only the final eight prompt tokens to initialize Qwen/DeepSeek
+streaming parsing. A prompt ending in `<think>` receives an opening marker;
+a prompt ending in `</think>` receives an empty closed block. The downstream
+think parser consumes these prefixes as state transitions, so reasoning or
+ordinary answer text streams immediately. The prefix bypasses tool parsing
+and does not add output frames or token usage.
+
+Both text and media paths in `MultiModelBatchSchedulerEngine` apply the
+probe before forwarding model output. This matters for media because
+`templateAdditionalContext` defaults `enable_thinking` to false unless the
+caller supplied a thinking control: the template already closes the block,
+and generated answers need not emit another marker. Explicit `.none`, other
+parser families, non-streaming requests, and unrecognized prompt tails receive
+no prefix. Unknown tails preserve legacy close-only reasoning parsing.
 
 ### Tool-call parsers
 

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -452,14 +452,11 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         await bridge.cancel(requestId: visionRequestId)
                         throw error
                     }
-                    // Qwen3.6/DeepSeek-style templates pre-open a <think>
-                    // block at the prompt tail (output carries only the
-                    // close). Without a synthesized open, the downstream
-                    // streaming think parser buffers the whole block —
-                    // TTFT becomes the full thinking duration. Same probe
-                    // as the text path below.
+                    // Initialize the think parser from the rendered media
+                    // prompt: reasoning for an open block, content for a
+                    // pre-closed block (thinking-disabled media).
                     try checkFirstContentDeadline()
-                    let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+                    let reasoningPrefix = ReasoningPromptProbe.streamingPrefix(
                         reasoningParser: visionRequest.reasoningParser,
                         stream: visionRequest.stream,
                         promptTokens: visionPrepared.promptTokens,
@@ -472,7 +469,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         toolHandler: nil,
                         prepared: prepared,
                         releaseBox: releaseBox,
-                        synthesizeThinkOpen: synthesizeThinkOpen
+                        reasoningPrefix: reasoningPrefix
                     )
                 } catch let failure as PreContentDeadlineFailure {
                     await mediaGate.release(requestId: mediaReqId)
@@ -594,19 +591,16 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             }
         }
 
-        // Qwen3.6/DeepSeek-style templates pre-open a <think> block at the
-        // prompt tail (the model's output carries only the close). Without a
-        // synthesized open, the downstream streaming think parser sits in its
-        // `undecided` state buffering the ENTIRE block — the consumer's first
-        // delta (TTFT) is delayed by the whole thinking duration. See
-        // `ReasoningPromptProbe`.
+        // The rendered prompt determines whether output starts in reasoning
+        // or content mode. Seed that state before any model output so neither
+        // thinking-enabled nor thinking-disabled answers buffer until finish.
         do {
             try checkFirstContentDeadline()
         } catch {
             await releaseBox.fire()
             throw error
         }
-        let synthesizeThinkOpen = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
+        let reasoningPrefix = ReasoningPromptProbe.streamingPrefix(
             reasoningParser: request.reasoningParser,
             stream: request.stream,
             promptTokens: promptTokens,
@@ -746,7 +740,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             toolHandler: toolHandler,
             prepared: prepared,
             releaseBox: releaseBox,
-            synthesizeThinkOpen: synthesizeThinkOpen
+            reasoningPrefix: reasoningPrefix
         )
     }
 
@@ -776,7 +770,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         toolHandler: BatchedToolStreamHandler?,
         prepared: ToolChoicePromptPolicy.Prepared,
         releaseBox: OneShotRelease,
-        synthesizeThinkOpen: Bool = false
+        reasoningPrefix: String? = nil
     ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         do {
             try checkFirstContentDeadline()
@@ -791,7 +785,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             toolHandler: toolHandler,
             prepared: prepared,
             releaseBox: releaseBox,
-            synthesizeThinkOpen: synthesizeThinkOpen)
+            reasoningPrefix: reasoningPrefix)
         do {
             try checkFirstContentDeadline()
             return stream
@@ -814,7 +808,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         toolHandler: BatchedToolStreamHandler?,
         prepared: ToolChoicePromptPolicy.Prepared,
         releaseBox: OneShotRelease,
-        synthesizeThinkOpen: Bool = false
+        reasoningPrefix: String? = nil
     ) -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
@@ -831,16 +825,13 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 var failedTerminal: MultiModelBatchSchedulerEngineError?
                 startedAt = Date()
 
-                // Synthetic <think> open (see `ReasoningPromptProbe`): the
-                // rendered prompt already opened a think block, so hand the
-                // downstream streaming parser the marker it will never see
-                // in model output. The parser consumes it as a pure state
-                // transition — no SSE frame reaches the consumer — and then
-                // streams reasoning deltas incrementally instead of
-                // buffering until `</think>`. Deliberately BYPASSES the
-                // tool handler: the marker is not model output.
-                if synthesizeThinkOpen {
-                    continuation.yield(.content(ReasoningPromptProbe.thinkOpen))
+                // Restore the prompt-side reasoning state in the downstream
+                // parser before model output. This prefix emits no SSE frame
+                // and bypasses the tool handler because it is not generated
+                // output. Real content and usage continue through the normal
+                // event handling below.
+                if let reasoningPrefix {
+                    continuation.yield(.content(reasoningPrefix))
                 }
 
                 for await event in upstream {

--- a/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift
@@ -1,73 +1,50 @@
 // Copyright © 2026 Eigen Labs.
 //
-// Detects prompts whose rendered chat template ends INSIDE an open
-// <think> block. Qwen3.6 / DeepSeek-R1-style templates append
-// `<think>\n` after the assistant header, so the model's OUTPUT carries
-// only the closing `</think>` — never the opening tag.
+// Seed the streaming think parser from the rendered generation prompt.
+// Qwen/DeepSeek templates can leave a think block open, or close an empty
+// block when thinking is disabled (the default for media). Those markers
+// belong to the prompt, so the generated output need not repeat them.
+// Without a seed the parser stays undecided and buffers reasoning until a
+// close marker, or an ordinary answer until generation finishes.
 //
-// Why this matters for TTFT: the streaming think parser
-// (`StreamingThinkReasoningParser`, MLXLMServer) can only stream
-// reasoning deltas incrementally once it has SEEN an opening tag.
-// Close-only output leaves it in its `undecided` state, where every
-// token buffers until `</think>` arrives — the consumer's first delta
-// (and thus TTFT) is delayed by the ENTIRE thinking duration.
-//
-// The fix: when the rendered prompt pre-opens a think block AND a
-// think-format reasoning parser will consume this stream, the engine
-// injects one synthetic `.content("<think>")` event ahead of the
-// model's output (`MultiModelBatchSchedulerEngine.makeEventStream`).
-// The parser consumes the marker as a pure state transition — nothing
-// is emitted downstream — then streams `reasoning_content` deltas
-// token-by-token.
+// The engine sends the returned prefix before model output. The selected
+// think parser consumes it only as a state transition: no content, usage,
+// or synthetic reasoning reaches the consumer.
 
 import MLXLMServer
 
 enum ReasoningPromptProbe {
-    /// The synthetic opening marker injected into the event stream.
     static let thinkOpen = "<think>"
+    static let thinkClose = "</think>"
 
-    /// Prompt-tail tokens to decode for the probe. The open tag sits in
-    /// the last few tokens of the rendered template
-    /// (`<|im_start|>assistant\n<think>\n`), so 8 is generous while
-    /// keeping the decode O(1) regardless of prompt length.
+    /// Both the open and the pre-closed empty block fit in the final few
+    /// template tokens. Keep decode O(1) regardless of prompt length.
     static let tailTokenCount = 8
 
-    /// Whether the engine should inject a synthetic `<think>` open ahead
-    /// of the model's output for this request.
-    ///
-    /// Gates, in order:
-    /// - A think-format parser (`.qwen3` / `.deepseekR1`) must be active
-    ///   downstream. A `.none`/unset parser passes chunks through
-    ///   verbatim, so an injected marker would leak to the consumer as
-    ///   literal content. (The coordinator path always sets the parser —
-    ///   `ProviderLoop.inferReasoningParser` fills nil.)
-    /// - Streaming only. The non-streaming collector's `ReasoningParser`
-    ///   already classifies close-only output correctly at completion;
-    ///   only the streaming path suffers the buffering.
-    /// - The rendered prompt's decoded tail must end inside an open
-    ///   think block.
-    static func shouldSynthesizeThinkOpen(
+    /// Only seed streaming think-format parsers. Explicit `.none`, other
+    /// families, and unknown prompt tails retain their existing behavior.
+    /// ProviderLoop resolves an omitted parser before calling the engine.
+    static func streamingPrefix(
         reasoningParser: ReasoningParserFormat?,
         stream: Bool?,
         promptTokens: [Int],
         decodeTail: ([Int]) -> String
-    ) -> Bool {
-        guard reasoningParser == .qwen3 || reasoningParser == .deepseekR1 else { return false }
-        guard stream == true else { return false }
-        guard !promptTokens.isEmpty else { return false }
-        return promptEndsInsideThinkBlock(decodeTail(Array(promptTokens.suffix(tailTokenCount))))
+    ) -> String? {
+        guard reasoningParser == .qwen3 || reasoningParser == .deepseekR1 else { return nil }
+        guard stream == true, !promptTokens.isEmpty else { return nil }
+        return streamingPrefix(forPromptTail: decodeTail(Array(promptTokens.suffix(tailTokenCount))))
     }
 
-    /// True when the tail ends with an unclosed `<think>` (ignoring
-    /// trailing whitespace). A template that embeds a pre-CLOSED empty
-    /// block (`<think>\n\n</think>` — thinking disabled) ends with
-    /// `</think>` and is correctly rejected: `"</think>"` does not have
-    /// the suffix `"<think>"`.
-    static func promptEndsInsideThinkBlock(_ tail: String) -> Bool {
+    static func streamingPrefix(forPromptTail tail: String) -> String? {
         var trimmed = Substring(tail)
         while let last = trimmed.last, last.isWhitespace {
             trimmed.removeLast()
         }
-        return trimmed.hasSuffix(thinkOpen)
+        if trimmed.hasSuffix(thinkOpen) { return thinkOpen }
+        // A completed prompt-side block means output starts in content
+        // mode. An empty synthetic block advances the existing parser
+        // there without flushing prompt text as reasoning or answer text.
+        if trimmed.hasSuffix(thinkClose) { return thinkOpen + thinkClose }
+        return nil
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2VisionRoutingTests.swift
@@ -103,11 +103,12 @@ private final class VisionScriptedEngine: CBv2Engine, @unchecked Sendable {
 }
 
 private struct VisionStubTokenizer: MLXLMCommon.Tokenizer {
+    var promptTail: String? = nil
     func encode(text: String, addSpecialTokens: Bool) -> [Int] {
         Array(repeating: 0, count: text.count)
     }
     func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
-        tokenIds.map { "t\($0)" }.joined()
+        promptTail ?? tokenIds.map { "t\($0)" }.joined()
     }
     func convertTokenToId(_ token: String) -> Int? { ["</s>": 2][token] }
     func convertIdToToken(_ id: Int) -> String? { nil }
@@ -226,6 +227,7 @@ private func makeRoutingEngine(
     bridge: EngineV2Bridge?,
     plumbing: EngineV2VisionPlumbing?,
     modelType: String = "gemma4",
+    tokenizer: VisionStubTokenizer = .init(),
     visionGate: VisionMemoryGate? = nil,
     templateControls: ChatTemplateControls = .init()
 ) -> MultiModelBatchSchedulerEngine {
@@ -233,7 +235,7 @@ private func makeRoutingEngine(
         registryProvider: { @Sendable in
             [
                 "test/vlm-stub": .init(
-                    tokenizer: TokenizerHandle(VisionStubTokenizer()),
+                    tokenizer: TokenizerHandle(tokenizer),
                     modelType: modelType,
                     container: container,
                     isVLM: true,
@@ -808,6 +810,57 @@ struct Qwen35CBv2FixedRequestAccountingTests {
 
 @Suite("MultiModelBatchSchedulerEngine vision-v2 routing")
 struct EngineV2VisionRoutingTests {
+
+    @Test("thinking-disabled text, image, and video stream before engine completion",
+          arguments: ["text", "image", "video"], [ReasoningParserFormat.qwen3, .deepseekR1, .none])
+    func nonThinkingContentBeforeCompletion(kind: String, parser: ReasoningParserFormat) async throws {
+        let engine = VisionScriptedEngine(script: .manual)
+        let (prepared, _) = makePreparedSubmission(mediaKind: kind == "video" ? .video : .image)
+        let router = makeRoutingEngine(
+            container: makeStubContainer(), bridge: makeBridge(engine: engine),
+            plumbing: EngineV2VisionPlumbing(
+                prepare: { _, _, _ in prepared }, emitTelemetry: { _ in }),
+            modelType: "qwen3_5",
+            tokenizer: VisionStubTokenizer(promptTail: "<|im_start|>assistant\n<think>\n\n</think>\n\n"))
+        var request = imageRequest()
+        if kind == "text" {
+            request.messages = [.init(role: .user, content: .text("Describe the scene."))]
+        } else if kind == "video" {
+            request.messages = [.init(role: .user, content: .parts([.videoURL(tinyMP4DataURI)]))]
+        }
+        request.stream = true
+        request.reasoningParser = parser
+        let service = MLXOpenAIService(engine: router)
+        let frames = try await service.streamChatCompletionFrames(request: request)
+        let producer = try #require(engine.manualContinuation)
+        defer { producer.finish() }
+        producer.yield(.delta(text: "A person walks.", tokens: [10], logprobs: nil))
+
+        // Deliberately keep the producer open: buffering until finish must
+        // fail this assertion even if the eventual collected answer is right.
+        let streamed = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for try await frame in frames {
+                    if frame.contains("A person walks.") {
+                        #expect(!frame.contains("reasoning_content"))
+                        #expect(!frame.contains("<think>"))
+                        #expect(!frame.contains("</think>"))
+                        return true
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(2))
+                return false
+            }
+            defer { group.cancelAll() }
+            return try await group.next() ?? false
+        }
+        #expect(streamed)
+        #expect(engine.submitted.count == 1)
+        #expect((engine.submitted.first?.multimodal != nil) == (kind != "text"))
+    }
 
     init() {
         // Some assertions evaluate MLXArrays (embedding comparisons) — see

--- a/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReasoningPromptProbeTests.swift
@@ -4,104 +4,63 @@ import Testing
 
 @testable import ProviderCore
 
-/// `ReasoningPromptProbe` — the detection behind the synthetic `<think>`
-/// open injection (Qwen3.6 TTFT fix).
-///
-/// Qwen3.6/DeepSeek-style chat templates pre-open a think block at the
-/// prompt tail, so the model's output carries only `</think>`. The
-/// streaming think parser buffers close-only output in its `undecided`
-/// state until the close arrives — TTFT then equals the entire thinking
-/// duration. The probe decides when the engine may inject a synthetic
-/// opening marker so reasoning streams incrementally instead.
 @Suite("Reasoning prompt probe")
 struct ReasoningPromptProbeTests {
-
-    // MARK: - Tail detection
-
-    @Test("a Qwen3.6-style generation prompt tail ends inside an open think block")
-    func qwenTailDetected() {
-        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock(
-            "<|im_start|>assistant\n<think>\n"))
-        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>"))
-        // Trailing whitespace variants the tokenizer may render.
-        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>\n\n"))
-        #expect(ReasoningPromptProbe.promptEndsInsideThinkBlock("<think> \t\n"))
+    @Test("open prompt blocks initialize reasoning", arguments: [
+        "<|im_start|>assistant\n<think>\n", "<think>", "<think> \t\n",
+    ])
+    func openBlock(tail: String) {
+        #expect(ReasoningPromptProbe.streamingPrefix(forPromptTail: tail) == "<think>")
     }
 
-    @Test("a pre-closed (thinking disabled) block is rejected")
-    func preClosedBlockRejected() {
-        // Thinking-off templates embed an EMPTY closed block in the prompt;
-        // the output is pure content and must stream as content.
-        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock(
-            "<|im_start|>assistant\n<think>\n\n</think>\n\n"))
-        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("</think>"))
+    @Test("closed prompt blocks initialize content", arguments: [
+        "<|im_start|>assistant\n<think>\n\n</think>\n\n",
+        "</think>", "<think>prompt-side reasoning</think> \t\n",
+    ])
+    func closedBlock(tail: String) {
+        #expect(ReasoningPromptProbe.streamingPrefix(forPromptTail: tail) == "<think></think>")
     }
 
-    @Test("prompts without a think tail are rejected")
-    func plainTailsRejected() {
-        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock(""))
-        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("<|im_start|>assistant\n"))
-        // An open tag mid-tail followed by other text is not "ends inside".
-        #expect(!ReasoningPromptProbe.promptEndsInsideThinkBlock("<think>\nalready reasoning"))
+    @Test("unknown or incomplete tails retain the parser's default state", arguments: [
+        "", "<|im_start|>assistant\n", "<think>\nalready reasoning",
+        "<think>\n</thi", "quoted </think> followed by text",
+    ])
+    func unknownTail(tail: String) {
+        #expect(ReasoningPromptProbe.streamingPrefix(forPromptTail: tail) == nil)
     }
 
-    // MARK: - Injection gating
-
-    private static let openThinkTail = "<|im_start|>assistant\n<think>\n"
-
-    private func shouldInject(
-        parser: ReasoningParserFormat?,
-        stream: Bool? = true,
-        tokens: [Int] = [1, 2, 3],
-        tail: String = Self.openThinkTail
-    ) -> Bool {
-        ReasoningPromptProbe.shouldSynthesizeThinkOpen(
-            reasoningParser: parser,
-            stream: stream,
-            promptTokens: tokens,
-            decodeTail: { _ in tail }
-        )
+    private func prefix(
+        parser: ReasoningParserFormat?, stream: Bool? = true,
+        tokens: [Int] = [1, 2, 3], tail: String = "<think>\n"
+    ) -> String? {
+        ReasoningPromptProbe.streamingPrefix(
+            reasoningParser: parser, stream: stream, promptTokens: tokens,
+            decodeTail: { _ in tail })
     }
 
-    @Test("only think-format parsers inject")
-    func parserGate() {
-        #expect(shouldInject(parser: .qwen3))
-        #expect(shouldInject(parser: .deepseekR1))
-        // A verbatim/none parser would leak the literal marker to consumers.
-        #expect(!shouldInject(parser: ReasoningParserFormat.none))
-        #expect(!shouldInject(parser: nil))
-        #expect(!shouldInject(parser: .harmony))
-        #expect(!shouldInject(parser: .gemma4))
-    }
-
-    @Test("only streaming requests inject")
-    func streamGate() {
-        // Non-streaming collection classifies close-only output correctly
-        // at completion; injection is a streaming-only concern.
-        #expect(!shouldInject(parser: .qwen3, stream: false))
-        #expect(!shouldInject(parser: .qwen3, stream: nil))
-    }
-
-    @Test("an empty prompt or a non-think tail never injects")
-    func tailGate() {
-        #expect(!shouldInject(parser: .qwen3, tokens: []))
-        #expect(!shouldInject(parser: .qwen3, tail: "<|im_start|>assistant\n"))
-        #expect(!shouldInject(parser: .qwen3, tail: "<think>\n\n</think>\n\n"))
+    @Test("only streaming think parsers receive a prefix", arguments: ["<think>\n", "</think>\n"])
+    func gates(tail: String) {
+        #expect(prefix(parser: .qwen3, tail: tail) != nil)
+        #expect(prefix(parser: .deepseekR1, tail: tail) != nil)
+        for parser: ReasoningParserFormat? in [nil, .some(.none), .harmony, .gemma4] {
+            #expect(prefix(parser: parser, tail: tail) == nil)
+        }
+        #expect(prefix(parser: .qwen3, stream: false, tail: tail) == nil)
+        #expect(prefix(parser: .qwen3, stream: nil, tail: tail) == nil)
+        #expect(prefix(parser: .qwen3, tokens: [], tail: tail) == nil)
     }
 
     @Test("the probe decodes only a bounded prompt tail")
     func boundedTailDecode() {
         let tokens = Array(0..<4096)
         var seen: [Int]?
-        _ = ReasoningPromptProbe.shouldSynthesizeThinkOpen(
-            reasoningParser: .qwen3,
-            stream: true,
-            promptTokens: tokens,
+        let result = ReasoningPromptProbe.streamingPrefix(
+            reasoningParser: .qwen3, stream: true, promptTokens: tokens,
             decodeTail: { ids in
                 seen = ids
-                return Self.openThinkTail
-            }
-        )
+                return "</think>\n"
+            })
         #expect(seen == Array(tokens.suffix(ReasoningPromptProbe.tailTokenCount)))
+        #expect(result == "<think></think>")
     }
 }

--- a/provider-swift/Tests/ProviderCoreTests/ThinkStreamingLatencyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ThinkStreamingLatencyTests.swift
@@ -48,6 +48,7 @@ struct ThinkStreamingLatencyTests {
             messages: [OpenAIChatMessage(role: .user, content: .text("hi"))]
         )
         request.stream = true
+        request.streamOptions = .init(includeUsage: true)
         request.reasoningParser = .qwen3
         var frames: [String] = []
         for try await frame in try await service.streamChatCompletionFrames(request: request) {
@@ -86,6 +87,35 @@ struct ThinkStreamingLatencyTests {
         let joined = frames.joined()
         #expect(!joined.contains("<think>"))
         #expect(!joined.contains("</think>"))
+    }
+
+    @Test("a pre-closed prompt streams ordinary chunks without adding content or usage")
+    func nonThinkingAnswerStreamsIncrementally() async throws {
+        let prefix = try #require(ReasoningPromptProbe.streamingPrefix(
+            reasoningParser: .qwen3, stream: true, promptTokens: [1, 2, 3],
+            decodeTail: { _ in "<|im_start|>assistant\n<think>\n\n</think>\n\n" }))
+        let frames = try await collectFrames(events: [
+            .content(prefix),
+            .content("A person "), .content("walks across "), .content("the room."),
+            .info(.init(promptTokens: 5, completionTokens: 3,
+                        promptTime: 0, generationTime: 0, stopReason: "stop")),
+        ])
+        let payloads = try frames.compactMap { frame -> [String: Any]? in
+            guard let data = frame.split(separator: "\n").first,
+                  data.hasPrefix("data:"), !data.contains("[DONE]") else { return nil }
+            return try JSONSerialization.jsonObject(
+                with: Data(data.dropFirst(5).utf8)) as? [String: Any]
+        }
+        let deltas = payloads.flatMap { $0["choices"] as? [[String: Any]] ?? [] }
+            .compactMap { $0["delta"] as? [String: Any] }
+        #expect(deltas.compactMap { $0["content"] as? String }
+            == ["A person ", "walks across ", "the room."])
+        #expect(deltas.compactMap { $0["reasoning_content"] as? String }.isEmpty)
+        let usage = try #require(payloads.compactMap { $0["usage"] as? [String: Any] }.last)
+        #expect(usage["prompt_tokens"] as? Int == 5)
+        #expect(usage["completion_tokens"] as? Int == 3)
+        #expect(!frames.joined().contains("<think>"))
+        #expect(!frames.joined().contains("</think>"))
     }
 
     @Test("without an opening tag, close-only reasoning buffers until the close (the bug the injection fixes)")


### PR DESCRIPTION
## Summary

Qwen image/video requests default thinking off, so their rendered prompt already contains a closed thinking block. The provider nevertheless left the streaming think parser undecided, buffering ordinary answer text until generation completed and potentially exhausting the first-content deadline even while the model was generating. Initialize the parser from the rendered prompt in both text and media paths so thinking-disabled answers stream immediately, while preserving incremental reasoning, explicit parser overrides, and token usage.

## Before

```mermaid
flowchart TD
  A[Text or media request with thinking disabled] --> B[Rendered prompt already closes thinking block]
  B --> C[MultiModelBatchSchedulerEngine calls ReasoningPromptProbe.shouldSynthesizeThinkOpen]
  C --> D[False: makeEventStream forwards output without initialization]
  D --> E[StreamingThinkReasoningParser remains undecided]
  E --> F[Ordinary answer chunks buffered until generation finishes]
  F --> G[Long answers can hit first-content timeout and HTTP 429]
```

## After

```mermaid
flowchart TD
  A[Text or media request] --> B[MultiModelBatchSchedulerEngine calls ReasoningPromptProbe.streamingPrefix]
  B --> C{Rendered prompt tail}
  C -->|Closed thinking block| D[makeEventStream sends an empty closed block before generated output]
  C -->|Open thinking block| E[Preserve opening-prefix initialization]
  C -->|Unknown tail or parser override| F[Preserve existing behavior]
  D --> G[StreamingThinkReasoningParser enters content state]
  G --> H[MLXOpenAIService emits each real answer delta immediately]
  E --> I[Reasoning deltas stream incrementally]
```

The prefix is consumed as a parser state transition, bypasses tool parsing, and adds no visible output or billed tokens. Prompt inspection remains bounded to the final eight tokens. No submodule update or protocol change is required.

## Linked issue

Discovered while investigating OpenRouter's `input-video-base64` test for Qwen3.5-9B; no linked issue.

## Test plan

- [x] `(cd provider-swift && swift test -j 6 --filter 'ReasoningPromptProbeTests|ThinkStreamingLatencyTests|EngineV2VisionRoutingTests|ReasoningParserSelectionTests')` — **59 tests in 9 suites passed**, using the source-matched Metal library prepared by `scripts/fetch-metallib.sh`.
- [x] Streaming-boundary regression uses the real provider router, engine bridge, and SSE service over scripted generation. It keeps generation open and requires content before completion for text, image, and video with `qwen3`, `deepseek_r1`, and explicit `none` parsing.
- [x] Negative control: disabling only the closed-block initialization reproduced **6 failures**; the **3 explicit-none controls passed**. Restoring the fix made all nine cases pass, followed by the full targeted run above.
- [x] Verify incremental reasoning, exact answer chunks, unchanged usage, parser gates, and bounded tail decoding.
- [x] `make docs-check` — 126 files OK; `git diff --check` passed.

## Components touched

- [x] provider-swift (Swift CLI)
- [x] docs and changelog

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

Unknown prompt tails retain legacy close-only reasoning behavior; explicit `none` and other parser families receive no prefix. The fix is local to provider stream initialization and does not change upload limits or first-content deadlines.

The exact OpenRouter video was not replayed. These tests establish the buffering defect and repair at the streaming boundary; validation against that original video remains a provider-release follow-up. No production deployment was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791189126&installation_model_id=21733&pr_number=833&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F833&signature=0b7c059bb7720c499f9fd69126898d2b8aec3f2132e48219dfac96c16c7d1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->