### PR TITLE
fix(provider-swift): bound the doctor/verify contention and sleep probes (#811)

### DIFF
--- a/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
@@ -40,21 +40,40 @@ struct LocalContentionSnapshot: Equatable, Sendable {
         )
     }
 
-    private static func runCapture(_ path: String, args: [String]) -> String? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: path)
-        p.arguments = args
-        let pipe = Pipe()
-        p.standardOutput = pipe
-        p.standardError = FileHandle.nullDevice
-        do {
-            try p.run()
-            p.waitUntilExit()
-        } catch {
-            return nil
-        }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)
+    /// Runs `path` and returns its stdout, or nil if the probe could not
+    /// produce any.
+    ///
+    /// This used to spawn the child itself and call `waitUntilExit()` before
+    /// reading the pipe, which deadlocks the moment the child outgrows the
+    /// ~64 KiB Darwin pipe buffer: the child blocks in `write(2)` with a full
+    /// pipe while the parent waits for it to exit. `ps -axo comm=` clears
+    /// 64 KiB on a busy Mac, so `doctor` and `verify` hung outright (#811).
+    ///
+    /// `FanProcessRunner` drains concurrently *and* enforces a deadline, which
+    /// is the part draining alone does not give: a child that never closes
+    /// stdout still holds `readDataToEndOfFile()` forever. Five seconds is the
+    /// budget for a probe documented above as degrading to empty, so a slow
+    /// `lsof` now costs a missing hint rather than a hung command.
+    static func runCapture(_ path: String, args: [String]) -> String? {
+        let result = FanProcessRunner.run(
+            path,
+            arguments: args,
+            timeout: 5,
+            discardStandardError: true,
+            // The runner's 64 KiB default is sized for fan install logs. `ps`
+            // was 78,689 bytes on the reporter's Mac, and a busy machine is
+            // exactly where this probe has to work, so capping at 64 KiB would
+            // drop the hints past the cap and report "no competitors" for a
+            // running Ollama. 1 MiB is ~13x the reported table and still bounds
+            // a runaway child.
+            maximumOutputBytes: 1024 * 1024
+        )
+        // -1 is a spawn failure or the deadline. A non-zero *exit* still yields
+        // usable text and the previous implementation never checked the status
+        // either, so `lsof` exiting 1 with no listener keeps degrading to no
+        // hint. Output is decoded lossily where `String(data:encoding:)` used
+        // to return nil on invalid UTF-8.
+        return result.status == -1 ? nil : result.output
     }
 }
 

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -245,17 +245,18 @@ enum DoctorRunner {
     /// via `pmset -g assertions`. Informational only (the provider
     /// self-caffeinates while serving), so nil/UNKNOWN on any failure is fine.
     private static func systemSleepPrevented() -> Bool? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
-        p.arguments = ["-g", "assertions"]
-        let out = Pipe()
-        p.standardOutput = out
-        p.standardError = Pipe()
-        guard (try? p.run()) != nil else { return nil }
-        p.waitUntilExit()
-        guard p.terminationStatus == 0 else { return nil }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        // Same pipe-buffer deadlock as #811's contention probe: this waited on
+        // the child before draining stdout, and its stderr `Pipe()` was never
+        // read at all. Route it through the bounded runner so a chatty or wedged
+        // `pmset` degrades to UNKNOWN instead of hanging `doctor`.
+        let result = FanProcessRunner.run(
+            "/usr/bin/pmset",
+            arguments: ["-g", "assertions"],
+            timeout: 5,
+            discardStandardError: true
+        )
+        guard result.status == 0 else { return nil }
+        let text = result.output
         // `PreventUserIdleSystemSleep` / `PreventSystemSleep` report 1 when an
         // assertion (e.g. caffeinate, an active inference) is holding the system
         // awake. Any "1" on those lines ⇒ sleep currently prevented.

--- a/provider-swift/Sources/darkbloom/Fan/FanProcessRunner.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanProcessRunner.swift
@@ -15,7 +15,9 @@ enum FanProcessRunner {
     static func run(
         _ executable: String,
         arguments: [String],
-        timeout: TimeInterval = 15
+        timeout: TimeInterval = 15,
+        discardStandardError: Bool = false,
+        maximumOutputBytes: Int = 64 * 1024
     ) -> FanProcessResult {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
@@ -23,12 +25,15 @@ enum FanProcessRunner {
         process.standardInput = FileHandle.nullDevice
 
         let pipe = Pipe()
-        let output = FanProcessOutputBox()
+        let output = FanProcessOutputBox(maximumBytes: maximumOutputBytes)
         pipe.fileHandleForReading.readabilityHandler = { handle in
             output.append(handle.availableData)
         }
         process.standardOutput = pipe
-        process.standardError = pipe
+        // A caller that text-matches the output must not have a warning folded
+        // into it: `lsof` complaining about `~/.ollama` would read as a running
+        // Ollama and raise exactly the false WARN the contention probe forbids.
+        process.standardError = discardStandardError ? FileHandle.nullDevice : pipe
 
         let finished = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in finished.signal() }
@@ -64,15 +69,19 @@ enum FanProcessRunner {
 }
 
 private final class FanProcessOutputBox: @unchecked Sendable {
-    private static let maximumBytes = 64 * 1024
+    private let maximumBytes: Int
     private let lock = NSLock()
     private var data = Data()
+
+    init(maximumBytes: Int) {
+        self.maximumBytes = maximumBytes
+    }
 
     func append(_ bytes: Data) {
         guard !bytes.isEmpty else { return }
         lock.lock()
         defer { lock.unlock() }
-        let remaining = max(0, Self.maximumBytes - data.count)
+        let remaining = max(0, maximumBytes - data.count)
         data.append(bytes.prefix(remaining))
     }
 

--- a/provider-swift/Tests/DarkbloomCLITests/FanProcessRunnerTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/FanProcessRunnerTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+
+@testable import darkbloom
+
+/// Regression coverage for the `doctor` / `verify` hang reported in #811.
+///
+/// `LocalContentionSnapshot.runCapture` used to wait on the child before
+/// draining its pipe, so a child that wrote past the ~64 KiB Darwin pipe buffer
+/// blocked in `write(2)` while the parent blocked in `waitUntilExit()`. On the
+/// reporter's Mac `/bin/ps -axo comm=` emitted 78,689 bytes and both commands
+/// hung until interrupted.
+///
+/// `.serialized` because `FanProcessRunner` drains through
+/// `FileHandle.readabilityHandler`, and Foundation runs every file handle's
+/// handler on one process-wide serial queue. Run in parallel, these cases jam
+/// that queue for each other: a trivial `echo` child took 20s and the two
+/// chatty cases never returned, because clearing the handler at the end of
+/// `run` waits on the same queue. Nothing in production runs two of these at
+/// once -- `doctor` probes sequentially -- so serializing the suite is the
+/// honest shape, not a workaround for a live defect.
+@Suite("Fan process runner", .serialized)
+struct FanProcessRunnerTests {
+    /// The pre-fix `runCapture` blocks in a syscall, which a swift-testing
+    /// `.timeLimit` (a `Task` cancellation) cannot interrupt. Running it
+    /// off-thread and joining on a semaphore keeps a reintroduced deadlock a
+    /// *named* failure instead of a wedged test bundle.
+    private final class Box: @unchecked Sendable {
+        var value: String?
+    }
+
+    @Test("runCapture survives a child that outruns the pipe buffer")
+    func runCaptureSurvivesChattyChild() {
+        // 200_000 bytes has to exceed the 64 KiB pipe buffer, or this passes
+        // against the unfixed implementation.
+        let args = ["-c", "yes darkbloom | head -c 200000"]
+        let box = Box()
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            box.value = LocalContentionSnapshot.runCapture("/bin/sh", args: args)
+            done.signal()
+        }
+        guard done.wait(timeout: .now() + 20) == .success else {
+            Issue.record("runCapture deadlocked on a child larger than the pipe buffer")
+            return
+        }
+        #expect(box.value?.contains("darkbloom") == true)
+    }
+
+    /// `ps -axo comm=` was 78,689 bytes on the reporter's machine, so a probe
+    /// capped at the runner's 64 KiB default would drop every process name past
+    /// the cap and report "no competitors" on exactly the busy Macs #811 is
+    /// about.
+    @Test("the contention probe keeps process names past the runner's default cap")
+    func runCaptureKeepsOutputPastTheDefaultCap() {
+        let args = ["-c", "yes darkbloom | head -c 200000; echo ollama"]
+        let box = Box()
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            box.value = LocalContentionSnapshot.runCapture("/bin/sh", args: args)
+            done.signal()
+        }
+        guard done.wait(timeout: .now() + 20) == .success else {
+            Issue.record("runCapture deadlocked on a child larger than the pipe buffer")
+            return
+        }
+        #expect(box.value?.contains("ollama") == true)
+    }
+
+    @Test("other callers keep the 64 KiB default bound")
+    func defaultOutputCapIsUnchanged() {
+        let result = FanProcessRunner.run(
+            "/bin/sh",
+            arguments: ["-c", "yes darkbloom | head -c 200000"]
+        )
+        #expect(result.output.utf8.count == 64 * 1024)
+    }
+
+    @Test("a chatty child is still bounded by the runner deadline")
+    func runCaptureReturnsNilWhenTheChildNeverExits() {
+        // A child that holds stdout open forever is what draining alone does not
+        // fix: `readDataToEndOfFile()` waits for EOF. The deadline is what makes
+        // a best-effort probe bounded, which is what #811 asks for.
+        let args = ["-c", "sleep 120"]
+        let box = Box()
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            box.value = LocalContentionSnapshot.runCapture("/bin/sh", args: args)
+            done.signal()
+        }
+        guard done.wait(timeout: .now() + 30) == .success else {
+            Issue.record("runCapture never returned for a child that outlives the deadline")
+            return
+        }
+        #expect(box.value == nil)
+    }
+
+    @Test("stderr is discarded when the caller only text-matches stdout")
+    func stderrIsDiscarded() {
+        let result = FanProcessRunner.run(
+            "/bin/sh",
+            arguments: ["-c", "echo out; echo err >&2"],
+            discardStandardError: true
+        )
+        #expect(result.output.contains("out"))
+        #expect(!result.output.contains("err"))
+    }
+
+    @Test("stderr is folded into the output by default")
+    func stderrIsMergedByDefault() {
+        let result = FanProcessRunner.run(
+            "/bin/sh",
+            arguments: ["-c", "echo out; echo err >&2"]
+        )
+        #expect(result.output.contains("out"))
+        #expect(result.output.contains("err"))
+    }
+
+    @Test("a spawn failure is reported as a failure, not as empty output")
+    func spawnFailureIsDistinguishable() {
+        let result = FanProcessRunner.run("/nonexistent/darkbloom-probe", arguments: [])
+        #expect(result.status == -1)
+        #expect(LocalContentionSnapshot.runCapture("/nonexistent/darkbloom-probe", args: []) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

`darkbloom doctor` and `darkbloom verify` hang forever on a Mac with a large process
table. `LocalContentionSnapshot.runCapture` and `DoctorRunner.systemSleepPrevented`
each hand their child a `Pipe`, call `waitUntilExit()`, and only read the pipe
afterwards. Once the child writes past the ~64 KiB Darwin pipe buffer it blocks in
`write(2)` and can never exit, so the parent waits on a child that is waiting on
the parent. On the reporter's Mac, `/bin/ps -axo comm=` emitted 78,689 bytes
against a 65,536-byte pipe.

Both probes now go through `FanProcessRunner.run`, which drains the pipe on a
readability handler while the child runs and enforces a SIGTERM-then-SIGKILL
deadline. Reordering the read above the wait (as #786 does) isn't sufficient on
its own: `readDataToEndOfFile()` still blocks until the child closes the stream,
so a child that never closes stdout keeps wedging the caller. The issue also asks
for a *bounded* runtime, which is the deadline, not just the drain — 5 seconds is
the budget for probes already documented as degrading to empty on failure.

`run` gains `discardStandardError` and `maximumOutputBytes`, both defaulted to
current behavior so the nine existing call sites are unchanged. `runCapture` needs
the first because the runner otherwise folds stderr into stdout, and an `lsof`
warning naming `~/.ollama` would text-match as a running Ollama — the false
positive the probe is documented to avoid. It needs the second because the
runner's 64 KiB cap is sized for fan install logs: `ps` was 78,689 bytes on the
reporter's Mac, so keeping that cap would drop every process name past it and
report "no competitors" on exactly the machines this fixes.

### Before / after

```mermaid
flowchart LR
  subgraph Before
    A1["doctor / verify"] --> B1["runCapture / systemSleepPrevented<br/>own Process + Pipe"]
    B1 --> C1["waitUntilExit()"]
    C1 --> D1["child blocked in write(2)<br/>pipe full at 64 KiB"]
    D1 --> E1["hang forever, no output"]
  end
  subgraph After
    A2["doctor / verify"] --> B2["runCapture / systemSleepPrevented"]
    B2 --> C2["FanProcessRunner.run<br/>timeout: 5, stderr discarded, 1 MiB cap"]
    C2 --> D2["readabilityHandler drains<br/>while the child runs"]
    D2 --> F2["exit -> full output"]
    C2 --> G2["deadline -> SIGTERM/SIGKILL<br/>-> status -1 -> nil"]
    F2 --> H2["check reported"]
    G2 --> I2["check degrades to empty"]
  end
```

### Relationship to the other open PRs

- Supersedes #786: same function, but that PR only reorders the read above the
  wait and adds no deadline, so a child that never closes stdout still hangs it.
- Overlaps #690's `DoctorRunner` hunk (a much larger `ProviderCore` sweep fixing
  #689). If #690 lands first, drop this PR's `DoctorRunner.swift` hunk and keep
  the rest — the two are compatible. #690 doesn't touch
  `CompetingInferenceDiagnostics.swift`, so it doesn't close this issue on its own.

## Linked issue

Closes #811

## Test plan

`Tests/DarkbloomCLITests/FanProcessRunnerTests.swift` adds seven cases:

- [x] `runCaptureSurvivesChattyChild` — `sh -c 'yes darkbloom | head -c 200000'`,
      200,000 bytes to clear the 64 KiB pipe buffer.
- [x] `runCaptureKeepsOutputPastTheDefaultCap` — a hint emitted past 64 KiB still
      reaches the caller.
- [x] `defaultOutputCapIsUnchanged` — the other nine callers keep the 64 KiB bound.
- [x] `runCaptureReturnsNilWhenTheChildNeverExits` — `sh -c 'sleep 120'`; draining
      alone doesn't fix this, only the 5s deadline does.
- [x] `stderrIsDiscarded` / `stderrIsMergedByDefault` — both sides of the new
      flag, pinning the nine existing callers' behavior.
- [x] `spawnFailureIsDistinguishable` — a missing executable stays `status == -1`
      and `nil`, not empty output.

Run on macOS 26.6.2 / arm64 / Swift 6.3.3:

```
$ swift build --build-tests
Build complete! (753.13s)

$ swift test --filter FanProcessRunnerTests
✔ Suite "Fan process runner" passed after 5.215 seconds.
✔ Test run with 7 tests in 1 suite passed after 5.215 seconds.
```

Not run: the rest of `swift test`. Those suites need the source-matched
`mlx.metallib` that `test-provider` stages, which I skipped — no claim is made
about them.

The suite is `.serialized`. `FanProcessRunner` drains through
`FileHandle.readabilityHandler`, and Foundation runs every file handle's handler on
one process-wide serial queue; run in parallel these cases jam that queue for each
other (a trivial `echo` child took 20s and the two chatty cases never returned,
because clearing the handler at the end of `run` waits on that same queue).
Nothing in production runs two of these at once — `doctor` probes sequentially.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [ ] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Notes for reviewers

- `runCapture` loses `private` so `@testable import darkbloom` can reach it (#786
  does the same).
- Output is decoded lossily, where the old code returned `nil` on invalid UTF-8.
  The probe raises the runner's byte cap to 1 MiB so a large `ps` is not truncated
  into a missed WARN; every other caller keeps 64 KiB.
- `runCapture` maps only `status == -1` (spawn failure or deadline) to `nil`; a
  non-zero exit still yields text, matching the old code, which never inspected
  the status. `systemSleepPrevented` keeps its stricter `== 0` guard.
- `systemSleepPrevented` stays `private` with a hardcoded path and has no test of
  its own; the shared runner is what the new cases exercise.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219676&installation_model_id=21733&pr_number=837&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F837&signature=b96a4b0d177891e315e92eb9752179e7e6ad194ce96713b8ab7a98a85b9a3483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->