### PR TITLE
fix(responses): preserve instructions in prompts and admission estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased - Responses instructions
+
+- Preserve top-level `instructions` on `/v1/responses` as the leading system message for both streaming and non-streaming inference, including them in routing and billing reservation estimates. Reject non-string, non-null instructions instead of silently ignoring them.
+
 ## Unreleased — Qwen non-thinking streaming
 
 - Stream Qwen answers as they are generated when the rendered prompt already closes its thinking block, including image and video requests that default thinking off. Preserve incremental reasoning, explicit parser overrides, and token usage.

--- a/coordinator/api/provider_body_identity_test.go
+++ b/coordinator/api/provider_body_identity_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -255,6 +256,24 @@ func TestProviderBodyByteIdentity(t *testing.T) {
 		}
 		assertProviderBytes(t, got, want)
 	})
+
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("responses instructions stream=%t", stream), func(t *testing.T) {
+			body := fmt.Sprintf(`{"model":%q,"instructions":"Answer in French.","input":"hello","max_output_tokens":16,"stream":%t}`, plainBuild, stream)
+			got := postAndCapture(t, ctx, ts, fp, "/v1/responses", "test-key", body)
+			want := forwardOracle(t, body, func(p map[string]any) {
+				delete(p, "instructions")
+				delete(p, "input")
+				delete(p, "max_output_tokens")
+				p["max_tokens"] = 16
+				p["messages"] = []any{
+					map[string]any{"role": "system", "content": "Answer in French."},
+					map[string]any{"role": "user", "content": "hello"},
+				}
+			})
+			assertProviderBytes(t, got, want)
+		})
+	}
 
 	t.Run("responses lowering after rewrite", func(t *testing.T) {
 		body := `{"model":"` + alias + `","input":"hello"}`

--- a/coordinator/api/request_introspection.go
+++ b/coordinator/api/request_introspection.go
@@ -189,7 +189,21 @@ func routingShape(parsed map[string]any) (routingTokens, mediaParts int) {
 	if v, ok := parsed["prompt"]; ok {
 		routingTokens += approximateTokenCount(v)
 	}
+	if instructions := responsesInstructions(parsed); instructions != "" {
+		routingTokens += 4 + approximateTokenCount(instructions)
+	}
 	return routingTokens, mediaParts
+}
+
+// The Responses instructions become a system message after admission. Count
+// them only when the handler selects the Responses lowering path.
+func responsesInstructions(parsed map[string]any) string {
+	messages, _ := parsed["messages"].([]any)
+	if parsed["input"] == nil || len(messages) > 0 {
+		return ""
+	}
+	instructions, _ := parsed["instructions"].(string)
+	return instructions
 }
 
 // billingBytes is the byte-length reservation bound over the same fields.
@@ -205,6 +219,11 @@ func billingBytes(parsed map[string]any) int {
 		if v, ok := parsed[field]; ok {
 			total += approximateTokenCountUpperBound(v)
 		}
+	}
+	if instructions := responsesInstructions(parsed); instructions != "" {
+		total += approximateTokenCountUpperBound([]any{
+			map[string]any{"role": "system", "content": instructions},
+		})
 	}
 	return total
 }

--- a/coordinator/api/responses_instructions_test.go
+++ b/coordinator/api/responses_instructions_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResponsesInstructionsAdmissionEstimates(t *testing.T) {
+	instructions := strings.Repeat("Follow these rules. ", 512)
+	input := []any{map[string]any{"role": "user", "content": "hello"}}
+	parsed := map[string]any{"input": input, "instructions": instructions}
+	chat := map[string]any{"messages": []any{
+		map[string]any{"role": "system", "content": instructions},
+		input[0],
+	}}
+	shape := introspectRequest(parsed)
+	if got, want := shape.routingPromptTokens(parsed), estimatePromptTokens(chat); got != want {
+		t.Fatalf("routing tokens = %d, want equivalent chat estimate %d", got, want)
+	}
+	if got, want := shape.billingPromptTokens(parsed), estimateBillingPromptTokens(chat); got < want {
+		t.Fatalf("billing bound = %d, below equivalent chat bound %d", got, want)
+	}
+	if estimatePromptTokens(parsed) != shape.routingPromptTokens(parsed) ||
+		estimateBillingPromptTokens(parsed) != shape.billingPromptTokens(parsed) {
+		t.Fatal("standalone estimates disagree with admission introspection")
+	}
+	if shape.requiresVision() {
+		t.Fatal("text instructions must not require vision")
+	}
+}
+
+func TestUnusedResponsesInstructionsDoNotChangeEstimates(t *testing.T) {
+	for _, body := range []string{
+		`{"input":"hello","instructions":null}`,
+		`{"input":"hello","instructions":""}`,
+		`{"messages":[{"role":"user","content":"hello"}],"instructions":"unused"}`,
+		`{"messages":[{"role":"user","content":"hello"}],"input":"hello","instructions":"unused"}`,
+	} {
+		parsed, err := decodeInferenceJSONObject([]byte(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := introspectRequest(parsed)
+		delete(parsed, "instructions")
+		if want := introspectRequest(parsed); got != want {
+			t.Fatalf("unused instructions changed estimates: got %+v, want %+v", got, want)
+		}
+	}
+}

--- a/coordinator/promptcontract/endpoint_lower_responses.go
+++ b/coordinator/promptcontract/endpoint_lower_responses.go
@@ -15,9 +15,20 @@ func lowerResponses(input map[string]any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if raw := input["instructions"]; raw != nil {
+		instructions, ok := raw.(string)
+		if !ok {
+			return nil, ErrEndpointBodyInvalid
+		}
+		if instructions != "" {
+			messages = append([]any{map[string]any{
+				"role": "system", "content": instructions,
+			}}, messages...)
+		}
+	}
 
 	output := cloneObject(input)
-	for _, key := range []string{"input", "endpoint", "max_output_tokens", "text"} {
+	for _, key := range []string{"input", "instructions", "endpoint", "max_output_tokens", "text"} {
 		delete(output, key)
 	}
 	output["messages"] = messages

--- a/coordinator/promptcontract/endpoint_lower_responses_test.go
+++ b/coordinator/promptcontract/endpoint_lower_responses_test.go
@@ -1,0 +1,43 @@
+package promptcontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLowerResponsesInstructions(t *testing.T) {
+	encoded, err := os.ReadFile(filepath.Join("..", "..", "fixtures", "prompt-contract", "v1", "responses_instructions.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cases []struct {
+		Name     string          `json:"name"`
+		Request  json.RawMessage `json:"request"`
+		Expected json.RawMessage `json:"expected"`
+		Invalid  bool            `json:"invalid"`
+	}
+	if err := json.Unmarshal(encoded, &cases); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got, err := LowerProviderBody(EndpointResponses, tc.Request)
+			if tc.Invalid {
+				if !errors.Is(err, ErrEndpointBodyInvalid) {
+					t.Fatalf("error = %v, want ErrEndpointBodyInvalid", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := canonicalJSON(t, tc.Expected); !bytes.Equal(got, want) {
+				t.Fatalf("provider body = %s, want %s", got, want)
+			}
+		})
+	}
+}

--- a/coordinator/promptsidecar/src/endpoint.rs
+++ b/coordinator/promptsidecar/src/endpoint.rs
@@ -90,9 +90,24 @@ fn lower_completions(input: &Map<String, Value>) -> Result<Map<String, Value>, E
 }
 
 fn lower_responses(input: &Map<String, Value>) -> Result<Map<String, Value>, EndpointError> {
-    let messages = responses_messages(input.get("input").ok_or(EndpointError::Invalid)?)?;
+    let mut messages = responses_messages(input.get("input").ok_or(EndpointError::Invalid)?)?;
+    match input.get("instructions") {
+        None | Some(Value::Null) => {}
+        Some(Value::String(instructions)) => {
+            if !instructions.is_empty() {
+                messages.insert(0, json!({"role": "system", "content": instructions}));
+            }
+        }
+        Some(_) => return Err(EndpointError::Invalid),
+    }
     let mut out = input.clone();
-    for key in ["input", "endpoint", "max_output_tokens", "text"] {
+    for key in [
+        "input",
+        "instructions",
+        "endpoint",
+        "max_output_tokens",
+        "text",
+    ] {
         out.remove(key);
     }
     out.insert("messages".into(), Value::Array(messages));
@@ -535,6 +550,31 @@ fn explicit_max_tokens(input: &Map<String, Value>) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lowers_responses_instructions_shared_vectors() {
+        let cases: Vec<Value> = serde_json::from_str(include_str!(
+            "../../../fixtures/prompt-contract/v1/responses_instructions.json"
+        ))
+        .unwrap();
+        for case in cases {
+            let result = lower(Endpoint::Responses, case["request"].clone());
+            if case["invalid"] == true {
+                assert!(
+                    matches!(result, Err(EndpointError::Invalid)),
+                    "{}: {result:?}",
+                    case["name"]
+                );
+            } else {
+                assert_eq!(
+                    Value::Object(result.unwrap()),
+                    case["expected"],
+                    "{}",
+                    case["name"]
+                );
+            }
+        }
+    }
 
     #[test]
     fn lowers_responses_function_history() {

--- a/docs/consumer/quickstart.md
+++ b/docs/consumer/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart: first request in five steps
 
-> Last updated: 2026-09-04 · commit `075d37a91`
+> Last updated: 2026-09-05 · commit `2df9d5c1b`
 
 Get an API key from the console, list the models your key can use, and make your first chat completion against `https://api.darkbloom.dev` — first with `curl`, then from the OpenAI and Anthropic SDKs. For developers integrating the API; each step is one action. Route details for everything used here are in [`../reference/api-contracts.md`](../reference/api-contracts.md).
 
@@ -89,6 +89,19 @@ print(resp.choices[0].message.content)
 ```
 
 `client.models.list()` and `client.responses.create(...)` also work: they hit `GET /v1/models` and `POST /v1/responses`, both registered routes. Endpoints the coordinator does not implement (embeddings, moderations, files) return a structured 404 from the `/v1/` catch-all (`handleUnimplementedEndpoint`, `coordinator/api/server.go`).
+
+For Responses requests, pass the system prompt in `instructions`:
+
+```python
+resp = client.responses.create(
+    model=MODEL,
+    instructions="Answer in French.",
+    input="Say hello in one sentence.",
+)
+print(resp.output_text)
+```
+
+The coordinator places it before `input`; see the [Responses contract](../reference/api-contracts.md#responses-api).
 
 ### 7. Use the Anthropic SDK
 

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,6 +1,6 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-04 · commit `fcecc3675`
+> Last updated: 2026-09-05 · commit `2df9d5c1b`
 
 The complete public HTTP surface of the coordinator, derived from the 105 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
@@ -351,6 +351,10 @@ Requests are decoded into a generic JSON object with `json.Number` preserved (`p
 | `location` | `ProviderApproxLocation` | Only with metadata details: `region`, `region_code`, `country`, `country_code`, `timezone` |
 
 ### Responses API
+
+`lowerResponses` (`coordinator/promptcontract/endpoint_lower_responses.go`) prepends non-empty string `instructions` as a system message before the messages derived from `input`, preserving existing system/developer messages and tool history. Omitted, null, or empty instructions add no message; other types return 400 `invalid_request_error`. The Rust sidecar mirrors this in `lower_responses` (`coordinator/promptsidecar/src/endpoint.rs`).
+
+Routing token estimates and the billing reservation bound include this system message before lowering (`routingShape`, `billingBytes`, `coordinator/api/request_introspection.go`).
 
 Bodies are lowered into the chat pipeline (`coordinator/promptcontract/endpoint_lower_responses.go`) and the provider's chat output is raised back into `ResponsesResponse` (`coordinator/api/types/types.go`): `id` (`resp_…`), `object`, `created_at`, `status`, `error`, `incomplete_details.reason`, `instructions`, `max_output_tokens`, `model`, `output[]`, `parallel_tool_calls`, `temperature`, `tool_choice`, `tools`, `top_p`, `metadata`, `usage` (`input_tokens`, `input_tokens_details.cached_tokens`, `output_tokens`, `output_tokens_details.reasoning_tokens`), `se_signature`, `response_hash`. Streams use `event:`-typed frames from `response.created` / `response.in_progress` through the item deltas to `response.completed` (or `response.incomplete` when truncated) and carry **no** `data: [DONE]` (`newResponsesStreamEmitter`, `coordinator/api/responses_stream.go`).
 

--- a/fixtures/prompt-contract/v1/production_vectors.json
+++ b/fixtures/prompt-contract/v1/production_vectors.json
@@ -519,8 +519,11 @@
           },
           "provider_body": {
             "model": "gemma-4-26b",
-            "instructions": "Be concise.",
             "messages": [
+              {
+                "role": "system",
+                "content": "Be concise."
+              },
               {
                 "role": "user",
                 "content": "Responses endpoint"
@@ -531,6 +534,10 @@
             "model": "gemma-4-26b",
             "messages": [
               {
+                "role": "system",
+                "content": "Be concise."
+              },
+              {
                 "role": "user",
                 "content": "Responses endpoint"
               }
@@ -538,11 +545,19 @@
           },
           "plan": {
             "prompt_contract_id": "775df5693a45b12a900f16bfd8775d14c080f2321fd3fef8e27ebd93bee276cf",
-            "prompt_token_count": 15,
+            "prompt_token_count": 23,
             "block_boundaries": []
           },
           "token_ids": [
             2,
+            105,
+            9731,
+            107,
+            3912,
+            63510,
+            236761,
+            106,
+            107,
             105,
             2364,
             107,
@@ -4142,8 +4157,11 @@
           },
           "provider_body": {
             "model": "gemma-4-26b-8bit",
-            "instructions": "Be concise.",
             "messages": [
+              {
+                "role": "system",
+                "content": "Be concise."
+              },
               {
                 "role": "user",
                 "content": "Responses endpoint"
@@ -4154,6 +4172,10 @@
             "model": "gemma-4-26b-8bit",
             "messages": [
               {
+                "role": "system",
+                "content": "Be concise."
+              },
+              {
                 "role": "user",
                 "content": "Responses endpoint"
               }
@@ -4161,11 +4183,19 @@
           },
           "plan": {
             "prompt_contract_id": "775df5693a45b12a900f16bfd8775d14c080f2321fd3fef8e27ebd93bee276cf",
-            "prompt_token_count": 15,
+            "prompt_token_count": 23,
             "block_boundaries": []
           },
           "token_ids": [
             2,
+            105,
+            9731,
+            107,
+            3912,
+            63510,
+            236761,
+            106,
+            107,
             105,
             2364,
             107,
@@ -7765,8 +7795,11 @@
           },
           "provider_body": {
             "model": "gemma-4-26b-qat-4bit",
-            "instructions": "Be concise.",
             "messages": [
+              {
+                "role": "system",
+                "content": "Be concise."
+              },
               {
                 "role": "user",
                 "content": "Responses endpoint"
@@ -7777,6 +7810,10 @@
             "model": "gemma-4-26b-qat-4bit",
             "messages": [
               {
+                "role": "system",
+                "content": "Be concise."
+              },
+              {
                 "role": "user",
                 "content": "Responses endpoint"
               }
@@ -7784,11 +7821,19 @@
           },
           "plan": {
             "prompt_contract_id": "260d5e73e744fb4bd023bc282702d507a7babca715ca1f6ebf5504fc9c010c55",
-            "prompt_token_count": 15,
+            "prompt_token_count": 23,
             "block_boundaries": []
           },
           "token_ids": [
             2,
+            105,
+            9731,
+            107,
+            3912,
+            63510,
+            236761,
+            106,
+            107,
             105,
             2364,
             107,

--- a/fixtures/prompt-contract/v1/responses_instructions.json
+++ b/fixtures/prompt-contract/v1/responses_instructions.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "string input preserves instruction whitespace",
+    "request": {"input": "hello", "instructions": "  Answer in French.\n"},
+    "expected": {"messages": [{"role": "system", "content": "  Answer in French.\n"}, {"role": "user", "content": "hello"}]}
+  },
+  {
+    "name": "instructions precede existing system and developer messages",
+    "request": {"instructions": "First rule", "input": [{"role": "system", "content": "Second rule"}, {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "Third rule"}]}, {"role": "user", "content": "hello"}]},
+    "expected": {"messages": [{"role": "system", "content": "First rule"}, {"role": "system", "content": "Second rule"}, {"role": "system", "content": "Third rule"}, {"role": "user", "content": "hello"}]}
+  },
+  {
+    "name": "instructions preserve function history",
+    "request": {"instructions": "Use tools", "input": [{"type": "function_call", "call_id": "c1", "name": "weather", "arguments": "{}"}, {"type": "function_call_output", "call_id": "c1", "output": "sunny"}]},
+    "expected": {"messages": [{"role": "system", "content": "Use tools"}, {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "weather", "arguments": "{}"}}]}, {"role": "tool", "tool_call_id": "c1", "content": "sunny"}]}
+  },
+  {
+    "name": "omitted instructions",
+    "request": {"input": "hello"},
+    "expected": {"messages": [{"role": "user", "content": "hello"}]}
+  },
+  {
+    "name": "null instructions",
+    "request": {"input": "hello", "instructions": null},
+    "expected": {"messages": [{"role": "user", "content": "hello"}]}
+  },
+  {
+    "name": "empty instructions",
+    "request": {"input": "hello", "instructions": ""},
+    "expected": {"messages": [{"role": "user", "content": "hello"}]}
+  },
+  {"name": "reject numeric instructions", "request": {"input": "hello", "instructions": 42}, "invalid": true},
+  {"name": "reject boolean instructions", "request": {"input": "hello", "instructions": false}, "invalid": true},
+  {"name": "reject object instructions", "request": {"input": "hello", "instructions": {"text": "rules"}}, "invalid": true},
+  {"name": "reject array instructions", "request": {"input": "hello", "instructions": ["rules"]}, "invalid": true},
+  {"name": "instructions do not replace required input", "request": {"instructions": "rules"}, "invalid": true}
+]


### PR DESCRIPTION
## Summary

`POST /v1/responses` accepted top-level `instructions` but forwarded them as an unused chat field, so the model never received the caller's system prompt. Prepend non-empty instructions as a system message in both Go endpoint lowering and the Rust prompt sidecar, preserving existing input messages and tool history. Omitted, null, and empty instructions add no message; other types are rejected.

Regenerate the production prompt vectors from the committed manifest snapshots so the provider bodies, template inputs, and token counts include the instructions. Document the behavior and add a Responses SDK example.

Include the instructions in pre-lowering routing and billing reservation estimates so a long system prompt cannot bypass the existing input-token budget.

## Linked issue

Closes #731

## Before

```mermaid
flowchart LR
    A["POST /v1/responses: instructions + input"] --> B["handleChatCompletions"]
    B --> C["Go lowerResponses: lower input only"]
    B --> I["routingShape / billingBytes omit instructions"]
    A --> D["Rust lower_responses: lower input only"]
    C --> E["Provider chat messages omit instructions"]
    D --> F["Prompt plan omits instruction tokens"]
    E --> G["Streaming or JSON answer lacks system prompt context"]
```

## After

```mermaid
flowchart LR
    A["POST /v1/responses: instructions + input"] --> B["handleChatCompletions"]
    B --> C["Go lowerResponses: validate and prepend system message"]
    B --> I["routingShape / billingBytes count the system instructions"]
    A --> D["Rust lower_responses: same validation and prepend"]
    C --> E["Encrypted dispatch: system instructions then input history"]
    D --> F["Prompt plan includes instruction tokens"]
    E --> G["Provider receives system prompt for streaming and JSON answers"]
    C --> H["Invalid instruction type: HTTP 400"]
```

## Test plan

- [x] `GOTOOLCHAIN=go1.25.0 go test -p 1 ./coordinator/...` and coordinator build. The parallel suite hit the existing supervisor restart test's short timing window; the serial suite passed.
- [x] Confirmed the new shared regression cases fail against the original Go and Rust lowering code.
- [x] Shared Go/Rust cases cover string and array inputs, existing system/developer messages, function history, whitespace, absent/null/empty instructions, invalid types, and required input.
- [x] Real HTTP/WebSocket regression verifies the decrypted provider body for streaming and non-streaming `/v1/responses` requests.
- [x] Admission regression compares a long Responses instruction against the equivalent chat system prompt and preserves estimates for unused instructions.
- [x] `cargo +1.88.0 test --locked` (83 tests), `cargo +1.88.0 clippy --locked --all-targets -- -D warnings`, and `cargo +1.88.0 fmt --all -- --check`.
- [x] Production vectors regenerated using `promptfixtureinput` with committed manifests and `prompt-fixtures`, including verified tokenizer/template artifacts.
- [x] `make docs-check`.
- [ ] Swift `ProductionPromptParityTests`: attempted, but this machine has Command Line Tools without the `Testing` module and no full Xcode installation; compilation stops at `import Testing` before running tests.

## Components touched

- [x] coordinator (Go and Rust prompt sidecar)
- [x] docs

## Protocol / interface changes

Existing Responses request semantics are repaired. No WebSocket changes, migration, provider release, or version bump is required. Go and Rust lowering remain aligned through shared regression fixtures.

## Notes for reviewers

This changes the context delivered to inference; it does not change the existing response envelope's `instructions` echo behavior or add persisted Responses history.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791214609&installation_model_id=21733&pr_number=835&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F835&signature=d0dd2a008582087dcc47d0be18a4cdcbf0b773e36b8bb53344b1c47cf960869d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->