### PR TITLE
feat(observability): separate incoming request outcomes from attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Open the provider workspace directly from the console home page, removing the Consumer/Provider selection page. Keep chat and API access in workspace navigation.
 
+## Unreleased: incoming request accounting
+
+- Add a compact unsampled request-outcome ledger with linked provider attempts, separate content ingress and local egress evidence, and explicit incomplete/lost-record coverage. Keep HTTP responses, retry policy, billing and existing uptime metrics unchanged.
+
 ## Unreleased — GPT-OSS prefill and decode
 
 - Skip unused GPT-OSS prefill vocabulary projections, fuse compatible 20B expert gate/up weights with bounded load materialization, reuse unchanged quantized constants, and enable the measured width-2880 MXFP4 decode path on M4 Max. Keep rollback controls and unsupported-shape fallbacks.

--- a/coordinator/api/chat_metadata_stream.go
+++ b/coordinator/api/chat_metadata_stream.go
@@ -100,11 +100,15 @@ func (s *Server) writeChatStreamTerminalError(
 	errorType string,
 	message string,
 ) {
+	accounting := pr.Accounting.Parent()
 	if hasChatCompletionMetadata(pr) {
 		event := newChatCompletionExtrasEvent(pr)
 		attachChatCompletionMetadata(event, pr)
 		if metadataEvent, err := json.Marshal(event); err == nil {
-			fmt.Fprintf(w, "data: %s\n\n", metadataEvent)
+			n, writeErr := fmt.Fprintf(w, "data: %s\n\n", metadataEvent)
+			if writeErr != nil || n != len(metadataEvent)+8 {
+				accounting.Egress(false, true)
+			}
 		}
 	}
 	errData, _ := json.Marshal(map[string]any{
@@ -113,6 +117,11 @@ func (s *Server) writeChatStreamTerminalError(
 			"type":    errorType,
 		},
 	})
-	fmt.Fprintf(w, "data: %s\n\n", errData)
+	n, writeErr := fmt.Fprintf(w, "data: %s\n\n", errData)
 	flusher.Flush()
+	if writeErr == nil && n == len(errData)+8 {
+		accounting.Egress(true, false, "error")
+	} else {
+		accounting.Egress(false, true)
+	}
 }

--- a/coordinator/api/chat_stream_relay.go
+++ b/coordinator/api/chat_stream_relay.go
@@ -44,8 +44,11 @@ type chatStreamRelay struct {
 	// them so the relay stamps can keep chunks_out in SSE frames, not flushes.
 	// The batch is bounded by maxCoalescedBatchBytes (see writeFrame), and
 	// flush releases a backing array that grew past that bound.
-	buf    bytes.Buffer
-	frames int
+	buf            bytes.Buffer
+	frames         int
+	contentWritten bool
+	batchContent   bool
+	batchTerminal  string
 }
 
 func newChatStreamRelay(pr *registry.PendingRequest, w http.ResponseWriter, flusher http.Flusher, stamps *relayStamps) *chatStreamRelay {
@@ -107,6 +110,14 @@ func (rl *chatStreamRelay) writeFrame(frame string) {
 	if rl.buf.Len() > 0 && rl.buf.Len()+len(frame)+len("\n\n") > maxCoalescedBatchBytes {
 		rl.flush()
 	}
+	if !rl.contentWritten && rl.stamps != nil && rl.stamps.accounting != nil && accountingChunkHasContent(frame) {
+		rl.batchContent = true
+	}
+	if rl.sawResponsesAPI && rl.stamps != nil && rl.stamps.accounting != nil {
+		if terminal := accountingStreamTerminal(frame); terminal != "" {
+			rl.batchTerminal = terminal
+		}
+	}
 	rl.buf.WriteString(frame)
 	rl.buf.WriteString("\n\n")
 	rl.frames++
@@ -128,7 +139,20 @@ func (rl *chatStreamRelay) flush() {
 		return
 	}
 	frames := rl.frames
+	wanted := rl.buf.Len()
 	n, err := rl.w.Write(rl.buf.Bytes())
+	if rl.batchContent && err == nil && n == wanted {
+		rl.stamps.content()
+		rl.contentWritten = true
+	}
+	rl.batchContent = false
+	if rl.batchTerminal != "" && err == nil && n == wanted {
+		rl.stamps.accounting.Egress(true, false, rl.batchTerminal)
+	}
+	rl.batchTerminal = ""
+	if n != wanted {
+		rl.stamps.writeErr()
+	}
 	if rl.buf.Cap() > maxCoalescedBatchBytes {
 		rl.buf = bytes.Buffer{}
 	} else {

--- a/coordinator/api/chat_stream_relay.go
+++ b/coordinator/api/chat_stream_relay.go
@@ -48,7 +48,7 @@ type chatStreamRelay struct {
 	frames         int
 	contentWritten bool
 	batchContent   bool
-	batchTerminal  string
+	batchTerminals responseTerminalObservations
 }
 
 func newChatStreamRelay(pr *registry.PendingRequest, w http.ResponseWriter, flusher http.Flusher, stamps *relayStamps) *chatStreamRelay {
@@ -113,10 +113,12 @@ func (rl *chatStreamRelay) writeFrame(frame string) {
 	if !rl.contentWritten && rl.stamps != nil && rl.stamps.accounting != nil && accountingChunkHasContent(frame) {
 		rl.batchContent = true
 	}
-	if rl.sawResponsesAPI && rl.stamps != nil && rl.stamps.accounting != nil {
-		if terminal := accountingStreamTerminal(frame); terminal != "" {
-			rl.batchTerminal = terminal
-		}
+	if rl.stamps != nil && rl.stamps.accounting != nil {
+		// Accounting recognizes terminal envelopes independently of the
+		// wire-format latch, including an event-prefixed or grouped first chunk.
+		terminals := accountingStreamTerminals(frame)
+		rl.batchTerminals.observe(terminals.first)
+		rl.batchTerminals.observe(terminals.conflicting)
 	}
 	rl.buf.WriteString(frame)
 	rl.buf.WriteString("\n\n")
@@ -146,10 +148,10 @@ func (rl *chatStreamRelay) flush() {
 		rl.contentWritten = true
 	}
 	rl.batchContent = false
-	if rl.batchTerminal != "" && err == nil && n == wanted {
-		rl.stamps.accounting.Egress(true, false, rl.batchTerminal)
+	if rl.batchTerminals.first != "" && err == nil && n == wanted {
+		rl.stamps.accounting.Egress(true, false, rl.batchTerminals.first, rl.batchTerminals.conflicting)
 	}
-	rl.batchTerminal = ""
+	rl.batchTerminals = responseTerminalObservations{}
 	if n != wanted {
 		rl.stamps.writeErr()
 	}

--- a/coordinator/api/consumer.go
+++ b/coordinator/api/consumer.go
@@ -1051,6 +1051,7 @@ func (s *Server) dispatchWithReserver(
 	}
 
 	requestID := uuid.New().String()
+	accounting := requestOutcomeFromContext(r.Context()).NewAttempt(requestID, attempt, backupOf)
 	ap := rp.NewAttempt(requestID, attempt, backupOf)
 	ap.Mark(registry.StampAttemptStart)
 	// Any failure return closes the attempt as not dispatched (terminal half; the handler half lands in finalizeProfile);
@@ -1058,11 +1059,13 @@ func (s *Server) dispatchWithReserver(
 	defer func() {
 		if provider == nil {
 			closeUndispatchedAttempt(ap, lastErr, lastErrCode)
+			accounting.Observe("not_dispatched", dispatchErrorClass(lastErr), lastErrCode)
 		}
 	}()
 	pr = &registry.PendingRequest{
-		RequestID: requestID,
-		Profile:   ap,
+		RequestID:  requestID,
+		Profile:    ap,
+		Accounting: accounting,
 		// Attempt is stamped at construction — BEFORE the request is encrypted
 		// and sent to the provider — so a fast provider that returns
 		// inference_complete immediately is correlated to the right route row.
@@ -1347,11 +1350,13 @@ func (s *Server) dispatchWithReserver(
 				onDispatched()
 			}
 			ap.MarkAt(registry.StampWriteDequeued, metadata.DequeuedAt)
+			accounting.Observe("write_started", "", 0)
 		},
 	)
 	cancelWrite()
 	if writeErr == nil {
 		ap.Mark(registry.StampWriteDone)
+		accounting.Observe("write_completed", "", 0)
 	}
 	if writeErr != nil {
 		s.registry.ForgetCacheAttempt(pr)
@@ -2480,7 +2485,7 @@ func (s *Server) handleStreamingResponseWithFirstChunkAndError(
 
 	writeSSEResponseHeader(w, pr.RequestID)
 	flusher.Flush()
-	rs := newRelayStamps(pr.Profile.Parent())
+	rs := newRelayStamps(pr.Profile.Parent(), pr.Accounting.Parent())
 
 	// Per-request relay state: the Responses-format latch, the held terminal
 	// usage/finish frames, and the batch buffer. Every chunk — the ones already
@@ -2905,7 +2910,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 									msg := extractMessage([]string{"data: " + string(encoded)})
 									resp := buildGenericEndpointResponse(pr, msg, completeUsage)
 									s.noteInferenceSuccess(pr)
-									writeNonStreamBody(w, pr.Profile.Parent(), resp)
+									writeNonStreamBody(w, pr.Profile.Parent(), resp, pr.Accounting.Parent())
 									return
 								}
 								if pr.IsResponsesAPI {
@@ -2925,7 +2930,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 										chatResp, consumerModel(pr), pr.SESignature,
 										pr.ResponseHash, pr.Traits)
 									s.noteInferenceSuccess(pr)
-									writeNonStreamBody(w, pr.Profile.Parent(), respObj)
+									writeNonStreamBody(w, pr.Profile.Parent(), respObj, pr.Accounting.Parent())
 									return
 								}
 							} else {
@@ -2945,7 +2950,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 								attachChatCompletionMetadata(obj, pr)
 							}
 							s.noteInferenceSuccess(pr)
-							writeNonStreamBody(w, pr.Profile.Parent(), obj)
+							writeNonStreamBody(w, pr.Profile.Parent(), obj, pr.Accounting.Parent())
 							return
 						}
 					}
@@ -2981,7 +2986,7 @@ func (s *Server) handleNonStreamingResponseWithFirstChunkAndError(
 						resp = chatResp
 					}
 					s.noteInferenceSuccess(pr)
-					writeNonStreamBody(w, pr.Profile.Parent(), resp)
+					writeNonStreamBody(w, pr.Profile.Parent(), resp, pr.Accounting.Parent())
 				case <-ctx.Done():
 					if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 						s.refundReservedBalance(pr, "provider_timeout:"+pr.RequestID)

--- a/coordinator/api/deadline_unreachable_integration_test.go
+++ b/coordinator/api/deadline_unreachable_integration_test.go
@@ -490,6 +490,11 @@ func TestDeadlineUnreachableAllProvidersReturnSingle429(t *testing.T) {
 			"deadline route rows = %d, want %d; routes=%+v",
 			deadlineRoutes, providerCount, routes)
 	}
+	r := waitRequestOutcome(t, st, 1)[0]
+	if r.Termination != "rejected" || r.NormalizedCode != "ext_coordinator_exhausted" || r.DeadlineRefusalCount != providerCount || r.DispatchedAttemptCount != providerCount || r.HTTPStatus == nil || *r.HTTPStatus != 429 {
+		t.Fatalf("request exhaustion accounting: %+v", r)
+	}
+
 }
 
 func postGenericInference(
@@ -513,9 +518,10 @@ func postGenericInference(
 }
 
 func TestAcceptedDoesNotStopSpeculativeFirstContentRace(t *testing.T) {
-	reg, _, _, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{
+	reg, st, srv, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{
 		FirstContentDeadlineBase: 400 * time.Millisecond,
 	})
+	t.Cleanup(srv.Close)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -556,6 +562,27 @@ func TestAcceptedDoesNotStopSpeculativeFirstContentRace(t *testing.T) {
 		t.Fatalf("dispatches = %+v, want accepted primary plus speculative backup", got)
 	}
 	assertCleanFailoverStream(t, status, body, markerFor(got[1].provider))
+	r := waitRequestOutcome(t, st, 1)[0]
+	if r.Termination != "completed" || !r.ResponseEgressCompleted || !r.ContentEgressObserved || r.DispatchedAttemptCount != 2 || r.DeadlineRefusalCount != 0 || r.NormalizedCode != "" {
+		t.Fatalf("speculative winner request accounting: %+v", r)
+	}
+	winners, losers := 0, 0
+	for _, a := range r.Attempts {
+		if a.Winning {
+			winners++
+			if a.BackupOf == "" || a.ProviderOutcome != "completed" {
+				t.Fatalf("winning backup lost its parent or terminal: %+v", a)
+			}
+		} else if a.WriteCompleted {
+			losers++
+			if !a.ProviderAcknowledged || a.ContentObserved {
+				t.Fatalf("acknowledged speculative loser confused with content: %+v", a)
+			}
+		}
+	}
+	if winners != 1 || losers != 1 {
+		t.Fatalf("want one winner and one internal loser: %+v", r.Attempts)
+	}
 }
 
 func TestDeadlineRefusalDoesNotMaskLaterProvider500(t *testing.T) {
@@ -605,6 +632,11 @@ func TestDeadlineRefusalDoesNotMaskLaterProvider500(t *testing.T) {
 		rejections[0].ReasonCode == rejectionReasonDeadlineUnreachable {
 		t.Fatalf("terminal rejection = %+v, want genuine provider fault", rejections)
 	}
+	r := waitRequestOutcome(t, st, 1)[0]
+	if r.Termination != "rejected" || r.NormalizedCode != "" || r.DeadlineRefusalCount != 1 || r.HTTPStatus == nil || *r.HTTPStatus != 500 {
+		t.Fatalf("genuine fault precedence accounting: %+v", r)
+	}
+
 }
 
 func TestNinthBoilerplateNeverCommitsFailedProvider(t *testing.T) {

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1022,19 +1022,20 @@ func dispatchErrorClass(errText string) string {
 }
 
 // queuedExitOutcome records the terminal route outcome of a queue-wait exit
-// and mirrors its status/reason onto the placeholder attempt profile. While
+// and mirrors its status/reason onto the placeholder attempt evidence. While
 // the request waits, d.pr is nil, so updateRoutingOutcome takes the request-id
 // path and never reaches the attempt profile; the pair is written here, in one
 // place, so the row and the profile cannot drift. It is deliberately NOT
 // routed through updateInferenceRouteOutcomeForPending, which would also fire
 // the cache-selection terminal for a request that never had a provider.
-func (d *dispatchState) queuedExitOutcome(ap *registry.AttemptProfile, status, reason string, code int) {
+func (d *dispatchState) queuedExitOutcome(pr *registry.PendingRequest, status, reason string, code int) {
 	outcome := d.errorRoutingOutcome(status, reason, code)
 	// No provider attempt was dispatched: the funnel counts this exit on
 	// inference.queue_outcome, never on inference.attempt_outcome.
 	outcome.QueueExit = true
 	d.updateRoutingOutcome(outcome)
-	ap.SetOutcome(status, reason, "", "", "")
+	pr.Profile.SetOutcome(status, reason, "", "", "")
+	pr.Accounting.Observe("not_dispatched", reason, code)
 }
 
 // closeQueuedAttempt closes the queue-path placeholder attempt when it never
@@ -1446,7 +1447,15 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		}
 		queuePR.Timing.QueuedAt = time.Now()
 		queuePR.Accounting = requestOutcomeFromContext(r.Context()).NewAttempt(d.requestID, d.attempt, "")
-		defer func() { queuePR.Accounting.Observe("not_dispatched", dispatchErrorClass(d.lastErr), d.lastErrCode) }()
+		queuedWriteCompleted := false
+		defer func() {
+			if !queuedWriteCompleted {
+				// Queue exits and pre-write route failures record their own
+				// reason/status below. Request-level lastErr can belong to a
+				// previous attempt and must never decorate this attempt.
+				queuePR.Accounting.Observe("not_dispatched", "", 0)
+			}
+		}()
 		queuePR.Profile = d.profile.NewAttempt(d.requestID, d.attempt, "")
 		queuePR.Profile.Mark(registry.StampAttemptStart)
 		queuePR.Profile.Mark(registry.StampQueued)
@@ -1465,6 +1474,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			// decision is recorded only after a successful enqueue); the
 			// placeholder carries the rejection vocabulary directly.
 			queuePR.Profile.SetOutcome("rejected", "queue_full", "", "", "")
+			queuePR.Accounting.Observe("not_dispatched", "queue_full", http.StatusTooManyRequests)
 			retryAfter := s.estimateRetryAfter(d.model)
 			d.refundReservation()
 			info := d.rejectionInfoWithDecision("queue", "queue_full", http.StatusTooManyRequests, retryAfter*1000, decision)
@@ -1500,7 +1510,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			if errors.Is(err, context.Canceled) {
 				s.recordWarmPoolQueueState(d.model)
 				d.emitClientGone(phaseBeforeFirstToken)
-				d.queuedExitOutcome(queuePR.Profile, "cancelled", "client_gone", 0)
+				d.queuedExitOutcome(queuePR, "cancelled", "client_gone", 0)
 				d.refundReservation()
 				return outcomeClientGone
 			}
@@ -1514,7 +1524,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				// resolveDominantExhaustedStatus keys the reason on. The route
 				// row and the attempt profile carry queue_deadline as well.
 				s.recordWarmPoolQueueState(d.model)
-				d.queuedExitOutcome(queuePR.Profile,
+				d.queuedExitOutcome(queuePR,
 					"timeout", rejectionReasonQueueDeadline, http.StatusGatewayTimeout)
 				d.setLastError(errQueueDeadlineExpired, http.StatusGatewayTimeout)
 				return outcomeFailFast
@@ -1524,7 +1534,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				// ceiling — deterministic, so answer with the standard
 				// ttft_too_slow 429 instead of waiting out the queue.
 				s.recordWarmPoolQueueState(d.model)
-				d.queuedExitOutcome(queuePR.Profile, "error", "ttft_too_slow", http.StatusTooManyRequests)
+				d.queuedExitOutcome(queuePR, "error", "ttft_too_slow", http.StatusTooManyRequests)
 				d.refundReservation()
 				s.registry.RecordWarmPoolTTFTMiss(d.model, d.deadline)
 				s.triggerWarmPool()
@@ -1538,7 +1548,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			}
 			if errors.Is(err, registry.ErrQueueToolConstraintUnavailable) {
 				s.recordWarmPoolQueueState(d.model)
-				d.queuedExitOutcome(queuePR.Profile,
+				d.queuedExitOutcome(queuePR,
 					"error", "model_capability_unsupported",
 					http.StatusServiceUnavailable)
 				d.refundReservation()
@@ -1554,7 +1564,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 					"model_unavailable")
 				return outcomeResponseWritten
 			}
-			d.queuedExitOutcome(queuePR.Profile, "timeout", "queue_timeout", http.StatusTooManyRequests)
+			d.queuedExitOutcome(queuePR, "timeout", "queue_timeout", http.StatusTooManyRequests)
 			d.refundReservation()
 			s.ddIncr("request_queue.timeout", []string{"model:" + d.model, "model_type:" + s.registry.ModelType(d.model)})
 			s.registry.RecordWarmPoolQueueTimeout(d.model, time.Since(queuedReq.EnqueuedAt))
@@ -1733,6 +1743,7 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 		)
 		cancelWrite()
 		if writeErr == nil {
+			queuedWriteCompleted = true
 			d.pr.Profile.Mark(registry.StampWriteDone)
 			d.pr.Accounting.Observe("write_completed", "", 0)
 		}

--- a/coordinator/api/dispatch.go
+++ b/coordinator/api/dispatch.go
@@ -1445,6 +1445,8 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 			ResponseCh: make(chan *registry.Provider, 1),
 		}
 		queuePR.Timing.QueuedAt = time.Now()
+		queuePR.Accounting = requestOutcomeFromContext(r.Context()).NewAttempt(d.requestID, d.attempt, "")
+		defer func() { queuePR.Accounting.Observe("not_dispatched", dispatchErrorClass(d.lastErr), d.lastErrCode) }()
 		queuePR.Profile = d.profile.NewAttempt(d.requestID, d.attempt, "")
 		queuePR.Profile.Mark(registry.StampAttemptStart)
 		queuePR.Profile.Mark(registry.StampQueued)
@@ -1726,11 +1728,13 @@ func (d *dispatchState) dispatchPrimary() dispatchOutcome {
 				d.timing.DispatchedAt = metadata.DequeuedAt
 				d.noteProviderDispatched()
 				d.pr.Profile.MarkAt(registry.StampWriteDequeued, metadata.DequeuedAt)
+				d.pr.Accounting.Observe("write_started", "", 0)
 			},
 		)
 		cancelWrite()
 		if writeErr == nil {
 			d.pr.Profile.Mark(registry.StampWriteDone)
+			d.pr.Accounting.Observe("write_completed", "", 0)
 		}
 		if writeErr != nil {
 			s.registry.ForgetCacheAttempt(d.pr)
@@ -3454,6 +3458,7 @@ func (d *dispatchState) waitAccepted() (outcome dispatchOutcome) {
 func (d *dispatchState) run() {
 	s := d.s
 	defer d.finalizeProfile()
+	requestOutcomeFromContext(d.r.Context()).Shape(d.model, d.stream)
 	w, r := d.w, d.r
 	d.preflightLegacyCacheBust()
 
@@ -3628,6 +3633,10 @@ exhausted:
 				s.ddIncr("routing.unservable_reclassified", []string{"model:" + d.model})
 			}
 		}
+		accountingExhausted := dominance == exhaustedDeadline ||
+			(dominance == exhaustedUndecided && reason == "dispatch_exhausted" &&
+				failure.terminalCause == "" && failure.statusCode == 0)
+		requestOutcomeFromContext(r.Context()).Rejection(reason, accountingExhausted)
 		// Resolved once: the telemetry event and the OR-uptime counter must agree
 		// on which slot's backend this failure belongs to, and on whether that
 		// backend was chosen or degraded into (v0.8.0 paged rollout).
@@ -3813,6 +3822,7 @@ func (d *dispatchState) writeCommittedResponse() {
 	writeCommittedProviderHeaders(w, info)
 	d.writeTimingHeaderWithProfile(w, pr)
 	d.stampCommitted(pr)
+	pr.Accounting.Observe("committed", "", 0)
 	writeInferenceJobIDHeader(w, pr.RequestID)
 	snapshotChatCompletionMetadata(pr, info)
 

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -224,20 +224,27 @@ func (e *completionsStreamEmitter) finish(usage protocol.UsageInfo) {
 }
 
 func (e *completionsStreamEmitter) emitError(kind, message string) {
-	e.emit(map[string]any{"error": map[string]any{"type": kind, "message": message}})
+	if e.emit(map[string]any{"error": map[string]any{"type": kind, "message": message}}) {
+		e.stamps.accounting.Egress(true, false, "error")
+	}
 }
 
-func (e *completionsStreamEmitter) emit(value any, content ...bool) {
+func (e *completionsStreamEmitter) emit(value any, content ...bool) bool {
 	encoded, err := json.Marshal(value)
 	if err != nil {
-		return
+		return false
 	}
 	n, werr := fmt.Fprintf(e.w, "data: %s\n\n", encoded)
-	if len(content) > 0 && content[0] && werr == nil && n == len(encoded)+8 {
+	accepted := werr == nil && n == len(encoded)+8
+	if len(content) > 0 && content[0] && accepted {
 		e.stamps.content()
+	}
+	if n != len(encoded)+8 {
+		e.stamps.writeErr()
 	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
+	return accepted
 }
 
 type messagesStreamEmitter struct {
@@ -380,21 +387,28 @@ func (e *messagesStreamEmitter) emitError(kind, message string) {
 	default:
 		kind = "api_error"
 	}
-	e.emit("error", map[string]any{
+	if e.emit("error", map[string]any{
 		"error": map[string]any{"type": kind, "message": message},
-	})
+	}) {
+		e.stamps.accounting.Egress(true, false, "error")
+	}
 }
 
-func (e *messagesStreamEmitter) emit(eventType string, fields map[string]any) {
+func (e *messagesStreamEmitter) emit(eventType string, fields map[string]any) bool {
 	fields["type"] = eventType
 	encoded, err := json.Marshal(fields)
 	if err != nil {
-		return
+		return false
 	}
 	n, werr := fmt.Fprintf(e.w, "event: %s\ndata: %s\n\n", eventType, encoded)
-	if !e.stamps.contentWritten && werr == nil && n == len(eventType)+len(encoded)+16 && accountingValueHasContent(fields, 0) {
+	accepted := werr == nil && n == len(eventType)+len(encoded)+16
+	if !e.stamps.contentWritten && accepted && accountingValueHasContent(fields, 0) {
 		e.stamps.content()
+	}
+	if n != len(eventType)+len(encoded)+16 {
+		e.stamps.writeErr()
 	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
+	return accepted
 }

--- a/coordinator/api/generic_endpoint_stream.go
+++ b/coordinator/api/generic_endpoint_stream.go
@@ -164,7 +164,7 @@ func newGenericEndpointStreamEmitter(
 	if pr.ConsumerEndpoint == messagesEndpoint {
 		return newMessagesStreamEmitter(w, flusher, pr)
 	}
-	return &completionsStreamEmitter{w: w, flusher: flusher, pr: pr, stamps: newRelayStamps(pr.Profile.Parent())}
+	return &completionsStreamEmitter{w: w, flusher: flusher, pr: pr, stamps: newRelayStamps(pr.Profile.Parent(), pr.Accounting.Parent())}
 }
 
 type completionsStreamEmitter struct {
@@ -198,7 +198,7 @@ func (e *completionsStreamEmitter) handleChunk(chunk string) {
 				"logprobs":      nil,
 				"finish_reason": nil,
 			}},
-		})
+		}, true)
 	}
 }
 
@@ -227,12 +227,15 @@ func (e *completionsStreamEmitter) emitError(kind, message string) {
 	e.emit(map[string]any{"error": map[string]any{"type": kind, "message": message}})
 }
 
-func (e *completionsStreamEmitter) emit(value any) {
+func (e *completionsStreamEmitter) emit(value any, content ...bool) {
 	encoded, err := json.Marshal(value)
 	if err != nil {
 		return
 	}
 	n, werr := fmt.Fprintf(e.w, "data: %s\n\n", encoded)
+	if len(content) > 0 && content[0] && werr == nil && n == len(encoded)+8 {
+		e.stamps.content()
+	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
 }
@@ -257,7 +260,7 @@ func newMessagesStreamEmitter(
 	pr *registry.PendingRequest,
 ) *messagesStreamEmitter {
 	return &messagesStreamEmitter{
-		stamps:    newRelayStamps(pr.Profile.Parent()),
+		stamps:    newRelayStamps(pr.Profile.Parent(), pr.Accounting.Parent()),
 		w:         w,
 		flusher:   flusher,
 		pr:        pr,
@@ -389,6 +392,9 @@ func (e *messagesStreamEmitter) emit(eventType string, fields map[string]any) {
 		return
 	}
 	n, werr := fmt.Fprintf(e.w, "event: %s\ndata: %s\n\n", eventType, encoded)
+	if !e.stamps.contentWritten && werr == nil && n == len(eventType)+len(encoded)+16 && accountingValueHasContent(fields, 0) {
+		e.stamps.content()
+	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
 }

--- a/coordinator/api/profiler.go
+++ b/coordinator/api/profiler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/env"
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -49,6 +50,7 @@ const (
 // middleware chain (same goroutine, before the handler runs, so plain fields).
 type requestMeta struct {
 	coordID string
+	outcome *outcomes.Tracker
 	start   time.Time
 
 	authDoneUS      int64

--- a/coordinator/api/profiler_dispatch.go
+++ b/coordinator/api/profiler_dispatch.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
 	"github.com/eigeninference/d-inference/coordinator/registry"
 )
 
@@ -160,7 +161,7 @@ func (d *dispatchState) stampClientGone(phase string) {
 // writeNonStreamBody writes a non-streaming 200 response body and stamps the
 // egress offsets (first/last flush, bytes out) so non-stream rows carry the
 // same egress waterfall as SSE relays. Output is byte-identical to writeJSON.
-func writeNonStreamBody(w http.ResponseWriter, rp *registry.RequestProfile, v any) {
+func writeNonStreamBody(w http.ResponseWriter, rp *registry.RequestProfile, v any, accounting ...*outcomes.Tracker) {
 	body, err := json.Marshal(v)
 	if err != nil {
 		writeJSON(w, http.StatusOK, v)
@@ -173,6 +174,13 @@ func writeNonStreamBody(w http.ResponseWriter, rp *registry.RequestProfile, v an
 		rp.Stamp(&rp.HeadersWrittenUS)
 	}
 	n, err := w.Write(body)
+	if len(accounting) > 0 {
+		terminal := responseAccountingTerminal(v)
+		accounting[0].Egress(err == nil && n == len(body), err != nil || n != len(body), terminal)
+		if err == nil && n == len(body) && accounting[0] != nil && responseAccountingHasContent(v) {
+			accounting[0].ContentWritten()
+		}
+	}
 	if rp == nil {
 		return
 	}
@@ -192,12 +200,18 @@ func writeNonStreamBody(w http.ResponseWriter, rp *registry.RequestProfile, v an
 
 // relayStamps is the per-stream bookkeeping the SSE relay loops feed.
 type relayStamps struct {
-	rp        *registry.RequestProfile
-	lastFlush time.Time
+	rp             *registry.RequestProfile
+	accounting     *outcomes.Tracker
+	contentWritten bool
+	lastFlush      time.Time
 }
 
-func newRelayStamps(rp *registry.RequestProfile) *relayStamps {
-	return &relayStamps{rp: rp}
+func newRelayStamps(rp *registry.RequestProfile, accounting ...*outcomes.Tracker) *relayStamps {
+	r := &relayStamps{rp: rp}
+	if len(accounting) > 0 {
+		r.accounting = accounting[0]
+	}
+	return r
 }
 
 // flushed records one chunk written + flushed to the client.
@@ -231,7 +245,14 @@ func (r *relayStamps) flushedFrames(frames, bytes int) {
 }
 
 // done records the terminal [DONE] flush.
-func (r *relayStamps) done() {
+func (r *relayStamps) done(terminal ...string) {
+	if r != nil {
+		status := "completed"
+		if len(terminal) > 0 {
+			status = terminal[0]
+		}
+		r.accounting.Egress(true, false, status)
+	}
 	if r == nil || r.rp == nil {
 		return
 	}
@@ -248,6 +269,9 @@ func (r *relayStamps) done() {
 // accepted count as flushed, and a failed or short write marks client_write_err
 // so the record never claims output the client did not receive.
 func (r *relayStamps) wrote(n int, err error) {
+	if err != nil && r != nil {
+		r.accounting.Egress(false, true)
+	}
 	if r == nil || r.rp == nil {
 		return
 	}
@@ -263,6 +287,9 @@ func (r *relayStamps) wrote(n int, err error) {
 // frames SSE frames (the chat relay's flush): the same contract as wrote,
 // with chunks_out advancing by the number of frames folded into the write.
 func (r *relayStamps) wroteFrames(frames, n int, err error) {
+	if err != nil && r != nil {
+		r.accounting.Egress(false, true)
+	}
 	if r == nil || r.rp == nil {
 		return
 	}
@@ -276,6 +303,9 @@ func (r *relayStamps) wroteFrames(frames, n int, err error) {
 
 // writeErr records a failed client write.
 func (r *relayStamps) writeErr() {
+	if r != nil {
+		r.accounting.Egress(false, true)
+	}
 	if r == nil || r.rp == nil {
 		return
 	}
@@ -294,4 +324,14 @@ func profileClientGone(pr *registry.PendingRequest, phase string) {
 	}
 	rp.Stamp(&rp.ClientGoneUS)
 	rp.SetClientGonePhase(phase)
+}
+
+// content records only the first successful generated-content write. Subsequent
+// tokens add no accounting locks, clocks, allocations or persistence work.
+func (r *relayStamps) content() {
+	if r == nil || r.contentWritten {
+		return
+	}
+	r.contentWritten = true
+	r.accounting.ContentWritten()
 }

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -1848,7 +1848,7 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		// left to stop"). Stop the real work here, like the deadline and
 		// overflow branches do.
 		s.sendProviderCancel(provider, msg.RequestID)
-		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
+		s.handleSyntheticInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
 			Type:        protocol.TypeInferenceError,
 			RequestID:   msg.RequestID,
 			Error:       "encrypted inference transport failed",
@@ -1861,6 +1861,9 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		ap.ChunksIn.Add(1)
 		ap.DecryptUSTotal.Add(time.Since(decryptStart).Microseconds())
 		ap.MarkAt(registry.StampFirstChunkIngress, receivedAt)
+	}
+	if pr.Accounting.NeedsContent() && accountingChunkHasContent(chunkData) {
+		pr.Accounting.Observe("content", "", 0)
 	}
 	contentBearing := !isBoilerplateChunk(chunkData)
 	firstContent := pr.FinishProviderChunkIngress(receivedAt, contentBearing)
@@ -1879,7 +1882,7 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		// classification as boilerplate only after the deadline.
 		s.ddIncr("inference.first_content_after_deadline", []string{})
 		s.sendAbandonCancel(provider, pr.RequestID, pr.Model, cancelCauseLateContent)
-		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
+		s.handleSyntheticInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
 			Type:        protocol.TypeInferenceError,
 			RequestID:   pr.RequestID,
 			Error:       "first content was unavailable at the request deadline",
@@ -1912,7 +1915,7 @@ func (s *Server) handleChunk(providerID string, provider *registry.Provider, msg
 		s.sendAbandonCancel(provider, pr.RequestID, pr.Model, cancelCauseOverflow)
 		// 499 + "request cancelled" classifies as a consumer-side terminal in
 		// handleInferenceError: no provider reputation hit for our backpressure.
-		s.handleInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
+		s.handleSyntheticInferenceError(providerID, provider, &protocol.InferenceErrorMessage{
 			Type:        protocol.TypeInferenceError,
 			RequestID:   msg.RequestID,
 			Error:       "request cancelled",
@@ -2009,6 +2012,7 @@ func (s *Server) handleInferenceAccepted(provider *registry.Provider, msg *proto
 		return
 	}
 	pr.Profile.Mark(registry.StampAccepted)
+	pr.Accounting.Observe("acknowledged", "", 0)
 	// Non-blocking signal — the dispatch loop may have already committed.
 	select {
 	case pr.AcceptedCh <- struct{}{}:
@@ -2053,6 +2057,7 @@ func (s *Server) handleCompleteAt(
 	// otherwise never finalize.
 	var claimed *registry.AttemptProfile
 	if pending := provider.GetPending(msg.RequestID); pending != nil {
+		pending.Accounting.Observe("provider_complete", "", 0)
 		pending.MarkCompletionIngress(receivedAt)
 		pending.Profile.MarkAt(registry.StampCompleteIngress, receivedAt)
 		// The claim is the single ownership token: only the frame that owns
@@ -2095,7 +2100,7 @@ func (s *Server) handleCompleteAt(
 				StatusCode:  http.StatusServiceUnavailable,
 				ErrorReason: errorReasonDeadlineUnreachable,
 				FailureCode: protocol.FailureCodeCapacity,
-			}, true)
+			}, true, false)
 			// handleInferenceError completes the terminal only when it still
 			// found the pending request; if a consumer-side cleanup removed it
 			// first, the provider still completed, so record that and close
@@ -2169,6 +2174,7 @@ func (s *Server) handleCompleteAt(
 		claimed.CompleteTerminal()
 		return
 	}
+	pr.Accounting.Observe("provider_complete", "", 0)
 	pr.Profile.MarkAt(registry.StampCompleteIngress, receivedAt)
 	if !terminalClaimed { // parked record (mutex single-winner): no pending entry above
 		terminalOwner = pr.Profile == nil || pr.Profile.ClaimTerminal()
@@ -2739,7 +2745,11 @@ func (s *Server) handleCompleteAt(
 // loop (and the coordinator-synthesized errors handleChunk raises there). The
 // frame holds no terminal claim; ownership is decided at the peek inside.
 func (s *Server) handleInferenceError(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage) {
-	s.handleInferenceErrorOwned(providerID, provider, msg, false)
+	s.handleInferenceErrorOwned(providerID, provider, msg, false, true)
+}
+
+func (s *Server) handleSyntheticInferenceError(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage) {
+	s.handleInferenceErrorOwned(providerID, provider, msg, false, false)
 }
 
 // handleInferenceErrorOwned is handleInferenceError with terminal ownership
@@ -2747,7 +2757,7 @@ func (s *Server) handleInferenceError(providerID string, provider *registry.Prov
 // terminal claim (handleCompleteAt converting a deadline-late empty
 // completion), so this path must neither re-claim nor drop that frame as a
 // duplicate.
-func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage, owned bool) {
+func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry.Provider, msg *protocol.InferenceErrorMessage, owned, providerObserved bool) {
 	if provider == nil {
 		s.logger.Warn("error from unregistered provider", "provider_id", providerID)
 		return
@@ -2779,6 +2789,9 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 	// completes a claimed terminal).
 	var claimedHere *registry.AttemptProfile
 	pending := provider.GetPending(msg.RequestID)
+	if pending != nil && providerObserved {
+		pending.Accounting.Observe("provider_error", normalizeInferenceErrorReason(msg.ErrorReason), msg.StatusCode)
+	}
 	if pending != nil && pending.Profile != nil && !owned {
 		if !pending.Profile.ClaimTerminal() {
 			s.logger.Warn("duplicate error for in-flight request", "provider_id", providerID)
@@ -2834,6 +2847,9 @@ func (s *Server) handleInferenceErrorOwned(providerID string, provider *registry
 		claimedHere.SetOutcome("", "", "", "error", "")
 		claimedHere.CompleteTerminal()
 		return
+	}
+	if pending == nil && providerObserved {
+		pr.Accounting.Observe("provider_error", normalizeInferenceErrorReason(msg.ErrorReason), msg.StatusCode)
 	}
 	// From this point onward use only the coordinator-owned identifier.
 	msg.RequestID = pr.RequestID

--- a/coordinator/api/queue_deadline_test.go
+++ b/coordinator/api/queue_deadline_test.go
@@ -30,7 +30,8 @@ func TestQueuedRequestExpiresAsQueueDeadlineLive(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	const model = "queue-deadline-live-model"
-	_, st, reg, ts := queuedFleetHarness(t, ctx, ServerConfig{FirstContentDeadlineBase: 400 * time.Millisecond}, model)
+	srv, st, reg, ts := queuedFleetHarness(t, ctx, ServerConfig{FirstContentDeadlineBase: 400 * time.Millisecond}, model)
+	t.Cleanup(srv.Close)
 
 	start := time.Now()
 	res := chatRequestWithID(ctx, ts.URL, model, "queue-deadline-live")
@@ -81,6 +82,36 @@ func TestQueuedRequestExpiresAsQueueDeadlineLive(t *testing.T) {
 	}
 	if rec.ResolvedModel != model {
 		t.Fatalf("rejection ResolvedModel = %q, want %q", rec.ResolvedModel, model)
+	}
+	row := waitRequestOutcome(t, st, 1)[0]
+	if row.Termination != "rejected" || row.RawReason != rejectionReasonQueueDeadline || row.NormalizedCode != "" || row.DispatchedAttemptCount != 0 || row.ContentEgressObserved || row.ResponseEgressCompleted {
+		t.Fatalf("queue expiry must remain distinct from a dispatched timeout: %+v", row)
+	}
+}
+
+func TestRequestAccountingClientDepartureWhileQueued(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "accounting-queued-departure"
+	srv, st, reg, ts := queuedFleetHarness(t, ctx, ServerConfig{FirstContentDeadlineBase: 5 * time.Second}, model)
+	t.Cleanup(srv.Close)
+	requestCtx, cancelRequest := context.WithCancel(ctx)
+	defer cancelRequest()
+	result := make(chan chatResult, 1)
+	go func() { result <- chatRequestWithID(requestCtx, ts.URL, model, "caller-departure-id") }()
+	waitForAdaptiveCondition(t, time.Second, func() bool { return reg.Queue().QueueSize(model) == 1 })
+	cancelRequest()
+	select {
+	case response := <-result:
+		if response.err == nil {
+			t.Fatalf("canceled request unexpectedly received a response: %+v", response)
+		}
+	case <-ctx.Done():
+		t.Fatal("canceled HTTP request did not return")
+	}
+	row := waitRequestOutcome(t, st, 1)[0]
+	if row.Termination != "client_departure" || !row.ClientDeparted || row.DispatchedAttemptCount != 0 || row.ContentEgressObserved || row.ResponseEgressCompleted || row.NormalizedCode != "" || row.CoordRequestID == "caller-departure-id" {
+		t.Fatalf("queued departure misclassified as delivered rejection: %+v", row)
 	}
 }
 

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -65,6 +65,14 @@ type rejectionInfo struct {
 // request path when the caller did not already do so. Best-effort: it never
 // blocks or fails the request.
 func (s *Server) recordRejection(info rejectionInfo) {
+	if info.r != nil {
+		// Routing records its proven exhaustion classification before this hook.
+		// Other rejection paths carry no such evidence.
+		requestOutcomeFromContext(info.r.Context()).Rejection(info.reasonCode, false)
+		if info.resolvedModel != "" {
+			requestOutcomeFromContext(info.r.Context()).Shape(info.resolvedModel, info.stream)
+		}
+	}
 	if s == nil || s.store == nil {
 		return
 	}

--- a/coordinator/api/request_outcome_accounting.go
+++ b/coordinator/api/request_outcome_accounting.go
@@ -61,11 +61,30 @@ func responseAccountingTerminal(v any) string {
 	}
 }
 
+// Two different observations suffice to preserve conflict without retaining
+// every terminal in a coalesced write. Matching observations are idempotent.
+type responseTerminalObservations struct {
+	first, conflicting string
+}
+
+func (o *responseTerminalObservations) observe(terminal string) {
+	if terminal == "" {
+		return
+	}
+	if o.first == "" {
+		o.first = terminal
+	} else if o.first != terminal && o.conflicting == "" {
+		o.conflicting = terminal
+	}
+}
+
 // Native Responses frames can pass through the chat relay without a generated
-// [DONE]. Inspect only candidate terminal envelopes, independently of content.
-func accountingStreamTerminal(frame string) string {
+// [DONE]. Inspect candidate terminal envelopes, including multiple SSE events
+// in one provider chunk, without discarding contradictory observations.
+func accountingStreamTerminals(frame string) responseTerminalObservations {
+	var observed responseTerminalObservations
 	if !strings.Contains(frame, "response.completed") && !strings.Contains(frame, "response.incomplete") && !strings.Contains(frame, "response.failed") {
-		return ""
+		return observed
 	}
 	for line := range strings.SplitSeq(frame, "\n") {
 		data, ok := strings.CutPrefix(line, "data:")
@@ -84,13 +103,16 @@ func accountingStreamTerminal(frame string) string {
 		switch event.Type {
 		case "response.completed":
 			if event.Response.Status == "completed" {
-				return "completed"
+				observed.observe("completed")
 			}
 		case "response.incomplete":
-			return "incomplete"
+			observed.observe("incomplete")
 		case "response.failed":
-			return "error"
+			observed.observe("error")
+		}
+		if observed.conflicting != "" {
+			return observed
 		}
 	}
-	return ""
+	return observed
 }

--- a/coordinator/api/request_outcome_accounting.go
+++ b/coordinator/api/request_outcome_accounting.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+)
+
+func inferenceOutcomeEndpoint(r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		return false
+	}
+	switch r.URL.Path {
+	case "/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages":
+		return true
+	}
+	return false
+}
+
+func requestOutcomeFromContext(ctx context.Context) *outcomes.Tracker {
+	if m := requestMetaFromContext(ctx); m != nil {
+		return m.outcome
+	}
+	return nil
+}
+
+// Read only the response envelope already assembled by the adapter. Accounting
+// never reparses or retains generated response bytes.
+func responseAccountingTerminal(v any) string {
+	status := "completed"
+	switch response := v.(type) {
+	case types.ResponsesResponse:
+		if response.Error != nil {
+			return "error"
+		}
+		status = response.Status
+	case *types.ResponsesResponse:
+		if response == nil {
+			return "unknown"
+		}
+		return responseAccountingTerminal(*response)
+	case map[string]any:
+		if response["error"] != nil || response["type"] == "error" {
+			return "error"
+		}
+		if response["object"] == "response" {
+			status, _ = response["status"].(string)
+		}
+	}
+	switch status {
+	case "completed", "incomplete":
+		return status
+	case "failed":
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// Native Responses frames can pass through the chat relay without a generated
+// [DONE]. Inspect only candidate terminal envelopes, independently of content.
+func accountingStreamTerminal(frame string) string {
+	if !strings.Contains(frame, "response.completed") && !strings.Contains(frame, "response.incomplete") && !strings.Contains(frame, "response.failed") {
+		return ""
+	}
+	for line := range strings.SplitSeq(frame, "\n") {
+		data, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue
+		}
+		var event struct {
+			Type     string `json:"type"`
+			Response struct {
+				Status string `json:"status"`
+			} `json:"response"`
+		}
+		if json.Unmarshal([]byte(data), &event) != nil {
+			continue
+		}
+		switch event.Type {
+		case "response.completed":
+			if event.Response.Status == "completed" {
+				return "completed"
+			}
+		case "response.incomplete":
+			return "incomplete"
+		case "response.failed":
+			return "error"
+		}
+	}
+	return ""
+}

--- a/coordinator/api/request_outcome_accounting_test.go
+++ b/coordinator/api/request_outcome_accounting_test.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func waitRequestOutcome(t *testing.T, st *store.MemoryStore, count int) []outcomes.Record {
+	t.Helper()
+	until := time.Now().Add(3 * time.Second)
+	for {
+		rows, err := st.RequestOutcomesBetween(context.Background(), time.Time{}, time.Now().Add(time.Minute), 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ready := len(rows) == count
+		for _, r := range rows {
+			ready = ready && r.FinalizedAt != nil
+		}
+		if ready {
+			return rows
+		}
+		if time.Now().After(until) {
+			t.Fatalf("outcomes did not settle: %+v", rows)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRequestAccountingAllEndpointsWithProfilerDisabled(t *testing.T) {
+	t.Setenv(envProfiler, "off")
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", endpoint, stream), func(t *testing.T) {
+				reg, st, srv, ts := setupTTFTFailoverServer(t)
+				t.Cleanup(srv.Close)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				const model = "accounting-model"
+				startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+					Name: "accounting-provider", Version: "0.8.10", Models: []failoverModelSpec{{ID: model}},
+					Script: fullServeScript(model),
+				})
+				shape := `"messages":[{"role":"user","content":"hello"}]`
+				switch endpoint {
+				case "/v1/responses":
+					shape = `"input":"hello"`
+				case "/v1/completions":
+					shape = `"prompt":"hello"`
+				}
+				body := fmt.Sprintf(`{"model":%q,"stream":%t,"max_tokens":64,%s}`, model, stream, shape)
+				r, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL+endpoint, strings.NewReader(body))
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.Header.Set("Authorization", "Bearer test-key")
+				r.Header.Set("X-Request-ID", "untrusted-repeated-client-id")
+				response, err := http.DefaultClient.Do(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				output, _ := io.ReadAll(response.Body)
+				response.Body.Close()
+				if response.StatusCode != 200 {
+					t.Fatalf("status=%d body=%s", response.StatusCode, output)
+				}
+				row := waitRequestOutcome(t, st, 1)[0]
+				if row.CoordRequestID == "" || row.CoordRequestID == "untrusted-repeated-client-id" {
+					t.Fatalf("untrusted identity: %+v", row)
+				}
+				if row.Termination != "completed" || row.ResponseProgress != "completion_confirmed" || row.ProviderOutcome != "completed" || !row.ResponseEgressCompleted || !row.ContentEgressObserved {
+					t.Fatalf("completion evidence: %+v", row)
+				}
+				if row.Stream == nil || *row.Stream != stream || row.Endpoint != endpoint || row.AttemptCount != 1 || row.DispatchedAttemptCount != 1 || len(row.Attempts) != 1 || !row.Attempts[0].Winning {
+					t.Fatalf("request/attempt shape: %+v", row)
+				}
+				if len(st.RequestProfilesSince(time.Time{})) != 0 {
+					t.Fatal("accounting enabled sampled profiler")
+				}
+			})
+		}
+	}
+}
+
+func TestRequestAccountingEarlyExitsAndClientIdentity(t *testing.T) {
+	t.Setenv(envProfiler, "off")
+	_, st, srv, _ := setupTTFTFailoverServer(t)
+	t.Cleanup(srv.Close)
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages"} {
+		for _, auth := range []bool{false, true} {
+			r := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(`invalid json`))
+			r.Header.Set("X-Request-ID", "same-client-id")
+			if auth {
+				r.Header.Set("Authorization", "Bearer test-key")
+			}
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, r)
+			want := 401
+			if auth {
+				want = 400
+			}
+			if w.Code != want {
+				t.Fatalf("%s auth=%t code=%d", endpoint, auth, w.Code)
+			}
+		}
+	}
+	rows := waitRequestOutcome(t, st, 8)
+	seen := map[string]bool{}
+	for _, r := range rows {
+		if seen[r.CoordRequestID] || r.CoordRequestID == "same-client-id" || r.Termination != "rejected" || r.AttemptCount != 0 || r.DispatchedAttemptCount != 0 {
+			t.Fatalf("early rejection: %+v", r)
+		}
+		seen[r.CoordRequestID] = true
+	}
+}
+
+func TestRequestAccountingRefusalThenRecovery(t *testing.T) {
+	t.Setenv(envProfileSampleRate, "0")
+	reg, st, srv, ts := setupTTFTFailoverServer(t)
+	t.Cleanup(srv.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "accounting-recovery-model"
+	recorder := &deadlineAttemptRecorder{}
+	script := func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, _ []byte) {
+		if recorder.capture(t, reg, fp, req) == 1 {
+			fp.sendTypedInferenceError(ctx, req, protocol.FailureCodeCapacity, errorReasonDeadlineUnreachable, 503)
+			return
+		}
+		fp.serveFull(ctx, req, model, "completed")
+	}
+	for _, name := range []string{"a", "b"} {
+		startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{Name: name, Version: "0.8.10", Models: []failoverModelSpec{{ID: model}}, Script: script})
+	}
+	status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, true, nil))
+	if err != nil || status != 200 {
+		t.Fatalf("request: %d %s %v", status, body, err)
+	}
+	r := waitRequestOutcome(t, st, 1)[0]
+	if r.Termination != "completed" || r.DeadlineRefusalCount != 1 || r.DispatchedAttemptCount != 2 || r.NormalizedCode != "" {
+		t.Fatalf("recovery: %+v", r)
+	}
+	if r.Attempts[0].NormalizedCode != "int_provider_deadline_rejected" || r.Attempts[0].HTTPStatus == nil || *r.Attempts[0].HTTPStatus != 503 {
+		t.Fatalf("refusal lost: %+v", r.Attempts)
+	}
+	if r.Attempts[1].RequestID == r.Attempts[0].RequestID {
+		t.Fatal("attempts collapsed")
+	}
+}
+
+func TestRequestAccountingPostContentErrorAcrossAdapters(t *testing.T) {
+	t.Setenv(envProfiler, "off")
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/stream=%t", endpoint, stream), func(t *testing.T) {
+				reg, st, srv, ts := setupTTFTFailoverServer(t)
+				t.Cleanup(srv.Close)
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				const model = "accounting-post-content-error"
+				startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+					Name: "broken-provider", Version: "0.8.10", Models: []failoverModelSpec{{ID: model}},
+					Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, _ []byte) {
+						fp.sendContentChunk(ctx, req, model, "partial output")
+						time.Sleep(30 * time.Millisecond)
+						fp.sendInferenceError(ctx, req, "provider kernel failed", 500)
+					},
+				})
+				shape := `"messages":[{"role":"user","content":"hello"}]`
+				switch endpoint {
+				case "/v1/responses":
+					shape = `"input":"hello"`
+				case "/v1/completions":
+					shape = `"prompt":"hello"`
+				}
+				body := fmt.Sprintf(`{"model":%q,"stream":%t,"max_tokens":64,%s}`, model, stream, shape)
+				status, output, err := postGenericInference(ctx, ts.URL, endpoint, body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wantStatus := 500
+				if stream {
+					wantStatus = 200
+				}
+				if status != wantStatus {
+					t.Fatalf("status=%d body=%s", status, output)
+				}
+				r := waitRequestOutcome(t, st, 1)[0]
+				if r.Termination == "completed" || r.ResponseProgress != "content_observed" || r.ProviderOutcome != "error" || r.ResponseEgressCompleted || r.ContentEgressObserved != stream {
+					t.Fatalf("interrupted progress conflates ingress/egress: %+v", r)
+				}
+				if r.NormalizedCode != "" {
+					t.Fatalf("mid-response error became pre-content timeout: %+v", r)
+				}
+			})
+		}
+	}
+}

--- a/coordinator/api/request_outcome_accounting_test.go
+++ b/coordinator/api/request_outcome_accounting_test.go
@@ -196,8 +196,11 @@ func TestRequestAccountingPostContentErrorAcrossAdapters(t *testing.T) {
 					t.Fatalf("status=%d body=%s", status, output)
 				}
 				r := waitRequestOutcome(t, st, 1)[0]
-				if r.Termination == "completed" || r.ResponseProgress != "content_observed" || r.ProviderOutcome != "error" || r.ResponseEgressCompleted || r.ContentEgressObserved != stream {
+				if r.Termination == "completed" || r.ResponseProgress != "content_observed" || r.ProviderOutcome != "error" || r.ResponseEgressCompleted != stream || r.ContentEgressObserved != stream {
 					t.Fatalf("interrupted progress conflates ingress/egress: %+v", r)
+				}
+				if stream && (r.ResponseTerminal != "error" || r.ClientWriteError) {
+					t.Fatalf("accepted error envelope lacks terminal evidence: %+v", r)
 				}
 				if r.NormalizedCode != "" {
 					t.Fatalf("mid-response error became pre-content timeout: %+v", r)

--- a/coordinator/api/request_outcome_content.go
+++ b/coordinator/api/request_outcome_content.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+)
+
+// accountingChunkHasContent is separate from isBoilerplateChunk: routing can
+// commit on finish/usage/DONE or unknown data, which is not generated content.
+// The caller stops parsing after the first content observation. Parsed values
+// never enter the tracker, sink, logs or store.
+func accountingChunkHasContent(chunk string) bool {
+	if strings.HasPrefix(strings.TrimSpace(chunk), "{") {
+		return accountingJSONHasContent([]byte(chunk))
+	}
+	for line := range strings.SplitSeq(chunk, "\n") {
+		if data, ok := strings.CutPrefix(line, "data:"); ok && accountingJSONHasContent([]byte(strings.TrimSpace(data))) {
+			return true
+		}
+	}
+	return false
+}
+
+func accountingJSONHasContent(data []byte) bool {
+	var value map[string]any
+	if json.Unmarshal(data, &value) != nil {
+		return false
+	}
+	return accountingValueHasContent(value, 0)
+}
+
+// responseAccountingHasContent examines the response already assembled by the
+// endpoint. Ingress reasoning omitted by the completions/messages adapter must
+// not be treated as delivered output. This does not reparse the response body.
+func responseAccountingHasContent(value any) bool {
+	switch response := value.(type) {
+	case types.ChatCompletionResponse:
+		for _, choice := range response.Choices {
+			m := choice.Message
+			if m.Content != "" || m.Reasoning != "" || m.ReasoningContent != "" || accountingReasoningDetails(m.ReasoningDetails) {
+				return true
+			}
+			for _, call := range m.ToolCalls {
+				if accountingToolCallHasContent(call) {
+					return true
+				}
+			}
+		}
+	case *types.ChatCompletionResponse:
+		if response != nil {
+			return responseAccountingHasContent(*response)
+		}
+	case types.ResponsesResponse:
+		return accountingValueHasContent(response.Output, 0)
+	case *types.ResponsesResponse:
+		if response != nil {
+			return accountingValueHasContent(response.Output, 0)
+		}
+	default:
+		return accountingValueHasContent(value, 0)
+	}
+	return false
+}
+
+func accountingToolCallHasContent(call map[string]any) bool {
+	function, _ := call["function"].(map[string]any)
+	name, _ := function["name"].(string)
+	arguments, _ := function["arguments"].(string)
+	return name != "" || arguments != ""
+}
+
+// Traverse only endpoint-defined output fields, bounded against malformed nested
+// shapes. IDs, role, finish reasons, usage, errors and metadata are not content.
+func accountingValueHasContent(value any, depth int) bool {
+	if depth > 8 {
+		return false
+	}
+	switch v := value.(type) {
+	case string:
+		return v != ""
+	case []map[string]any:
+		for _, item := range v {
+			if accountingValueHasContent(item, depth+1) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if accountingValueHasContent(item, depth+1) {
+				return true
+			}
+		}
+	case map[string]any:
+		kind, _ := v["type"].(string)
+		switch kind {
+		case "response.output_text.delta", "response.reasoning_text.delta", "response.reasoning_summary_text.delta", "response.function_call_arguments.delta", "response.refusal.delta":
+			delta, _ := v["delta"].(string)
+			return delta != ""
+		case "error", "response.failed", "response.created", "response.in_progress":
+			return false
+		case "response.completed", "response.incomplete":
+			return accountingValueHasContent(v["response"], depth+1)
+		case "content_block_delta":
+			return accountingValueHasContent(v["delta"], depth+1)
+		case "content_block_start":
+			return accountingValueHasContent(v["content_block"], depth+1)
+		case "response.output_item.added", "response.output_item.done":
+			return accountingValueHasContent(v["item"], depth+1)
+		case "function_call", "tool_use":
+			name, _ := v["name"].(string)
+			arguments, _ := v["arguments"].(string)
+			return name != "" || arguments != ""
+		}
+		if accountingReasoningDetails(v["reasoning_details"]) {
+			return true
+		}
+		for _, field := range []string{"text", "reasoning", "reasoning_content", "refusal", "thinking", "partial_json"} {
+			if text, ok := v[field].(string); ok && text != "" {
+				return true
+			}
+		}
+		for _, field := range []string{"content", "choices", "output", "summary"} {
+			if accountingValueHasContent(v[field], depth+1) {
+				return true
+			}
+		}
+		for _, field := range []string{"message", "delta"} {
+			if nested, ok := v[field].(map[string]any); ok && accountingValueHasContent(nested, depth+1) {
+				return true
+			}
+		}
+		if calls, ok := v["tool_calls"].([]any); ok {
+			for _, item := range calls {
+				if call, ok := item.(map[string]any); ok && accountingToolCallHasContent(call) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func accountingReasoningDetails(value any) bool {
+	switch details := value.(type) {
+	case []types.ReasoningDetail:
+		for _, detail := range details {
+			if detail.Type == "reasoning.text" && detail.Text != "" {
+				return true
+			}
+		}
+	case []any:
+		for _, detail := range details {
+			if item, ok := detail.(map[string]any); ok && accountingReasoningText(item) {
+				return true
+			}
+		}
+	case []map[string]any:
+		for _, detail := range details {
+			if accountingReasoningText(detail) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func accountingReasoningText(detail map[string]any) bool {
+	kind, _ := detail["type"].(string)
+	text, _ := detail["text"].(string)
+	return kind == "reasoning.text" && text != ""
+}

--- a/coordinator/api/request_outcome_content_test.go
+++ b/coordinator/api/request_outcome_content_test.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/api/types"
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestAccountingChunkContentEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name, chunk string
+		want        bool
+	}{
+		{"done", "data: [DONE]", false},
+		{"role", `data: {"choices":[{"delta":{"role":"assistant","content":""}}]}`, false},
+		{"finish", `data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`, false},
+		{"usage", `data: {"choices":[],"usage":{"completion_tokens":12}}`, false},
+		{"error", `data: {"type":"error","message":"failure","text":"failure"}`, false},
+		{"metadata", `data: {"metadata":{"content":"diagnostic"},"id":"output-id"}`, false},
+		{"invalid", `data: {"choices":`, false},
+		{"text", `data: {"choices":[{"delta":{"content":"answer"}}]}`, true},
+		{"reasoning", `data: {"choices":[{"delta":{"reasoning_content":"thought"}}]}`, true},
+		{"reasoning details", `data: {"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","text":"thought"}]}}]}`, true},
+		{"opaque reasoning details", `data: {"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.encrypted","data":"opaque","signature":"sig"}]}}]}`, false},
+		{"tool name", `data: {"choices":[{"delta":{"tool_calls":[{"id":"call-id","function":{"name":"clock"}}]}}]}`, true},
+		{"tool ID only", `data: {"choices":[{"delta":{"tool_calls":[{"id":"call-id","function":{}}]}}]}`, false},
+		{"responses reasoning", `event: response.reasoning_summary_text.delta` + "\n" + `data: {"type":"response.reasoning_summary_text.delta","delta":"thought"}`, true},
+		{"responses empty lifecycle", `data: {"type":"response.completed","response":{"output":[]}}`, false},
+		{"responses failed", `data: {"type":"response.failed","response":{"error":{"message":"failure"}}}`, false},
+		{"multiple events", "data: [DONE]\n\nevent: chunk\ndata:{\"choices\":[{\"delta\":{\"content\":\"answer\"}}]}\n", true},
+		{"bare JSON", `{"choices":[{"message":{"content":"answer"}}]}`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := accountingChunkHasContent(tc.chunk); got != tc.want {
+				t.Fatalf("content=%t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func contentAccountingRequest(endpoint string) (*outcomes.Tracker, *registry.PendingRequest) {
+	tracker := outcomes.New("content-request", endpoint, time.Now(), nil)
+	pr := &registry.PendingRequest{
+		RequestID: "content-attempt", Model: "content-model", ConsumerEndpoint: endpoint,
+		Accounting: tracker.NewAttempt("content-attempt", 1, ""),
+	}
+	return tracker, pr
+}
+
+func TestAccountingChatTerminalOnlyIsNotContent(t *testing.T) {
+	tracker, pr := contentAccountingRequest("/v1/chat/completions")
+	w := httptest.NewRecorder()
+	stamps := newRelayStamps(nil, tracker)
+	relay := newChatStreamRelay(pr, w, w, stamps)
+	for _, frame := range []string{
+		`data: {"choices":[{"delta":{"role":"assistant","content":""}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`data: {"choices":[],"usage":{"completion_tokens":0}}`,
+		"data: [DONE]",
+	} {
+		relay.writeFrame(frame)
+	}
+	relay.flush()
+	stamps.done()
+	if !strings.Contains(w.Body.String(), "[DONE]") {
+		t.Fatal("terminal bytes were not written")
+	}
+	row := tracker.Snapshot()
+	if row.ContentEgressObserved || !row.ResponseEgressCompleted {
+		t.Fatalf("empty completion confused with content: %+v", row)
+	}
+}
+
+func TestAccountingResponsesReasoningOnlyEgress(t *testing.T) {
+	tracker, pr := contentAccountingRequest("/v1/responses")
+	w := httptest.NewRecorder()
+	emitter := newResponsesStreamEmitter(w, w, pr, "response-id", 1)
+	emitter.start()
+	if tracker.Snapshot().ContentEgressObserved {
+		t.Fatal("response preamble counted as generated content")
+	}
+	emitter.handleChunk(`data: {"choices":[{"delta":{"reasoning_content":"thought"}}]}`)
+	if !strings.Contains(w.Body.String(), "response.reasoning_summary_text.delta") || !tracker.Snapshot().ContentEgressObserved {
+		t.Fatalf("written reasoning not recorded: %s", w.Body.String())
+	}
+}
+
+func TestAccountingToolNameOnlyEgress(t *testing.T) {
+	const chunk = `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-id","type":"function","function":{"name":"clock","arguments":""}}]}}]}`
+	for _, endpoint := range []string{"/v1/messages", "/v1/responses"} {
+		t.Run(endpoint, func(t *testing.T) {
+			tracker, pr := contentAccountingRequest(endpoint)
+			w := httptest.NewRecorder()
+			if endpoint == "/v1/messages" {
+				emitter := newMessagesStreamEmitter(w, w, pr)
+				emitter.start()
+				emitter.handleChunk(chunk)
+				emitter.finish(protocol.UsageInfo{})
+			} else {
+				emitter := newResponsesStreamEmitter(w, w, pr, "response-id", 1)
+				emitter.start()
+				emitter.handleChunk(chunk)
+			}
+			if !strings.Contains(w.Body.String(), `"name":"clock"`) || !tracker.Snapshot().ContentEgressObserved {
+				t.Fatalf("written tool name not recorded: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAccountingResponsesSplitToolNameEgress(t *testing.T) {
+	tracker, pr := contentAccountingRequest("/v1/responses")
+	w := httptest.NewRecorder()
+	emitter := newResponsesStreamEmitter(w, w, pr, "response-id", 1)
+	emitter.handleChunk(`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-id","type":"function"}]}}]}`)
+	if tracker.Snapshot().ContentEgressObserved {
+		t.Fatal("tool ID counted as generated content")
+	}
+	emitter.handleChunk(`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"clock"}}]}}]}`)
+	if tracker.Snapshot().ContentEgressObserved {
+		t.Fatal("buffered tool name counted before the adapter emitted it")
+	}
+	emitter.closeFunctionCalls()
+	if !strings.Contains(w.Body.String(), `"name":"clock"`) || !tracker.Snapshot().ContentEgressObserved {
+		t.Fatalf("name in completed output item not recorded: %s", w.Body.String())
+	}
+}
+
+func TestAccountingNonstreamUsesAdapterOutput(t *testing.T) {
+	for _, endpoint := range []string{"/v1/completions", "/v1/messages"} {
+		t.Run(endpoint, func(t *testing.T) {
+			tracker, pr := contentAccountingRequest(endpoint)
+			pr.Accounting.Observe("content", "", 0)
+			body := buildGenericEndpointResponse(pr, extractedMessage{Reasoning: "provider thought"}, protocol.UsageInfo{})
+			w := httptest.NewRecorder()
+			writeNonStreamBody(w, nil, body, tracker)
+			row := tracker.Snapshot()
+			if !tracker.HasContent() || strings.Contains(w.Body.String(), "provider thought") || row.ContentEgressObserved || !row.ResponseEgressCompleted {
+				t.Fatalf("ingress reasoning omitted by adapter counted as egress: %+v body=%s", row, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAccountingNonstreamActualEnvelopes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body any
+		want bool
+	}{
+		{"empty chat", types.ChatCompletionResponse{Choices: []types.ChatCompletionChoice{{Message: types.ChatCompletionMessage{Role: "assistant"}}}}, false},
+		{"chat text", types.ChatCompletionResponse{Choices: []types.ChatCompletionChoice{{Message: types.ChatCompletionMessage{Content: "answer"}}}}, true},
+		{"chat reasoning details", types.ChatCompletionResponse{Choices: []types.ChatCompletionChoice{{Message: types.ChatCompletionMessage{ReasoningDetails: []types.ReasoningDetail{{Type: "reasoning.text", Text: "thought"}}}}}}, true},
+		{"chat tool", &types.ChatCompletionResponse{Choices: []types.ChatCompletionChoice{{Message: types.ChatCompletionMessage{ToolCalls: []map[string]any{{"function": map[string]any{"name": "clock"}}}}}}}, true},
+		{"empty responses", types.ResponsesResponse{Status: "completed", Output: []any{}}, false},
+		{"responses text", &types.ResponsesResponse{Output: []any{map[string]any{"type": "message", "content": []any{map[string]any{"type": "output_text", "text": "answer"}}}}}, true},
+		{"messages tool", map[string]any{"type": "message", "content": []any{map[string]any{"type": "tool_use", "name": "clock", "input": map[string]any{}}}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker, _ := contentAccountingRequest("/v1/chat/completions")
+			w := httptest.NewRecorder()
+			writeNonStreamBody(w, nil, tc.body, tracker)
+			if got := tracker.Snapshot().ContentEgressObserved; got != tc.want {
+				t.Fatalf("content=%t, want %t; emitted=%s", got, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestAccountingNativeResponsesTerminal(t *testing.T) {
+	for _, tc := range []struct{ kind, status, want string }{
+		{"response.completed", "completed", "completed"},
+		{"response.incomplete", "incomplete", "incomplete"},
+		{"response.failed", "failed", "error"},
+		{"response.completed", "", "unknown"},
+		{"response.output_text.delta", "completed", "unknown"},
+	} {
+		t.Run(tc.kind+tc.status, func(t *testing.T) {
+			tracker, pr := contentAccountingRequest("/v1/chat/completions")
+			pr.Accounting.Observe("committed", "", 0)
+			pr.Accounting.Observe("provider_complete", "", 0)
+			w := httptest.NewRecorder()
+			relay := newChatStreamRelay(pr, w, w, newRelayStamps(nil, tracker))
+			relay.handleChunk(`data: {"type":"` + tc.kind + `","response":{"status":"` + tc.status + `"}}`)
+			relay.flush()
+			tracker.Finish(200, false, false)
+			row := tracker.Snapshot()
+			if row.ResponseTerminal != tc.want || row.ContentEgressObserved || (row.Termination == "completed") != (tc.want == "completed") {
+				t.Fatalf("native terminal classification: %+v", row)
+			}
+		})
+	}
+}
+
+func TestAccountingNonstreamErrorTerminal(t *testing.T) {
+	for _, body := range []any{
+		map[string]any{"object": "chat.completion", "error": map[string]any{"message": "failed"}},
+		map[string]any{"type": "error"},
+		types.ResponsesResponse{Status: "completed", Error: "failed"},
+		&types.ResponsesResponse{Status: "failed"},
+	} {
+		tracker, pr := contentAccountingRequest("/v1/responses")
+		pr.Accounting.Observe("committed", "", 0)
+		pr.Accounting.Observe("provider_complete", "", 0)
+		writeNonStreamBody(httptest.NewRecorder(), nil, body, tracker)
+		tracker.Finish(200, false, false)
+		if row := tracker.Snapshot(); row.ResponseTerminal != "error" || row.Termination == "completed" {
+			t.Fatalf("error envelope counted as completion: %+v", row)
+		}
+	}
+}

--- a/coordinator/api/request_outcome_lifecycle_test.go
+++ b/coordinator/api/request_outcome_lifecycle_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/ratelimit"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"nhooyr.io/websocket"
+)
+
+func TestRequestAccountingMiddlewareRateLimitAndDrain(t *testing.T) {
+	t.Setenv(envProfiler, "off")
+	_, st, srv, _ := setupTTFTFailoverServer(t)
+	t.Cleanup(srv.Close)
+	key, err := st.CreateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.SetRateLimiter(ratelimit.New(ratelimit.Config{RPS: 0.001, Burst: 1}))
+	for _, expected := range []int{400, 429} {
+		r := httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(`invalid`))
+		r.Header.Set("Authorization", "Bearer "+key)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, r)
+		if w.Code != expected {
+			t.Fatalf("expected%d, got%d: %s", expected, w.Code, w.Body.String())
+		}
+	}
+	srv.SetDraining(true)
+	r := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, r)
+	if w.Code != 429 {
+		t.Fatalf("drain status%d", w.Code)
+	}
+	for _, row := range waitRequestOutcome(t, st, 3) {
+		if row.Termination != "rejected" || row.AttemptCount != 0 || row.DispatchedAttemptCount != 0 || row.ResponseEgressCompleted {
+			t.Fatalf("pre-handler outcome: %+v", row)
+		}
+	}
+}
+
+func TestRequestAccountingParkedProviderCompletionRetainsDeparture(t *testing.T) {
+	srv, st, _ := billingTestServer(t)
+	t.Cleanup(srv.Close)
+	srv.settleGrace = time.Second
+	provider := srv.registry.Register("accounting-parked", nil, &protocol.RegisterMessage{Models: []protocol.ModelInfo{{ID: "parked", ModelType: "chat"}}})
+	tracker := outcomes.New("parked-coordinator", "/v1/chat/completions", time.Now(), srv.requestOutcomes.submit)
+	a := tracker.NewAttempt("parked-attempt", 0, "")
+	a.Observe("write_completed", "", 0)
+	a.Observe("content", "", 0)
+	a.Observe("committed", "", 0)
+	tracker.ContentWritten()
+	tracker.Finish(200, true, false)
+	pr := &registry.PendingRequest{RequestID: "parked-attempt", Accounting: a, Model: "parked", ConsumerKey: testConsumerID, ChunkCh: make(chan registry.ProviderChunk, 1), CompleteCh: make(chan protocol.UsageInfo, 1), ErrorCh: make(chan protocol.InferenceErrorMessage, 1)}
+	parkConsumerGone(srv, provider, pr)
+	srv.handleComplete(provider.ID, provider, &protocol.InferenceCompleteMessage{Type: protocol.TypeInferenceComplete, RequestID: pr.RequestID, Usage: protocol.UsageInfo{PromptTokens: 1, CompletionTokens: 1}})
+	row := waitRequestOutcome(t, st, 1)[0]
+	if row.Termination != "client_departure" || row.ProviderOutcome != "completed" || !row.ClientDeparted || !row.ContentEgressObserved || row.ResponseEgressCompleted || !row.ObservedAt.After(*row.FinalizedAt) {
+		t.Fatalf("late completion lost independent departure: %+v", row)
+	}
+}
+
+func TestRequestAccountingTypedProviderTimeoutVersusCoordinatorTimeout(t *testing.T) {
+	for _, typed := range []bool{false, true} {
+		name := "coordinator"
+		if typed {
+			name = "provider"
+		}
+		t.Run(name, func(t *testing.T) {
+			reg, st, srv, ts := setupTTFTFailoverServerWithConfig(t, ServerConfig{FirstContentDeadlineBase: 200 * time.Millisecond})
+			t.Cleanup(srv.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			const model = "accounting-timeout-model"
+			startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{Name: "timeout-provider", Version: "0.8.10", Models: []failoverModelSpec{{ID: model}}, Script: func(ctx context.Context, fp *failoverProvider, req protocol.InferenceRequestMessage, _ []byte) {
+				if !typed {
+					return
+				}
+				msg := protocol.InferenceErrorMessage{Type: protocol.TypeInferenceError, RequestID: req.RequestID, StatusCode: 504, FailureCode: protocol.FailureCodeGenerationFailure, TerminalCause: terminalCauseSafetyDeadline, ErrorReason: errorReasonProviderError}
+				data, _ := json.Marshal(msg)
+				if err := fp.conn.Write(ctx, websocket.MessageText, data); err != nil {
+					t.Error(err)
+				}
+			}})
+			status, body, err := postChat(ctx, ts.URL, "test-key", buildChatBody(t, model, false, nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := 429
+			code := "ext_first_content_timeout"
+			if typed {
+				want = 504
+				code = ""
+			}
+			if status != want {
+				t.Fatalf("status%d want%d: %s", status, want, body)
+			}
+			row := waitRequestOutcome(t, st, 1)[0]
+			if row.Termination != "rejected" || row.NormalizedCode != code || row.DeadlineRefusalCount != 0 {
+				t.Fatalf("timeout scope: %+v", row)
+			}
+		})
+	}
+}

--- a/coordinator/api/request_outcome_queue_test.go
+++ b/coordinator/api/request_outcome_queue_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func TestRequestAccountingQueuedDispatchDoesNotInheritPriorError(t *testing.T) {
+	t.Setenv(envProfiler, "off")
+	t.Setenv(envQueueBeforeShed, "true")
+	t.Setenv(envColdDispatch, "false")
+	t.Setenv("EIGENINFERENCE_SERVABILITY_GATE", "false")
+	for _, priorOverflow := range []bool{false, true} {
+		name := "first attempt"
+		if priorOverflow {
+			name = "retry after incompatible provider"
+		}
+		t.Run(name, func(t *testing.T) {
+			reg, _, srv, ts := setupTTFTFailoverServer(t)
+			t.Cleanup(srv.Close)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			const model = "accounting-queued-dispatch"
+			fp := startFailoverProvider(t, ctx, ts, reg, failoverProviderConfig{
+				Name: "queued-provider", Version: "0.8.10", Models: []failoverModelSpec{{ID: model}},
+				Script: func(ctx context.Context, _ *failoverProvider, _ protocol.InferenceRequestMessage, _ []byte) {
+					<-ctx.Done()
+				},
+			})
+			p := reg.GetProvider(fp.registryID)
+			capacity := func(used int64) {
+				writeAdaptiveHeartbeat(t, ctx, fp.conn, model, &protocol.BackendCapacity{
+					TotalMemoryGB: 64,
+					Slots:         []protocol.BackendSlotCapacity{{Model: model, State: "running", MaxConcurrency: 1, ActiveTokenBudgetUsed: used, ActiveTokenBudgetMax: 1000}},
+				})
+			}
+			capacity(950)
+			waitForAdaptiveCondition(t, time.Second, func() bool {
+				p.Mu().Lock()
+				defer p.Mu().Unlock()
+				return p.BackendCapacity != nil && p.BackendCapacity.Slots[0].ActiveTokenBudgetUsed == 950
+			})
+			received := time.Now()
+			tracker := outcomes.New("queued-accounting", "/v1/chat/completions", received, nil)
+			ctx = context.WithValue(ctx, requestMetaKey{}, &requestMeta{coordID: "queued-accounting", start: received, outcome: tracker})
+			d := &dispatchState{
+				s: srv, r: httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx), w: httptest.NewRecorder(),
+				model: model, publicModel: model, rawBody: []byte(`{"model":"accounting-queued-dispatch","messages":[{"role":"user","content":"hello"}],"max_tokens":64}`),
+				consumerKey: "test-key", estimatedPromptTokens: 16, requestedMaxTokens: 64,
+				deadline: 5 * time.Second, timing: &registry.RequestTiming{ReceivedAt: received},
+				excludeProviders: map[string]struct{}{}, refundReservation: func() {},
+			}
+			if priorOverflow {
+				// This is the supported retry-to-queue path: an incompatible
+				// provider failed preparation while the compatible one was busy.
+				d.attempt = 1
+				d.lastErr = errProviderBodyTooLarge.Error()
+				d.lastErrCode = http.StatusRequestEntityTooLarge
+				d.providerBodyTooLargeErr = d.lastErr
+			}
+			previousError, previousStatus := d.lastErr, d.lastErrCode
+			result := make(chan dispatchOutcome, 1)
+			go func() { result <- d.dispatchPrimary() }()
+			waitForAdaptiveCondition(t, time.Second, func() bool { return reg.Queue().QueueSize(model) == 1 })
+			capacity(0)
+			select {
+			case got := <-result:
+				if got != outcomeProceed {
+					t.Fatalf("dispatch outcome=%v error=%q code=%d", got, d.lastErr, d.lastErrCode)
+				}
+			case <-ctx.Done():
+				t.Fatal("queued dispatch did not finish")
+			}
+			row := tracker.Snapshot()
+			var dispatched *outcomes.AttemptRecord
+			for i := range row.Attempts {
+				if row.Attempts[i].RequestID == d.pr.RequestID {
+					dispatched = &row.Attempts[i]
+				}
+			}
+			if dispatched == nil || !dispatched.WriteStarted || !dispatched.WriteCompleted || row.DispatchedAttemptCount != 1 {
+				t.Fatalf("missing queued write evidence: %+v", row)
+			}
+			if dispatched.RawReason != "" || dispatched.HTTPStatus != nil || dispatched.ProviderOutcome != "no_terminal" {
+				t.Fatalf("successful queued dispatch inherited an error: %+v", *dispatched)
+			}
+			if d.lastErr != previousError || d.lastErrCode != previousStatus {
+				t.Fatalf("accounting changed routing history: error=%q status=%d", d.lastErr, d.lastErrCode)
+			}
+		})
+	}
+}
+
+func TestRequestAccountingQueuedDeadlineKeepsAttemptReason(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	const model = "accounting-queue-deadline-reason"
+	srv, st, _, ts := queuedFleetHarness(t, ctx, ServerConfig{FirstContentDeadlineBase: 300 * time.Millisecond}, model)
+	t.Cleanup(srv.Close)
+	response := chatRequestWithID(ctx, ts.URL, model, "queued-deadline")
+	if response.err != nil || response.status != http.StatusTooManyRequests {
+		t.Fatalf("queue deadline response: %+v", response)
+	}
+	row := waitRequestOutcome(t, st, 1)[0]
+	queued := row.Attempts[len(row.Attempts)-1]
+	if row.RawReason != rejectionReasonQueueDeadline || row.DispatchedAttemptCount != 0 || queued.WriteStarted || queued.WriteCompleted || queued.ProviderOutcome != "not_dispatched" {
+		t.Fatalf("queue deadline dispatch evidence: %+v", row)
+	}
+	if queued.RawReason != rejectionReasonQueueDeadline || queued.HTTPStatus == nil || *queued.HTTPStatus != http.StatusGatewayTimeout {
+		t.Fatalf("queue attempt lost its own terminal diagnostic: %+v", queued)
+	}
+}
+
+func TestRequestAccountingQueuedWriteFailureKeepsAttemptReason(t *testing.T) {
+	s := newTestServerForDispatch(t)
+	s.registry.SetQueue(registry.NewRequestQueue(4, 5*time.Second))
+	const model = "accounting-queue-write-failure"
+	tracker := outcomes.New("queued-write-failure", "/v1/completions", time.Now(), nil)
+	ctx := context.WithValue(context.Background(), requestMetaKey{}, &requestMeta{outcome: tracker})
+	d := queueDispatchState(s, model, nil, httptest.NewRequest(http.MethodPost, "/v1/completions", nil).WithContext(ctx), 5*time.Second)
+	d.lastErr, d.lastErrCode = "prior provider error", http.StatusBadGateway
+	result := make(chan dispatchOutcome, 1)
+	go func() { result <- d.dispatchPrimary() }()
+	waitForAdaptiveCondition(t, time.Second, func() bool { return s.registry.Queue().QueueSize(model) == 1 })
+	makeRoutableProvider(t, s.registry, "accounting-write-failure-provider", model) // nil socket fails the actual writer
+	s.registry.DrainQueuedRequestsForModel(model)
+	select {
+	case got := <-result:
+		if got != outcomeRetry {
+			t.Fatalf("write failure outcome=%v, want retry", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued write failure did not return")
+	}
+	row := tracker.Snapshot()
+	queued := row.Attempts[len(row.Attempts)-1]
+	if row.DispatchedAttemptCount != 0 || queued.WriteCompleted || queued.RawReason != "provider_error" || queued.HTTPStatus != nil {
+		t.Fatalf("queued write failure lost its own diagnostic: %+v", queued)
+	}
+	if d.lastErr != "failed to send request to provider" || d.lastErrCode != 0 {
+		t.Fatalf("write failure changed routing behavior: %q/%d", d.lastErr, d.lastErrCode)
+	}
+}

--- a/coordinator/api/request_outcome_sink.go
+++ b/coordinator/api/request_outcome_sink.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/saferun"
+)
+
+// Request accounting has its own bounded unsampled sink. It cannot evict route
+// or profile records. Loss is counted and never advertised as zero traffic or a
+// complete traffic denominator. At most 64 compact snapshots per store call.
+type requestOutcomeSink struct {
+	s          *Server
+	ch         chan *outcomes.Record
+	done       chan struct{}
+	stopped    chan struct{}
+	mu         sync.RWMutex
+	closed     bool
+	shutdownAt time.Time
+	dropped    atomic.Int64
+}
+
+func newRequestOutcomeSink(s *Server, capacity int) *requestOutcomeSink {
+	if s.store == nil {
+		return nil
+	}
+	if capacity <= 0 {
+		capacity = 4096
+	}
+	p := &requestOutcomeSink{s: s, ch: make(chan *outcomes.Record, capacity), done: make(chan struct{}), stopped: make(chan struct{})}
+	go p.run()
+	go p.pruneLoop()
+	return p
+}
+
+func (p *requestOutcomeSink) submit(r *outcomes.Record) {
+	if p == nil || r == nil {
+		return
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.closed {
+		select {
+		case p.ch <- r:
+			return
+		default:
+		}
+	}
+	p.dropped.Add(1)
+	p.s.ddIncr("request_outcomes.records", []string{"status:dropped"})
+}
+
+func (p *requestOutcomeSink) close() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	if !p.closed {
+		p.closed = true
+		p.shutdownAt = time.Now().Add(telemetrySinkShutdownFlush)
+		close(p.done)
+	}
+	p.mu.Unlock()
+	select {
+	case <-p.stopped:
+	case <-time.After(telemetrySinkShutdownFlush):
+		p.s.ddIncr("request_outcomes.shutdown_unconfirmed", nil)
+	}
+}
+
+func (p *requestOutcomeSink) flush(batch []*outcomes.Record) {
+	if len(batch) == 0 {
+		return
+	}
+	persisted := false
+	defer func() {
+		status := "written"
+		if !persisted {
+			status = "write_failed"
+			p.dropped.Add(int64(len(batch)))
+		}
+		p.s.ddCount("request_outcomes.records", int64(len(batch)), []string{"status:" + status})
+	}()
+	defer saferun.Recover(p.s.logger, "requestOutcomeSink.flush")
+	if err := p.s.store.RecordRequestOutcomes(batch); err != nil {
+		if p.s.logger != nil {
+			p.s.logger.Error("request outcome persistence failed", "rows", len(batch), "error", err)
+		}
+		return
+	}
+	persisted = true
+}
+
+func (p *requestOutcomeSink) run() {
+	defer close(p.stopped)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	batch := make([]*outcomes.Record, 0, 64)
+	for {
+		select {
+		case r := <-p.ch:
+			batch = append(batch, r)
+			if len(batch) == 64 {
+				p.flush(batch)
+				batch = batch[:0]
+			}
+		case <-tick.C:
+			p.flush(batch)
+			batch = batch[:0]
+		case <-p.done:
+			for {
+				if time.Now().After(p.shutdownAt) {
+					n := int64(len(batch) + len(p.ch))
+					p.dropped.Add(n)
+					p.s.ddCount("request_outcomes.records", n, []string{"status:shutdown_dropped"})
+					return
+				}
+				select {
+				case r := <-p.ch:
+					batch = append(batch, r)
+					if len(batch) == 64 {
+						p.flush(batch)
+						batch = batch[:0]
+					}
+				default:
+					p.flush(batch)
+					return
+				}
+			}
+		}
+	}
+}
+
+// Retention has a separate worker so deletion never blocks the accounting
+// writer. Every minute it drains 5000-row transactions until caught up or the
+// five-second budget expires; cancellation stops the scan during shutdown.
+func (p *requestOutcomeSink) pruneLoop() {
+	defer saferun.Recover(p.s.logger, "requestOutcomeSink.prune")
+	timer := time.NewTicker(time.Minute)
+	defer timer.Stop()
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-timer.C:
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		before := time.Now().Add(-14 * 24 * time.Hour)
+		for ctx.Err() == nil {
+			select {
+			case <-p.done:
+				cancel()
+				return
+			default:
+			}
+			n, err := p.s.store.PruneRequestOutcomes(ctx, before, 5000)
+			if err != nil {
+				if p.s.logger != nil {
+					p.s.logger.Warn("request outcome retention failed", "error", err)
+				}
+				break
+			}
+			if n < 5000 {
+				break
+			}
+		}
+		cancel()
+	}
+}

--- a/coordinator/api/request_outcome_sink_test.go
+++ b/coordinator/api/request_outcome_sink_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+type accountingBlockingStore struct {
+	store.Store
+	started    chan struct{}
+	release    chan struct{}
+	calls      atomic.Int64
+	panicFirst bool
+}
+
+func (s *accountingBlockingStore) RecordRequestOutcomes(rows []*outcomes.Record) error {
+	if s.calls.Add(1) == 1 {
+		close(s.started)
+		if s.panicFirst {
+			panic("test accounting sink failure")
+		}
+		<-s.release
+	}
+	return s.Store.RecordRequestOutcomes(rows)
+}
+
+func TestRequestAccountingSinkBoundedDuringStoreStall(t *testing.T) {
+	st := &accountingBlockingStore{Store: store.NewMemory(store.Config{}), started: make(chan struct{}), release: make(chan struct{})}
+	srv := &Server{store: st}
+	sink := newRequestOutcomeSink(srv, 1)
+	tracker := outcomes.New("one", "/v1/messages", time.Now(), sink.submit)
+	select {
+	case <-st.started:
+	case <-time.After(time.Second):
+		t.Fatal("sink did not write")
+	}
+	tracker.Finish(401, false, false)
+	for i := 0; i < 20; i++ {
+		sink.submit(&outcomes.Record{})
+	}
+	if sink.dropped.Load() != 20 || len(sink.ch) != 1 {
+		t.Fatalf("sink pressure: dropped=%d queued=%d", sink.dropped.Load(), len(sink.ch))
+	}
+	close(st.release)
+	sink.close()
+	rows, err := st.RequestOutcomesBetween(context.Background(), time.Time{}, time.Now(), 10)
+	if err != nil || len(rows) != 1 || rows[0].Termination != "rejected" {
+		t.Fatalf("terminal drain: %+v %v", rows, err)
+	}
+	sink.submit(&outcomes.Record{})
+	if sink.dropped.Load() != 21 {
+		t.Fatal("closed sink accepted a snapshot")
+	}
+}
+
+func TestRequestAccountingSinkSurvivesStorePanicAndRescuesMissingReceipt(t *testing.T) {
+	st := &accountingBlockingStore{Store: store.NewMemory(store.Config{}), started: make(chan struct{}), panicFirst: true}
+	sink := newRequestOutcomeSink(&Server{store: st}, 4)
+	tracker := outcomes.New("rescued", "/v1/messages", time.Now(), sink.submit)
+	select {
+	case <-st.started:
+	case <-time.After(time.Second):
+		t.Fatal("sink did not write")
+	}
+	tracker.Finish(429, false, false)
+	sink.close()
+	rows, err := st.RequestOutcomesBetween(context.Background(), time.Time{}, time.Now(), 10)
+	if err != nil || len(rows) != 1 || rows[0].Revision != 2 || rows[0].Termination != "rejected" {
+		t.Fatalf("terminal snapshot did not rescue lost receipt: %+v %v", rows, err)
+	}
+	if sink.dropped.Load() != 1 {
+		t.Fatalf("lost receipt not counted: %d", sink.dropped.Load())
+	}
+}

--- a/coordinator/api/request_outcome_stream_error_test.go
+++ b/coordinator/api/request_outcome_stream_error_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+type accountingErrorWriter struct {
+	header http.Header
+	body   strings.Builder
+	mode   string
+	failAt int
+	writes int
+}
+
+func (w *accountingErrorWriter) Header() http.Header { return w.header }
+func (w *accountingErrorWriter) WriteHeader(int)     {}
+func (w *accountingErrorWriter) Flush()              {}
+func (w *accountingErrorWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if w.failAt > 0 && w.writes != w.failAt {
+		return w.body.Write(p)
+	}
+	switch w.mode {
+	case "short":
+		return w.body.Write(p[:len(p)-1])
+	case "error":
+		return 0, errors.New("consumer disconnected")
+	case "full with error":
+		n, _ := w.body.Write(p)
+		return n, errors.New("consumer disconnected")
+	default:
+		return w.body.Write(p)
+	}
+}
+
+func TestAccountingStreamErrorTerminalRequiresAcceptedWrite(t *testing.T) {
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages"} {
+		for _, mode := range []string{"full", "short", "error", "full with error"} {
+			for _, priorContent := range []bool{false, true} {
+				name := endpoint + "/" + mode
+				if priorContent {
+					name += "/after-content"
+				}
+				t.Run(name, func(t *testing.T) {
+					tracker, pr := contentAccountingRequest(endpoint)
+					pr.Accounting.Observe("committed", "", 0)
+					pr.Accounting.Observe("provider_error", "", 500)
+					if priorContent {
+						pr.Accounting.Observe("content", "", 0)
+						tracker.ContentWritten()
+					}
+					w := &accountingErrorWriter{header: make(http.Header), mode: mode}
+					emitAccountingTestError(endpoint, w, pr)
+					tracker.Finish(http.StatusOK, false, false)
+					row := tracker.Snapshot()
+					accepted := mode == "full"
+					wantTerminal := "unknown"
+					if accepted {
+						wantTerminal = "error"
+					}
+					if row.ResponseTerminal != wantTerminal || row.ResponseEgressCompleted != accepted || row.ClientWriteError == accepted {
+						t.Fatalf("terminal write evidence: %+v", row)
+					}
+					if row.Termination != "interrupted" || row.ProviderOutcome != "error" || row.ContentEgressObserved != priorContent || row.ResponseProgress == "completion_confirmed" {
+						t.Fatalf("error envelope changed fulfillment/content evidence: %+v", row)
+					}
+					if accepted && (!strings.Contains(w.body.String(), `"message":"failed"`) || strings.Contains(w.body.String(), "[DONE]")) {
+						t.Fatalf("error envelope changed: %s", w.body.String())
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestAccountingChatErrorRetainsEarlierMetadataWriteFailure(t *testing.T) {
+	for _, mode := range []string{"short", "error", "full with error"} {
+		t.Run(mode, func(t *testing.T) {
+			tracker, pr := contentAccountingRequest("/v1/chat/completions")
+			pr.MetadataDetails = true
+			snapshotChatCompletionMetadata(pr, committedProviderInfo{ProviderID: "provider-id"})
+			pr.Accounting.Observe("committed", "", 0)
+			pr.Accounting.Observe("provider_error", "", 500)
+			w := &accountingErrorWriter{header: make(http.Header), mode: mode, failAt: 1}
+			emitAccountingTestError(pr.ConsumerEndpoint, w, pr)
+			tracker.Finish(http.StatusOK, false, false)
+			row := tracker.Snapshot()
+			if w.writes != 2 || row.ResponseTerminal != "error" || !row.ClientWriteError || row.ResponseEgressCompleted || row.ContentEgressObserved || row.Termination != "interrupted" {
+				t.Fatalf("accepted terminal erased earlier metadata write failure: writes=%d record=%+v", w.writes, row)
+			}
+		})
+	}
+}
+
+func TestAccountingStreamErrorDoesNotFulfillCompletedProvider(t *testing.T) {
+	for _, endpoint := range []string{"/v1/chat/completions", "/v1/responses", "/v1/completions", "/v1/messages"} {
+		t.Run(endpoint, func(t *testing.T) {
+			tracker, pr := contentAccountingRequest(endpoint)
+			pr.Accounting.Observe("committed", "", 0)
+			pr.Accounting.Observe("provider_complete", "", 0)
+			w := &accountingErrorWriter{header: make(http.Header)}
+			emitAccountingTestError(endpoint, w, pr)
+			tracker.Finish(http.StatusOK, false, false)
+			row := tracker.Snapshot()
+			if row.ResponseTerminal != "error" || !row.ResponseEgressCompleted || row.Termination == "completed" || row.ResponseProgress == "completion_confirmed" {
+				t.Fatalf("accepted error envelope counted as fulfilled response: %+v", row)
+			}
+		})
+	}
+}
+
+func emitAccountingTestError(endpoint string, w *accountingErrorWriter, pr *registry.PendingRequest) {
+	switch endpoint {
+	case "/v1/chat/completions":
+		(&Server{}).writeChatStreamTerminalError(w, w, pr, "provider_error", "failed")
+	case "/v1/responses":
+		newResponsesStreamEmitter(w, w, pr, "response-id", 1).emitError("provider_error", "failed")
+	default:
+		newGenericEndpointStreamEmitter(w, w, pr).emitError("provider_error", "failed")
+	}
+}

--- a/coordinator/api/request_outcome_terminal_conflict_test.go
+++ b/coordinator/api/request_outcome_terminal_conflict_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAccountingNativeResponseTerminalConflicts(t *testing.T) {
+	for _, order := range [][]string{{"completed", "failed"}, {"failed", "completed"}, {"completed", "incomplete"}, {"completed", "completed"}} {
+		for _, grouping := range []string{"separate_flushes", "coalesced_frames", "single_frame_group"} {
+			for _, preamble := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/%s/preamble=%t", strings.Join(order, "_"), grouping, preamble), func(t *testing.T) {
+					tracker, pr := contentAccountingRequest("/v1/chat/completions")
+					pr.Accounting.Observe("committed", "", 0)
+					pr.Accounting.Observe("provider_complete", "", 0)
+					w := httptest.NewRecorder()
+					relay := newChatStreamRelay(pr, w, w, newRelayStamps(nil, tracker))
+					if preamble {
+						relay.handleChunk(`data: {"type":"response.created"}`)
+					}
+					var frames []string
+					for _, status := range order {
+						frames = append(frames, fmt.Sprintf("event: response.%s\ndata: {\"type\":\"response.%s\",\"response\":{\"status\":\"%s\"}}", status, status, status))
+					}
+					if grouping == "single_frame_group" {
+						relay.handleChunk(strings.Join(frames, "\n\n"))
+					} else {
+						for _, frame := range frames {
+							relay.handleChunk(frame)
+							if grouping == "separate_flushes" {
+								relay.flush()
+							}
+						}
+					}
+					relay.flush()
+					tracker.Finish(200, false, false)
+					row := tracker.Snapshot()
+					conflict := order[0] != order[1]
+					first := order[0]
+					if first == "failed" {
+						first = "error"
+					}
+					if row.EvidenceConflict != conflict || row.ResponseTerminal != first || !row.ResponseEgressCompleted {
+						t.Fatalf("terminal evidence changed with flush grouping: %+v", row)
+					}
+					if conflict && (row.Termination != "unknown" || row.ResponseProgress == "completion_confirmed") {
+						t.Fatalf("contradictory terminal presented as completion: %+v", row)
+					}
+					if !conflict && row.Termination != "completed" {
+						t.Fatalf("matching terminal replay stopped completion: %+v", row)
+					}
+					for _, status := range order {
+						if !strings.Contains(w.Body.String(), `"type":"response.`+status+`"`) {
+							t.Fatal("accounting changed the emitted terminal frames")
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/coordinator/api/responses_stream.go
+++ b/coordinator/api/responses_stream.go
@@ -175,20 +175,25 @@ func newResponsesStreamEmitter(w http.ResponseWriter, flusher http.Flusher, pr *
 }
 
 // emit writes one SSE event with an `event:` line and a sequence_number.
-func (e *responsesStreamEmitter) emit(eventType string, fields map[string]any) {
+func (e *responsesStreamEmitter) emit(eventType string, fields map[string]any) bool {
 	fields["type"] = eventType
 	fields["sequence_number"] = e.seq
 	e.seq++
 	data, err := json.Marshal(fields)
 	if err != nil {
-		return
+		return false
 	}
 	n, werr := fmt.Fprintf(e.w, "event: %s\ndata: %s\n\n", eventType, data)
-	if !e.stamps.contentWritten && werr == nil && n == len(eventType)+len(data)+16 && accountingValueHasContent(fields, 0) {
+	accepted := werr == nil && n == len(eventType)+len(data)+16
+	if !e.stamps.contentWritten && accepted && accountingValueHasContent(fields, 0) {
 		e.stamps.content()
+	}
+	if n != len(eventType)+len(data)+16 {
+		e.stamps.writeErr()
 	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
+	return accepted
 }
 
 // start emits response.created and response.in_progress.
@@ -501,12 +506,14 @@ func (e *responsesStreamEmitter) finish(usage protocol.UsageInfo) {
 
 // emitError emits a Responses-API error event.
 func (e *responsesStreamEmitter) emitError(errType, message string) {
-	e.emit("error", map[string]any{
+	if e.emit("error", map[string]any{
 		"error": map[string]any{
 			"type":    errType,
 			"code":    errType,
 			"message": message,
 			"param":   nil,
 		},
-	})
+	}) {
+		e.stamps.accounting.Egress(true, false, "error")
+	}
 }

--- a/coordinator/api/responses_stream.go
+++ b/coordinator/api/responses_stream.go
@@ -166,7 +166,7 @@ func newResponsesStreamEmitter(w http.ResponseWriter, flusher http.Flusher, pr *
 		w:               w,
 		flusher:         flusher,
 		pr:              pr,
-		stamps:          newRelayStamps(pr.Profile.Parent()),
+		stamps:          newRelayStamps(pr.Profile.Parent(), pr.Accounting.Parent()),
 		responseID:      responseID,
 		createdAt:       createdAt,
 		model:           consumerModel(pr),
@@ -184,6 +184,9 @@ func (e *responsesStreamEmitter) emit(eventType string, fields map[string]any) {
 		return
 	}
 	n, werr := fmt.Fprintf(e.w, "event: %s\ndata: %s\n\n", eventType, data)
+	if !e.stamps.contentWritten && werr == nil && n == len(eventType)+len(data)+16 && accountingValueHasContent(fields, 0) {
+		e.stamps.content()
+	}
 	e.flusher.Flush()
 	e.stamps.wrote(n, werr)
 }
@@ -493,7 +496,7 @@ func (e *responsesStreamEmitter) finish(usage protocol.UsageInfo) {
 		snap["response_hash"] = e.pr.ResponseHash
 	}
 	e.emit(eventType, map[string]any{"response": snap})
-	e.stamps.done()
+	e.stamps.done(status)
 }
 
 // emitError emits a Responses-API error event.

--- a/coordinator/api/route_outcome.go
+++ b/coordinator/api/route_outcome.go
@@ -205,6 +205,9 @@ func (s *Server) updateInferenceRouteOutcomeForPending(pr *registry.PendingReque
 	if pr == nil {
 		return
 	}
+	if outcome != nil && outcome.ErrorClass != "" {
+		pr.Accounting.Observe("route_terminal", profileErrorReason(outcome), outcome.ErrorCode)
+	}
 	terminal := outcome != nil && outcome.FinalStatus != ""
 	if terminal {
 		if !pr.MarkRouteOutcomeFinalized() {

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/internal/e2e"
 	"github.com/eigeninference/d-inference/coordinator/mdm"
 	"github.com/eigeninference/d-inference/coordinator/mediafetch"
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
 	"github.com/eigeninference/d-inference/coordinator/payments"
 	"github.com/eigeninference/d-inference/coordinator/payments/baserewards"
 	"github.com/eigeninference/d-inference/coordinator/profilesign"
@@ -53,6 +54,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/eigeninference/d-inference/coordinator/telemetry"
+	"github.com/google/uuid"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/singleflight"
 )
@@ -500,7 +502,8 @@ type Server struct {
 
 	// profiler owns the per-request profile records and their dedicated sink
 	// (system profiler). Nil on a Server built without NewServer.
-	profiler *profiler
+	profiler        *profiler
+	requestOutcomes *requestOutcomeSink
 	// unknownRequestFrames counts provider frames for requests the coordinator
 	// no longer tracks (zombie streams); exported on the fleet coordinator row.
 	unknownRequestFrames atomic.Int64
@@ -877,6 +880,7 @@ func NewServer(reg *registry.Registry, st store.Store, cfg ServerConfig, logger 
 		s.ddHistogram("registry.gate.wait_ms", float64(wait.Microseconds())/1000, []string{"site:" + site})
 	})
 	s.profiler = newProfilerFromEnv(s)
+	s.requestOutcomes = newRequestOutcomeSink(s, defaultTelemetrySinkCapacity)
 	s.registerDefaultGauges()
 	s.routes()
 
@@ -981,6 +985,7 @@ func (s *Server) Close() {
 		s.trustAuthority = nil
 	}
 	s.trustAuthorityMu.Unlock()
+	s.requestOutcomes.close()
 	if s.profiler != nil {
 		s.profiler.close()
 	}
@@ -3611,16 +3616,29 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), ctxKeyRequestID, reqID)
 		// Profiler correlation id is ALWAYS coordinator-minted (the client-supplied
 		// X-Request-ID above is echoed and logged but never persisted).
-		if s.profilerEnabled() {
+		if s.profilerEnabled() || s.requestOutcomes != nil && inferenceOutcomeEndpoint(r) {
 			meta := &requestMeta{coordID: reqID, start: start}
 			if r.Header.Get("X-Request-ID") != "" {
 				meta.coordID = newRequestID()
+			}
+			if s.requestOutcomes != nil && inferenceOutcomeEndpoint(r) {
+				meta.coordID = uuid.NewString()
+				meta.outcome = outcomes.New(meta.coordID, r.URL.Path, start, s.requestOutcomes.submit)
 			}
 			ctx = context.WithValue(ctx, requestMetaKey{}, meta)
 		}
 		r = r.WithContext(ctx)
 
+		returned := false
+		defer func() {
+			status := sw.status
+			if !returned {
+				status = 0
+			} // Outer recovery writes after this defer.
+			requestOutcomeFromContext(ctx).Finish(status, r.Context().Err() != nil, sw.writeError)
+		}()
 		next.ServeHTTP(sw, r)
+		returned = true
 
 		dur := time.Since(start)
 
@@ -3717,6 +3735,13 @@ type statusWriter struct {
 	http.ResponseWriter
 	status      int
 	wroteHeader bool
+	writeError  bool
+}
+
+func (sw *statusWriter) Write(body []byte) (int, error) {
+	n, err := sw.ResponseWriter.Write(body)
+	sw.writeError = sw.writeError || err != nil || n != len(body)
+	return n, err
 }
 
 func (sw *statusWriter) WriteHeader(code int) {

--- a/coordinator/outcomes/record.go
+++ b/coordinator/outcomes/record.go
@@ -1,0 +1,83 @@
+// Package outcomes defines versioned, prompt-free incoming-request accounting.
+// It is independent of the sampled waterfall profiler and routing policy.
+package outcomes
+
+import "time"
+
+const SchemaVersion = 1
+const MaxAttempts = 64
+
+// Record is one coordinator-minted request, selected into windows by ReceivedAt.
+// Revision orders snapshots, never request counts. FinalizedAt is handler exit;
+// ObservedAt can advance later when a parked provider terminal arrives.
+type Record struct {
+	CoordRequestID          string          `json:"coord_request_id"`
+	SchemaVersion           int             `json:"schema_version"`
+	Revision                int64           `json:"revision"`
+	ReceivedAt              time.Time       `json:"received_at"`
+	FinalizedAt             *time.Time      `json:"finalized_at"`
+	ObservedAt              time.Time       `json:"observed_at"`
+	Endpoint                string          `json:"endpoint"`
+	Stream                  *bool           `json:"stream"`
+	Model                   string          `json:"model"`
+	HTTPStatus              *int            `json:"http_status"`
+	RawReason               string          `json:"raw_reason"`
+	NormalizedCode          string          `json:"normalized_code"`
+	Termination             string          `json:"termination"`
+	ResponseProgress        string          `json:"response_progress"`
+	ResponseTerminal        string          `json:"response_terminal"`
+	ProviderOutcome         string          `json:"provider_outcome"`
+	ContentEgressObserved   bool            `json:"content_egress_observed"`
+	ClientWriteError        bool            `json:"client_write_error"`
+	ResponseEgressCompleted bool            `json:"response_egress_completed"`
+	ClientDeparted          bool            `json:"client_departed"`
+	EvidenceConflict        bool            `json:"evidence_conflict"`
+	AttemptsTruncated       bool            `json:"attempts_truncated"`
+	AttemptCount            int             `json:"attempt_count"`
+	DispatchedAttemptCount  int             `json:"dispatched_attempt_count"`
+	DeadlineRefusalCount    int             `json:"deadline_refusal_count"`
+	Attempts                []AttemptRecord `json:"attempts"`
+}
+
+// AttemptRecord describes observations, not an inferred engine admission.
+// WriteStarted is the writer's dequeue callback, WriteCompleted its successful
+// return. A failed write can still have delivered bytes to a provider.
+type AttemptRecord struct {
+	RequestID            string `json:"request_id"`
+	Attempt              int    `json:"attempt"`
+	BackupOf             string `json:"backup_of"`
+	Winning              bool   `json:"winning"`
+	WriteStarted         bool   `json:"write_started"`
+	WriteCompleted       bool   `json:"write_completed"`
+	ProviderAcknowledged bool   `json:"provider_acknowledged"`
+	ContentObserved      bool   `json:"content_observed"`
+	ProviderOutcome      string `json:"provider_outcome"`
+	RawReason            string `json:"raw_reason"`
+	NormalizedCode       string `json:"normalized_code"`
+	HTTPStatus           *int   `json:"http_status"`
+}
+
+// RequestCode only maps the authoritative final classification. exhausted is
+// supplied by the dispatch classifier, not guessed from a provider status.
+func RequestCode(reason string, exhausted bool) string {
+	switch reason {
+	case "first_chunk_timeout":
+		return "ext_first_content_timeout"
+	case "deadline_unreachable":
+		if exhausted {
+			return "ext_coordinator_exhausted"
+		}
+	case "dispatch_exhausted":
+		if exhausted {
+			return "ext_coordinator_exhausted"
+		}
+	}
+	return ""
+}
+
+func AttemptCode(reason string) string {
+	if reason == "deadline_unreachable" {
+		return "int_provider_deadline_rejected"
+	}
+	return ""
+}

--- a/coordinator/outcomes/tracker.go
+++ b/coordinator/outcomes/tracker.go
@@ -169,13 +169,25 @@ func (t *Tracker) Egress(completed, writeError bool, terminal ...string) {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	priorTerminal, priorConflict := t.record.ResponseTerminal, t.record.EvidenceConflict
+	priorEgress, priorWriteError := t.record.ResponseEgressCompleted, t.record.ClientWriteError
 	t.record.ClientWriteError = t.record.ClientWriteError || writeError
 	t.record.ResponseEgressCompleted = (t.record.ResponseEgressCompleted || completed) && !t.record.ClientWriteError
-	if len(terminal) > 0 {
-		switch terminal[0] {
+	for _, observed := range terminal {
+		switch observed {
 		case "completed", "incomplete", "error":
-			t.record.ResponseTerminal = terminal[0]
+			if t.record.ResponseTerminal == "unknown" {
+				t.record.ResponseTerminal = observed
+			} else if t.record.ResponseTerminal != observed {
+				// Keep the first observation and make disagreement sticky. A
+				// repeated matching terminal is evidence of the same outcome.
+				t.record.EvidenceConflict = true
+			}
 		}
+	}
+	if t.record.FinalizedAt != nil && (t.record.ResponseTerminal != priorTerminal || t.record.EvidenceConflict != priorConflict || t.record.ResponseEgressCompleted != priorEgress || t.record.ClientWriteError != priorWriteError) {
+		t.classifyLocked()
+		t.emitLocked()
 	}
 }
 
@@ -223,7 +235,7 @@ func (t *Tracker) classifyLocked() {
 	} else if r.AttemptCount == 0 {
 		r.ProviderOutcome = "not_dispatched"
 	}
-	complete := r.ProviderOutcome == "completed" && r.ResponseTerminal == "completed" && r.ResponseEgressCompleted && !r.ClientWriteError
+	complete := !r.EvidenceConflict && r.ProviderOutcome == "completed" && r.ResponseTerminal == "completed" && r.ResponseEgressCompleted && !r.ClientWriteError
 	if complete {
 		r.ResponseProgress = "completion_confirmed"
 	}

--- a/coordinator/outcomes/tracker.go
+++ b/coordinator/outcomes/tracker.go
@@ -1,0 +1,280 @@
+package outcomes
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Tracker keeps bounded request evidence. No content or provider text is ever
+// accepted. publish must be nonblocking; it is called under the per-request lock
+// so revisions enter the sink in order. Store replay also enforces revision order.
+type Tracker struct {
+	mu        sync.Mutex
+	record    Record
+	publish   func(*Record)
+	winning   *Attempt
+	content   bool
+	committed bool
+	rejected  bool
+}
+
+type Attempt struct {
+	parent      *Tracker
+	record      AttemptRecord
+	index       int
+	refused     bool
+	contentSeen atomic.Bool
+}
+
+func New(id, endpoint string, received time.Time, publish func(*Record)) *Tracker {
+	t := &Tracker{publish: publish, record: Record{
+		CoordRequestID: id, SchemaVersion: SchemaVersion, ReceivedAt: received,
+		Endpoint: endpoint, Termination: "open", ResponseProgress: "unknown",
+		ProviderOutcome: "unknown", ResponseTerminal: "unknown", Attempts: []AttemptRecord{},
+	}}
+	t.emitLocked()
+	return t
+}
+
+func (t *Tracker) Shape(model string, stream bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.record.Model = model
+	t.record.Stream = &stream
+}
+
+func (t *Tracker) NewAttempt(id string, ordinal int, backup string) *Attempt {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	a := &Attempt{parent: t, index: -1, record: AttemptRecord{RequestID: id, Attempt: ordinal, BackupOf: backup, ProviderOutcome: "no_terminal"}}
+	t.record.AttemptCount++
+	if len(t.record.Attempts) < MaxAttempts {
+		a.index = len(t.record.Attempts)
+		t.record.Attempts = append(t.record.Attempts, a.record)
+	} else {
+		t.record.AttemptsTruncated = true
+	}
+	return a
+}
+
+func (a *Attempt) Parent() *Tracker {
+	if a == nil {
+		return nil
+	}
+	return a.parent
+}
+
+// Observe accepts only code-owned milestone names and normalized raw reasons.
+// provider_error and provider_complete are independent of the route's terminal:
+// a speculative loser may complete, or a client may leave before completion.
+func (a *Attempt) Observe(event, reason string, status int) {
+	if a == nil {
+		return
+	}
+	t := a.parent
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	before, conflictBefore, reasonBefore := a.record, t.record.EvidenceConflict, t.record.RawReason
+	switch event {
+	case "write_started":
+		a.record.WriteStarted = true
+	case "write_completed":
+		if !a.record.WriteCompleted {
+			t.record.DispatchedAttemptCount++
+		}
+		a.record.WriteCompleted = true
+	case "acknowledged":
+		a.record.ProviderAcknowledged = true
+	case "content":
+		a.contentSeen.Store(true)
+		a.record.ContentObserved = true
+		t.content = true
+	case "committed":
+		if t.winning != nil && t.winning != a {
+			t.record.EvidenceConflict = true
+		}
+		a.record.Winning = true
+		t.winning = a
+		t.committed = true
+	case "provider_complete", "provider_error":
+		outcome := "completed"
+		if event == "provider_error" {
+			outcome = "error"
+		}
+		if a.record.ProviderOutcome != "no_terminal" && a.record.ProviderOutcome != outcome {
+			t.record.EvidenceConflict = true
+		}
+		if a.record.ProviderOutcome == "no_terminal" {
+			a.record.ProviderOutcome = outcome
+		}
+	case "not_dispatched":
+		if !a.record.WriteStarted && !a.record.WriteCompleted && a.record.ProviderOutcome == "no_terminal" {
+			a.record.ProviderOutcome = "not_dispatched"
+		}
+	case "route_terminal": // Synthetic cancellation/timeout is not a provider terminal.
+		if a.record.Winning && reason != "" && t.record.RawReason == "" {
+			t.record.RawReason = reason
+		}
+	}
+	if reason != "" {
+		// Keep the actual diagnostic terminal class. A provider refusal remains
+		// linked even if a later synthetic loser outcome supersedes its class.
+		if a.record.RawReason == "" || a.record.RawReason == "unknown" {
+			a.record.RawReason = reason
+		}
+		if event == "provider_error" && AttemptCode(reason) != "" && !a.refused {
+			a.refused = true
+			t.record.DeadlineRefusalCount++
+			a.record.NormalizedCode = AttemptCode(reason)
+		}
+	}
+	if status > 0 && a.record.HTTPStatus == nil {
+		a.record.HTTPStatus = &status
+	}
+	if a.index >= 0 {
+		t.record.Attempts[a.index] = a.record
+	}
+	if t.record.FinalizedAt != nil && (a.record != before || t.record.EvidenceConflict != conflictBefore || t.record.RawReason != reasonBefore) {
+		t.classifyLocked()
+		t.emitLocked()
+	}
+}
+
+func (t *Tracker) Rejection(reason string, exhausted bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.rejected && t.record.RawReason != reason {
+		t.record.EvidenceConflict = true
+	}
+	if !t.rejected {
+		t.record.RawReason = reason
+		t.record.NormalizedCode = RequestCode(reason, exhausted)
+	}
+	t.rejected = true
+}
+
+func (t *Tracker) Egress(completed, writeError bool, terminal ...string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.record.ClientWriteError = t.record.ClientWriteError || writeError
+	t.record.ResponseEgressCompleted = (t.record.ResponseEgressCompleted || completed) && !t.record.ClientWriteError
+	if len(terminal) > 0 {
+		switch terminal[0] {
+		case "completed", "incomplete", "error":
+			t.record.ResponseTerminal = terminal[0]
+		}
+	}
+}
+
+// ContentWritten records a fully accepted write containing generated content.
+// Header/preamble/error writes never call it. It is independent of provider ingress.
+func (t *Tracker) ContentWritten() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.record.ContentEgressObserved = true
+}
+
+func (t *Tracker) Finish(status int, departed, writeError bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.record.FinalizedAt != nil {
+		return
+	}
+	now := time.Now()
+	t.record.FinalizedAt = &now
+	t.record.HTTPStatus = &status
+	t.record.ClientDeparted = departed
+	t.record.ClientWriteError = t.record.ClientWriteError || writeError
+	if t.record.ClientWriteError {
+		t.record.ResponseEgressCompleted = false
+	}
+	t.classifyLocked()
+	t.emitLockedAt(now)
+}
+
+func (t *Tracker) classifyLocked() {
+	r := &t.record
+	r.ResponseProgress = "none"
+	if t.content {
+		r.ResponseProgress = "content_observed"
+	}
+	r.ProviderOutcome = "unknown"
+	if t.winning != nil {
+		r.ProviderOutcome = t.winning.record.ProviderOutcome
+	} else if r.AttemptCount == 0 {
+		r.ProviderOutcome = "not_dispatched"
+	}
+	complete := r.ProviderOutcome == "completed" && r.ResponseTerminal == "completed" && r.ResponseEgressCompleted && !r.ClientWriteError
+	if complete {
+		r.ResponseProgress = "completion_confirmed"
+	}
+	switch {
+	case r.EvidenceConflict:
+		r.Termination = "unknown"
+	case r.ClientDeparted:
+		r.Termination = "client_departure"
+	case complete:
+		r.Termination = "completed"
+	case t.committed || r.ClientWriteError && r.HTTPStatus != nil && *r.HTTPStatus < 400:
+		r.Termination = "interrupted"
+	case r.HTTPStatus != nil && *r.HTTPStatus >= 400:
+		r.Termination = "rejected"
+		if r.RawReason == "" {
+			r.RawReason = "unknown"
+		}
+	default:
+		r.Termination = "unknown"
+	}
+}
+
+func (t *Tracker) emitLocked() { t.emitLockedAt(time.Now()) }
+
+func (t *Tracker) emitLockedAt(at time.Time) {
+	t.record.Revision++
+	t.record.ObservedAt = at
+	if t.publish == nil {
+		return
+	}
+	r := t.record
+	r.Attempts = append([]AttemptRecord{}, r.Attempts...)
+	t.publish(&r)
+}
+
+func (t *Tracker) Snapshot() Record {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	r := t.record
+	r.Attempts = append([]AttemptRecord{}, r.Attempts...)
+	return r
+}
+
+func (t *Tracker) HasContent() bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.content
+}
+
+// NeedsContent is a cheap per-attempt gate for the first-content parser.
+func (a *Attempt) NeedsContent() bool { return a != nil && !a.contentSeen.Load() }

--- a/coordinator/outcomes/tracker_egress_test.go
+++ b/coordinator/outcomes/tracker_egress_test.go
@@ -1,0 +1,66 @@
+package outcomes
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRequestAccountingResponseTerminalAgreement(t *testing.T) {
+	for _, first := range []string{"completed", "incomplete", "error"} {
+		for _, next := range []string{"completed", "incomplete", "error"} {
+			t.Run(first+"_then_"+next, func(t *testing.T) {
+				tr := accountingFixture()
+				a := sentAttempt(tr, "winner", 0, "")
+				a.Observe("committed", "", 0)
+				a.Observe("provider_complete", "", 0)
+				tr.Egress(true, false, first)
+				tr.Egress(true, false, next)
+				tr.Egress(true, false, first)
+				tr.Finish(200, false, false)
+				row := tr.Snapshot()
+				conflict := first != next
+				if row.ResponseTerminal != first || row.EvidenceConflict != conflict {
+					t.Fatalf("response terminals lost agreement evidence: %+v", row)
+				}
+				if conflict && (row.Termination != "unknown" || row.ResponseProgress == "completion_confirmed") {
+					t.Fatalf("contradictory response terminal claimed completion: %+v", row)
+				}
+				if !conflict && (row.Termination == "completed") != (first == "completed") {
+					t.Fatalf("duplicate terminal changed the outcome: %+v", row)
+				}
+			})
+		}
+	}
+}
+
+func TestRequestAccountingLateResponseTerminalConflictIsPersistedOnce(t *testing.T) {
+	var published []*Record
+	tr := New("late-egress", "/v1/responses", time.Now().Add(-time.Second), func(r *Record) { published = append(published, r) })
+	a := sentAttempt(tr, "winner", 0, "")
+	a.Observe("committed", "", 0)
+	a.Observe("provider_complete", "", 0)
+	tr.Egress(true, false, "completed")
+	tr.Finish(200, false, false)
+	before := tr.Snapshot()
+	tr.Egress(true, false, "completed", "unknown", "")
+	if tr.Snapshot().Revision != before.Revision {
+		t.Fatal("duplicate or unknown terminal published a new revision")
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); tr.Egress(true, false, "error") }()
+	}
+	wg.Wait()
+	after := tr.Snapshot()
+	if !after.EvidenceConflict || after.Termination != "unknown" || after.ResponseProgress == "completion_confirmed" || after.ResponseTerminal != "completed" {
+		t.Fatalf("late contradictory terminal was lost: %+v", after)
+	}
+	if after.Revision != before.Revision+1 || len(published) != 3 || !published[2].EvidenceConflict {
+		t.Fatalf("late conflict was not persisted exactly once: revision=%d snapshots=%d", after.Revision, len(published))
+	}
+	if !after.ReceivedAt.Equal(before.ReceivedAt) || !after.FinalizedAt.Equal(*before.FinalizedAt) || !after.ObservedAt.After(before.ObservedAt) {
+		t.Fatal("late conflict moved the receipt or handler-exit cohort")
+	}
+}

--- a/coordinator/outcomes/tracker_test.go
+++ b/coordinator/outcomes/tracker_test.go
@@ -1,0 +1,225 @@
+package outcomes
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func accountingFixture() *Tracker {
+	return New("incoming", "/v1/chat/completions", time.Now().Add(-time.Second), nil)
+}
+
+func sentAttempt(tr *Tracker, id string, ordinal int, backup string) *Attempt {
+	a := tr.NewAttempt(id, ordinal, backup)
+	a.Observe("write_started", "", 0)
+	a.Observe("write_completed", "", 0)
+	return a
+}
+
+func TestRequestAccountingRecoveredRefusalAndSpeculativeLoser(t *testing.T) {
+	for _, speculative := range []bool{false, true} {
+		t.Run(fmt.Sprintf("speculative=%t", speculative), func(t *testing.T) {
+			tr := accountingFixture()
+			a := sentAttempt(tr, "attempt-a", 0, "")
+			a.Observe("provider_error", "deadline_unreachable", 503)
+			a.Observe("provider_error", "deadline_unreachable", 503)
+			backup := ""
+			if speculative {
+				backup = "attempt-a"
+			}
+			b := sentAttempt(tr, "attempt-b", 1, backup)
+			b.Observe("acknowledged", "", 0)
+			b.Observe("content", "", 0)
+			b.Observe("committed", "", 0)
+			b.Observe("provider_complete", "", 0)
+			tr.Egress(true, false, "completed")
+			tr.Finish(200, false, false)
+			got := tr.Snapshot()
+			if got.Termination != "completed" || got.AttemptCount != 2 || got.DispatchedAttemptCount != 2 || got.DeadlineRefusalCount != 1 {
+				t.Fatalf("recovered request counted incorrectly: %+v", got)
+			}
+			if got.NormalizedCode != "" || got.Attempts[0].NormalizedCode != "int_provider_deadline_rejected" || got.Attempts[1].BackupOf != backup || !got.Attempts[1].Winning {
+				t.Fatalf("internal/final scope or attempt linkage lost: %+v", got)
+			}
+		})
+	}
+}
+
+func TestRequestAccountingFinalReasonIsIndependentOfAttempts(t *testing.T) {
+	for _, tc := range []struct {
+		reason    string
+		exhausted bool
+		status    int
+		want      string
+	}{
+		{"deadline_unreachable", true, 429, "ext_coordinator_exhausted"},
+		{"first_chunk_timeout", false, 429, "ext_first_content_timeout"},
+		{"dispatch_exhausted", true, 503, "ext_coordinator_exhausted"},
+		{"dispatch_exhausted", false, 504, ""},
+		{"queue_deadline", false, 429, ""},
+		{"invalid_request", false, 400, ""},
+	} {
+		t.Run(fmt.Sprintf("%s/%d/%t", tc.reason, tc.status, tc.exhausted), func(t *testing.T) {
+			tr := accountingFixture()
+			for i := 0; i < 3; i++ {
+				sentAttempt(tr, fmt.Sprint(i), i, "").Observe("provider_error", "deadline_unreachable", 503)
+			}
+			tr.Rejection(tc.reason, tc.exhausted)
+			tr.Finish(tc.status, false, false)
+			tr.Finish(200, false, false)
+			got := tr.Snapshot()
+			if got.Termination != "rejected" || got.NormalizedCode != tc.want || got.RawReason != tc.reason || *got.HTTPStatus != tc.status || got.DeadlineRefusalCount != 3 {
+				t.Fatalf("final classification changed by retry history or duplicate finish: %+v", got)
+			}
+		})
+	}
+}
+
+func TestRequestAccountingRequiresProviderTerminalAndSuccessfulEgress(t *testing.T) {
+	for _, tc := range []struct {
+		name, provider, terminal    string
+		content, egress, writeError bool
+		want                        string
+	}{
+		{"normal", "provider_complete", "completed", true, true, false, "completed"},
+		{"zero tokens", "provider_complete", "completed", false, true, false, "completed"},
+		{"missing provider terminal", "", "completed", true, true, false, "interrupted"},
+		{"provider failed", "provider_error", "completed", true, true, false, "interrupted"},
+		{"no body sent", "provider_complete", "completed", true, false, false, "interrupted"},
+		{"short write", "provider_complete", "completed", true, true, true, "interrupted"},
+		{"incomplete Responses", "provider_complete", "incomplete", true, true, false, "interrupted"},
+		{"error terminal", "provider_complete", "error", true, true, false, "interrupted"},
+		{"unknown terminal", "provider_complete", "unknown", true, true, false, "interrupted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := accountingFixture()
+			a := sentAttempt(tr, "attempt", 0, "")
+			a.Observe("committed", "", 0)
+			if tc.content {
+				a.Observe("content", "", 0)
+			}
+			if tc.provider != "" {
+				a.Observe(tc.provider, "", 0)
+			}
+			tr.Egress(tc.egress, tc.writeError, tc.terminal)
+			tr.Finish(200, false, false)
+			got := tr.Snapshot()
+			if got.Termination != tc.want {
+				t.Fatalf("got %+v; want %s", got, tc.want)
+			}
+			if tc.want != "completed" && got.ResponseProgress == "completion_confirmed" {
+				t.Fatalf("fabricated completion: %+v", got)
+			}
+		})
+	}
+}
+
+func TestRequestAccountingDepartureRetainsLateProviderCompletion(t *testing.T) {
+	tr := accountingFixture()
+	a := sentAttempt(tr, "parked", 0, "")
+	a.Observe("content", "", 0)
+	a.Observe("committed", "", 0)
+	tr.Finish(200, true, false)
+	first := tr.Snapshot()
+	if !first.ObservedAt.Equal(*first.FinalizedAt) {
+		t.Fatal("initial terminal must not appear late")
+	}
+	a.Observe("provider_complete", "", 0)
+	got := tr.Snapshot()
+	if got.Termination != "client_departure" || got.ProviderOutcome != "completed" || got.ResponseEgressCompleted || got.ResponseProgress == "completion_confirmed" || got.Revision <= first.Revision || !got.ObservedAt.After(*got.FinalizedAt) {
+		t.Fatalf("departure and late provider evidence were conflated: %+v", got)
+	}
+	if !got.ReceivedAt.Equal(first.ReceivedAt) || !got.FinalizedAt.Equal(*first.FinalizedAt) {
+		t.Fatal("late evidence moved the request's cohort or exit time")
+	}
+}
+
+func TestRequestAccountingSelectionAndFailedWriteAreNotDispatch(t *testing.T) {
+	tr := accountingFixture()
+	a := tr.NewAttempt("selection", 0, "")
+	a.Observe("not_dispatched", "queue_deadline", 429)
+	b := tr.NewAttempt("ambiguous-write", 1, "")
+	b.Observe("write_started", "", 0)
+	b.Observe("not_dispatched", "provider_error", 503)
+	tr.Rejection("queue_deadline", false)
+	tr.Finish(429, false, false)
+	got := tr.Snapshot()
+	if got.DispatchedAttemptCount != 0 || got.Attempts[0].ProviderOutcome != "not_dispatched" || got.Attempts[1].ProviderOutcome != "no_terminal" {
+		t.Fatalf("failed write claimed provider receipt/nonreceipt: %+v", got)
+	}
+}
+
+func TestRequestAccountingConcurrentTerminalIsIdempotent(t *testing.T) {
+	tr := accountingFixture()
+	a := sentAttempt(tr, "attempt", 0, "")
+	a.Observe("committed", "", 0)
+	tr.Egress(true, false, "completed")
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.Observe("write_completed", "", 0)
+			a.Observe("provider_complete", "", 0)
+			tr.Finish(200, false, false)
+		}()
+	}
+	wg.Wait()
+	got := tr.Snapshot()
+	if got.Termination != "completed" || got.AttemptCount != 1 || got.DispatchedAttemptCount != 1 || got.EvidenceConflict {
+		t.Fatalf("duplicate terminal inflated counts: %+v", got)
+	}
+	a.Observe("provider_error", "provider_error", 500)
+	if got = tr.Snapshot(); !got.EvidenceConflict || got.Termination != "unknown" {
+		t.Fatalf("contradictory terminal hidden: %+v", got)
+	}
+}
+
+func TestRequestAccountingHistoryBoundRetainsCounters(t *testing.T) {
+	tr := accountingFixture()
+	for i := 0; i < MaxAttempts+3; i++ {
+		sentAttempt(tr, fmt.Sprint(i), i, "").Observe("provider_error", "deadline_unreachable", 503)
+	}
+	tr.Rejection("deadline_unreachable", true)
+	tr.Finish(429, false, false)
+	got := tr.Snapshot()
+	if !got.AttemptsTruncated || len(got.Attempts) != MaxAttempts || got.AttemptCount != MaxAttempts+3 || got.DispatchedAttemptCount != MaxAttempts+3 || got.DeadlineRefusalCount != MaxAttempts+3 {
+		t.Fatalf("history bound lost accurate counters: %+v", got)
+	}
+	got.Attempts[0].RawReason = "mutated"
+	if tr.Snapshot().Attempts[0].RawReason == "mutated" {
+		t.Fatal("snapshot aliases live attempt history")
+	}
+}
+
+func TestRequestAccountingContentIngressIsNotClientEgress(t *testing.T) {
+	for _, written := range []bool{false, true} {
+		tr := accountingFixture()
+		a := sentAttempt(tr, "content-attempt", 0, "")
+		a.Observe("content", "", 0)
+		a.Observe("committed", "", 0)
+		if written {
+			tr.ContentWritten()
+		}
+		a.Observe("provider_error", "provider_error", 500)
+		tr.Finish(200, false, false)
+		got := tr.Snapshot()
+		if !tr.HasContent() || got.ResponseProgress != "content_observed" || got.ContentEgressObserved != written || got.ResponseEgressCompleted || got.Termination != "interrupted" {
+			t.Fatalf("content ingress became delivery evidence: written=%t record=%+v", written, got)
+		}
+	}
+}
+
+func TestRequestAccountingSyntheticTerminalIsNotProviderRefusal(t *testing.T) {
+	tr := accountingFixture()
+	a := sentAttempt(tr, "synthetic-timeout", 0, "")
+	a.Observe("route_terminal", "deadline_unreachable", 503)
+	tr.Rejection("first_chunk_timeout", false)
+	tr.Finish(429, false, false)
+	got := tr.Snapshot()
+	if got.DeadlineRefusalCount != 0 || got.Attempts[0].ProviderOutcome != "no_terminal" || got.Attempts[0].NormalizedCode != "" {
+		t.Fatalf("coordinator terminal invented provider refusal: %+v", got)
+	}
+}

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/eigeninference/d-inference/coordinator/attestation"
 	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
 	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/saferun"
 	"github.com/eigeninference/d-inference/coordinator/store"
@@ -267,8 +268,9 @@ type PendingRequest struct {
 	Timing *RequestTiming
 	// Profile is this attempt's profiler record (system profiler). Nil when the
 	// profiler is off. Stamped lock-free from any goroutine; see request_profile.go.
-	Profile  *AttemptProfile
-	timingMu sync.Mutex
+	Accounting *outcomes.Attempt
+	Profile    *AttemptProfile
+	timingMu   sync.Mutex
 	// contentCommitted marks THIS attempt as the one that delivered its first
 	// content chunk to the client (set by commitFirstContent / the generic
 	// first-content stamp, in the dispatch/handler goroutine). It distinguishes the

--- a/coordinator/store/harness_test.go
+++ b/coordinator/store/harness_test.go
@@ -54,6 +54,7 @@ func testPostgresStore(t testing.TB) *PostgresStore {
 		"code_attestations",
 		"code_attest_push_budgets",
 		"request_profiles",
+		"request_outcomes",
 		"fleet_snapshots",
 	} {
 		if _, err := s.pool.Exec(ctx, "TRUNCATE "+table+" CASCADE"); err != nil {

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -173,6 +173,7 @@ type UsageStore interface {
 // TelemetryStore persists routing-decision snapshots and rejection records
 // (privacy-safe, no prompt/response content). Forwarded to Datadog elsewhere.
 type TelemetryStore interface {
+	RequestOutcomeStore
 	// RecordInferenceRoute writes or refreshes the routing decision snapshot for a
 	// request attempt. Best-effort; failures must not block inference.
 	RecordInferenceRoute(record *InferenceRouteRecord) error

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -142,6 +142,7 @@ type MemoryStore struct {
 
 	// Rejected inbound inference requests (4xx/5xx) with servability snapshot.
 	inferenceRejections []RejectionRecord
+	requestOutcomes     map[string]json.RawMessage
 
 	// System profiler: per-attempt request profiles (write-once per
 	// request_id/attempt, mirroring the Postgres UNIQUE + DO NOTHING) and

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -1156,6 +1156,8 @@ func (s *PostgresStore) migrate(ctx context.Context) error {
 		// index on these tables must be built CONCURRENTLY outside this loop
 		// (see ensureProviderEarningsJobIndex). The request_waterfall view is NOT
 		// here — it is applied by hand from store/migrations/request_waterfall.sql.
+		requestOutcomesTableDDL,
+		`CREATE INDEX IF NOT EXISTS idx_request_outcomes_received ON request_outcomes (received_at, coord_request_id)`,
 		requestProfilesTableDDL,
 		requestProfilesCreatedIndexDDL,
 		requestProfilesCoordIndexDDL,

--- a/coordinator/store/postgres_request_outcomes.go
+++ b/coordinator/store/postgres_request_outcomes.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+	"github.com/jackc/pgx/v5"
+)
+
+const requestOutcomesTableDDL = `CREATE TABLE IF NOT EXISTS request_outcomes (
+ coord_request_id TEXT PRIMARY KEY CHECK (coord_request_id <> ''),
+ schema_version INT NOT NULL, revision BIGINT NOT NULL,
+ received_at TIMESTAMPTZ NOT NULL, finalized_at TIMESTAMPTZ, observed_at TIMESTAMPTZ NOT NULL,
+ endpoint TEXT NOT NULL, stream BOOL, model TEXT NOT NULL,
+ http_status INT, raw_reason TEXT NOT NULL, normalized_code TEXT NOT NULL,
+ termination TEXT NOT NULL, response_progress TEXT NOT NULL, response_terminal TEXT NOT NULL, provider_outcome TEXT NOT NULL,
+ content_egress_observed BOOL NOT NULL, client_write_error BOOL NOT NULL, response_egress_completed BOOL NOT NULL,
+ client_departed BOOL NOT NULL, evidence_conflict BOOL NOT NULL, attempts_truncated BOOL NOT NULL,
+ attempt_count INT NOT NULL, dispatched_attempt_count INT NOT NULL, deadline_refusal_count INT NOT NULL,
+ attempts JSONB NOT NULL CHECK (jsonb_typeof(attempts) = 'array' AND jsonb_array_length(attempts) <= 64)
+) WITH (autovacuum_vacuum_scale_factor = 0.02, autovacuum_analyze_scale_factor = 0.02)`
+
+var requestOutcomeUpsertSQL = buildRequestOutcomeUpsertSQL()
+
+func buildRequestOutcomeUpsertSQL() string {
+	columns := []string{"schema_version", "revision", "finalized_at", "observed_at", "stream", "model", "http_status", "raw_reason", "normalized_code", "termination", "response_progress", "response_terminal", "provider_outcome", "content_egress_observed", "client_write_error", "response_egress_completed", "client_departed", "attempts_truncated", "attempt_count", "dispatched_attempt_count", "deadline_refusal_count", "attempts"}
+	parts := make([]string, 0, len(columns)+1)
+	advance := "EXCLUDED.revision > request_outcomes.revision AND EXCLUDED.received_at = request_outcomes.received_at AND EXCLUDED.endpoint = request_outcomes.endpoint"
+	for _, c := range columns {
+		parts = append(parts, fmt.Sprintf("%s = CASE WHEN %s THEN EXCLUDED.%s ELSE request_outcomes.%s END", c, advance, c, c))
+	}
+	parts = append(parts, `evidence_conflict = request_outcomes.evidence_conflict OR EXCLUDED.evidence_conflict
+ OR EXCLUDED.received_at <> request_outcomes.received_at OR EXCLUDED.endpoint <> request_outcomes.endpoint
+ OR (EXCLUDED.revision = request_outcomes.revision AND
+ (to_jsonb(EXCLUDED) - 'evidence_conflict') <> (to_jsonb(request_outcomes) - 'evidence_conflict'))`)
+	return "INSERT INTO request_outcomes SELECT * FROM jsonb_populate_record(NULL::request_outcomes, $1::jsonb) ON CONFLICT (coord_request_id) DO UPDATE SET " + strings.Join(parts, ", ")
+}
+
+// Bounded pipelined writes preserve repeated keys' order inside a batch. A late
+// older revision cannot overwrite terminal data; conflicting same revisions or
+// reused IDs are flagged instead of selecting an arbitrary last row.
+func (s *PostgresStore) RecordRequestOutcomes(records []*outcomes.Record) error {
+	for start := 0; start < len(records); start += 64 {
+		end := min(start+64, len(records))
+		batch := &pgx.Batch{}
+		for _, r := range records[start:end] {
+			if r == nil {
+				continue
+			}
+			encoded, err := encodeRequestOutcome(r)
+			if err != nil {
+				return err
+			}
+			batch.Queue(requestOutcomeUpsertSQL, encoded)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		result := s.pool.SendBatch(ctx, batch)
+		err := result.Close()
+		cancel()
+		if err != nil {
+			return fmt.Errorf("record request outcomes: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *PostgresStore) RequestOutcomesBetween(ctx context.Context, from, to time.Time, limit int) ([]outcomes.Record, error) {
+	rows, err := s.pool.Query(ctx, `SELECT to_jsonb(o) FROM request_outcomes o WHERE received_at >= $1 AND received_at < $2 ORDER BY received_at DESC, coord_request_id LIMIT $3`, from, to, outcomeReadLimit(limit))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []outcomes.Record{}
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var r outcomes.Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) PruneRequestOutcomes(ctx context.Context, before time.Time, batch int) (int, error) {
+	if batch <= 0 || batch > 5000 {
+		batch = 5000
+	}
+	tag, err := s.pool.Exec(ctx, `DELETE FROM request_outcomes WHERE coord_request_id IN (SELECT coord_request_id FROM request_outcomes WHERE received_at < $1 ORDER BY received_at LIMIT $2)`, before, batch)
+	return int(tag.RowsAffected()), err
+}

--- a/coordinator/store/request_outcomes.go
+++ b/coordinator/store/request_outcomes.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+)
+
+// RequestOutcomeStore is unsampled request accounting. Reads are bounded and
+// use receipt-time half-open windows, regardless of terminal/persistence time.
+type RequestOutcomeStore interface {
+	RecordRequestOutcomes([]*outcomes.Record) error
+	RequestOutcomesBetween(context.Context, time.Time, time.Time, int) ([]outcomes.Record, error)
+	PruneRequestOutcomes(context.Context, time.Time, int) (int, error)
+}
+
+func encodeRequestOutcome(r *outcomes.Record) ([]byte, error) {
+	if strings.TrimSpace(r.CoordRequestID) == "" || len(r.CoordRequestID) > 64 || r.Revision < 1 || r.SchemaVersion != outcomes.SchemaVersion || r.ReceivedAt.IsZero() || r.ObservedAt.IsZero() || len(r.Attempts) > outcomes.MaxAttempts {
+		return nil, errors.New("invalid request outcome identity, version or bounds")
+	}
+	return json.Marshal(r)
+}
+
+func outcomeReadLimit(limit int) int {
+	if limit <= 0 || limit > maxTelemetryReadRows {
+		return maxTelemetryReadRows
+	}
+	return limit
+}
+
+// Memory storage retains encoded immutable snapshots, so callers cannot mutate
+// stored pointer fields or attempt slices after persistence or reads.
+func (s *MemoryStore) RecordRequestOutcomes(records []*outcomes.Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.requestOutcomes == nil {
+		s.requestOutcomes = make(map[string]json.RawMessage)
+	}
+	for _, r := range records {
+		if r == nil {
+			continue
+		}
+		encoded, err := encodeRequestOutcome(r)
+		if err != nil {
+			return err
+		}
+		if previous := s.requestOutcomes[r.CoordRequestID]; previous != nil {
+			var old outcomes.Record
+			if err := json.Unmarshal(previous, &old); err != nil {
+				return err
+			}
+			identityConflict := !old.ReceivedAt.Equal(r.ReceivedAt) || old.Endpoint != r.Endpoint
+			if r.Revision <= old.Revision || identityConflict {
+				if r.EvidenceConflict || identityConflict || r.Revision == old.Revision && string(previous) != string(encoded) {
+					old.EvidenceConflict = true
+					s.requestOutcomes[r.CoordRequestID], _ = json.Marshal(old)
+				}
+				continue
+			}
+			copy := *r
+			copy.EvidenceConflict = copy.EvidenceConflict || old.EvidenceConflict
+			encoded, _ = json.Marshal(&copy)
+		}
+		s.requestOutcomes[r.CoordRequestID] = encoded
+	}
+	return nil
+}
+
+func (s *MemoryStore) RequestOutcomesBetween(ctx context.Context, from, to time.Time, limit int) ([]outcomes.Record, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rows := []outcomes.Record{}
+	for _, raw := range s.requestOutcomes {
+		var r outcomes.Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, err
+		}
+		if !r.ReceivedAt.Before(from) && r.ReceivedAt.Before(to) {
+			rows = append(rows, r)
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].ReceivedAt.Equal(rows[j].ReceivedAt) {
+			return rows[i].CoordRequestID < rows[j].CoordRequestID
+		}
+		return rows[i].ReceivedAt.After(rows[j].ReceivedAt)
+	})
+	if len(rows) > outcomeReadLimit(limit) {
+		rows = rows[:outcomeReadLimit(limit)]
+	}
+	return rows, nil
+}
+
+func (s *MemoryStore) PruneRequestOutcomes(ctx context.Context, before time.Time, batch int) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if batch <= 0 || batch > 5000 {
+		batch = 5000
+	}
+	deleted := 0
+	for id, raw := range s.requestOutcomes {
+		var r outcomes.Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return deleted, err
+		}
+		if r.ReceivedAt.Before(before) {
+			delete(s.requestOutcomes, id)
+			deleted++
+		}
+		if deleted == batch {
+			break
+		}
+	}
+	return deleted, nil
+}

--- a/coordinator/store/request_outcomes_test.go
+++ b/coordinator/store/request_outcomes_test.go
@@ -1,0 +1,198 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/outcomes"
+)
+
+func outcomeStoreRecord(id string, received time.Time) outcomes.Record {
+	tr := outcomes.New(id, "/v1/chat/completions", received, nil)
+	tr.Shape("fixture-model", true)
+	a := tr.NewAttempt(id+"-attempt", 0, "")
+	a.Observe("write_completed", "", 0)
+	a.Observe("committed", "", 0)
+	a.Observe("provider_complete", "", 0)
+	tr.Egress(true, false, "completed")
+	tr.Finish(200, false, false)
+	return tr.Snapshot()
+}
+
+func readOutcomeRows(t *testing.T, s RequestOutcomeStore, from, to time.Time) []outcomes.Record {
+	t.Helper()
+	rows, err := s.RequestOutcomesBetween(context.Background(), from, to, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func TestRequestOutcomesReplayAndReceiptWindows(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			from := time.Date(2026, 11, 1, 5, 0, 0, 0, time.UTC) // repeated ET fall-back hour
+			to := from.Add(time.Hour)
+			terminal := outcomeStoreRecord("window-request", from)
+			initial := outcomes.New(terminal.CoordRequestID, terminal.Endpoint, from, nil).Snapshot()
+			boundary := outcomeStoreRecord("next-window", to)
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&terminal, &initial, &terminal, &boundary}); err != nil {
+				t.Fatal(err)
+			}
+			rows := readOutcomeRows(t, s, from, to)
+			if len(rows) != 1 || rows[0].CoordRequestID != terminal.CoordRequestID || rows[0].Termination != "completed" || rows[0].EvidenceConflict {
+				t.Fatalf("replay or receipt window drifted: %+v", rows)
+			}
+			later := terminal
+			later.Revision++
+			later.ObservedAt = to.Add(time.Hour)
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&later}); err != nil {
+				t.Fatal(err)
+			}
+			if rows = readOutcomeRows(t, s, from, to); len(rows) != 1 || rows[0].Revision != later.Revision {
+				t.Fatalf("late evidence lost original request: %+v", rows)
+			}
+			if rows = readOutcomeRows(t, s, to, to.Add(time.Hour)); len(rows) != 1 || rows[0].CoordRequestID != boundary.CoordRequestID {
+				t.Fatalf("late persistence double-counted adjacent window: %+v", rows)
+			}
+		})
+	}
+}
+
+func TestRequestOutcomesConflictsAreSticky(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			from := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+			r := outcomeStoreRecord("conflicting-request", from)
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&r}); err != nil {
+				t.Fatal(err)
+			}
+			conflict := r
+			conflict.Termination = "rejected"
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&conflict}); err != nil {
+				t.Fatal(err)
+			}
+			rows := readOutcomeRows(t, s, from, from.Add(time.Hour))
+			if len(rows) != 1 || !rows[0].EvidenceConflict || rows[0].Termination != "completed" {
+				t.Fatalf("same-revision conflict selected arbitrary outcome: %+v", rows)
+			}
+			r.Revision++
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&r}); err != nil {
+				t.Fatal(err)
+			}
+			if rows = readOutcomeRows(t, s, from, from.Add(time.Hour)); len(rows) != 1 || !rows[0].EvidenceConflict {
+				t.Fatalf("new revision hid conflict: %+v", rows)
+			}
+			reused := r
+			reused.Revision++
+			reused.ReceivedAt = from.Add(time.Hour)
+			reused.Endpoint = "/v1/messages"
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&reused}); err != nil {
+				t.Fatal(err)
+			}
+			if rows = readOutcomeRows(t, s, from.Add(time.Hour), from.Add(2*time.Hour)); len(rows) != 0 {
+				t.Fatalf("reused ID moved cohort: %+v", rows)
+			}
+			rows = readOutcomeRows(t, s, from, from.Add(time.Hour))
+			if len(rows) != 1 || !rows[0].EvidenceConflict || rows[0].Endpoint != r.Endpoint {
+				t.Fatalf("identity conflict overwrote authoritative identity: %+v", rows)
+			}
+		})
+	}
+}
+
+func TestRequestOutcomesRejectMissingIdentityAndBoundHistory(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, id := range []string{"", " \t", strings.Repeat("x", 65)} {
+				r := outcomeStoreRecord(id, time.Now())
+				if err := s.RecordRequestOutcomes([]*outcomes.Record{&r}); err == nil {
+					t.Errorf("accepted invalid request ID %q", id)
+				}
+			}
+			r := outcomeStoreRecord("oversized-history", time.Now())
+			r.Attempts = make([]outcomes.AttemptRecord, outcomes.MaxAttempts+1)
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&r}); err == nil {
+				t.Fatal("accepted unbounded attempt history")
+			}
+		})
+	}
+}
+
+func TestRequestOutcomesLateConflictCannotBeHiddenByRevision(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			from := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+			terminal := outcomeStoreRecord("late-conflict", from)
+			older := terminal
+			older.Revision--
+			older.EvidenceConflict = true
+			if err := s.RecordRequestOutcomes([]*outcomes.Record{&terminal, &older}); err != nil {
+				t.Fatal(err)
+			}
+			rows := readOutcomeRows(t, s, from, from.Add(time.Hour))
+			if len(rows) != 1 || !rows[0].EvidenceConflict || rows[0].Revision != terminal.Revision {
+				t.Fatalf("late conflict hidden by revision: %+v", rows)
+			}
+		})
+	}
+}
+
+func TestRequestOutcomesPruneAndReadAreBounded(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			from := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+			var records []*outcomes.Record
+			for _, id := range []string{"prune-a", "prune-b", "prune-c"} {
+				r := outcomeStoreRecord(id, from)
+				records = append(records, &r)
+			}
+			boundary := outcomeStoreRecord("keep-boundary", from.Add(time.Hour))
+			records = append(records, &boundary)
+			if err := s.RecordRequestOutcomes(records); err != nil {
+				t.Fatal(err)
+			}
+			rows, err := s.RequestOutcomesBetween(context.Background(), from, from.Add(2*time.Hour), 2)
+			if err != nil || len(rows) != 2 || rows[0].CoordRequestID != boundary.CoordRequestID {
+				t.Fatalf("bounded ordered read: rows=%+v err=%v", rows, err)
+			}
+			n, err := s.PruneRequestOutcomes(context.Background(), boundary.ReceivedAt, 2)
+			if err != nil || n != 2 {
+				t.Fatalf("bounded prune=%d err=%v", n, err)
+			}
+			if rows = readOutcomeRows(t, s, from, from.Add(2*time.Hour)); len(rows) != 2 {
+				t.Fatalf("prune exceeded batch: %+v", rows)
+			}
+			n, err = s.PruneRequestOutcomes(context.Background(), boundary.ReceivedAt, 2)
+			if err != nil || n != 1 {
+				t.Fatalf("second prune=%d err=%v", n, err)
+			}
+			if rows = readOutcomeRows(t, s, from, from.Add(2*time.Hour)); len(rows) != 1 || rows[0].CoordRequestID != boundary.CoordRequestID {
+				t.Fatalf("prune removed boundary: %+v", rows)
+			}
+		})
+	}
+}
+
+func TestMemoryRequestOutcomesDoNotAliasCallerRecords(t *testing.T) {
+	s := NewMemory(Config{})
+	from := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	r := outcomeStoreRecord("immutable-record", from)
+	if err := s.RecordRequestOutcomes([]*outcomes.Record{&r}); err != nil {
+		t.Fatal(err)
+	}
+	r.Attempts[0].RawReason = "caller-mutated"
+	*r.HTTPStatus = 500
+	rows := readOutcomeRows(t, s, from, from.Add(time.Hour))
+	if *rows[0].HTTPStatus != 200 || rows[0].Attempts[0].RawReason != "" {
+		t.Fatalf("write aliases caller: %+v", rows)
+	}
+	*rows[0].HTTPStatus = 503
+	rows[0].Attempts[0].RawReason = "reader-mutated"
+	rows = readOutcomeRows(t, s, from, from.Add(time.Hour))
+	if *rows[0].HTTPStatus != 200 || rows[0].Attempts[0].RawReason != "" {
+		t.Fatalf("read aliases storage: %+v", rows)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Darkbloom documentation
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 > Darkbloom is a decentralized private-inference network: an OpenAI- and
 > Anthropic-compatible HTTP API served by a Go coordinator that routes each
@@ -43,6 +43,7 @@
 - [`architecture/billing.md`](architecture/billing.md): pricing, reservations, ledger, the platform fee (stated only here), Stripe deposits and payouts, referrals, base rewards.
 - [`architecture/telemetry.md`](architecture/telemetry.md): what telemetry exists, how the Go/Swift/TS mirrors stay symmetric, where it goes.
 - [`architecture/request-outcome-observability.md`](architecture/request-outcome-observability.md): the closed outcome taxonomy for client, provider, and billing dimensions.
+- [`architecture/request-accounting.md`](architecture/request-accounting.md): incoming request identities, linked attempts, response egress evidence and observed coverage.
 - [`architecture/system-profiler.md`](architecture/system-profiler.md): per-attempt request profiles and fleet snapshots — schema, clocks, validation.
 - [`architecture/hardware-support.md`](architecture/hardware-support.md): the memory model — unified-memory cap, activation floors, load gate, KV budget and re-slice; platform and hardware gates.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Architecture — how Darkbloom works
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 Explanation pages: context, mechanism, invariants, failure modes, and a code
 map for each part of the system. The code in `coordinator/`,
@@ -63,6 +63,7 @@ how-to and runbook directories listed in [`../README.md`](../README.md).
 | [storage.md](storage.md) | Coordinator persistence: Postgres tables and migrations, memory store, retention jobs |
 | [billing.md](billing.md) | Pricing, reservations, ledger, Stripe deposits and Connect payouts, referrals, base rewards |
 | [telemetry.md](telemetry.md) | What telemetry exists, Go/Swift/TS symmetry, ingestion allowlist, Datadog |
+| [request-accounting.md](request-accounting.md) | Unsampled incoming request identities, linked attempts, egress evidence and coverage limits |
 | [request-outcome-observability.md](request-outcome-observability.md) | Closed outcome taxonomy across client, provider, and billing dimensions |
 | [system-profiler.md](system-profiler.md) | Per-attempt request profiles and fleet snapshots: schema, clocks, validation |
 

--- a/docs/architecture/request-accounting.md
+++ b/docs/architecture/request-accounting.md
@@ -1,6 +1,6 @@
 # Incoming request accounting
 
-> Last updated: 2026-09-05 · commit `bbf6f83d4`
+> Last updated: 2026-09-05 · commit `881f9ff50`
 
 The coordinator's `request_outcomes` ledger records one incoming request with
 linked internal attempts and separate provider, response and client evidence.
@@ -64,6 +64,9 @@ socket write (`write_completed`), provider acknowledgment, first content
 ingress, and provider terminal. A failed write may have delivered bytes;
 selection or acknowledgment does not prove engine admission. Synthetic route
 timeouts and cancellations never become observed provider refusals.
+Queued attempts retain their own exit diagnostics. A successful queued write
+does not inherit a previous attempt's error reason or HTTP status
+(`dispatchState.dispatchPrimary`, `dispatchState.queuedExitOutcome`).
 
 `Tracker.Finish` records handler exit, HTTP status, context departure and write
 errors. A subsequent terminal can revise an attempt while the coordinator
@@ -88,11 +91,21 @@ The record keeps the following dimensions distinct
 | `evidence_conflict` | Contradictory evidence; consumers must retain it as conflicting/unknown rather than count it as completion. |
 
 Completion requires a completed winning provider, a completed endpoint
-terminal, successful full response egress and no write error. A legitimate
-zero-token completion can satisfy this without generated-content egress.
+terminal, successful full response egress, no write error and no conflicting
+evidence. A legitimate zero-token completion can satisfy this without
+generated-content egress.
 Responses `incomplete` or error terminals do not satisfy it. Observed client
 departure takes precedence over completion; a later provider completion
 remains visible. Successful local writes do not prove downstream receipt.
+
+A fully accepted streamed error envelope records `response_terminal=error`
+and complete local egress, while failed or short writes do not establish that
+terminal. This error response still does not fulfill the request. `Tracker.Egress`
+preserves the first valid response terminal; differing later terminals set
+sticky `evidence_conflict`, including terminals coalesced in one relay write.
+Matching observations are idempotent. Changed evidence after finalization
+publishes a revised snapshot without moving the receipt or handler-exit cohort
+(`coordinator/api/request_outcome_accounting.go`, `Tracker.Egress`).
 
 | Normalized code | Required evidence | Owner |
 |---|---|---|
@@ -109,8 +122,8 @@ history and does not become a final rejection.
 
 `NewServer` starts a dedicated unsampled sink, independent of profiler enablement
 and sample rate. It publishes receipt and final snapshots, then changed late
-attempt evidence. Detailed per-token events and full provider profiles are
-excluded. Only the first generated-content ingress/egress adds accounting work.
+attempt or egress evidence. Detailed per-token events and full provider profiles
+are excluded. Only the first generated-content ingress/egress adds accounting work.
 
 The channel holds 4,096 snapshots. The worker batches at most 64 rows and
 flushes every 100 ms or on a full batch. PostgreSQL calls have a five-second

--- a/docs/architecture/request-accounting.md
+++ b/docs/architecture/request-accounting.md
@@ -1,0 +1,189 @@
+# Incoming request accounting
+
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
+
+The coordinator's `request_outcomes` ledger records one incoming request with
+linked internal attempts and separate provider, response and client evidence.
+It gives operators an observed receipt cohort without treating sampled
+profiles, retries or a committed HTTP 200 as completed requests.
+
+## Context
+
+A provider can decline an attempt and a retry can complete the same incoming
+request. A provider can also complete after the client leaves, or an HTTP 200
+stream can fail after its first content. The existing
+[route and profile taxonomy](request-outcome-observability.md) remains useful
+for diagnostics and billing attribution, but it cannot supply a complete
+incoming-request denominator or prove successful response egress.
+
+This ledger implements the coordinator part of
+[#845](https://github.com/Layr-Labs/d-inference/issues/845). The linked
+[Intelligence dashboard](https://github.com/Layr-Labs/darkbloom-intelligence)
+consumes its versioned schema. Routing calibration is independent;
+[#844](https://github.com/Layr-Labs/d-inference/issues/844) owns additional
+provider-refusal evidence.
+
+## Mechanism
+
+### Receipt, attempts and finalization
+
+`loggingMiddleware` in `coordinator/api/server.go` creates a fresh UUID before
+authentication, rate limits, parsing, validation, balance checks, admission or
+queueing for exact POST paths `/v1/chat/completions`, `/v1/responses`,
+`/v1/completions` and `/v1/messages`. Other methods and paths, and failures
+before this middleware, are outside the cohort. Both response modes are
+covered; `stream` is null and `model` is empty before those values are known.
+Client-supplied `X-Request-ID` never becomes the ledger identity.
+
+```mermaid
+flowchart LR
+  A[Incoming POST] --> B[loggingMiddleware: outcomes.New]
+  B --> C[Receipt snapshot]
+  B --> D[dispatchWithReserver or queued attempt]
+  D --> E[Attempt.Observe: write, acknowledgment, content, terminal]
+  E --> F[Linked attempt evidence]
+  D --> G[Relay: generated-content writes and endpoint terminal]
+  G --> H[Tracker.Finish at handler exit]
+  F --> H
+  H --> I[Final snapshot]
+  L[Late terminal for retained attempt] --> J[Revise original request]
+  C --> K[Bounded requestOutcomeSink]
+  I --> K
+  J --> K
+  K --> M[(request_outcomes: one primary key)]
+```
+
+`outcomes.NewAttempt` records selection attempts as well as dispatched work.
+The provider request UUID joins existing `inference_routes.request_id` and
+`request_profiles.request_id`; `coord_request_id` joins the sampled profile
+parent and `request_rejections.request_id`. Attempt ordinal, `backup_of` and
+`winning` keep retries and speculation inside the parent request.
+
+Attempt evidence distinguishes writer dequeue (`write_started`), successful
+socket write (`write_completed`), provider acknowledgment, first content
+ingress, and provider terminal. A failed write may have delivered bytes;
+selection or acknowledgment does not prove engine admission. Synthetic route
+timeouts and cancellations never become observed provider refusals.
+
+`Tracker.Finish` records handler exit, HTTP status, context departure and write
+errors. A subsequent terminal can revise an attempt while the coordinator
+still retains it, including a parked request after client departure. It does
+not move `received_at` or `finalized_at`. Expired or unknown provider frames
+cannot be joined retrospectively.
+
+### Completion and normalized reasons
+
+The record keeps the following dimensions distinct
+(`coordinator/outcomes/record.go`, `coordinator/outcomes/tracker.go`):
+
+| Field | Values or meaning |
+|---|---|
+| `termination` | `open`, `completed`, `rejected`, `interrupted`, `client_departure`, `unknown` |
+| `response_progress` | `unknown` before finalization; `none`, `content_observed`, or `completion_confirmed` afterward. Content here is provider ingress from any linked attempt. |
+| `content_egress_observed` | At least one fully accepted write containing generated content; headers, preamble, usage and terminal frames alone are insufficient. |
+| `response_terminal` | `unknown`, `completed`, `incomplete`, `error`; the endpoint adapter's terminal meaning, separate from writing its bytes. |
+| `provider_outcome` | The winning attempt's `completed`, `error`, `not_dispatched` or `no_terminal`; `unknown` without a winner, or `not_dispatched` with no attempts. |
+| `response_egress_completed`, `client_write_error`, `client_departed` | Complete local response write, failed/short write, and observed request-context departure, respectively. |
+| `raw_reason`, `http_status`, `normalized_code` | Existing bounded diagnostic classification and raw status alongside the new authoritative label. No free-form provider text. |
+| `evidence_conflict` | Contradictory evidence; consumers must retain it as conflicting/unknown rather than count it as completion. |
+
+Completion requires a completed winning provider, a completed endpoint
+terminal, successful full response egress and no write error. A legitimate
+zero-token completion can satisfy this without generated-content egress.
+Responses `incomplete` or error terminals do not satisfy it. Observed client
+departure takes precedence over completion; a later provider completion
+remains visible. Successful local writes do not prove downstream receipt.
+
+| Normalized code | Required evidence | Owner |
+|---|---|---|
+| `int_provider_deadline_rejected` | An actual provider error with normalized raw reason `deadline_unreachable`; once per attempt | `Attempt.Observe`, `AttemptCode` |
+| `ext_first_content_timeout` | The incoming request's authoritative final `first_chunk_timeout` classification | `Tracker.Rejection`, `RequestCode` |
+| `ext_coordinator_exhausted` | Final `deadline_unreachable` or `dispatch_exhausted` with explicit routing-stop evidence from the dispatch classifier | `dispatchState.run`, `RequestCode` |
+
+The raw `dispatch_exhausted` string alone is insufficient: genuine provider
+faults and typed provider timeouts keep their final distinction. An internal
+refusal or first-content timeout followed by recovery stays in the attempt
+history and does not become a final rejection.
+
+### Persistence and coverage
+
+`NewServer` starts a dedicated unsampled sink, independent of profiler enablement
+and sample rate. It publishes receipt and final snapshots, then changed late
+attempt evidence. Detailed per-token events and full provider profiles are
+excluded. Only the first generated-content ingress/egress adds accounting work.
+
+The channel holds 4,096 snapshots. The worker batches at most 64 rows and
+flushes every 100 ms or on a full batch. PostgreSQL calls have a five-second
+timeout. `Server.Close` allows the existing two-second telemetry shutdown
+window; an in-flight write can remain unconfirmed. These limits come from
+`coordinator/api/request_outcome_sink.go`, `defaultTelemetrySinkCapacity` and
+`telemetrySinkShutdownFlush`.
+
+The new table is created by boot migration and indexed by
+`(received_at, coord_request_id)`. Revision-ordered upserts preserve one row per
+coordinator ID, reject identity reuse by retaining the original cohort and
+marking conflict, ignore older state, and retain same-revision contradictions.
+Both stores preserve immutable snapshots. Attempt detail stops at 64 entries;
+scalar attempt, successful-write and provider-deadline-refusal counts continue.
+Read helpers use half-open receipt bounds and the existing telemetry row cap.
+Storage and cleanup are implemented in
+`coordinator/store/postgres_request_outcomes.go` and
+`coordinator/store/request_outcomes.go`.
+
+Retention deletes receipts older than 14 days in a separate worker every
+minute, in 5,000-row batches with a five-second sweep budget. It cannot block
+the accounting writer. Deployment creates an additive table; no historical
+backfill, existing-table rewrite, provider release or wire change is required.
+
+Unsampled does not mean lossless. Queue pressure, failed writes, process exit,
+missing middleware traffic and retention can remove observations. Loss metrics
+count snapshots, not incoming requests, so they cannot repair a denominator.
+Dashboards must use **observed records**, distinguish unavailable from recorded
+zero, and leave full-traffic fulfillment percentages unset without independent
+coverage evidence. Receipt windows are `[from, to)` UTC instants; display in
+America/New_York must preserve both repeated fall-back hours. Late evidence
+updates the original receipt cohort, never the finalization hour.
+
+## Invariants
+
+1. One incoming UUID survives retries and speculation; client IDs are never
+   authoritative (`loggingMiddleware`, `Tracker.NewAttempt`).
+2. Accounting does not drive routing, retries, deadlines, billing or wire
+   statuses (`coordinator/outcomes/tracker.go`; hooks only observe milestones).
+3. Provider ingress, generated-content egress, endpoint completion and client
+   departure are separate facts (`Tracker.classifyLocked`).
+4. Replayed revisions do not add requests or move receipt cohorts; conflicts
+   remain sticky (`buildRequestOutcomeUpsertSQL`, `RecordRequestOutcomes`).
+5. No request/response content, client keys, raw provider messages or new
+   provider telemetry enters the compact schema (`outcomes.Record`).
+
+## Failure modes
+
+| Condition | Representation or effect |
+|---|---|
+| Only receipt persisted | `open`, finalization unknown; never presumed rejected |
+| Only final snapshot persisted | Upsert retains the request's original receipt timestamp |
+| Queue full, store error or shutdown loss | Nonblocking request path; `request_outcomes.records` pipeline counts, incomplete coverage |
+| Storage slow during shutdown | `request_outcomes.shutdown_unconfirmed`; do not assume that in-flight batch was either committed or lost |
+| Conflicting terminal, winner, identity or same revision | `evidence_conflict`; excluded from authoritative completion |
+| Provider completes after departure | `client_departure` plus provider completion when still correlatable |
+| Sink/process dies or retention falls behind | Missing or stale observations; no lossless traffic claim |
+| Recorder absent or schema incompatible in dashboard source | Explicit unavailable/incompatible state or last-good snapshot, never fabricated zero traffic |
+
+## Code map
+
+| Concern | Location |
+|---|---|
+| Compact schema, reason mapping and lifecycle | `coordinator/outcomes/record.go`, `coordinator/outcomes/tracker.go` |
+| Middleware and sink ownership | `coordinator/api/server.go`, `coordinator/api/request_outcome_sink.go` |
+| Adapter evidence, content classification and response terminal | `coordinator/api/request_outcome_accounting.go`, `coordinator/api/request_outcome_content.go`, `coordinator/api/profiler_dispatch.go` |
+| Dispatch and provider observations | `coordinator/api/dispatch.go`, `coordinator/api/consumer.go`, `coordinator/api/provider.go`, `coordinator/registry/registry.go` |
+| Storage/replay and bounded reads | `coordinator/store/request_outcomes.go`, `coordinator/store/postgres_request_outcomes.go` |
+| Regression coverage | `coordinator/outcomes/tracker_test.go`, `coordinator/api/request_outcome_accounting_test.go`, `coordinator/api/request_outcome_sink_test.go`, `coordinator/store/request_outcomes_test.go` |
+
+## Related
+
+- [Request outcome observability](request-outcome-observability.md): established route, profile, metric and billing dimensions.
+- [System profiler](system-profiler.md): sampled waterfalls and joins for diagnosis.
+- [Storage](storage.md): boot migration and persistence ownership.
+- [Telemetry inventory](../reference/telemetry-inventory.md): pipeline metrics and source grains.

--- a/docs/architecture/request-outcome-observability.md
+++ b/docs/architecture/request-outcome-observability.md
@@ -1,10 +1,15 @@
 # Request Outcome Observability
 
-> Last updated: 2026-09-04 · commit `6f364e64b`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
-Every inference request the coordinator dispatches ends in exactly one terminal outcome, and that outcome is recorded three ways: a closed `final_status` / `error_class` / `error_reason` triple on the `inference_routes` row, a per-attempt `request_profiles` row with separate `client_outcome` and `provider_outcome` columns, and a small set of low-cardinality Datadog counters. Requests refused before dispatch land in the `request_rejections` ledger instead. This page explains the taxonomy as the code implements it, where each value is decided, and what is still not modelled.
+`inference_routes`, sampled `request_profiles` and the established Datadog
+counters describe provider attempts and legacy outcome semantics. They are not
+a complete incoming-request denominator. The unsampled [incoming request
+accounting ledger](request-accounting.md) separately records request identity,
+final classification, provider progress and local response egress with explicit
+coverage limits. This page describes the preserved legacy taxonomy.
 
-Scope: `/v1/chat/completions`, `/v1/responses`, `/v1/completions`, `/v1/messages`. All four flow through `dispatchState` (`coordinator/api/dispatch.go`, `coordinator/api/consumer.go`), so all four write route rows and profile rows.
+Scope: `/v1/chat/completions`, `/v1/responses`, `/v1/completions`, `/v1/messages`. All four share `dispatchState` (`coordinator/api/dispatch.go`, `coordinator/api/consumer.go`); route and sampled profile coverage depends on how far a request progresses.
 
 ## Context
 
@@ -13,7 +18,7 @@ A single success flag cannot describe a streamed inference request. The client c
 Two design rules follow from that:
 
 - Outcome strings are closed enums chosen in Go. Raw provider error text stays in logs; the route row and every metric tag carry only a value from the tables below.
-- The commit point (first content-bearing chunk written to the client) is a transition, not a terminal. Anything that happens after commit is reported as `partial_success` with an `_after_commit` class, never left as `success`.
+- The commit point (selection of a winning provider attempt) is a transition, not proof of content delivery or a terminal. Abnormal post-commit outcomes use `partial_success` with an `_after_commit` class; normal provider completion can remain `success` without proving complete response egress.
 
 ## Mechanism
 
@@ -107,7 +112,14 @@ The profiler keeps the two dimensions the route row folds together. Both are clo
 | `provider_outcome` | `completed`, `error`, `not_dispatched`, `no_terminal` | `handleComplete` / `handleInferenceError` (`coordinator/api/provider.go`), `closeUndispatchedAttempt`, and the 31 s fallback timer in `coordinator/registry/attempt_profile_finalize.go` |
 | `terminal_cause` | the `inference_error.terminal_cause` enum, verbatim | `handleInferenceError` |
 
-The full column list, retention and export rules are in [system-profiler.md](./system-profiler.md); the `terminal_cause` vocabulary is in [protocol-messages.md](../reference/protocol-messages.md).
+`client_outcome = completed` is the legacy dispatch-finalization label, not
+proof that the full body or stream reached the response writer. Likewise,
+`success` and `partial_success` route labels do not establish completed
+incoming requests. The [accounting ledger](request-accounting.md) records
+provider ingress, response terminal, complete local egress and departure
+separately. The full profile column list, retention and export rules are in
+[system-profiler.md](./system-profiler.md); the `terminal_cause` vocabulary is in
+[protocol-messages.md](../reference/protocol-messages.md).
 
 ### Pre-dispatch rejections
 
@@ -215,8 +227,8 @@ All admin reads require the admin key (`requireAdminKey`).
 
 ## Not modelled at this commit
 
-- `inference_routes` has no `client_outcome`, `provider_outcome`, `billing_outcome`, `response_committed`, `terminal_source` or client-request correlation columns; the client/provider split exists only in `request_profiles`, and billing settlement is visible through `cost_micro_usd` and the `error_class` rather than a dedicated column.
-- `request_rejections` receives no `auth` or `rate_limit` rows; those exits return before `recordRejection` runs.
+- `inference_routes` has no `client_outcome`, `provider_outcome`, `billing_outcome`, `response_committed`, `terminal_source` or client-request correlation columns; its client/provider split is available through linked `request_profiles` and `request_outcomes`. Billing settlement is visible through `cost_micro_usd` and the `error_class` rather than a dedicated column.
+- `request_rejections` receives no `auth` or `rate_limit` rows; those exits return before `recordRejection` runs. The separate receipt middleware records them in `request_outcomes` without changing this legacy table.
 - Per-provider aggregate counters for cancellations, disconnects and no-terminal drops are not exported; `RecordJobSuccess`/`RecordJobFailure` remain the only provider aggregates.
 - No `request_events` timeline table exists; point-in-time reconstruction uses the microsecond stamps in `request_profiles`.
 

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,6 +1,6 @@
 # Storage
 
-> Last updated: 2026-09-05 · commit `4d9811f7c`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 What the coordinator persists, through which interface, in which backend, and
 how the schema reaches a fresh database; then what a provider keeps on its own
@@ -37,7 +37,7 @@ on the narrow slice they need; both implementations satisfy all twelve.
 |---|---|
 | `APIKeyStore` | Consumer API keys: create, seed, validate, per-key limits and counts. |
 | `UsageStore` | Usage events and settled payments plus the totals, time-series, geo and leaderboard aggregations behind `/v1/stats`. |
-| `TelemetryStore` | Routing-decision snapshots (`inference_routes`), rejection records and the profiler's `request_profiles`/`fleet_snapshots`; prompt-free by construction. |
+| `TelemetryStore` | Routing-decision snapshots (`inference_routes`), rejection records, unsampled `request_outcomes`, and the profiler's `request_profiles`/`fleet_snapshots`; prompt-free by construction. |
 | `LedgerStore` | The double-entry balance ledger; every amount is micro-USD. |
 | `BillingStore` | Referrals, deposit sessions, per-account model prices and Stripe Connect withdrawals. |
 | `ModelRegistryStore` | The manifest-backed model catalog and the public aliases that resolve to concrete builds. |
@@ -50,6 +50,20 @@ on the narrow slice they need; both implementations satisfy all twelve.
 
 Telemetry *events* are not in the store at all: `TelemetryEventRecord` goes to
 Datadog only (see [`telemetry.md`](telemetry.md)).
+
+### Incoming-request outcome ledger
+
+`RequestOutcomeStore` is embedded in `TelemetryStore` and therefore delegated
+through `CachedStore` without a new cache domain. The `request_outcomes` table
+has a coordinator UUID primary key and a `(received_at, coord_request_id)` index.
+Its versioned snapshots are upserted with monotonic revision and sticky conflict
+checks; both memory and Postgres enforce equivalent replay semantics.
+`coordinator/store/postgres_request_outcomes.go` owns the additive startup DDL
+and bounded reads/deletes; `coordinator/api/request_outcome_sink.go` owns
+unsampled persistence and retention independently of the profiler. See the
+[accounting contract](request-accounting.md) for coverage, lifecycle evidence,
+retention and loss semantics. This schema writes neither users nor model data,
+so it does not invalidate their read-through caches.
 
 ### Two implementations and when each runs
 
@@ -117,7 +131,7 @@ Roughly forty tables; grouped by what would be lost if the family vanished.
 |---|---|---|
 | Identity and access | `api_keys`, `users`, `device_codes`, `provider_tokens`, `publishing_api_keys`, `invite_codes`, `invite_redemptions` | Keys are stored as hashes with a display prefix; `users` carries the Stripe Connect fields. |
 | Money | `balances`, `ledger_entries`, `billing_sessions`, `model_prices`, `referrers`, `referrals`, `stripe_withdrawals`, `provider_earnings`, `earnings_summary`, `provider_payouts`, `provider_floor_draws`, `payments` (legacy) | The ledger is append-only; `balances` is the materialised view of it. Semantics in [`billing.md`](billing.md). |
-| Usage and routing telemetry | `usage`, `usage_totals`, `inference_routes`, `request_rejections`, `request_profiles`, `fleet_snapshots` | Row per request, per dispatched attempt, per rejection, per profiled attempt, per fleet sample; `usage_totals` is a single-row counter kept by `migrateUsageTotals`. |
+| Usage and routing telemetry | `usage`, `usage_totals`, `inference_routes`, `request_rejections`, `request_outcomes`, `request_profiles`, `fleet_snapshots` | Billed usage, internal route attempts, rejection observations, incoming request snapshots, sampled profiles and fleet samples; `usage_totals` is a single-row counter kept by `migrateUsageTotals`. |
 | Provider fleet and trust | `providers`, `provider_reputation`, `provider_sessions`, `provider_trust_reuse`, `provider_verification_jobs`, `code_attestations`, `code_attest_push_budgets`, `provider_log_reports` | Trust reuse and code attestations are durable so a redeploy does not re-challenge the whole fleet; see [`security/attestation.md`](security/attestation.md). `provider_log_reports.serial_number` is kept empty by trigger. |
 | Models and releases | `model_registry`, `model_versions`, `model_version_files`, `model_active_versions`, `model_aliases`, `releases` | The catalog the registry syncs at boot; see [`model-registry.md`](model-registry.md). |
 | Bookkeeping | `schema_migrations` | Markers for one-shot data migrations. |
@@ -129,6 +143,7 @@ The store keeps most business rows forever; the loops that exist are narrow.
 | Loop | Where | What it bounds |
 |---|---|---|
 | Profiler retention sweep, hourly | `coordinator/api/profiler_fleet.go` (`StartProfilerLoops` → `PruneTelemetry`) | `request_profiles` and `fleet_snapshots` older than their retention windows ([telemetry-inventory](../reference/telemetry-inventory.md#coordinator-per-request-records-postgres)), in batches; runs even when the profiler is off. |
+| Request accounting retention sweep, every minute | `coordinator/api/request_outcome_sink.go` (`pruneLoop` → `PruneRequestOutcomes`) | `request_outcomes` by receipt time; bounded batches on a separate worker ([accounting contract](request-accounting.md#persistence-and-coverage)). |
 | Memory-store pruner, every 15 minutes | `coordinator/cmd/coordinator/main.go` (`memory_store_pruner`, `MemoryStore.Prune`) | Append-only history slices to `DefaultPruneMaxEntries` (100 000); memory store only. |
 | Session reconciliation, once at boot | `coordinator/cmd/coordinator/main.go` (`CloseOpenProviderSessions`) | Closes `provider_sessions` rows whose last heartbeat is more than 3 minutes old, so a blue-green cutover does not truncate live sessions. |
 | Read-cache janitor, every minute | `coordinator/api/server.go` (`StartReadCacheJanitor`) | In-process response cache, not a table. |

--- a/docs/architecture/system-profiler.md
+++ b/docs/architecture/system-profiler.md
@@ -1,10 +1,10 @@
 # System profiler
 
-> Last updated: 2026-09-04 · commit `4a08f2a44`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 The profiler answers "where did the time go, and what did the router know when
 it chose?" for one request, without carrying a single prompt-derived byte. It
-writes one prompt-free row per dispatched attempt (`request_profiles`), one
+writes sampled prompt-free attempt rows (`request_profiles`), one
 fleet row per provider slot per minute plus one coordinator row
 (`fleet_snapshots`), and reads the provider's own per-attempt `profile` object
 off the existing terminal frames. Postgres is the system of record; Datadog
@@ -12,6 +12,12 @@ gets only pipeline-health counters. Wire shapes of the heartbeat sub-objects:
 [`../reference/protocol-messages.md`](../reference/protocol-messages.md); the
 outcome vocabularies the rows carry:
 [`request-outcome-observability.md`](request-outcome-observability.md).
+
+The profiler can be disabled or sampled, includes some selection-only attempts,
+and does not cover every early middleware exit. Its rows never supply a full
+incoming-request denominator. Use the separate [request accounting
+ledger](request-accounting.md) for receipt cohorts and response completion
+evidence; profile stamps remain optional diagnostic links.
 
 ## Context
 
@@ -26,7 +32,7 @@ per-token cost, or a free-form provider string to storage.
 
 | Artefact | Grain | Producer | Sink | Retention |
 |---|---|---|---|---|
-| `request_profiles` row | dispatched attempt (pre-dispatch rejections never produce one) | stamps on `registry.RequestProfile` / `AttemptProfile`, flattened by `buildProfileRecord` (`coordinator/api/profiler_record.go`) | `profileSink` (`coordinator/api/profiler_sink.go`) → multi-row INSERT | `profileRetainProfiles` — value in [`../reference/telemetry-inventory.md#coordinator-per-request-records-postgres`](../reference/telemetry-inventory.md#coordinator-per-request-records-postgres) |
+| `request_profiles` row | sampled dispatched or selection-only attempt; middleware exits are not covered | stamps on `registry.RequestProfile` / `AttemptProfile`, flattened by `buildProfileRecord` (`coordinator/api/profiler_record.go`) | `profileSink` (`coordinator/api/profiler_sink.go`) → multi-row INSERT | `profileRetainProfiles` — value in [`../reference/telemetry-inventory.md#coordinator-per-request-records-postgres`](../reference/telemetry-inventory.md#coordinator-per-request-records-postgres) |
 | `fleet_snapshots` row | (provider session, slot) per 60 s + one `provider_id = 'coordinator'` row | `registry.FleetSample`, `CoordinatorSample` (`coordinator/registry/fleet_sample.go`) | sampler goroutine, `pgx.CopyFrom` (`coordinator/store/postgres_profiles.go`) | `profileRetainFleet` — same page |
 | `X-Timing` additive keys | committed response | `writeTimingHeaderWithProfile` (`coordinator/api/profiler_dispatch.go`) | response header ([`../reference/api-contracts.md#headers`](../reference/api-contracts.md#headers)) | n/a |
 | Datadog counters | process | [Operations](#operations) | DogStatsD / HTTPS series | n/a |
@@ -392,7 +398,7 @@ to the replication set, and accepts the hourly retention DELETE volume.
 
 Stated so nobody reads a `NULL` as a defect: full-pool candidate sample
 (top-4 + runner-up + near-tie size answer regret); rejection-stage timing
-(pre-dispatch rejections get only `request_rejections`); per-request
+(the compact request ledger covers receipts, not detailed stage timings); per-request
 provider-side cancel detail for already-abandoned requests (the cumulative
 `HeartbeatStats` cancel counters cover it); per-step engine ring; MLX GPU-busy
 counters; per-token ITL arrays; deadline-survival canary; metallib/git

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-04 · commit `6f364e64b`
+> Last updated: 2026-09-05 · commit `bbf6f83d4`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -122,6 +122,8 @@ lists every name).
 | `telemetry.sink_depth` | gauge | `sink:profile`, `sink:route` | each 60 s fleet sample |
 | `telemetry.sink_dropped` | count | `sink:profile` | non-blocking submit found the 4096-slot profile channel full (warned at powers of ten). The route sink counts drops in an atomic exposed as `fleet_snapshots.route_sink_dropped_total` and in its slog line, not as a Datadog counter |
 | `profiler.records` | count | `status:written`, `write_failed`, `sampled_out` | each profile batch |
+| `request_outcomes.records` | count | `status:written`, `write_failed`, `dropped`, `shutdown_dropped` | Dedicated accounting sink (`coordinator/api/request_outcome_sink.go`); counts snapshots, including revisions, not requests. Failed writes can have uncertain persistence. |
+| `request_outcomes.shutdown_unconfirmed` | count | none | The accounting worker did not confirm shutdown within `telemetrySinkShutdownFlush`; an in-flight write remains uncertain (`requestOutcomeSink.close`). |
 | `profiler.provider_profile` | count | `valid`, `reason` (`none`, `size`, `decode`, `schema`, `range`, `order`, `enum`, `duplicate`, `late`) | each provider `profile` |
 | `profiler.fleet_snapshot` | count | `status:written`, `write_failed` | each fleet sample |
 | `profiler.pruned_rows` | count | — | each hourly retention sweep |
@@ -169,6 +171,7 @@ Datadog's; nothing is stored locally.
 |---|---|---|---|
 | `inference_routes` | one row per `(request_id, attempt)` | `recordRoutingDecisionFor` (`coordinator/api/dispatch.go`) → `RecordInferenceRoute` (upsert), outcome patched by `UpdateInferenceRouteOutcome` with `COALESCE` | none |
 | `request_rejections` | one row per pre-dispatch or exhausted rejection | `recordRejection` (`coordinator/api/rejection_telemetry.go`); insert errors swallowed | none |
+| `request_outcomes` | one row per coordinator-minted incoming request; revision-ordered snapshots | `loggingMiddleware`, `outcomes.Tracker`, dedicated unsampled sink (`coordinator/api/request_outcome_sink.go`); observed coverage, not a verified full-traffic denominator | [Accounting retention and bounds](../architecture/request-accounting.md#persistence-and-coverage) |
 | `usage` (+ `usage_totals`) | one row per billed completion | `RecordUsageFullWithPublicModel` | none |
 | `providers`, `provider_reputation` | one row per provider | `UpsertProvider`, `UpsertReputation`, throttled to 30 s | none |
 | `provider_sessions` | one row per WebSocket session | `OpenProviderSession`, `TouchProviderSession`, `CloseProviderSession` | none |
@@ -176,8 +179,9 @@ Datadog's; nothing is stored locally.
 | `request_profiles` | one row per `(request_id, attempt)`, sampled | profile sink (`coordinator/api/profiler_sink.go`), batches of 64 or 250 ms | 14 d, hourly sweep, 5000-id windows |
 | `fleet_snapshots` | one row per provider slot plus one `provider_id = "coordinator"` row | fleet sampler (`coordinator/api/profiler_fleet.go`) every 60 s | 30 d, same sweep |
 
-The retention sweep (`PruneTelemetry`, `coordinator/store/postgres_profiles.go`)
-runs even when the profiler is off. Every other table grows without bound;
+The profiler retention sweep (`PruneTelemetry`, `coordinator/store/postgres_profiles.go`)
+runs even when the profiler is off. Request accounting has its own retention
+worker. The other telemetry/usage tables listed here grow without bound;
 `DeleteExpiredDeviceCodes` exists but has no production caller. Details of the
 two profiler tables: [`../architecture/system-profiler.md`](../architecture/system-profiler.md).
 


### PR DESCRIPTION
## Summary

A provider can refuse an internal attempt and a retry can complete the same incoming request. Existing route rows count attempts, profiles can be sampled or disabled, and a committed HTTP 200 does not establish complete response egress. Add one coordinator-minted request identity with bounded linked attempt evidence, final classification, and separate provider ingress, response egress and client-departure facts.

## Linked issue

Addresses A1/A2 of #845 and the shared plan in #847. [Intelligence #9](https://github.com/Layr-Labs/darkbloom-intelligence/pull/9) implements A3/A4. The independent calibration correction is #848; additional provider refusal evidence remains scoped to #844.

## Behavior and implementation

The receipt middleware runs before authentication, rate limits, validation, balance checks, admission and queueing for all four inference POST endpoints, in both response modes. Client-supplied request IDs cannot collide with the coordinator identity. Existing raw reasons and statuses remain alongside authoritative `int_provider_deadline_rejected`, `ext_first_content_timeout` and `ext_coordinator_exhausted` labels. The last label requires explicit routing-stop evidence; genuine provider faults, typed timeouts, queue exits and interrupted responses retain their distinctions.

Only actual provider error frames establish a provider deadline refusal. Synthetic cancellations/timeouts, writer selection, successful socket writes, acknowledgment, content ingress and engine admission remain different facts. A speculative loser cannot turn a successful winner into a failed incoming request.

Completion requires a completed winning provider, a completed endpoint terminal, successful full local egress, no write error and no conflicting evidence. Zero-token completion can qualify without generated-content delivery; preamble, usage and terminal frames alone do not count as generated content. Responses `incomplete` and error terminals do not qualify. Client departure remains the request outcome even if the provider completes later. A successful local write does not prove downstream receipt.

Queued attempts retain their own exit reason/status and a successful queued write does not emit an undispatched observation. All four streaming adapters explicitly record fully accepted error envelopes as error terminals; failed or short writes retain write-failure evidence. `Tracker.Egress` preserves the first valid response terminal, flags differing observations across separate flushes, coalesced frames and grouped initial chunks, and publishes changed late evidence without moving the receipt cohort.

## Before

```mermaid
flowchart LR
  A[Incoming request] --> B[dispatchState: attempt A refuses]
  B --> C[Retry B completes]
  B --> D[Route error and optional sampled profile]
  C --> E[Route success and legacy client completed]
  A --> F[Early middleware rejection]
  F --> G[May have no rejection or profile row]
  D --> H[Attempt signals mistaken for request failures]
  E --> I[Commit or provider completion mistaken for full egress]
```

## After

```mermaid
flowchart LR
  A[Incoming POST] --> B[loggingMiddleware: outcomes.New UUID]
  B --> C[Receipt snapshot before middleware exits]
  B --> D[dispatchWithReserver or queued attempt]
  D --> E[Attempt.Observe: write, acknowledgment, content and provider terminal]
  D --> F[Endpoint relay: content writes and response terminal]
  E --> G[Tracker.Finish: one final request with linked attempts]
  F --> M[Tracker.Egress: preserve first terminal and flag contradictions]
  M --> G
  L[Changed late provider or response evidence] --> H[Revise same receipt cohort]
  C --> I[Dedicated bounded requestOutcomeSink]
  G --> I
  H --> I
  I --> J[(request_outcomes: revision-ordered upsert)]
  J --> K[Observed completion, rejection, interruption, departure or unknown]
```

## Storage and rollout

The additive `request_outcomes` table has a coordinator-ID primary key and a receipt-time index. Replays cannot double-count requests or move cohorts; older revisions cannot overwrite newer data and contradictions stay flagged. Detail stops at 64 attempts while scalar counts continue. Receipt and final snapshots use a dedicated unsampled 4,096-slot channel, 64-row batches and bounded storage calls, independent of the profiler. A separate retention worker prunes receipts older than 14 days in bounded transactions.

Unsampled is not lossless. Queue pressure, storage failure, process exit and retention can remove observations; sink counters count snapshots, not requests. Consumers must show observed coverage and unknown/conflicting records, and must not claim an exact full-traffic fulfillment rate. The companion dashboard preserves last-good snapshots and handles missing source schema explicitly before rollout.

Joining only existing profiles would lose early rejections and sampled-out requests. Making profile persistence synchronous would add storage latency to inference. A compact independent recorder keeps lifecycle evidence available with bounded asynchronous cost and explicit coverage limits.

## Test plan

The cross-repository check used the actual Go tracker and PostgreSQL store, persisted snapshots in reverse order, replayed them twice, and ran the actual Intelligence source query. It returned exactly two requests: one completion recovered from a refusal and one client departure with late provider completion, three internal attempts, one refusal/recovery, one late-evidence record, no conflicts and no fabricated fulfillment percentage. This also checks the real Go migration/serialization against the TypeScript schema and SQL.

- [x] `go test ./...` across the coordinator passed, including API (158.8 s), registry, store and all other packages. Final adapter-only corrections were checked with focused race tests afterward.
- [x] `go test -race ./outcomes ./api -run 'TestRequestAccounting|TestAccounting|TestRequestMetaAlwaysMintsCoordinatorID'`.
- [x] Real HTTP/WebSocket speculative winner, queue expiry and queued client departure with `-race`.
- [x] Memory and isolated PostgreSQL replay/storage tests with `-race`, including receipt boundaries, late finalization, missing receipt rescue, duplicate revisions, sticky conflicts, identity reuse, bounded history and immutable snapshots.
- [x] All four endpoints in streaming and non-streaming modes with profiling disabled, early middleware exits, refusal recovery/exhaustion, provider-fault precedence, typed versus coordinator timeout, interrupted responses and late provider completion after departure.
- [x] Adapter regressions for terminal-only/zero-token output, reasoning, tool names with split delivery, omitted non-streaming reasoning and short/failed writes; bounded sink stall and panic recovery tests.
- [x] `go build ./...`, `bash scripts/docs-check.sh --all`, formatting and `git diff --check`.

- [x] Review regressions cover successful queued writes with and without prior retry errors, queue deadline/write failures, all four adapters' error terminals under full/short/failed writes, and matching/conflicting terminals across separate/coalesced/initial grouped SSE events. Final focused race tests passed for API (10.062 s) and outcomes (1.272 s), including concurrent late-terminal replay.
- [x] Final review-fix commit `ec06ef652`: repository pre-push formatting and full coordinator unit-test suite passed; coordinator build and docs lint passed.
- [x] Both independent coordinator commits combine without conflicts. Combined focused race tests passed for API (13.225 s), registry (2.123 s), and outcomes (1.281 s), including pending-prefill admission, accounting, refusal recovery/exhaustion, speculation and queueing; combined docs check passed.

The [accounting contract](https://github.com/Layr-Labs/d-inference/blob/ec06ef652/docs/architecture/request-accounting.md) documents schema, lifecycle, replay, resource bounds and coverage limits.

## CI observations (2026-09-05)

The following observations refer to `881f9ff50`; GitHub checks rerun for the review-fix commit `ec06ef652`.

The [Threat Model Review](https://github.com/Layr-Labs/d-inference/actions/runs/33998550055/job/101393212453) fails with Anthropic authentication error 401 (`API key is invalid`). Early coordinator lint, docs, console UI, release-integrity and preview checks passed; longer tests are tracked in the PR checks.

The same-base companion #848 also exposed an existing Gemma Swift assertion failure and a local-server bind timeout; its description links the exact base and PR logs. This PR changes no provider sources, submodule pins or CI workflow. These CI results do not replace the passing local coordinator, PostgreSQL and combined-branch checks above.

## Components touched

- [x] coordinator (Go)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- No HTTP, provider WebSocket, CLI or configuration changes. No provider release required.
- Additive internal `RequestOutcomeStore` interface and startup table/index creation; no historical backfill or rewrite of existing telemetry tables.

## Notes for reviewers

Routing selection, admission thresholds, deadline/retry policy, billing, wire statuses and established uptime metrics are unchanged. The standalone accounting module and store adapters own the schema; request-path changes observe existing milestones. No production deployment or database mutation has been performed. Production coverage and new-table volume/query performance require observation after an approved rollout. Reverting the recorder leaves the additive table in place; the dashboard must retain its explicit stale/unavailable semantics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791242614&installation_model_id=21733&pr_number=849&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F849&signature=49bb31e61d7228195e04bf82eade113b1d1cc7970b466df7abf67c9be47f60ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

