### PR TITLE
feat(models): prefer verified Hugging Face downloads with R2 fallback

### DIFF
--- a/.github/workflows/register-model.yml
+++ b/.github/workflows/register-model.yml
@@ -51,6 +51,10 @@ on:
         description: Runtime parameters JSON object
         required: false
         default: '{}'
+      hugging_face_artifact_json:
+        description: Optional exact public HF artifact JSON (repo_id, full commit revision, optional path_prefix); null keeps R2 only.
+        required: false
+        default: 'null'
       metadata_json:
         description: Metadata JSON object
         required: false
@@ -92,6 +96,7 @@ jobs:
           MIN_RAM_GB: ${{ inputs.min_ram_gb }}
           DESCRIPTION: ${{ inputs.description }}
           RUNTIME_PARAMETERS_JSON: ${{ inputs.runtime_parameters_json }}
+          HUGGING_FACE_ARTIFACT_JSON: ${{ inputs.hugging_face_artifact_json }}
           METADATA_JSON: ${{ inputs.metadata_json }}
           PROMOTE: ${{ inputs.promote }}
           INPUT_PRICE: ${{ inputs.input_price }}
@@ -111,6 +116,7 @@ jobs:
             --argjson min_ram_gb "$MIN_RAM_GB" \
             --arg description "$DESCRIPTION" \
             --argjson runtime_parameters "$RUNTIME_PARAMETERS_JSON" \
+            --argjson hugging_face_artifact "${HUGGING_FACE_ARTIFACT_JSON:-null}" \
             --argjson metadata "$METADATA_JSON" \
             --argjson promote "$PROMOTE" \
             --argjson input_price "$INPUT_PRICE" \
@@ -144,6 +150,7 @@ jobs:
               required_provider_capabilities: ($required_provider_capabilities_csv | required_provider_capabilities),
               description: $description,
               runtime_parameters: $runtime_parameters,
+              hugging_face_artifact: $hugging_face_artifact,
               metadata: $metadata,
               promote: $promote,
               input_price: $input_price,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — Hugging Face model downloads
+
+- Add an optional, commit-pinned Hugging Face artifact to each registry version. Foreground model downloads and background prefetch prefer HF, verify the existing per-file SHA-256 and aggregate hashes, and fall back to R2 on download or integrity failure. Existing registry entries keep using R2.
+
 ## Unreleased — stats location refresh
 
 - Restore public stats refreshes on large usage tables by aggregating locations per provider before combining location totals. Preserve distinct-provider and token counts and request-weighted coordinates without sorting every usage row. Keep the selective cutoff's query plan local to the analytics transaction.

--- a/console-ui/src/lib/api/types.ts
+++ b/console-ui/src/lib/api/types.ts
@@ -34,6 +34,12 @@ export interface Model {
   // OpenRouter provider schema fields (from the enriched /v1/models endpoint).
   name?: string;
   hugging_face_id?: string;
+  // Exact download artifact on the public catalog; independent of upstream metadata.
+  hugging_face_artifact?: {
+    repo_id: string;
+    revision: string;
+    path_prefix?: string;
+  };
   created?: number;
   description?: string;
   context_length?: number;

--- a/coordinator/api/hugging_face_artifact_test.go
+++ b/coordinator/api/hugging_face_artifact_test.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"github.com/eigeninference/d-inference/coordinator/store"
+	"strings"
+	"testing"
+)
+
+func TestRegisterModelRejectsMutableHuggingFaceRevision(t *testing.T) {
+	err := validateRegisterModelRequest(registerModelRequest{HuggingFaceArtifact: &store.HuggingFaceArtifact{RepoID: "EigenLabs/test", Revision: "main"}})
+	if err == nil || !strings.Contains(err.Error(), "hugging_face_artifact.revision") {
+		t.Fatalf("expected pinned-revision rejection, got %v", err)
+	}
+}
+
+func TestLegacyCatalogOmitsHuggingFaceArtifact(t *testing.T) {
+	model := catalogModelFromRegistryRecord(&store.ModelRegistryRecord{ActiveVersion: &store.ModelVersion{Version: "v1"}})
+	if _, ok := model["hugging_face_artifact"]; ok {
+		t.Fatal("legacy catalog must omit optional artifact")
+	}
+}

--- a/coordinator/api/model_registry_handlers.go
+++ b/coordinator/api/model_registry_handlers.go
@@ -23,23 +23,24 @@ import (
 const defaultModelRegistryCDNBaseURL = "https://models.darkbloom.ai"
 
 type registerModelRequest struct {
-	ModelID                      string         `json:"model_id"`
-	Version                      string         `json:"version"`
-	DisplayName                  string         `json:"display_name"`
-	Family                       string         `json:"family"`
-	Architecture                 string         `json:"architecture"`
-	Quantization                 string         `json:"quantization"`
-	MaxContextLength             int            `json:"max_context_length"`
-	MaxOutputLength              int            `json:"max_output_length"`
-	MinRAMGB                     int            `json:"min_ram_gb"`
-	Capabilities                 []string       `json:"capabilities"`
-	RequiredProviderCapabilities []string       `json:"required_provider_capabilities"`
-	Description                  string         `json:"description"`
-	RuntimeParameters            map[string]any `json:"runtime_parameters"`
-	Metadata                     map[string]any `json:"metadata"`
-	Promote                      bool           `json:"promote"`
-	InputPrice                   int64          `json:"input_price"`  // micro-USD per 1M tokens (required)
-	OutputPrice                  int64          `json:"output_price"` // micro-USD per 1M tokens (required)
+	HuggingFaceArtifact          *store.HuggingFaceArtifact `json:"hugging_face_artifact,omitempty"`
+	ModelID                      string                     `json:"model_id"`
+	Version                      string                     `json:"version"`
+	DisplayName                  string                     `json:"display_name"`
+	Family                       string                     `json:"family"`
+	Architecture                 string                     `json:"architecture"`
+	Quantization                 string                     `json:"quantization"`
+	MaxContextLength             int                        `json:"max_context_length"`
+	MaxOutputLength              int                        `json:"max_output_length"`
+	MinRAMGB                     int                        `json:"min_ram_gb"`
+	Capabilities                 []string                   `json:"capabilities"`
+	RequiredProviderCapabilities []string                   `json:"required_provider_capabilities"`
+	Description                  string                     `json:"description"`
+	RuntimeParameters            map[string]any             `json:"runtime_parameters"`
+	Metadata                     map[string]any             `json:"metadata"`
+	Promote                      bool                       `json:"promote"`
+	InputPrice                   int64                      `json:"input_price"`  // micro-USD per 1M tokens (required)
+	OutputPrice                  int64                      `json:"output_price"` // micro-USD per 1M tokens (required)
 }
 
 type publishingActor struct {
@@ -138,15 +139,16 @@ func (s *Server) handleRegisterModel(w http.ResponseWriter, r *http.Request) {
 		entry.DisplayName = req.ModelID
 	}
 	version := &store.ModelVersion{
-		ModelID:         req.ModelID,
-		Version:         req.Version,
-		R2Prefix:        r2Prefix,
-		AggregateSHA256: manifest.AggregateSHA256,
-		TotalSizeBytes:  manifest.TotalSizeBytes,
-		FileCount:       manifest.FileCount,
-		Status:          "ready",
-		UploadedBy:      actor.Name,
-		Metadata:        req.Metadata,
+		HuggingFaceArtifact: req.HuggingFaceArtifact,
+		ModelID:             req.ModelID,
+		Version:             req.Version,
+		R2Prefix:            r2Prefix,
+		AggregateSHA256:     manifest.AggregateSHA256,
+		TotalSizeBytes:      manifest.TotalSizeBytes,
+		FileCount:           manifest.FileCount,
+		Status:              "ready",
+		UploadedBy:          actor.Name,
+		Metadata:            req.Metadata,
 	}
 	files := make([]store.ModelVersionFile, len(manifest.Files))
 	for i, f := range manifest.Files {
@@ -573,6 +575,9 @@ func parseAdminModelActionPath(p string) (string, string, bool) {
 }
 
 func validateRegisterModelRequest(req registerModelRequest) error {
+	if err := req.HuggingFaceArtifact.Validate(); err != nil {
+		return err
+	}
 	if strings.TrimSpace(req.ModelID) == "" {
 		return fmt.Errorf("model_id is required")
 	}
@@ -888,6 +893,9 @@ func catalogModelFromRegistryRecord(rec *store.ModelRegistryRecord) map[string]a
 		model["created"] = rec.CreatedAt.Unix()
 	}
 	if version != nil {
+		if version.HuggingFaceArtifact != nil {
+			model["hugging_face_artifact"] = version.HuggingFaceArtifact
+		}
 		model["version"] = version.Version
 		model["r2_prefix"] = version.R2Prefix
 		model["aggregate_sha256"] = version.AggregateSHA256

--- a/coordinator/api/model_registry_handlers_test.go
+++ b/coordinator/api/model_registry_handlers_test.go
@@ -236,22 +236,23 @@ func TestRegisterModelHandlerPromotesActiveRecord(t *testing.T) {
 	reg := registry.New(logger)
 	srv := NewServer(reg, st, ServerConfig{}, logger)
 	payload := map[string]any{
-		"model_id":           "mlx-community/test",
-		"version":            "v1",
-		"display_name":       "Test Model",
-		"family":             "qwen",
-		"architecture":       "dense",
-		"quantization":       "4bit",
-		"max_context_length": 32768,
-		"max_output_length":  8192,
-		"min_ram_gb":         16,
-		"capabilities":       []string{"chat"},
-		"description":        "test",
-		"runtime_parameters": map[string]any{"default_temperature": 0, "chat_template_required": true},
-		"metadata":           map[string]any{"tier": "test"},
-		"promote":            true,
-		"input_price":        50000,
-		"output_price":       200000,
+		"hugging_face_artifact": &store.HuggingFaceArtifact{RepoID: "EigenLabs/test", Revision: "0123456789abcdef0123456789abcdef01234567", PathPrefix: "mlx"},
+		"model_id":              "mlx-community/test",
+		"version":               "v1",
+		"display_name":          "Test Model",
+		"family":                "qwen",
+		"architecture":          "dense",
+		"quantization":          "4bit",
+		"max_context_length":    32768,
+		"max_output_length":     8192,
+		"min_ram_gb":            16,
+		"capabilities":          []string{"chat"},
+		"description":           "test",
+		"runtime_parameters":    map[string]any{"default_temperature": 0, "chat_template_required": true},
+		"metadata":              map[string]any{"tier": "test"},
+		"promote":               true,
+		"input_price":           50000,
+		"output_price":          200000,
 	}
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest(http.MethodPost, "/v1/admin/models/register", bytes.NewReader(body))
@@ -290,6 +291,10 @@ func TestRegisterModelHandlerPromotesActiveRecord(t *testing.T) {
 	}
 	if len(catalog.Models) != 1 || catalog.Models[0]["id"] != "mlx-community/test" || catalog.Models[0]["version"] != "v1" {
 		t.Fatalf("unexpected catalog response: %#v", catalog.Models)
+	}
+	artifact, ok := catalog.Models[0]["hugging_face_artifact"].(map[string]any)
+	if !ok || artifact["repo_id"] != "EigenLabs/test" || artifact["revision"] != "0123456789abcdef0123456789abcdef01234567" || artifact["path_prefix"] != "mlx" {
+		t.Fatalf("artifact did not round-trip registration to catalog: %#v", artifact)
 	}
 }
 

--- a/coordinator/store/cached_clone.go
+++ b/coordinator/store/cached_clone.go
@@ -47,6 +47,7 @@ func cloneRegistryEntryForCache(entry *ModelRegistryEntry) ModelRegistryEntry {
 func cloneModelVersionForCache(version *ModelVersion) ModelVersion {
 	cp := *version
 	cp.PromotedAt = cloneTimePtr(version.PromotedAt)
+	cp.HuggingFaceArtifact = cloneHuggingFaceArtifact(version.HuggingFaceArtifact)
 	cp.Metadata = cloneJSONMap(version.Metadata)
 	return cp
 }

--- a/coordinator/store/hugging_face_artifact.go
+++ b/coordinator/store/hugging_face_artifact.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// HuggingFaceArtifact locates the exact published bytes, independently of the
+// upstream hugging_face_id used for model metadata. Paths mirror the manifest.
+type HuggingFaceArtifact struct {
+	RepoID     string `json:"repo_id"`
+	Revision   string `json:"revision"`
+	PathPrefix string `json:"path_prefix,omitempty"`
+}
+
+var hfRepositoryComponent = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]*$`)
+var hfCommitRevision = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func (a *HuggingFaceArtifact) Validate() error {
+	if a == nil {
+		return nil
+	}
+	parts := strings.Split(a.RepoID, "/")
+	if len(parts) != 2 || len(a.RepoID) > 192 {
+		return fmt.Errorf("hugging_face_artifact.repo_id must be owner/repository")
+	}
+	for _, part := range parts {
+		if !hfRepositoryComponent.MatchString(part) || strings.Contains(part, "..") {
+			return fmt.Errorf("hugging_face_artifact.repo_id contains invalid characters")
+		}
+	}
+	if !hfCommitRevision.MatchString(a.Revision) {
+		return fmt.Errorf("hugging_face_artifact.revision must be a full lowercase 40-character commit SHA")
+	}
+	if a.PathPrefix != "" {
+		if len(a.PathPrefix) > 1024 {
+			return fmt.Errorf("hugging_face_artifact.path_prefix is too long")
+		}
+		for _, part := range strings.Split(a.PathPrefix, "/") {
+			if !hfRepositoryComponent.MatchString(part) || strings.Contains(part, "..") {
+				return fmt.Errorf("hugging_face_artifact.path_prefix must be a relative path of repository components")
+			}
+		}
+	}
+	return nil
+}
+
+func cloneHuggingFaceArtifact(a *HuggingFaceArtifact) *HuggingFaceArtifact {
+	if a == nil {
+		return nil
+	}
+	cp := *a
+	return &cp
+}

--- a/coordinator/store/hugging_face_artifact_test.go
+++ b/coordinator/store/hugging_face_artifact_test.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHuggingFaceArtifactValidation(t *testing.T) {
+	valid := HuggingFaceArtifact{RepoID: "EigenLabs/model-4bit", Revision: strings.Repeat("a", 40), PathPrefix: "mlx/4bit"}
+	if err := valid.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (*HuggingFaceArtifact)(nil).Validate(); err != nil {
+		t.Fatal(err)
+	}
+	for _, change := range []func(*HuggingFaceArtifact){
+		func(a *HuggingFaceArtifact) { a.RepoID = "https://huggingface.co/org/repo" },
+		func(a *HuggingFaceArtifact) { a.RepoID = "org//repo" },
+		func(a *HuggingFaceArtifact) { a.RepoID = "org/../repo" },
+		func(a *HuggingFaceArtifact) { a.RepoID = "org/repo?token=x" },
+		func(a *HuggingFaceArtifact) { a.Revision = "main" },
+		func(a *HuggingFaceArtifact) { a.Revision = strings.Repeat("A", 40) },
+		func(a *HuggingFaceArtifact) { a.PathPrefix = "../weights" },
+		func(a *HuggingFaceArtifact) { a.PathPrefix = "/weights" },
+		func(a *HuggingFaceArtifact) { a.PathPrefix = "weights/" },
+		func(a *HuggingFaceArtifact) { a.PathPrefix = "%2e%2e" },
+	} {
+		a := valid
+		change(&a)
+		if err := a.Validate(); err == nil {
+			t.Errorf("accepted invalid artifact: %+v", a)
+		}
+	}
+}
+
+func TestHuggingFaceArtifactMemoryAndCache(t *testing.T) {
+	testHuggingFaceArtifactStore(t, NewMemory(Config{}))
+}
+
+func TestHuggingFaceArtifactPostgresAndCache(t *testing.T) {
+	testHuggingFaceArtifactStore(t, testPostgresStore(t))
+}
+
+func testHuggingFaceArtifactStore(t *testing.T, backing Store) {
+	t.Helper()
+	cached := NewCached(backing, DefaultCacheConfig())
+	id := uniqueID("hf-artifact")
+	entry := &ModelRegistryEntry{ID: id, Status: "active", Capabilities: []string{}, RequiredProviderCapabilities: []string{}}
+	version := &ModelVersion{ModelID: id, Version: "v1", R2Prefix: "v2/test/v1", Status: "ready", AggregateSHA256: strings.Repeat("a", 64), FileCount: 1,
+		HuggingFaceArtifact: &HuggingFaceArtifact{RepoID: "EigenLabs/test", Revision: strings.Repeat("a", 40), PathPrefix: "mlx"}}
+	files := []ModelVersionFile{{Path: "config.json", SHA256: strings.Repeat("b", 64), Role: "config"}}
+	if err := cached.SetModelVersion(entry, version, files); err != nil {
+		t.Fatal(err)
+	}
+	if err := cached.PromoteModelVersion(id, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	// The backing store must own its input, and callers must not mutate the cache.
+	version.HuggingFaceArtifact.RepoID = "mutated/input"
+	got, err := cached.GetModelRegistryRecord(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ActiveVersion.HuggingFaceArtifact == nil || got.ActiveVersion.HuggingFaceArtifact.RepoID != "EigenLabs/test" || got.ActiveVersion.HuggingFaceArtifact.PathPrefix != "mlx" {
+		t.Fatalf("artifact lost: %+v", got.ActiveVersion)
+	}
+	got.ActiveVersion.HuggingFaceArtifact.RepoID = "mutated/output"
+	again, err := cached.GetModelRegistryRecord(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.ActiveVersion.HuggingFaceArtifact.RepoID != "EigenLabs/test" {
+		t.Fatal("cache aliasing")
+	}
+	// Re-registration clears the optional source and invalidates the cached version.
+	version.HuggingFaceArtifact = nil
+	if err := cached.SetModelVersion(entry, version, files); err != nil {
+		t.Fatal(err)
+	}
+	again, err = cached.GetModelRegistryRecord(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.ActiveVersion.HuggingFaceArtifact != nil {
+		t.Fatal("stale HF source after clearing")
+	}
+	for _, record := range cached.ListActiveModelRegistry() {
+		if record.ID == id && record.ActiveVersion.HuggingFaceArtifact != nil {
+			t.Fatal("stale list source")
+		}
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -647,18 +647,19 @@ type ModelRegistryEntry struct {
 
 // ModelVersion is an uploaded manifest version for a registered model.
 type ModelVersion struct {
-	ID              int64          `json:"id"`
-	ModelID         string         `json:"model_id"`
-	Version         string         `json:"version"`
-	R2Prefix        string         `json:"r2_prefix"`
-	AggregateSHA256 string         `json:"aggregate_sha256"`
-	TotalSizeBytes  int64          `json:"total_size_bytes"`
-	FileCount       int            `json:"file_count"`
-	Status          string         `json:"status"`
-	UploadedBy      string         `json:"uploaded_by,omitempty"`
-	UploadedAt      time.Time      `json:"uploaded_at"`
-	PromotedAt      *time.Time     `json:"promoted_at,omitempty"`
-	Metadata        map[string]any `json:"metadata"`
+	HuggingFaceArtifact *HuggingFaceArtifact `json:"hugging_face_artifact,omitempty"`
+	ID                  int64                `json:"id"`
+	ModelID             string               `json:"model_id"`
+	Version             string               `json:"version"`
+	R2Prefix            string               `json:"r2_prefix"`
+	AggregateSHA256     string               `json:"aggregate_sha256"`
+	TotalSizeBytes      int64                `json:"total_size_bytes"`
+	FileCount           int                  `json:"file_count"`
+	Status              string               `json:"status"`
+	UploadedBy          string               `json:"uploaded_by,omitempty"`
+	UploadedAt          time.Time            `json:"uploaded_at"`
+	PromotedAt          *time.Time           `json:"promoted_at,omitempty"`
+	Metadata            map[string]any       `json:"metadata"`
 }
 
 // ModelVersionFile is one file in a model version manifest.

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2025,6 +2025,7 @@ func cloneModelVersion(version *ModelVersion) ModelVersion {
 	}
 	cp := *version
 	cp.PromotedAt = cloneTimePtr(version.PromotedAt)
+	cp.HuggingFaceArtifact = cloneHuggingFaceArtifact(version.HuggingFaceArtifact)
 	cp.Metadata = cloneMetadata(version.Metadata)
 	return cp
 }

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -448,6 +448,7 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 			metadata JSONB NOT NULL DEFAULT '{}',
 			UNIQUE(model_id, version)
 		)`,
+		`ALTER TABLE model_versions ADD COLUMN IF NOT EXISTS hugging_face_artifact JSONB`,
 		`DO $$ BEGIN
 			ALTER TABLE model_registry ADD COLUMN IF NOT EXISTS max_context_length INTEGER NOT NULL DEFAULT 0;
 		EXCEPTION WHEN others THEN NULL;

--- a/coordinator/store/postgres_model_registry.go
+++ b/coordinator/store/postgres_model_registry.go
@@ -78,15 +78,15 @@ func (s *PostgresStore) SetModelVersion(entry *ModelRegistryEntry, version *Mode
 		return err
 	}
 	err = tx.QueryRow(ctx, `
-		INSERT INTO model_versions (model_id, version, r2_prefix, aggregate_sha256, total_size_bytes, file_count, status, uploaded_by, uploaded_at, metadata)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), $9)
+		INSERT INTO model_versions (model_id, version, r2_prefix, aggregate_sha256, total_size_bytes, file_count, status, uploaded_by, uploaded_at, metadata, hugging_face_artifact)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), $9, $10)
 		ON CONFLICT (model_id, version) DO UPDATE SET
 		  r2_prefix = $3, aggregate_sha256 = $4, total_size_bytes = $5, file_count = $6,
-		  status = $7, uploaded_by = $8, metadata = $9
+		  status = $7, uploaded_by = $8, metadata = $9, hugging_face_artifact = $10
 		RETURNING id, uploaded_at, promoted_at`,
 		version.ModelID, version.Version, version.R2Prefix, version.AggregateSHA256,
 		version.TotalSizeBytes, version.FileCount, version.Status, version.UploadedBy,
-		versionMetadata).Scan(&version.ID, &version.UploadedAt, &version.PromotedAt)
+		versionMetadata, version.HuggingFaceArtifact).Scan(&version.ID, &version.UploadedAt, &version.PromotedAt)
 	if err != nil {
 		return fmt.Errorf("store: upsert model version: %w", err)
 	}
@@ -297,7 +297,7 @@ const activeModelRegistryQuery = `
 	       mr.status, mr.description, mr.runtime_parameters, mr.metadata, mr.created_at, mr.updated_at,
 	       mv.id, mv.model_id, mv.version, mv.r2_prefix, mv.aggregate_sha256,
 	       mv.total_size_bytes, mv.file_count, mv.status, mv.uploaded_by,
-	       mv.uploaded_at, mv.promoted_at, mv.metadata
+	       mv.uploaded_at, mv.promoted_at, mv.metadata, mv.hugging_face_artifact
 	FROM model_registry mr
 	JOIN model_active_versions mav ON mav.model_id = mr.id
 	JOIN model_versions mv ON mv.id = mav.model_version_id
@@ -313,7 +313,7 @@ func scanModelRegistryRecord(row scanner) (*ModelRegistryRecord, error) {
 		&rec.Status, &rec.Description, &entryRuntimeParameters, &entryMetadata, &rec.CreatedAt, &rec.UpdatedAt,
 		&version.ID, &version.ModelID, &version.Version, &version.R2Prefix, &version.AggregateSHA256,
 		&version.TotalSizeBytes, &version.FileCount, &version.Status, &version.UploadedBy,
-		&version.UploadedAt, &version.PromotedAt, &versionMetadata,
+		&version.UploadedAt, &version.PromotedAt, &versionMetadata, &version.HuggingFaceArtifact,
 	)
 	if err != nil {
 		return nil, err

--- a/docs/architecture/model-registry.md
+++ b/docs/architecture/model-registry.md
@@ -1,11 +1,12 @@
 # Model registry
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 How Darkbloom decides which model builds exist, which bytes are trusted, which
 providers may serve them, and what public name a consumer uses for them. The
 registry is a set of Postgres tables owned by the coordinator; model bytes live
-in Cloudflare R2 and are fetched by providers directly, never proxied by the
+in Cloudflare R2 and optionally a pinned Hugging Face repository. Providers fetch
+them directly, never proxied by the
 coordinator. Public model names are **aliases** that resolve to concrete builds,
 which is what makes zero-downtime quantisation swaps possible. Exact field
 tables are in [`../reference/model-registry-format.md`](../reference/model-registry-format.md);
@@ -127,7 +128,7 @@ carries a hash per advertised model, and any mismatch against
 (`coordinator/api/provider.go`, log line
 `provider model weight hash mismatch — possible model swap`).
 
-### 5. Providers download from R2, verify, then announce
+### 5. Providers select a source, verify, then announce
 
 `provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift` reads
 `GET /v1/models/catalog` (optionally `?type=text&include_aliases=1`) and
@@ -142,6 +143,16 @@ SHA-256 before it leaves staging, and the aggregate is recomputed with
 |---|---|---|---|
 | Foreground download | `ModelDownloader.download` (`ModelDownloader.swift`) | `darkbloom models download` (`provider-swift/Sources/darkbloom/ModelsCommand.swift`) and the `darkbloom start` model picker | 4 concurrent file fetches; resumes into `.local-staging-<r2Prefix>` |
 | Background prefetch | `ModelDownloader.prefetch` (`ModelDownloader+Prefetch.swift`) | `desired_models` reconciliation | sequential, resume-aware, reports verified bytes against the manifest total; refuses models whose `required_provider_capabilities` the machine lacks (`ModelRuntimeRequirements.evaluate`) |
+
+Both flows call `downloadManifestFileWithResume` in
+`provider-swift/Sources/ProviderCore/Models/ModelDownloader+Sources.swift`.
+When the catalog version has `hugging_face_artifact`, it tries the pinned HF
+file first and falls back to R2 on failure, including SHA mismatch. A failed
+HF attempt discards its partial file before switching sources; cancellation
+preserves the partial and propagates without fallback. Without an artifact,
+R2 remains the source. Both sources use the same registered hashes; source
+selection never changes model identity. See the
+[artifact field contract](../reference/model-registry-format.md#hugging-face-download-artifact).
 
 On an aggregate mismatch over individually valid files (a poisoned manifest)
 `finalizeStagedManifest` deletes the staging directory so a corrected manifest

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-> Last updated: 2026-09-04 · commit `d574bd5af`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 What the coordinator persists, through which interface, in which backend, and
 how the schema reaches a fresh database; then what a provider keeps on its own
@@ -9,6 +9,10 @@ does not, and which files an operator may touch. Configuration values are
 listed once in [`../reference/configuration.md`](../reference/configuration.md);
 the SSD cache file format is in
 [`../reference/ssd-kv-cache.md`](../reference/ssd-kv-cache.md).
+
+Model versions also store the optional `hugging_face_artifact` as nullable JSONB
+(`coordinator/store/postgres.go`). `SetModelVersion` replaces it and invalidates
+the existing model read-through cache; [artifact schema](../reference/model-registry-format.md#hugging-face-download-artifact).
 
 ## Context
 

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,11 +1,15 @@
 # Build
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
 source-matched `mlx.metallib`), and the two Next.js UIs. `make build` does all
 of it; the per-component steps below explain what each target runs.
+
+Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
+`scripts/publish-model.sh` to registration. See the
+[model publishing procedure](../operations/model-migration.md).
 
 ## Prerequisites
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -9,6 +9,12 @@ the docs lint locally; CI runs a subset per pull request (see the CI workflow
 map: the console UI job lints and builds but does not run vitest, and the
 benchmark-wrapper tests run only locally). The e2e suite needs an Apple Silicon
 Mac with the test checkpoints cached.
+
+For HF artifact downloads, `HuggingFaceDownloadTests` covers source preference,
+checksum rejection, fallback, and cancellation. `scripts/test-publish-model.sh`
+checks the artifact workflow payload. `TestHuggingFaceArtifactPostgresAndCache`
+in `coordinator/store/hugging_face_artifact_test.go` uses a disposable
+`DATABASE_URL` to check storage and cache invalidation.
 
 ## Prerequisites
 

--- a/docs/operations/model-migration.md
+++ b/docs/operations/model-migration.md
@@ -1,6 +1,6 @@
 # Migrate a public model to a new build
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 Runbook for moving a public model name (an **alias**, e.g. `gemma-4-26b`) from
 one concrete build to another with no downtime and without consumers ever
@@ -86,6 +86,15 @@ R2_ACCOUNT_ID=<cloudflare account id> GCP_PROJECT=<gcp project> scripts/publish-
 #   Version (no slashes): 2026-09-03-r1
 #   Required provider capabilities (comma-separated, optional):
 ```
+
+To prefer an existing public HF mirror, set `HUGGING_FACE_ARTIFACT_JSON` before
+running the script. Supply `repo_id`, a full commit `revision`, and optionally
+`path_prefix`; see the [artifact field contract](../reference/model-registry-format.md#hugging-face-download-artifact).
+The script carries it into the printed `hugging_face_artifact_json` workflow
+input. It does not upload HF files. Check the HF files against the manifest
+before registering; mismatched files will use the R2 fallback. For an existing
+version, re-run registration with the artifact field (or `null` to clear it)
+under the same production approval boundary.
 
 The script runs `darkbloom-publish hash` (`provider-swift/Sources/darkbloom-publish/HashCommand.swift`)
 to write `manifest.json` (per-file and aggregate SHA-256, `r2_prefix` derived

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,10 +1,14 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-04 · commit `fcecc3675`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 The complete public HTTP surface of the coordinator, derived from the 105 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
 Production base URL: `https://api.darkbloom.dev`. Unless a file is named, handler symbols below live in `coordinator/api/server.go`.
+
+The public model catalog optionally includes `hugging_face_artifact` for direct
+provider downloads; the admin registration accepts the same object. See the
+[registry artifact contract](model-registry-format.md#hugging-face-download-artifact).
 
 ## Conventions used in the route tables
 

--- a/docs/reference/model-registry-format.md
+++ b/docs/reference/model-registry-format.md
@@ -1,6 +1,6 @@
 # Model registry format
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `4d9811f7c`
 
 Exact shapes for everything the model registry stores or accepts: the
 `manifest.json` a publisher uploads to R2, the registration and admin requests,
@@ -182,6 +182,46 @@ Keys in `model_registry.metadata` the coordinator reads
 | `openrouter_slug` | `openrouter-slug` action | OpenRouter marketplace slug in the feed |
 | `deprecation_date` | `deprecation` action | `YYYY-MM-DD`; OpenRouter deprecation metadata |
 
+## Hugging Face download artifact
+
+`registerModelRequest.hugging_face_artifact` is an optional object stored on
+`model_versions.hugging_face_artifact` (nullable JSONB) and emitted on each
+public catalog model by `catalogModelFromRegistryRecord`. Its fields are
+validated by `HuggingFaceArtifact.Validate` in
+`coordinator/store/hugging_face_artifact.go`:
+
+| Field | Rule |
+|---|---|
+| `repo_id` | `owner/repository`, at most 192 bytes; repository components use ASCII letters, digits, `_`, `-`, `.` and start with a letter, digit, or `_`; no `..` |
+| `revision` | Full 40-character lowercase hexadecimal HF commit SHA; branches and tags are rejected |
+| `path_prefix` | Optional directory relative to the repository root, at most 1024 bytes; same component rules; no empty or traversal components |
+
+Example registration field (substitute the commit of your published artifact):
+
+```json
+"hugging_face_artifact": {
+  "repo_id": "EigenLabs/your-model",
+  "revision": "0123456789abcdef0123456789abcdef01234567",
+  "path_prefix": "mlx"
+}
+```
+
+The artifact is independent of `metadata.hugging_face_id`, which identifies the
+upstream model for feeds. Use a public, ungated repository whose files match the
+registered manifest, including any modified templates and configs. Provider
+requests carry no HF credentials. Missing, gated, unavailable, or mismatched
+files fall back to R2 individually. HF gets one attempt with a 30-second idle
+request timeout; R2 retains the existing three-attempt policy. Every accepted
+file must pass size and SHA-256 checks, then the complete snapshot must pass the
+aggregate hash (`provider-swift/Sources/ProviderCore/Models/ModelDownloader+Sources.swift`,
+`downloadManifestFileWithResume`). No speed comparison or automatic source race
+is performed. The manifest and checksum authority remain the coordinator/R2.
+
+Omitting the field or sending `null` on re-registration clears the source for
+that version. Existing entries and older providers continue using R2. Adding or
+clearing it on an existing version uses the normal registration endpoint;
+production registration still requires approval.
+
 ## Admin actions
 
 `POST /v1/admin/models/{model_id}/{action}` — `handleAdminModelRegistryAction`
@@ -342,7 +382,8 @@ Catalog model fields (`catalogModelFromRegistryRecord`): `id`, `s3_name`
 (= `aggregate_sha256`), `family`, `quantization`, `max_context_length`,
 `max_output_length`, `capabilities`, `required_provider_capabilities`,
 `runtime_parameters`, `metadata`, `status`, `created`, `version`, `r2_prefix`,
-`aggregate_sha256`, `total_size_bytes`, `file_count`, plus the
+`aggregate_sha256`, `total_size_bytes`, `file_count`, optional
+`hugging_face_artifact`, plus the
 OpenRouter-shaped `name`, `hugging_face_id`, `input_modalities`,
 `output_modalities`, `supported_features`, `supported_sampling_parameters`.
 
@@ -356,8 +397,8 @@ build; aliases with neither are omitted).
 | Tool | Interface | Notes |
 |---|---|---|
 | `darkbloom-publish hash <dir> --id <model_id> --version <version> [-o manifest.json]` | `provider-swift/Sources/darkbloom-publish/HashCommand.swift` | validates id/version before hashing; writes to stdout without `-o` |
-| `scripts/publish-model.sh` | interactive; env `R2_ACCOUNT_ID` (required), `R2_BUCKET` (`darkbloom-models`), `R2_ACCESS_KEY_SECRET` / `R2_SECRET_KEY_SECRET` (GCP Secret Manager names `darkbloom-r2-access-key-id`, `darkbloom-r2-secret-access-key`) | runs the hasher via `swift run -c release`, uploads files with concurrency 8, uploads `manifest.json` last, prints a `gh workflow run register-model.yml` command; defaults `required_provider_capabilities` to `apple_m5,mlx_nax` for `EigenLabs/Qwen3.8-27B-4bit` |
-| `.github/workflows/register-model.yml` | `workflow_dispatch` inputs mirroring the registration request (`capabilities_csv` and `required_provider_capabilities` are comma-separated; `runtime_parameters_json`, `metadata_json` are JSON objects; `coordinator_url` defaults to `https://api.darkbloom.dev`) | builds the payload with `jq` and POSTs with `Authorization: Bearer ${{ secrets.MODEL_REGISTRY_PUBLISHING_KEY }}` |
+| `scripts/publish-model.sh` | interactive; env `R2_ACCOUNT_ID` (required), `R2_BUCKET` (`darkbloom-models`), `R2_ACCESS_KEY_SECRET` / `R2_SECRET_KEY_SECRET` (GCP Secret Manager names `darkbloom-r2-access-key-id`, `darkbloom-r2-secret-access-key`) | runs the hasher via `swift run -c release`, uploads files with concurrency 8, uploads `manifest.json` last; optional env `HUGGING_FACE_ARTIFACT_JSON` validates an existing public HF artifact and passes it into the printed registration command; prints a `gh workflow run register-model.yml` command; defaults `required_provider_capabilities` to `apple_m5,mlx_nax` for `EigenLabs/Qwen3.8-27B-4bit` |
+| `.github/workflows/register-model.yml` | `workflow_dispatch` inputs mirroring the registration request (`capabilities_csv` and `required_provider_capabilities` are comma-separated; `runtime_parameters_json`, `metadata_json` are JSON objects; `hugging_face_artifact_json` is an artifact object or `null`; `coordinator_url` defaults to `https://api.darkbloom.dev`) | builds the payload with `jq` and POSTs with `Authorization: Bearer ${{ secrets.MODEL_REGISTRY_PUBLISHING_KEY }}` |
 
 ## Related
 

--- a/provider-swift/Sources/ProviderCore/Models/HuggingFaceArtifact.swift
+++ b/provider-swift/Sources/ProviderCore/Models/HuggingFaceArtifact.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Exact artifact bytes; separate from the upstream repository used for metadata.
+/// Only public, ungated repositories are needed: no publisher credentials are sent.
+public struct HuggingFaceArtifact: Codable, Sendable, Equatable {
+    public let repoID: String
+    public let revision: String
+    public let pathPrefix: String?
+
+    public init(repoID: String, revision: String, pathPrefix: String? = nil) {
+        self.repoID = repoID
+        self.revision = revision
+        self.pathPrefix = pathPrefix
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case repoID = "repo_id"
+        case revision
+        case pathPrefix = "path_prefix"
+    }
+
+    internal func downloadURL(for relativePath: String) throws -> URL {
+        let components = repoID.split(separator: "/", omittingEmptySubsequences: false)
+        guard repoID.utf8.count <= 192, components.count == 2,
+              components.allSatisfy({ Self.validComponent(String($0)) }),
+              revision.utf8.count == 40,
+              revision.utf8.allSatisfy({ (48...57).contains($0) || (97...102).contains($0) }) else {
+            throw ModelCatalogError.downloadFailed("invalid Hugging Face repository or commit revision")
+        }
+        let prefix = pathPrefix ?? ""
+        guard prefix.utf8.count <= 1024,
+              prefix.isEmpty || prefix.split(separator: "/", omittingEmptySubsequences: false)
+                .allSatisfy({ Self.validComponent(String($0)) }) else {
+            throw ModelCatalogError.downloadFailed("invalid Hugging Face artifact path_prefix")
+        }
+        let path = try ModelDownloader.validatedManifestRelativePath(relativePath)
+        let artifactPath = prefix.isEmpty ? path : "\(prefix)/\(path)"
+        // Escape per component, including literal percent, query and fragment characters.
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+        let escaped = artifactPath.split(separator: "/").map {
+            String($0).addingPercentEncoding(withAllowedCharacters: allowed)!
+        }.joined(separator: "/")
+        guard let url = URL(string: "https://huggingface.co/\(repoID)/resolve/\(revision)/\(escaped)") else {
+            throw ModelCatalogError.downloadFailed("invalid Hugging Face file URL")
+        }
+        return url
+    }
+
+    private static func validComponent(_ value: String) -> Bool {
+        guard let first = value.utf8.first,
+              (48...57).contains(first) || (65...90).contains(first)
+                || (97...122).contains(first) || first == 95,
+              !value.contains("..") else { return false }
+        return value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0)
+                || $0 == 95 || $0 == 45 || $0 == 46
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalog.swift
@@ -6,7 +6,8 @@
 /// endpoint is consumed by the console UI and the `darkbloom models`
 /// CLI verb.
 ///
-/// Downloads pull from R2 directly (the coordinator never fronts model
+/// Downloads prefer a pinned Hugging Face artifact when configured, with R2
+/// fallback (the coordinator never fronts model
 /// weights). The model lives in the standard HuggingFace cache layout
 /// at `~/.cache/huggingface/hub/models--{org}--{name}/snapshots/{hash}/`,
 /// matching what `ModelScanner` already discovers.
@@ -34,6 +35,7 @@ public struct CatalogModel: Codable, Sendable, Equatable {
     public let weightHash: String?
     public let version: String?
     public let r2Prefix: String?
+    public let huggingFaceArtifact: HuggingFaceArtifact?
     public let aggregateSHA256: String?
     public let totalSizeBytes: Int64?
     public let fileCount: Int?
@@ -59,6 +61,7 @@ public struct CatalogModel: Codable, Sendable, Equatable {
         case weightHash = "weight_hash"
         case version
         case r2Prefix = "r2_prefix"
+        case huggingFaceArtifact = "hugging_face_artifact"
         case aggregateSHA256 = "aggregate_sha256"
         case totalSizeBytes = "total_size_bytes"
         case fileCount = "file_count"
@@ -85,6 +88,7 @@ public struct CatalogModel: Codable, Sendable, Equatable {
         weightHash: String? = nil,
         version: String? = nil,
         r2Prefix: String? = nil,
+        huggingFaceArtifact: HuggingFaceArtifact? = nil,
         aggregateSHA256: String? = nil,
         totalSizeBytes: Int64? = nil,
         fileCount: Int? = nil,
@@ -109,6 +113,7 @@ public struct CatalogModel: Codable, Sendable, Equatable {
         self.weightHash = weightHash
         self.version = version
         self.r2Prefix = r2Prefix
+        self.huggingFaceArtifact = huggingFaceArtifact
         self.aggregateSHA256 = aggregateSHA256
         self.totalSizeBytes = totalSizeBytes
         self.fileCount = fileCount

--- a/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelCatalogClient.swift
@@ -236,6 +236,8 @@ public struct ModelCatalogClient: Sendable {
             model.id, model.s3Name, model.displayName, model.modelType,
             model.architecture, model.description, model.weightHash, model.version,
             model.r2Prefix, model.aggregateSHA256, model.family, model.quantization,
+            model.huggingFaceArtifact?.repoID, model.huggingFaceArtifact?.revision,
+            model.huggingFaceArtifact?.pathPrefix,
         ].compactMap { $0 }
         guard strings.allSatisfy({ $0.utf8.count <= maximumJSONStringBytes }),
             (model.capabilities?.count ?? 0) <= maximumJSONCollectionCount,

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Download.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Download.swift
@@ -17,37 +17,6 @@ extension ModelDownloader {
         return hex == sha256.lowercased()
     }
 
-    /// Download a single manifest file into its staging destination, resuming
-    /// from a `.part` file when present, verifying size + SHA-256 before
-    /// promoting to the final staged path. Reuses the resume-capable
-    /// `downloadFile` helper (Range requests, Content-Range validation, retries).
-    ///
-    /// `onChunk(bytesOnDisk)` reports cumulative bytes-on-disk for this file as
-    /// it streams, so the foreground path can render a live per-shard bar; the
-    /// background prefetch passes nil and accounts progress per whole file.
-    internal func downloadManifestFileWithResume(
-        _ job: (file: ManifestFile, destination: URL, url: String),
-        onChunk: (@Sendable (Int64) -> Void)? = nil
-    ) async throws {
-        let ok = try await downloadFile(
-            from: job.url,
-            to: job.destination,
-            label: job.file.path,
-            onProgress: nil,
-            required: true,
-            expectedSHA256: job.file.sha256.lowercased(),
-            maximumBytes: job.file.sizeBytes,
-            onChunk: onChunk
-        )
-        guard ok else {
-            throw ModelCatalogError.downloadFailed("\(job.file.path): required file could not be fetched")
-        }
-        let size = fileSize(job.destination)
-        guard size == job.file.sizeBytes else {
-            throw ModelCatalogError.downloadFailed("\(job.file.path): size \(size) != manifest size \(job.file.sizeBytes)")
-        }
-    }
-
     internal func fetchManifestFromCDN(model: CatalogModel) async throws -> ModelManifest {
         guard let r2Prefix = model.r2Prefix else {
             throw ModelCatalogError.downloadFailed("model missing r2_prefix")
@@ -244,7 +213,7 @@ extension ModelDownloader {
                     let job = pending[next]
                     next += 1
                     group.addTask {
-                        try await self.downloadManifestFileWithResume(job, onChunk: { bytes in
+                        try await self.downloadManifestFileWithResume(job, huggingFaceArtifact: model.huggingFaceArtifact, onChunk: { bytes in
                             progress.update(label: job.file.path, downloadedBytes: bytes)
                         })
                         progress.complete(label: job.file.path)
@@ -256,7 +225,7 @@ extension ModelDownloader {
                         let job = pending[next]
                         next += 1
                         group.addTask {
-                            try await self.downloadManifestFileWithResume(job, onChunk: { bytes in
+                            try await self.downloadManifestFileWithResume(job, huggingFaceArtifact: model.huggingFaceArtifact, onChunk: { bytes in
                                 progress.update(label: job.file.path, downloadedBytes: bytes)
                             })
                             progress.complete(label: job.file.path)

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+HTTP.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+HTTP.swift
@@ -43,6 +43,8 @@ extension ModelDownloader {
         required: Bool,
         expectedSHA256: String? = nil,
         maximumBytes: Int64? = nil,
+        attempts: Int = 3,
+        requestTimeout: TimeInterval = 6 * 60 * 60,
         onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         guard let url = URL(string: urlString) else {
@@ -55,7 +57,8 @@ extension ModelDownloader {
         let partial = destination.appendingPathExtension("part")
 
         var lastError: Error?
-        for attempt in 1...3 {
+        for attempt in 1...attempts {
+            try Task.checkCancellation()
             do {
                 // True byte-level resume: stream the HTTP body straight to the
                 // `.part` file as bytes arrive (appending when a `.part` prefix
@@ -68,6 +71,7 @@ extension ModelDownloader {
                     label: label,
                     required: required,
                     maximumBytes: maximumBytes,
+                    requestTimeout: requestTimeout,
                     onChunk: onChunk
                 )
                 guard ok else {
@@ -99,8 +103,10 @@ extension ModelDownloader {
                 // intact so a later run can resume it. Never retry.
                 throw CancellationError()
             } catch {
+                try Task.checkCancellation()
+                if (error as? URLError)?.code == .cancelled { throw error }
                 lastError = error
-                if attempt < 3 {
+                if attempt < attempts {
                     try await Task.sleep(nanoseconds: UInt64(attempt) * 1_000_000_000)
                     continue
                 }
@@ -130,6 +136,7 @@ extension ModelDownloader {
         label: String,
         required: Bool,
         maximumBytes: Int64?,
+        requestTimeout: TimeInterval,
         onChunk: (@Sendable (Int64) -> Void)? = nil
     ) async throws -> Bool {
         let existingBytes = fileSize(partial)
@@ -139,7 +146,7 @@ extension ModelDownloader {
         // Model shards are multi-GB files. A short request timeout causes
         // legitimate downloads to fail; the streamed transfer keeps the
         // connection alive across the whole download.
-        request.timeoutInterval = 6 * 60 * 60
+        request.timeoutInterval = requestTimeout
         if existingBytes > 0 {
             request.setValue("bytes=\(existingBytes)-", forHTTPHeaderField: "Range")
         }

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Prefetch.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Prefetch.swift
@@ -120,7 +120,7 @@ extension ModelDownloader {
             if Self.fileMatches(job.destination, size: job.file.sizeBytes, sha256: job.file.sha256) {
                 continue
             }
-            try await downloadManifestFileWithResume(job)
+            try await downloadManifestFileWithResume(job, huggingFaceArtifact: model.huggingFaceArtifact)
             progress.add(job.file.sizeBytes)
             onByteProgress?(progress.done, total)
         }

--- a/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Sources.swift
+++ b/provider-swift/Sources/ProviderCore/Models/ModelDownloader+Sources.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Logging
+
+// Shared by foreground downloads and background prefetch. Every source uses
+// the same registry checksums and staged publication gate.
+extension ModelDownloader {
+    private static let huggingFaceIdleTimeout: TimeInterval = 30
+    private static let sourceLogger = Logger(label: "ai.darkbloom.ModelDownloader")
+
+    /// Download a single manifest file into its staging destination, resuming
+    /// from a `.part` file when present, verifying size + SHA-256 before
+    /// promoting to the final staged path. Reuses the resume-capable
+    /// `downloadFile` helper (Range requests, Content-Range validation, retries).
+    ///
+    /// `onChunk(bytesOnDisk)` reports cumulative bytes-on-disk for this file as
+    /// it streams, so the foreground path can render a live per-shard bar; the
+    /// background prefetch passes nil and accounts progress per whole file.
+    internal func downloadManifestFileWithResume(
+        _ job: (file: ManifestFile, destination: URL, url: String),
+        huggingFaceArtifact: HuggingFaceArtifact? = nil,
+        onChunk: (@Sendable (Int64) -> Void)? = nil
+    ) async throws {
+        if let artifact = huggingFaceArtifact {
+            let hfURL = try artifact.downloadURL(for: job.file.path)
+            do {
+                let ok = try await downloadFile(
+                    from: hfURL.absoluteString, to: job.destination, label: job.file.path,
+                    onProgress: nil, required: true, expectedSHA256: job.file.sha256.lowercased(),
+                    maximumBytes: job.file.sizeBytes, attempts: 1,
+                    requestTimeout: Self.huggingFaceIdleTimeout, onChunk: onChunk)
+                if ok, fileSize(job.destination) == job.file.sizeBytes { return }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try Task.checkCancellation()
+                if (error as? URLError)?.code == .cancelled { throw error }
+                Self.sourceLogger.warning("Hugging Face download failed; falling back to R2",
+                    metadata: ["file": "\(job.file.path)", "error": "\(error)"])
+            }
+            // Never carry a potentially corrupt HF prefix into the R2 fallback.
+            let partial = job.destination.appendingPathExtension("part")
+            if FileManager.default.fileExists(atPath: partial.path) {
+                try FileManager.default.removeItem(at: partial)
+            }
+            onChunk?(0)
+        }
+        try Task.checkCancellation()
+        let ok = try await downloadFile(
+            from: job.url,
+            to: job.destination,
+            label: job.file.path,
+            onProgress: nil,
+            required: true,
+            expectedSHA256: job.file.sha256.lowercased(),
+            maximumBytes: job.file.sizeBytes,
+            onChunk: onChunk
+        )
+        guard ok else {
+            throw ModelCatalogError.downloadFailed("\(job.file.path): required file could not be fetched")
+        }
+        let size = fileSize(job.destination)
+        guard size == job.file.sizeBytes else {
+            throw ModelCatalogError.downloadFailed("\(job.file.path): size \(size) != manifest size \(job.file.sizeBytes)")
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/HuggingFaceDownloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/HuggingFaceDownloadTests.swift
@@ -1,0 +1,217 @@
+import Crypto
+import Foundation
+import Testing
+@testable import ProviderCore
+import ProviderCoreFoundation
+
+private final class HFDownloadProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var bodies: [String: Data] = [:]
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var failure: URLError.Code?
+    private static let lock = NSLock()
+
+    static func reset(bodies: [String: Data], failure: URLError.Code? = nil) {
+        lock.lock(); defer { lock.unlock() }
+        self.bodies = bodies; self.failure = failure; requests = []
+    }
+
+    static func captured() -> [URLRequest] {
+        lock.lock(); defer { lock.unlock() }; return requests
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        let url = request.url!
+        Self.lock.lock()
+        Self.requests.append(request)
+        let body = Self.bodies[url.host!]
+        let failure = url.host == "huggingface.co" ? Self.failure : nil
+        Self.lock.unlock()
+        if let failure {
+            client?.urlProtocol(self, didFailWithError: URLError(failure))
+            return
+        }
+        var status = body == nil ? 404 : 200
+        var payload = body
+        var headers = ["Content-Length": "\(body?.count ?? 0)"]
+        if let body, let range = request.value(forHTTPHeaderField: "Range"),
+           range.hasPrefix("bytes="), let offset = Int(range.dropFirst(6).dropLast()),
+           offset < body.count {
+            payload = Data(body.dropFirst(offset))
+            status = 206
+            headers["Content-Range"] = "bytes \(offset)-\(body.count - 1)/\(body.count)"
+            headers["Content-Length"] = "\(body.count - offset)"
+        }
+        let response = HTTPURLResponse(url: url, statusCode: status,
+            httpVersion: "HTTP/1.1", headerFields: headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let payload { client?.urlProtocol(self, didLoad: payload) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+@Suite("Hugging Face verified downloads", .serialized)
+struct HuggingFaceDownloadTests {
+    private let revision = String(repeating: "a", count: 40)
+    private let bytes = Data("registered model bytes".utf8)
+    private var artifact: HuggingFaceArtifact {
+        HuggingFaceArtifact(repoID: "EigenLabs/test", revision: revision, pathPrefix: "mlx")
+    }
+    private func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+    private func downloader() -> ModelDownloader {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [HFDownloadProtocol.self]
+        return ModelDownloader(r2CDNURL: "https://r2.test", urlSession: URLSession(configuration: config))
+    }
+    private func job(_ destination: URL) -> (file: ManifestFile, destination: URL, url: String) {
+        (ManifestFile(path: "weights/model.safetensors", sizeBytes: Int64(bytes.count),
+            sha256: digest(bytes), role: "weight"), destination, "https://r2.test/v2/test/model.safetensors")
+    }
+
+    @Test("pinned URLs escape paths and reject mutable or unsafe artifact locators")
+    func urls() throws {
+        let url = try artifact.downloadURL(for: "weights/file #?%.safetensors")
+        #expect(url.absoluteString == "https://huggingface.co/EigenLabs/test/resolve/\(revision)/mlx/weights/file%20%23%3F%25.safetensors")
+        for invalid in [
+            HuggingFaceArtifact(repoID: "EigenLabs/test", revision: "main"),
+            HuggingFaceArtifact(repoID: "https://evil.test/repo", revision: revision),
+            HuggingFaceArtifact(repoID: "org//repo", revision: revision),
+            HuggingFaceArtifact(repoID: "org/repo", revision: revision, pathPrefix: "../weights"),
+            HuggingFaceArtifact(repoID: "org/repo", revision: revision, pathPrefix: "weights/"),
+        ] {
+            #expect(throws: (any Error).self) { try invalid.downloadURL(for: "config.json") }
+        }
+        #expect(throws: (any Error).self) { try artifact.downloadURL(for: "../config.json") }
+    }
+
+    @Test("catalog decodes optional artifact independently from upstream identity")
+    func catalogDecoding() throws {
+        let json = """
+        {"id":"test","s3_name":"v2/test/v1","display_name":"Test","model_type":"text","size_gb":1,
+         "hugging_face_id":"upstream/base","hugging_face_artifact":{
+         "repo_id":"EigenLabs/test","revision":"\(revision)","path_prefix":"mlx"}}
+        """
+        let model = try JSONDecoder().decode(CatalogModel.self, from: Data(json.utf8))
+        #expect(model.huggingFaceArtifact == artifact)
+        let encoded = try JSONEncoder().encode(model)
+        #expect(try JSONDecoder().decode(CatalogModel.self, from: encoded).huggingFaceArtifact == artifact)
+    }
+
+    @Test("HF resumes a saved prefix with Range and verifies the completed file")
+    func resume() async throws {
+        HFDownloadProtocol.reset(bodies: ["huggingface.co": bytes])
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let destination = dir.appendingPathComponent("model.safetensors")
+        try Data(bytes.prefix(4)).write(to: destination.appendingPathExtension("part"))
+        try await downloader().downloadManifestFileWithResume(job(destination), huggingFaceArtifact: artifact)
+        #expect(try Data(contentsOf: destination) == bytes)
+        #expect(HFDownloadProtocol.captured().count == 1)
+        #expect(HFDownloadProtocol.captured().first?.value(forHTTPHeaderField: "Range") == "bytes=4-")
+    }
+
+    @Test("HF is preferred and verified without touching R2")
+    func prefersHF() async throws {
+        HFDownloadProtocol.reset(bodies: ["huggingface.co": bytes])
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let destination = dir.appendingPathComponent("model.safetensors")
+        try await downloader().downloadManifestFileWithResume(job(destination), huggingFaceArtifact: artifact)
+        #expect(try Data(contentsOf: destination) == bytes)
+        let requests = HFDownloadProtocol.captured()
+        #expect(requests.count == 1)
+        #expect(requests.first?.url?.host == "huggingface.co")
+        #expect(requests.first?.timeoutInterval == 30)
+        #expect(requests.first?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test("HF missing, offline, stalled, or corrupt falls back to verified R2", arguments: ["missing", "offline", "timeout", "corrupt"])
+    func fallback(reason: String) async throws {
+        var bodies = ["r2.test": bytes]
+        if reason == "corrupt" { bodies["huggingface.co"] = Data(repeating: 0, count: bytes.count) }
+        let failure: URLError.Code? = reason == "offline" ? .networkConnectionLost : (reason == "timeout" ? .timedOut : nil)
+        HFDownloadProtocol.reset(bodies: bodies, failure: failure)
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let destination = dir.appendingPathComponent("model.safetensors")
+        // A corrupt saved prefix must not leak into the R2 request after HF fails.
+        try Data([0, 1]).write(to: destination.appendingPathExtension("part"))
+        try await downloader().downloadManifestFileWithResume(job(destination), huggingFaceArtifact: artifact)
+        #expect(try Data(contentsOf: destination) == bytes)
+        let requests = HFDownloadProtocol.captured()
+        #expect(requests.map { $0.url!.host! } == ["huggingface.co", "r2.test"])
+        #expect(requests.last?.value(forHTTPHeaderField: "Range") == nil)
+    }
+
+    @Test("cancellation does not retry on R2 or delete resumable bytes")
+    func cancellation() async throws {
+        HFDownloadProtocol.reset(bodies: ["r2.test": bytes], failure: .cancelled)
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let destination = dir.appendingPathComponent("model.safetensors")
+        let partial = destination.appendingPathExtension("part")
+        try Data([1, 2]).write(to: partial)
+        await #expect(throws: (any Error).self) {
+            try await downloader().downloadManifestFileWithResume(job(destination), huggingFaceArtifact: artifact)
+        }
+        #expect(HFDownloadProtocol.captured().count == 1)
+        #expect(try Data(contentsOf: partial) == Data([1, 2]))
+    }
+
+    @Test("legacy entry downloads only from R2")
+    func legacy() async throws {
+        HFDownloadProtocol.reset(bodies: ["r2.test": bytes])
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await downloader().downloadManifestFileWithResume(job(dir.appendingPathComponent("model.safetensors")))
+        #expect(HFDownloadProtocol.captured().map { $0.url!.host! } == ["r2.test"])
+    }
+
+    @Test("foreground and prefetch publish only verified HF bytes", arguments: [false, true])
+    func publication(prefetch: Bool) async throws {
+        HFDownloadProtocol.reset(bodies: ["huggingface.co": bytes])
+        let id = "test-hf/\(UUID().uuidString)"
+        let modelDir = ModelDownloader.cacheModelDirectory(for: id)
+        defer { try? FileManager.default.removeItem(at: modelDir) }
+        let file = job(modelDir).file
+        let rawDigest = Data(SHA256.hash(data: bytes))
+        let aggregate = digest(rawDigest)
+        let model = CatalogModel(id: id, s3Name: "v2/test/v1", displayName: "Test", sizeGb: 0,
+            r2Prefix: "v2/test/v1", huggingFaceArtifact: artifact, aggregateSHA256: aggregate)
+        let manifest = ModelManifest(schemaVersion: 1, modelID: id, version: "v1", r2Prefix: "v2/test/v1",
+            aggregateSHA256: aggregate, totalSizeBytes: Int64(bytes.count), fileCount: 1, files: [file], createdAt: Date())
+        if prefetch {
+            try await downloader().prefetch(model: model, manifest: manifest)
+        } else {
+            try await downloader().downloadManifestModel(model: model, manifest: manifest, onProgress: nil)
+        }
+        let snapshot = ModelDownloader.cacheSnapshotDirectory(for: id)
+        #expect(try Data(contentsOf: snapshot.appendingPathComponent(file.path)) == bytes)
+        #expect(try String(contentsOf: modelDir.appendingPathComponent("refs/main"), encoding: .utf8) == "local")
+        #expect(HFDownloadProtocol.captured().map { $0.url!.host! } == ["huggingface.co"])
+    }
+
+    @Test("corruption on both sources never publishes a snapshot")
+    func rejectsBothCorrupt() async throws {
+        HFDownloadProtocol.reset(bodies: ["huggingface.co": Data([0]), "r2.test": Data([0])])
+        let id = "test-hf/\(UUID().uuidString)"
+        let modelDir = ModelDownloader.cacheModelDirectory(for: id)
+        defer { try? FileManager.default.removeItem(at: modelDir) }
+        let file = job(modelDir).file
+        let aggregate = digest(Data(SHA256.hash(data: bytes)))
+        let model = CatalogModel(id: id, s3Name: "v2/test/v1", displayName: "Test", sizeGb: 0,
+            r2Prefix: "v2/test/v1", huggingFaceArtifact: artifact, aggregateSHA256: aggregate)
+        let manifest = ModelManifest(schemaVersion: 1, modelID: id, version: "v1", r2Prefix: "v2/test/v1",
+            aggregateSHA256: aggregate, totalSizeBytes: Int64(bytes.count), fileCount: 1, files: [file], createdAt: Date())
+        await #expect(throws: (any Error).self) { try await downloader().prefetch(model: model, manifest: manifest) }
+        #expect(!FileManager.default.fileExists(atPath: modelDir.appendingPathComponent("refs/main").path))
+        #expect(!FileManager.default.fileExists(atPath: ModelDownloader.cacheSnapshotDirectory(for: id).path))
+    }
+}

--- a/scripts/publish-model.sh
+++ b/scripts/publish-model.sh
@@ -87,6 +87,28 @@ if [[ -z "${R2_ACCOUNT_ID:-}" ]]; then
   exit 1
 fi
 
+# Pin an existing public HF mirror; the registry remains the checksum authority.
+# This script uploads R2 bytes, while HF publication remains a separate operation.
+HUGGING_FACE_ARTIFACT_JSON="$(python3 - "${HUGGING_FACE_ARTIFACT_JSON:-null}" <<'PYHF'
+import json, re, sys
+artifact = json.loads(sys.argv[1])
+if artifact is not None:
+    component = r"[A-Za-z0-9_][A-Za-z0-9._-]*"
+    if not isinstance(artifact, dict) or set(artifact) - {"repo_id", "revision", "path_prefix"}:
+        raise SystemExit("Invalid HUGGING_FACE_ARTIFACT_JSON object")
+    repo, revision, prefix = (artifact.get(k, "") for k in ("repo_id", "revision", "path_prefix"))
+    if not all(isinstance(v, str) for v in (repo, revision, prefix)):
+        raise SystemExit("HF artifact fields must be strings")
+    if len(repo) > 192 or ".." in repo or not re.fullmatch(component + "/" + component, repo):
+        raise SystemExit("HF repo_id must be owner/repository")
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise SystemExit("HF revision must be a full lowercase commit SHA")
+    if len(prefix) > 1024 or ".." in prefix or (prefix and not re.fullmatch(component + "(?:/" + component + ")*", prefix)):
+        raise SystemExit("HF path_prefix must be a relative repository path")
+print(json.dumps(artifact, separators=(",", ":")))
+PYHF
+)"
+
 MANIFEST="$(mktemp -t darkbloom-model-manifest.XXXXXX.json)"
 trap 'rm -f "$MANIFEST"' EXIT
 
@@ -150,6 +172,7 @@ Register with GitHub Actions:
     -f min_ram_gb="<minimum RAM GB>" \
     -f description="" \
     -f runtime_parameters_json='{}' \
+    -f hugging_face_artifact_json='$HUGGING_FACE_ARTIFACT_JSON' \
     -f metadata_json='{}' \
     -f promote="false" \
     -f coordinator_url="https://api.darkbloom.dev"

--- a/scripts/test-publish-model.sh
+++ b/scripts/test-publish-model.sh
@@ -143,3 +143,19 @@ if [[ -e "$FAKE_SWIFT_MARKER" ]]; then
 fi
 
 printf 'publish model contract tests passed\n'
+
+# Optional artifact survives the real workflow payload builder and publisher output.
+export HUGGING_FACE_ARTIFACT_JSON='{"repo_id":"EigenLabs/test","revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","path_prefix":"mlx"}'
+build_payload '' "$TEST_ROOT/hf"
+jq -e '.hugging_face_artifact.repo_id == "EigenLabs/test" and .hugging_face_artifact.revision == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" and .hugging_face_artifact.path_prefix == "mlx"' "$TEST_ROOT/hf/payload.json" >/dev/null
+hf_output="$(run_publish 'test-model' '')"
+printf '%s\n' "$hf_output" | grep -Fq -- "-f hugging_face_artifact_json='$HUGGING_FACE_ARTIFACT_JSON'"
+export HUGGING_FACE_ARTIFACT_JSON='{"repo_id":"EigenLabs/test","revision":"main"}'
+if run_publish 'test-model' '' >/dev/null 2>&1; then
+  printf 'Publisher accepted mutable HF revision.\n' >&2
+  exit 1
+fi
+unset HUGGING_FACE_ARTIFACT_JSON
+build_payload '' "$TEST_ROOT/hf-legacy"
+jq -e '.hugging_face_artifact == null' "$TEST_ROOT/hf-legacy/payload.json" >/dev/null
+printf 'Hugging Face publish payload tests passed.\n'


### PR DESCRIPTION
Model downloads currently depend on R2 even when the same artifact is published to Hugging Face. This adds an optional `hugging_face_artifact` to each registry version so foreground downloads and background prefetch can prefer HF while retaining the registry's SHA-256 checks and R2 fallback.

The artifact specifies `repo_id`, a full commit `revision`, and optional `path_prefix`. It is separate from the upstream `hugging_face_id` used in model metadata. Entries without it and older providers continue using R2.

- Persist the optional artifact in `model_versions` as nullable JSONB, return it in the catalog, and deep-copy it across memory/cache boundaries. Re-registration replaces or clears it using existing cache invalidation.
- Share source selection through `downloadManifestFileWithResume`: try the pinned HF file once with a 30-second idle request timeout, then use the existing R2 retry policy on download or integrity failure. Clear the failed HF partial before fallback; cancellation preserves resumable bytes and does not fall back.
- Require the existing per-file size/SHA-256 checks and final aggregate hash before publishing a snapshot. HF artifacts must be public and ungated; providers send no HF credentials.
- Wire the field through registration, publishing-script/workflow inputs, the Swift catalog client, the console catalog type, and documentation.

### Before

```mermaid
flowchart TD
  R[handleRegisterModel] --> V[SetModelVersion: R2 prefix and manifest hashes]
  V --> C[catalogModelFromRegistryRecord]
  C --> D[ModelDownloader.download / prefetch]
  D --> F[downloadManifestFileWithResume]
  F --> H[downloadFile: R2 with resume and retries]
  H --> P{File size and SHA-256 match?}
  P -- No --> E[Download fails; model unavailable]
  P -- Yes --> A{Aggregate hash matches?}
  A -- No --> E
  A -- Yes --> S[Publish snapshot and refs/main; model available]
```

### After

```mermaid
flowchart TD
  R[handleRegisterModel validates pinned HF artifact] --> V[SetModelVersion: optional artifact plus existing R2 prefix and hashes]
  V --> C[catalogModelFromRegistryRecord returns artifact]
  C --> D[ModelDownloader.download / prefetch]
  D --> F[downloadManifestFileWithResume in Sources.swift]
  F --> Q{Artifact configured?}
  Q -- Yes --> HF[HuggingFaceArtifact.downloadURL and downloadFile: pinned HF file]
  HF --> P{Download, size and SHA-256 valid?}
  P -- No --> X[Clear failed HF partial]
  X --> R2[downloadFile: R2 with existing verification and retries]
  Q -- No --> R2
  HF -- Cancelled --> K[Preserve partial and propagate cancellation]
  P -- Yes --> A{Aggregate hash matches?}
  R2 -- Verified --> A
  R2 -- Failed --> E[Download fails; model unavailable]
  A -- No --> E
  A -- Yes --> S[Publish snapshot and refs/main; model available]
```

### Validation

- Coordinator: `go test ./api ./store` passed.
- Swift: `swift build --build-tests` passed; 45 tests passed with `swift test --filter 'HuggingFaceDownloadTests|ModelCatalogTests|ModelPrefetchDownloaderTests'`.
- Real disposable Postgres: `TestHuggingFaceArtifactPostgresAndCache` passed, covering persistence, clearing, and cache invalidation.
- Pre-commit Go formatting and console ESLint passed (0 errors, 75 warnings in unchanged UI files).
- `bash scripts/test-publish-model.sh`, `make docs-check`, and `git diff --check` passed.
- Live read-only inspection: Qwen3.5-9B's main/MTP weight shards and tokenizer had matching HF-reported SHA-256 metadata; seven downloaded small files from pinned commit `556dcba57d1ae8101be4c7a04199ec3bde7b5dfb` also matched the registry hashes. No full-model speed benchmark was performed.

Deployment, a provider release, and registration of artifact locations are separate rollout steps. This PR does not change production registry entries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791192243&installation_model_id=21733&pr_number=834&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F834&signature=ce3b087019edb07cf04a06d7933c65ba1d5677d82e60090ef44a376546419759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->