### PR TITLE
fix(routing): price pending prefill from known prompt sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased: pending prompt admission estimates
+
+- Price newly reserved prefill work using each request's own prompt length. Keep applied capacity freshness separate from heartbeat liveness, so reordered heartbeats cannot erase that work. Preserve provider resource gates, retry deadlines, and billing reservations.
+
 ## Unreleased — provider console entry
 
 - Open the provider workspace directly from the console home page, removing the Consumer/Provider selection page. Keep chat and API access in workspace navigation.

--- a/coordinator/api/ttft_pending_prefill_integration_test.go
+++ b/coordinator/api/ttft_pending_prefill_integration_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Synthetic service fixture: the real HTTP, scheduler, encrypted WebSocket,
+// content-commit and terminal paths run, but the provider returns scripted text.
+// This proves recovery from a false shed, not MLX performance or production lift.
+func TestPendingPrefillAdmissionCompletesRequest(t *testing.T) {
+	registry.ResetTTFTCalibration()
+	t.Cleanup(registry.ResetTTFTCalibration)
+	reg, _, srv, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{FirstContentDeadlineBase: 5 * time.Second})
+	srv.SetTTFTHardReject(true)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "pending-prefill-delivery-model"
+	const marker = "known pending prompt admitted"
+	fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+		Name: "provider", Version: "0.8.10", DecodeTPS: 100,
+		Models: []failoverModelSpec{{ID: model}},
+		Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, _ []byte) {
+			if req.FirstContentBudgetMS <= 0 {
+				t.Error("first-content budget missing from provider dispatch")
+			}
+			fp.serveFull(ctx, req, model, marker)
+		},
+	})
+	p := reg.GetProvider(fp.registryID)
+	p.Mu().Lock()
+	p.PrefillTPS = 250
+	p.Mu().Unlock()
+	reg.Heartbeat(fp.registryID, &protocol.HeartbeatMessage{Status: "idle", BackendCapacity: &protocol.BackendCapacity{TotalMemoryGB: 64, Slots: []protocol.BackendSlotCapacity{{Model: model, State: "running", MaxConcurrency: 8, ActiveTokenBudgetMax: 100_000}}}})
+	p.AddPending(&registry.PendingRequest{RequestID: "synthetic-pending", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128})
+	t.Cleanup(func() { p.RemovePending("synthetic-pending") })
+	body, err := json.Marshal(map[string]any{
+		"model": model, "messages": []map[string]any{{"role": "user", "content": strings.Repeat("a", 4_000)}},
+		"stream": true, "max_tokens": 64,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, response, err := postChat(ctx, ts.URL, "test-key", string(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertCleanFailoverStream(t, status, response, marker)
+	if got := fp.dispatchCount(); got != 1 {
+		t.Fatalf("provider dispatches=%d, want one completed attempt", got)
+	}
+	// The fixture cohort has one received/finalized request and one dispatch,
+	// complete egress, no refusal, timeout, retry, interruption or departure.
+	t.Log("synthetic cohort: requests=1 dispatches=1 completed=1 timely_first_content=1 provider_refusals=0 retries=0 final_rejections=0 interruptions=0 client_departures=0")
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -78,6 +78,10 @@ type ProviderChunk struct {
 // PendingRequest is a channel-based handle for an in-flight inference request.
 type PendingRequest struct {
 	RequestID string
+	// reservedAt is the coordinator-local reservation instant, guarded by the
+	// owning provider's mu. A reservation after capacitySnapshotAt cannot be part
+	// of that snapshot's queue counts. This is not a provider admission timestamp.
+	reservedAt time.Time
 	// Attempt is the zero-based dispatch attempt number that produced this
 	// pending request. It lets outcome telemetry correlate the final result
 	// with the routing decision record for the same attempt.
@@ -930,6 +934,11 @@ type Provider struct {
 
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
 	BackendCapacity *protocol.BackendCapacity
+	// capacitySnapshotAt is the local receipt/application instant of the current
+	// BackendCapacity. Stale capacity_seq frames advance LastHeartbeat for
+	// liveness but do not refresh this timestamp. Guarded by p.mu; nil capacity
+	// clears it and reconnect creates a fresh Provider with no snapshot.
+	capacitySnapshotAt time.Time
 
 	// capacitySeq is the highest BackendCapacity.CapacitySeq applied on THIS
 	// connection; capacityQuoteCapable latches true the first time a heartbeat
@@ -1142,6 +1151,7 @@ func (p *Provider) AddPending(pr *PendingRequest) {
 
 // addPendingLocked registers a pending request. Caller must hold p.mu.
 func (p *Provider) addPendingLocked(pr *PendingRequest) {
+	pr.reservedAt = time.Now()
 	p.pendingReqs[pr.RequestID] = pr
 }
 
@@ -4016,6 +4026,10 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) bool {
 	// Update backend capacity from heartbeat. A nil report clears prior live
 	// capacity so stale slot state cannot keep influencing routing.
 	p.BackendCapacity = backendCapacity
+	p.capacitySnapshotAt = time.Time{}
+	if backendCapacity != nil {
+		p.capacitySnapshotAt = now
+	}
 	// Per-slot KV backend (v0.8.0 paged rollout). Recorded from the canonical
 	// report after unaccepted model identifiers have been removed,
 	// BEFORE the nil-clearing semantics above take effect for it: the record is

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -114,6 +114,11 @@ type routingSnapshot struct {
 	totalPending     int
 	pendingForModel  int
 	pendingMaxTokens int
+	// Prefill work known to have arrived after the current heartbeat. Older
+	// pending attempts still use the count reconciliation in queuedPrefillTokensAhead.
+	pendingAfterHeartbeat int
+	pendingPrefillTokens  float64
+	pendingPrefillUnknown int
 	// pendingMaxTokensAllModels is pendingMaxTokens WITHOUT the model filter:
 	// the token budgets of every coordinator-pending request on this provider,
 	// any model. Feeds the pooled-budget admission check (pooledBudgetAdmits)
@@ -2126,6 +2131,7 @@ func fillSnapshotPendingAndPool(snap *routingSnapshot, p *Provider, model string
 		}
 		snap.pendingForModel++
 		snap.pendingMaxTokens += tokens
+		addPendingPrefillToSnapshot(snap, pr, p.capacitySnapshotAt)
 	}
 	snap.pendingBytesKnown = bytesKnown
 }
@@ -3138,21 +3144,6 @@ func ttftOccupancyMs(snap *routingSnapshot) float64 {
 		perReqDecodeTPS = 1.0
 	}
 	return alpha * float64(occ) * 1000.0 / perReqDecodeTPS
-}
-
-func queuedPrefillTokensAhead(snap *routingSnapshot, reqPromptTokens int) float64 {
-	if reqPromptTokens <= 0 {
-		return 0
-	}
-	waiting := snap.backendWaiting
-	reflected := snap.backendRunning + snap.backendWaiting
-	if extraPending := snap.pendingForModel - reflected; extraPending > 0 {
-		waiting += extraPending
-	}
-	if waiting <= 0 {
-		return 0
-	}
-	return float64(waiting * reqPromptTokens)
 }
 
 // DrainQueuedRequestsForModel attempts to assign queued requests for a

--- a/coordinator/registry/ttft_calibration_scheduler_test.go
+++ b/coordinator/registry/ttft_calibration_scheduler_test.go
@@ -15,6 +15,7 @@ func calibrationTestProvider(t *testing.T, reg *Registry, id, model string, deco
 	p := makeSchedulerProvider(t, reg, id, model, decodeTPS)
 	p.mu.Lock()
 	p.PrefillTPS = prefillTPS
+	p.capacitySnapshotAt = time.Now()
 	p.mu.Unlock()
 	return p
 }

--- a/coordinator/registry/ttft_prefill_backlog.go
+++ b/coordinator/registry/ttft_prefill_backlog.go
@@ -1,0 +1,46 @@
+package registry
+
+import "time"
+
+// addPendingPrefillToSnapshot accounts only for reservations made after the
+// current capacity snapshot was applied. Their prompt estimates are available and
+// they cannot already be included in that heartbeat. Older pending requests
+// cannot be matched to anonymous backend counts, so retain the existing count
+// fallback for those. Caller holds the owning provider's mu. Liveness-only
+// heartbeat updates must never advance this boundary.
+func addPendingPrefillToSnapshot(snap *routingSnapshot, pr *PendingRequest, heartbeat time.Time) {
+	if heartbeat.IsZero() || !pr.reservedAt.After(heartbeat) {
+		return
+	}
+	snap.pendingAfterHeartbeat++
+	// Content ingress is per attempt, unlike the shared retry Timing pointer.
+	// Once content arrived, this attempt has finished prefill even if the next
+	// heartbeat has not yet reported it running. Its memory reservation remains.
+	if pr.HasFirstContentIngress() {
+		return
+	}
+	if pr.EstimatedPromptTokens > 0 {
+		snap.pendingPrefillTokens += float64(pr.EstimatedPromptTokens)
+	} else {
+		snap.pendingPrefillUnknown++
+	}
+}
+
+func queuedPrefillTokensAhead(snap *routingSnapshot, reqPromptTokens int) float64 {
+	// Reconcile only older pending requests with the reported counts. New
+	// reservations are separately priced above and must not be subtracted from
+	// unrelated work in the older heartbeat, nor counted twice as extraPending.
+	waiting := snap.backendWaiting
+	reflected := snap.backendRunning + snap.backendWaiting
+	olderPending := snap.pendingForModel - snap.pendingAfterHeartbeat
+	if extraPending := olderPending - reflected; extraPending > 0 {
+		waiting += extraPending
+	}
+	if reqPromptTokens < 0 {
+		reqPromptTokens = 0
+	}
+	// A missing prompt estimate uses the legacy incoming-prompt proxy. Known
+	// work still counts when the incoming prompt estimate is zero. Convert before
+	// multiplying so a large count cannot overflow an integer token product.
+	return snap.pendingPrefillTokens + float64(waiting+snap.pendingPrefillUnknown)*float64(reqPromptTokens)
+}

--- a/coordinator/registry/ttft_prefill_backlog_test.go
+++ b/coordinator/registry/ttft_prefill_backlog_test.go
@@ -1,0 +1,245 @@
+package registry
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestTTFTPendingPromptSizesThroughScheduler(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		pendingPrompt int
+		incoming      int
+		ceiling       float64
+		wantMs        float64
+		wantSelected  bool
+	}{
+		{"long ahead of short", 8_000, 100, 5_000, 8_110, false},
+		{"short ahead of long", 100, 4_000, 5_000, 4_110, true},
+		{"equal sizes", 2_000, 2_000, 5_000, 4_010, true},
+		{"unknown pending keeps proxy", 0, 4_000, 5_000, 8_010, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCalibrator(t)
+			reg := New(testLogger())
+			const model = "pending-prompt-model"
+			p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+			p.AddPending(&PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: tc.pendingPrompt, RequestedMaxTokens: 128})
+			_, _, _, preflight, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, tc.incoming, 128, RequestTraits{}, false)
+			if !hasTTFT || math.Abs(float64(preflight.Microseconds())/1000-tc.wantMs) > .01 {
+				t.Fatalf("preflight=%v hasTTFT=%v, want %.2fms", preflight, hasTTFT, tc.wantMs)
+			}
+			pr := &PendingRequest{RequestID: "incoming", Model: model, EstimatedPromptTokens: tc.incoming, RequestedMaxTokens: 128, MaxTTFTMs: tc.ceiling}
+			selected, decision := reg.ReserveProviderEx(model, pr)
+			if (selected != nil) != tc.wantSelected {
+				t.Fatalf("selected=%v, want selected=%v; decision=%+v", selected != nil, tc.wantSelected, decision)
+			}
+			prediction := decision.BestTTFTMs
+			if selected != nil {
+				prediction = decision.RawTTFTMs
+			}
+			if math.Abs(prediction-tc.wantMs) > .01 {
+				t.Fatalf("scheduler=%.2fms, want %.2fms", prediction, tc.wantMs)
+			}
+			t.Logf("pending=%d incoming=%d raw_ms=%.0f ceiling_ms=%.0f selected=%v", tc.pendingPrompt, tc.incoming, prediction, tc.ceiling, selected != nil)
+		})
+	}
+}
+
+func TestTTFTPendingWorkWithZeroIncomingEstimate(t *testing.T) {
+	snap := routingSnapshot{pendingForModel: 1, pendingAfterHeartbeat: 1, pendingPrefillTokens: 8_000}
+	if got := queuedPrefillTokensAhead(&snap, 0); got != 8_000 {
+		t.Fatalf("queued work=%v, want 8000 even without an incoming estimate", got)
+	}
+}
+
+func TestTTFTPendingPrefillIgnoresStaleCapacityFrames(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	const model = "ordered-capacity-prompt-model"
+	p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+	heartbeat := func(seq uint64, waiting int) {
+		reg.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle", BackendCapacity: &protocol.BackendCapacity{CapacitySeq: seq, TotalMemoryGB: 64, Slots: []protocol.BackendSlotCapacity{{Model: model, State: "running", MaxConcurrency: 8, NumWaiting: waiting}}}})
+	}
+	heartbeat(10, 0)
+	p.AddPending(&PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: 8_000, RequestedMaxTokens: 128})
+	p.mu.Lock()
+	appliedAt := p.capacitySnapshotAt
+	p.mu.Unlock()
+	for _, seq := range []uint64{9, 10} {
+		heartbeat(seq, 1)
+		p.mu.Lock()
+		stamp, liveness := p.capacitySnapshotAt, p.LastHeartbeat
+		p.mu.Unlock()
+		if !stamp.Equal(appliedAt) || !liveness.After(appliedAt) {
+			t.Fatalf("stale seq %d changed snapshot time or failed to refresh liveness", seq)
+		}
+		_, _, _, got, has := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+		if !has || got != 8_110*time.Millisecond {
+			t.Fatalf("stale seq %d erased known prompt: TTFT=%v has=%v", seq, got, has)
+		}
+	}
+	// A newly applied snapshot changes the identity boundary; its waiting row
+	// is anonymous, so the legacy proxy applies without adding the request twice.
+	heartbeat(11, 1)
+	_, _, _, got, has := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if !has || got != 210*time.Millisecond {
+		t.Fatalf("new snapshot reconciliation: TTFT=%v has=%v", got, has)
+	}
+	reg.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle"})
+	p.mu.Lock()
+	cleared := p.BackendCapacity == nil && p.capacitySnapshotAt.IsZero()
+	p.mu.Unlock()
+	if !cleared {
+		t.Fatal("nil capacity must clear its provenance")
+	}
+	_, _, _, _, has = reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if has {
+		t.Fatal("nil capacity must retain the unknown-TTFT fallback")
+	}
+}
+
+func TestTTFTPendingPrefillResetsOnReconnect(t *testing.T) {
+	reg := New(testLogger())
+	first := reg.Register("provider", nil, testRegisterMessage())
+	reg.Heartbeat(first.ID, seqHeartbeat(10, 0))
+	first.AddPending(&PendingRequest{RequestID: "old-attempt", Model: seqTestModel, EstimatedPromptTokens: 8_000, ErrorCh: make(chan protocol.InferenceErrorMessage, 1)})
+	reg.Disconnect(first.ID)
+	second := reg.Register(first.ID, nil, testRegisterMessage())
+	second.mu.Lock()
+	defer second.mu.Unlock()
+	if second == first || !second.capacitySnapshotAt.IsZero() || len(second.pendingReqs) != 0 {
+		t.Fatal("reconnect retained applied capacity or old pending work")
+	}
+}
+
+func TestTTFTPendingPrefillHeartbeatBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		heartbeat string
+		running   int
+		waiting   int
+		content   bool
+		wantMs    float64
+	}{
+		{"after idle heartbeat", "before", 0, 0, false, 8_110},
+		{"fresh heartbeat reports pending waiting", "after", 0, 1, false, 210},
+		{"fresh heartbeat reports pending running", "after", 1, 0, false, 113.9},
+		{"equal instant is not known new", "equal", 0, 1, false, 210},
+		{"unknown heartbeat uses legacy proxy", "missing", 0, 0, false, 210},
+		{"old running count cannot hide new work", "before", 1, 0, false, 8_113.9},
+		{"old waiting count cannot absorb new work", "before", 0, 1, false, 8_210},
+		{"known content stops prefill before next heartbeat", "before", 0, 0, true, 110},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCalibrator(t)
+			reg := New(testLogger())
+			const model = "heartbeat-prompt-model"
+			p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+			pr := &PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: 8_000, RequestedMaxTokens: 128}
+			p.AddPending(pr)
+			p.mu.Lock()
+			switch tc.heartbeat {
+			case "before":
+				p.capacitySnapshotAt = pr.reservedAt.Add(-time.Second)
+			case "after":
+				p.capacitySnapshotAt = pr.reservedAt.Add(time.Millisecond)
+			case "equal":
+				p.capacitySnapshotAt = pr.reservedAt
+			case "missing":
+				p.capacitySnapshotAt = time.Time{}
+			}
+			p.BackendCapacity.Slots[0].NumRunning = tc.running
+			p.BackendCapacity.Slots[0].NumWaiting = tc.waiting
+			p.mu.Unlock()
+			if tc.content {
+				pr.FinishProviderChunkIngress(pr.BeginProviderChunkIngress(), true)
+			}
+			_, _, _, got, hasTTFT := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+			if !hasTTFT || math.Abs(float64(got.Microseconds())/1000-tc.wantMs) > .01 {
+				t.Fatalf("TTFT=%v has=%v, want %.2fms", got, hasTTFT, tc.wantMs)
+			}
+		})
+	}
+}
+
+func TestTTFTPendingPrefillModelIsolationAndRelease(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	const model = "prompt-model-a"
+	p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+	p.AddPending(&PendingRequest{RequestID: "other-model", Model: "prompt-model-b", EstimatedPromptTokens: 30_000, RequestedMaxTokens: 128})
+	p.AddPending(&PendingRequest{RequestID: "same-model", Model: model, EstimatedPromptTokens: 2_000, RequestedMaxTokens: 128})
+	check := func(wantMs float64) {
+		t.Helper()
+		_, _, _, got, has := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+		if !has || math.Abs(float64(got.Microseconds())/1000-wantMs) > .01 {
+			t.Fatalf("TTFT=%v has=%v, want %.2fms", got, has, wantMs)
+		}
+	}
+	check(2_110)
+	p.RemovePending("same-model")
+	check(110)
+}
+
+func TestTTFTPendingPromptUsesObservedRateAndExistingCalibration(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	const model = "calibrated-prompt-model"
+	p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ObservedPrefillTPS = 2_000
+	p.Hardware.ChipFamily = "M4"
+	p.mu.Unlock()
+	feedObservations(t, model, "M4", ttftCalibrationWarmupObs, .5)
+	p.AddPending(&PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: 8_000, RequestedMaxTokens: 128})
+	pr := &PendingRequest{RequestID: "incoming", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, MaxTTFTMs: 5_000}
+	selected, decision := reg.ReserveProviderEx(model, pr)
+	if selected == nil || math.Abs(decision.RawTTFTMs-4_060) > .01 || math.Abs(decision.TTFTMs-2_030) > .01 || decision.TTFTCalibrationRatio != .5 {
+		t.Fatalf("observed rate/calibrator not reused: %+v", decision)
+	}
+}
+
+func TestTTFTPendingPromptDoesNotSpendOutputReservationsAsCompute(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	const model = "prompt-vs-output-model"
+	p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 100_000
+	p.mu.Unlock()
+	pr := &PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 50_000}
+	p.AddPending(pr)
+	_, _, _, got, has := reg.QuickCapacityCheckWithTTFTForRequest(model, 100, 128, RequestTraits{}, false)
+	if !has || got != 210*time.Millisecond {
+		t.Fatalf("TTFT=%v has=%v, want 210ms without the output reservation", got, has)
+	}
+	// Completion of prefill does not release this large KV reservation.
+	pr.FinishProviderChunkIngress(pr.BeginProviderChunkIngress(), true)
+	p.mu.Lock()
+	p.BackendCapacity.Slots[0].ActiveTokenBudgetMax = 1_000
+	p.mu.Unlock()
+	selected, _ := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "must-not-fit", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128})
+	if selected != nil {
+		t.Fatal("prefill progress released the pending KV reservation")
+	}
+}
+
+func TestTTFTPendingPromptRetainsVisionGateExemption(t *testing.T) {
+	resetCalibrator(t)
+	reg := New(testLogger())
+	const model = "vision-prompt-model"
+	p := calibrationTestProvider(t, reg, "provider", model, 100, 1_000)
+	p.mu.Lock()
+	p.Models[0].IsVision = true
+	p.BackendCapacity.Slots[0] = protocol.BackendSlotCapacity{Model: model, State: "running", MaxConcurrency: 8}
+	p.mu.Unlock()
+	p.AddPending(&PendingRequest{RequestID: "ahead", Model: model, EstimatedPromptTokens: 8_000, RequestedMaxTokens: 128})
+	selected, decision := reg.ReserveProviderEx(model, &PendingRequest{RequestID: "vision", Model: model, EstimatedPromptTokens: 100, RequestedMaxTokens: 128, RequiresVision: true, MaxTTFTMs: 1})
+	if selected == nil {
+		t.Fatalf("text-prefill correction gated an unsupported vision prediction: %+v", decision)
+	}
+}

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-04 · commit `0be2aa074`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -232,12 +232,28 @@ fast prefill is dwarfed by the load. The setters are
 **TTFT estimate.** Separately from cost, each candidate carries an estimated
 time-to-first-token (`ttftMsFromSnapshot`): slot state penalty + prefill of
 tokens queued ahead + this request's prefill + one decode step
-(`1000 / effectiveTPS`), then multiplied by the per-(model, chip family)
-calibration ratio learned from settled requests
-(`ttftCalibration.appliedRatio`, `coordinator/registry/ttft_calibration.go`).
-`ttftOccupancyAlpha` (default `0.0`, `SetTTFTOccupancyAlpha`) optionally
-blends in occupancy. This estimate drives the `ttft_ceiling` gate, hedge
-timing and the `Retry-After` header; it is not a cost term.
+(`1000 / effectiveTPS`). The per-(model, chip family) calibration ratio scales
+the prefill/decode portion and leaves the cold-load state penalty unchanged
+(`calibratedTTFTMsWithRatio`, `coordinator/registry/ttft_calibration.go`). It
+learns from committed first content, which does not establish full delivery.
+`ttftOccupancyAlpha` affects only the separate diagnostic shadow estimate.
+The live estimate drives the `ttft_ceiling` gate, hedge timing and the
+`Retry-After` header; it is not a cost term.
+
+For reservations made after the current capacity snapshot was applied,
+`queuedPrefillTokensAhead` uses each pending request's own estimated prompt
+length. Per-attempt first-content ingress removes that request's prefill work
+while preserving its KV/output reservation. The provider's anonymous waiting
+count and unmatched older requests retain the incoming-prompt proxy. New
+reservations are reconciled separately so older running/waiting counts cannot
+hide them or count them twice (`coordinator/registry/ttft_prefill_backlog.go`).
+Both preflight and reservation use this calculation. `capacitySnapshotAt`
+advances only when `Heartbeat` applies capacity; discarded `capacity_seq`
+frames update liveness alone. Nil capacity clears the timestamp and reconnect
+starts fresh (`coordinator/registry/registry.go`). This boundary identifies
+known arrivals, not the provider's complete current prefill queue. The
+[calibration audit](../reports/2026-09-05-admission-calibration-audit.md)
+records the remaining measurement limits and the synthetic comparison.
 
 **Cache discount.** After pricing, `applyCacheRoutingDiscount` subtracts a
 bounded discount for providers holding a confirmed prefix cache for the

--- a/docs/architecture/system-profiler.md
+++ b/docs/architecture/system-profiler.md
@@ -1,6 +1,6 @@
 # System profiler
 
-> Last updated: 2026-09-04 · commit `4a08f2a44`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 The profiler answers "where did the time go, and what did the router know when
 it chose?" for one request, without carrying a single prompt-derived byte. It
@@ -211,7 +211,7 @@ JSON-encoded on the sink worker.
 | `runner_up_provider_id`, `runner_up_cost_ms` | lowest-cost candidate of the narrowed pool other than the winner; absent with one candidate | `lowestCostOther` |
 | `best_idle_provider_id`, `best_idle_ttft_ms` | lowest-TTFT candidate with the model resident and `backend_running + backend_waiting == 0`, computed over every gate-passing candidate before pool narrowing | `scheduler.go` |
 | `near_tie_pool_size`, `selection_path` | candidates within `nearTieCostWindowMs` of the minimum; branch of `selectRoutingCandidate`: `none`, `unique_min`, `tie_queue`, `tie_pending`, `cache_tiebreak`, `random` (`selectionPathNames`) | `selectRoutingCandidate` |
-| `snapshot_age_ms`, per-candidate `hb_age_ms` | `now − LastHeartbeat` when the routing snapshot was taken; observability only | `heartbeatAgeMs` |
+| `snapshot_age_ms`, per-candidate `hb_age_ms` | `now − LastHeartbeat` when the routing snapshot was taken; liveness age, which can refresh on a discarded `capacity_seq` frame. The applied capacity timestamp used for pending-prefill accounting is separate and is not emitted here. | `heartbeatAgeMs`, `capacitySnapshotAt` |
 | `predicted_ttft_ms`, `raw_ttft_ms`, `ttft_calibration_ratio`, `prefill_decode_ratio`, `predicted_decode_tps` | calibrated vs raw estimate, the (model, chip) ratio applied, the decode→prefill fallback multiplier, `projectedPerRequestDecodeTPS` | `scheduler.go` |
 | `pending_for_model`, `total_pending` | winner's coordinator-side pending counts before this reservation | `scheduler.go` |
 | `capacity_rate_ms`, `cache_discount_ms` | gray-box capacity-503 penalty; exact-cache discount | `scheduler.go` |

--- a/docs/reports/2026-09-05-admission-calibration-audit.md
+++ b/docs/reports/2026-09-05-admission-calibration-audit.md
@@ -1,0 +1,198 @@
+# Coordinator/provider admission calibration audit
+
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
+
+The coordinator substituted an incoming request's prompt length for every
+pending prefill. This creates deterministic errors in both directions for
+mixed prompt lengths. The accompanying correction uses known prompt lengths
+for reservations newer than the applied capacity snapshot. Scripted local
+tests demonstrate corrected admission and complete response delivery; they
+do not measure MLX service time or production fulfillment improvement.
+
+## Evidence scope and related work
+
+This audit covers source `bbf6f83d4` plus the accompanying correction. The
+provider engine pin is `d4335f02d9c466a9d02e4bd576354b6b10ac7674`; its
+`EngineLoopV2.swift` was read at that exact GitHub ref. Production coordinator
+revision, provider versions, effective flags, and model/rate distributions
+were not verified. No production experiment or configuration change ran.
+
+The existing private audit from the separate session was inspected for query
+provenance. Its profile aggregates cannot establish the full request
+denominator: profiles are sampled, incomplete delivery is not equivalent to
+provider failure, and the historical projection branch omits refusal details.
+Its average budget subtraction does not establish provider-local remaining
+time at atomic admission. No raw
+identifiers or production counts from that artifact are published here. The
+reproducible public baseline below is entirely synthetic.
+
+| Related work, checked 2026-09-05 | Current finding and disposition |
+|---|---|
+| [#755](https://github.com/Layr-Labs/d-inference/pull/755) | Open, unmerged. Do not assume its candidate/capacity tables exist. Current `request_profiles` already store raw/calibrated prediction, ratio, top-four candidates, and provider timing; current fleet snapshots store slot rates. No duplicate schema is added. |
+| [#835](https://github.com/Layr-Labs/d-inference/pull/835) | Open, unmerged. Responses instruction normalization/estimation remains owned there. This change uses existing `EstimatedPromptTokens`; it does not duplicate normalization or change billing. |
+| [#720](https://github.com/Layr-Labs/d-inference/issues/720) | Issue still open, but current `recordFinish` updates decode EWMA only for successful tokens after `firstEmissionTokens`. A startup single-token/first-burst-only completion no longer seeds it. `EngineV2PrefillSamplingTests.firstMTPBurstDoesNotInflateDecodeRate` already covers this guard. No duplicate provider fix. |
+| [#844](https://github.com/Layr-Labs/d-inference/issues/844) | Owns missing refusal mechanism/projected-work telemetry. Explicit missing evidence below stays with that issue. |
+| [#845](https://github.com/Layr-Labs/d-inference/issues/845) | Owns request identity, durable outcome coverage, delivery evidence and normalized analytics. This independent branch preserves raw wire/outcome names and uses its agreed semantics in evaluation. |
+
+## Common comparison contract
+
+| Boundary | Available source and meaning | Limits |
+|---|---|---|
+| Selection/reservation | `scheduler.go`: canonical build `Model`, public alias separately, chip family, provider version, matching slot, rates, raw TTFT, applied ratio, calibrated TTFT, pending counts, original deadline | `snapshot_age_ms` measures liveness age; stale-sequence frames refresh it without applying capacity. New private `capacitySnapshotAt` tracks the actual applied boundary. |
+| Dispatch | `RequestTiming.DispatchedAt` to committed `FirstContentAt`; profiler offsets describe reservation/encryption/writer phases | The raw forecast is made before dispatch. Do not interpret this learned pair as engine service time or subtract timestamps from different host clocks. |
+| Provider preparation | `EngineV2Bridge.submitTokenized`: tokenization/cache preparation/shared-KV work before serialized admission | Prefix cache participation changes work and preparation time. Queue state can change after selection; provider knows more and has less time left. |
+| Atomic provider admission | `EngineLoopV2` asks `scheduler.firstTokenWorkProjection`; bounded duration must fit `deadline - clock.now()`, while unbounded work is refused | Generic `deadline_unreachable` also represents actual expiry. The refusal branch discards projected-work details; an absent duration must stay unknown. |
+| First content | API `observeTTFTCalibration` joins attempt ID/attempt number to the raw reservation prediction | First content does not establish terminal delivery. Speculative-race and cache-routing participants are excluded, cold/vision reservations do not create training pairs, absent/invalid/expired pairs are ignored. |
+| Final request | Deduplicate on incoming `coord_request_id`, join actual dispatched attempt IDs, then apply #845 final outcome and egress dimensions | Route IDs identify attempts. Selection-only profiles and speculative losers cannot create extra requests. Neither a successful route nor a `completed` profile alone proves upstream receipt. |
+
+## Calculation and sample audit
+
+| Dimension | Inspected behavior | Result |
+|---|---|---|
+| Live TTFT | `ttftMsFromSnapshot`: state penalty + queued prompt work/prefill TPS + this prompt/prefill TPS + one decode step | Active and output token budgets remain memory reservations. No serial drain of all reserved output is added. |
+| Prefill rate | `resolvePrefillTPS`: matching slot observed rate, registration prefill, or decode × configured fallback; observed value capped | Provider `observedPrefillTpsEwma` divides cold prompt tokens by submit-to-first-token, including queue interference. It is not isolated service TPS. |
+| Decode rate | `resolveEffectiveTPS`: observed matching slot, model/chip fleet median, load-scaled benchmark | Same model/chip does not isolate memory tier, engine version or workload. No new unvalidated hardware pooling or rate multiplier. |
+| Provider projection | Isolated cold-prefill EWMA requires no other active/pending work at submission. Decode EWMA excludes first emission. `firstTokenDeadlineAdmission` halves each available phase rate | Deliberate conservative envelope remains unchanged. No claim that a coordinator median predicts this bound. Projection also requires enforce mode, supported scheduler posture, measured prefill, and non-multimodal input. |
+| Existing calibrator | Per model/chip median, model fallback, 50-observation warm-up, 200-sample ring, applied clamp `[0.2, 1.5]`, raw denominator, cold penalty unscaled | No competing calibrator. Unmatched pairs expire after 10 minutes; learned windows have no time expiry and do not key engine version. Their current production bias is unknown. |
+| Calibration censoring | Only eligible attempts reaching first content train; refusals/timeouts do not reveal actual service time | A median of survivors cannot establish the tail of all incoming requests. A later successful provider does not prove the first would have served. |
+| Request shape | `request_introspection.go` supplies raw routing estimates. `prompt_calibration.go` changes context-fit only. Billing is a separate byte upper bound | Template/tools/media inaccuracies remain separate hypotheses or #835 work. Vision retains its text-TTFT hard-gate exemption. |
+| Queue identity | Anonymous provider counts are reconciled with pending count. Previously every implied waiting row used this arrival's prompt | Proven defect for reservations after the applied snapshot, where each existing prompt estimate is available and cannot be reflected already. Corrected here. |
+| Queue telemetry | Provider `queuedPrefillTokens` counts submissions whose engine submit has not returned; engine running includes partial prefill | This is not automatically total remaining prefill work. Do not replace the whole queue formula with that field or add it without overlap accounting. |
+| Clock/configuration | Request-absolute deadline decreases through queue, retry and writer dequeue. Provider carries a monotonic deadline through preparation. `TTFT_ADMISSION_MODE=enforce` is still diagnostic shadow; `TTFT_HARD_REJECT` is separate | No deadline extension, retry change, shadow activation, safety-margin change, or runtime inference from checked-in env files. |
+
+## Correction and ownership
+
+`Provider.addPendingLocked` records a coordinator-local reservation instant.
+`Heartbeat` records the instant it applies the current capacity snapshot.
+Discarded/duplicate sequence frames advance only `LastHeartbeat`; a nil
+capacity frame clears the applied timestamp. Reconnect creates a new
+`Provider`, so no timestamp or old pending set survives the session.
+
+`fillSnapshotPendingAndPool` also collects the known new prefill work for the
+requested model. `queuedPrefillTokensAhead` separates these new reservations
+from older pending-count reconciliation. It sums their own prompt estimates,
+uses the existing incoming-prompt proxy for unknown lengths and older anonymous
+work, and stops charging a new attempt after per-attempt content ingress.
+All reads and mutations follow the existing provider/ingress lock order.
+
+The memory/KV/output accounting, rates, cache discounts, speculative policy,
+retry policy, absolute deadline, and billing stay unchanged. New reservations
+are not counted twice against the older heartbeat. State exists on the pending
+request and current provider, so normal removal/disconnect releases it without
+a new side map or timeout cleanup process.
+
+Residual limitation: a fresh heartbeat received after reservation may have
+been generated before provider receipt. Without per-request queue identities,
+that overlap is unknowable; the existing anonymous fallback remains. Partial
+prefill, cross-model compute contention, cache reuse and provider processing
+time cannot be fully inferred from coordinator pending lengths.
+
+## Reproducible synthetic baseline
+
+Run from `coordinator` with the pinned Go toolchain:
+
+```sh
+go test ./registry ./api -run 'TestTTFTPending|TestPendingPrefillAdmissionCompletesRequest|TestDeadlineUnreachableFailoverCarriesDecreasingBudgets|TestObserveTTFTCalibration|TestTTFTCalibration' -count=1 -v
+```
+
+The before run substitutes the original `queuedPrefillTokensAhead` body from
+`bbf6f83d4`; the after run uses the correction. Both run the same fixtures.
+These are fixed inputs, with no stochastic performance confidence interval.
+The two mixed-length regression cases and HTTP test fail under the original
+body and pass after restoration of the correction.
+
+| Scheduler cohort, one incoming request each | Before raw TTFT | After raw TTFT | Gate at 5,000 ms |
+|---|---:|---:|---|
+| Pending 8,000 tokens, arrival 100 | 210 ms | 8,110 ms | Old admits; corrected declines this candidate |
+| Pending 100 tokens, arrival 4,000 | 8,010 ms | 4,110 ms | Old falsely sheds; corrected admits |
+| Both prompts 2,000 | 4,010 ms | 4,010 ms | Both admit |
+| Unknown pending length, arrival 4,000 | 8,010 ms | 8,010 ms | Legacy fallback retained |
+
+These numbers use a warm model, 1,000 prefill TPS and 100 decode TPS. The
+observed-rate/calibration test separately uses 2,000 measured prefill TPS and
+the existing learned ratio 0.5: raw 4,060 ms, calibrated 2,030 ms. All these
+tests call the real scheduler and preflight; neither establishes the
+counterfactual service time of a rejected provider.
+
+The HTTP fixture has one received/finalized streaming request, one provider,
+a known 100-token pending prompt, a 4,000-character incoming prompt, registered
+fixture prefill 250 TPS, and configured first-content base of 5 seconds.
+The actual budget follows the unchanged prompt-scaled policy. Its provider
+returns scripted content through the real encrypted WebSocket and terminal
+path; no MLX compute occurs.
+
+| Covered request/attempt measure | Before | After |
+|---|---:|---:|
+| Distinct requests / final results | 1 / 1 | 1 / 1 |
+| Provider dispatches / admitted scripted attempts | 0 / 0 | 1 / 1 |
+| Complete response delivery / timely first content | 0 / 0 | 1 / 1 |
+| Final rejections | 1 (429) | 0 |
+| Provider deadline refusals / timed-out attempts | 0 / 0 | 0 / 0 |
+| Retries / client departures / interrupted delivery | 0 / 0 / 0 | 0 / 0 / 0 |
+
+This fixture improves completed requests even though its refusal count is
+unchanged. Identity/join coverage is 1/1 request and all dispatched attempts;
+there is no sampling or dropped fixture evidence. The existing deadline
+refusal/fallback test adds one request, two attempts, one refusal, one complete
+response, and strictly decreasing wire/admission budgets. Results for that
+separate guardrail are not pooled into the one-request comparison.
+
+## Ranked findings and evidence gaps
+
+| Rank | Discrepancy/cohorts | Evidence/confidence | Correction or next measurement | Benefit and regression risk |
+|---|---|---|---|---|
+| 1 | Mixed prompt lengths during a heartbeat gap | Exact source arithmetic plus real scheduler/HTTP regression; high confidence | Use own prompt estimates for known new reservations | Removes deterministic false shedding and optimism; unknown remaining prefill/cache work can still overstate work |
+| 2 | Liveness age mistaken for applied capacity freshness | Real sequence-10/reserve/sequence-9 test; high confidence | Separate private applied-capacity timestamp, clear on nil/reset on reconnect | Stale frames cannot erase known work; legacy/unknown snapshots retain fallback |
+| 3 | Refusal mode versus bounded projection/actual expiry | Refusal branch drops details; high confidence in evidence gap, unknown production incidence | #844: preserve mechanism, work, remaining monotonic budget and phase-rate provenance | Needed to assess avoidable refusal; no provider policy change justified yet |
+| 4 | Learned ratio age, censoring, sparse chip/version cohorts | Source ring/exclusions verified; production effect unknown | Held-out time/cohort evaluation before changing expiry, keying or clamps | Could reveal drift; arbitrary reset/ratio changes can reject more requests |
+| 5 | Prompt normalization, cache and queue overlap | Source distinctions verified; exact contribution unknown | #835 normalization; compare provider-tokenized lengths, actual reuse and queue timing | Avoid duplicate fixes and double-counted work |
+| 6 | Actual capacity shortage or excessively conservative projection | No controlled compute evidence in this PR | Isolated representative engine runs with fixed retry policy | No capacity/throughput or unnecessary-refusal claim supported yet |
+
+## Outcome evaluation and rollout gate
+
+Use #845's covered population selected by request receipt time, retain open
+requests until the original clock plus terminal-settle allowance, and report
+late terminals/unknowns separately. Join `coord_request_id` first, then actual
+dispatched attempt IDs. Report missing/duplicate joins, invalid provider
+profiles, sampling mode/rate, sink drops and source lag beside every cohort.
+The current profiler defaults to 0.1 sampling with always-retain predicates;
+it is not the request denominator. `inference_routes` and profile sinks are
+best effort, so absent attempt rows are unknown rather than refusals.
+
+For each canonical model/build, chip/tier, provider version, prompt bin,
+warm/cold/cache state and load band, compare raw and calibrated error medians
+and quantiles, signed under/overprediction, timely first content and complete
+delivery. Retain refusal, timeout, cancellation and speculative exclusions in
+the population audit instead of silently training/evaluating only survivors.
+Use `int_provider_deadline_rejected` for attempt refusal, with
+`ext_first_content_timeout` and `ext_coordinator_exhausted` only when their
+final request evidence supports them. Preserve raw wire codes.
+
+Before rollout, collect matched baseline windows that include the relevant
+peak and quiet traffic regimes, then select experiment duration and minimum
+per-cohort sample counts from observed variance and the smallest meaningful
+effect. Predeclare tolerances for completion, timely content, final rejection,
+interruption and departure, plus provider memory pressure/OOM, crashes, token
+budget refusals and latency tails. Keep retries and provider deadline margins
+fixed. Do not invent a universal percentage threshold or silently combine
+unsupported model cohorts. Sparse cohorts remain inconclusive.
+
+A human-approved staged rollout may proceed only after those denominators,
+coverage and tolerances are established. Roll back on a resource-safety
+failure or a cohort breach; stop evaluation when joins/coverage are unreliable.
+Reverting the change restores the old queue estimate. Do not use the TTFT
+calibration off switch as a substitute for reverting the queue calculation.
+No rollout was performed here. Retry-policy changes remain deferred until
+this outcome comparison and any required #844 evidence exist.
+
+## Code map
+
+| Concern | Source |
+|---|---|
+| Applied snapshot and reservation ownership | [`registry.go`](../../coordinator/registry/registry.go), `Heartbeat`, `addPendingLocked`, `PendingRequest.HasFirstContentIngress` |
+| Pending-work correction | [`ttft_prefill_backlog.go`](../../coordinator/registry/ttft_prefill_backlog.go), `addPendingPrefillToSnapshot`, `queuedPrefillTokensAhead` |
+| Real scheduler regressions | [`ttft_prefill_backlog_test.go`](../../coordinator/registry/ttft_prefill_backlog_test.go) |
+| Real transport/delivery regression | [`ttft_pending_prefill_integration_test.go`](../../coordinator/api/ttft_pending_prefill_integration_test.go) |
+| Existing learning loop | [`ttft_calibration.go`](../../coordinator/registry/ttft_calibration.go), [`settlement.go`](../../coordinator/api/settlement.go) |
+| Provider phase rates and refusal branch | [`EngineV2Bridge.swift`](../../provider-swift/Sources/ProviderCore/Inference/EngineV2Bridge.swift), `recordFinish`, `recordPrefillSample`, `firstTokenDeadlineAdmission` |
+| Engine atomic verdict | [Pinned `EngineLoopV2.swift`](https://github.com/Layr-Labs/mlx-swift-lm/blob/d4335f02d9c466a9d02e4bd576354b6b10ac7674/Libraries/MLXLMCommon/ContinuousBatchingV2/EngineLoopV2.swift) |

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-05 · commit `94c7c31eb`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -10,6 +10,12 @@ what was decided and whether it shipped read [`../design/README.md`](../design/R
 
 File names start with the date of the work (`YYYY-MM-DD-slug.md`). Each file's
 freshness stamp carries its own date, not the current one.
+
+## Routing measurements and audits
+
+| Date | Report | One line |
+|---|---|---|
+| 2026-09-05 | [admission-calibration-audit](2026-09-05-admission-calibration-audit.md) | Coordinator/provider timing contract, pending-prompt correction, synthetic baseline, and evaluation limits |
 
 ## Incidents and root causes
 


### PR DESCRIPTION
## Summary

When prompt lengths vary during a heartbeat gap, the coordinator prices every pending request using the incoming request's length. This can dispatch behind expensive work or reject a request behind a short prompt. Price reservations newer than the applied capacity snapshot using their own prompt estimates, and stop charging prefill once that attempt's first content arrives.

Keep applied capacity freshness separate from heartbeat liveness: a stale or duplicate `capacity_seq` frame refreshes liveness but must not erase known new work. Older anonymous queue entries retain the existing proxy because their identities and remaining prefill are unknown.

## Linked issue

Addresses #846, with the shared plan in #847 and the outcome contract owned by #845. The included audit completes the existing-code investigation, evidence-supported correction, isolated comparison, and evaluation plan. Production outcome measurement and unresolved refusal evidence remain explicit dependencies on #845/#844; this PR does not claim a measured production improvement or automatically close those investigations.

The #845 implementation is split between coordinator #849 and [Intelligence #9](https://github.com/Layr-Labs/darkbloom-intelligence/pull/9). The coordinator commits combine without conflicts and pass focused race tests together (API, registry and request accounting).

## Evidence

At 1,000 prefill TPS and 100 decode TPS:

| Pending prompt → incoming prompt | Before raw TTFT | After raw TTFT | Decision with a 5 s ceiling |
|---|---:|---:|---|
| 8,000 → 100 | 210 ms | 8,110 ms | Admit → decline this candidate |
| 100 → 4,000 | 8,010 ms | 4,110 ms | False rejection → admit |

The real HTTP/encrypted-WebSocket regression has one request and scripted provider output: the original formula returns 429 with zero dispatches; the corrected formula returns complete streaming 200 with one dispatch and one `[DONE]`. Refusals remain zero in both cases, so the improvement is completed requests, not a reduced internal-error counter. This fixture measures control flow and local delivery, not MLX throughput.

The [audit report](https://github.com/Layr-Labs/d-inference/blob/249036f4b/docs/reports/2026-09-05-admission-calibration-audit.md) records timing/rate/cohort semantics, sampling and join limits, ranked discrepancies, synthetic denominators, and rollout/rollback criteria. #755 and #835 remain open/unmerged. The original #720 first-emission decode-seed defect is already guarded in current provider source and is not duplicated.

## Before

```mermaid
flowchart LR
  A[Incoming request] --> B[fillSnapshotPendingAndPool: count pending]
  B --> C[queuedPrefillTokensAhead: count times incoming prompt]
  C --> D[Existing calibrator and TTFT ceiling]
  D --> E[Short arrival behind long work appears cheap]
  D --> F[Long arrival behind short work returns 429]
  H[Stale capacity frame] --> I[LastHeartbeat advances while capacity stays old]
```

## After

```mermaid
flowchart LR
  H[Accepted Heartbeat] --> S[capacitySnapshotAt]
  R[addPendingLocked] --> T[Reservation instant and own prompt]
  S --> B[fillSnapshotPendingAndPool]
  T --> B
  A[Incoming request] --> B
  B --> C[queuedPrefillTokensAhead: own new prompts plus older count fallback]
  P[Per-attempt content ingress] --> Q[Stop prefill charge; retain KV reservation]
  Q --> C
  C --> D[Existing calibrator and TTFT ceiling]
  D --> E[Decline candidate with expensive known work]
  D --> F[Admit viable request; encrypted dispatch; complete 200]
  O[Stale capacity frame] --> L[Refresh liveness only; preserve applied snapshot]
```

## Test plan

- [x] `go test ./registry ./api -count=1 -timeout 240s`.
- [x] `go test -race ./registry ./api -run 'TestTTFTPending|TestPendingPrefillAdmissionCompletesRequest|TestDeadlineUnreachableFailoverCarriesDecreasingBudgets|TestGateDecisionsIdenticalAcrossCommitModesUnderConcurrentRecorders' -count=1 -timeout 180s`.
- [x] Reconnect cleanup regression also passes with `-race`.
- [x] Replace only the backlog formula with the original implementation: mixed-prompt and HTTP completion regressions fail as expected; restore the correction and pass.
- [x] `go build ./...`, `bash scripts/docs-check.sh --all`, `git diff --check`.

Coverage includes older running/waiting overlap, fresh/stale/duplicate/missing capacity, model isolation, unknown prompt fallback, first-content progress, output/KV reservations, observed rates, existing calibration warm-up/clamps/fallback, vision exemption, speculative/cache tests in the full suites, and successful deadline-refusal failover with decreasing budgets.

## CI observations (2026-09-05)

Coordinator tests/lint, docs, CodeQL, console UI and prompt-sidecar checks passed. The [Threat Model Review](https://github.com/Layr-Labs/d-inference/actions/runs/33997807467/job/101391281662) fails with Anthropic authentication error 401 (`API key is invalid`).

[Provider Tests](https://github.com/Layr-Labs/d-inference/actions/runs/33997807476/job/101391281587) failed on Gemma prefill interval 18 versus expected 0 (`CBv2ModelTests.swift:885`), reproduced on the [exact base commit](https://github.com/Layr-Labs/d-inference/actions/runs/33989758302/job/101369773075), and a local-server bind timeout (`StandaloneServerTests.swift:220`) whose cause remains unproven. Provider sources, submodule pins and the CI workflow are unchanged by this PR. E2E jobs remain separate checks; no deployment was performed.

## Components touched

- [x] coordinator (Go)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes. Both timestamps are private coordinator state; no migration, telemetry fields, new configuration, or provider release.

## Notes for reviewers

Provider safety margins, memory admission, retry policy, request-absolute deadlines, wire statuses, cache discounts, and billing reservations are unchanged. The correction can move TTFT candidate acceptance in either direction, so the report requires per-model outcome evaluation before any rollout. Provider-local remaining prefill/cache preparation is not fully observable; older anonymous counts intentionally retain their existing fallback.

All tests use isolated fixtures. No Swift source changed, no live model performance run was needed for the arithmetic/control-flow claim, and no production deployment/configuration change occurred. Revert this change to restore the old queue formula; the calibration kill switch does not disable queue accounting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791241651&installation_model_id=21733&pr_number=848&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F848&signature=d37e69699084ce1487c6216be6f92260adb335f8cfd98fc124a8cee19fe5555b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
