### PR TITLE
fix(stats): aggregate request flows before provider joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — stats request-flow refresh
+
+- Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.
+
 ## Unreleased — provider console entry
 
 - Open the provider workspace directly from the console home page, removing the Consumer/Provider selection page. Keep chat and API access in workspace navigation.

--- a/coordinator/store/analytics_flows_oracle_test.go
+++ b/coordinator/store/analytics_flows_oracle_test.go
@@ -1,0 +1,31 @@
+package store
+
+// Independent pre-optimization query: pin the existing flow semantics rather
+// than constructing expected results with the new grouped query.
+const originalFlowAggregateSQL = `SELECT
+				COALESCE(u.request_location->>'city', '')         AS c_city,
+				COALESCE(u.request_location->>'region', '')       AS c_region,
+				COALESCE(u.request_location->>'region_code', '')  AS c_region_code,
+				COALESCE(u.request_location->>'country', '')      AS c_country,
+				COALESCE(u.request_location->>'country_code', '') AS c_country_code,
+				COALESCE(AVG(NULLIF(u.request_location->>'latitude',  '')::double precision), 0) AS c_lat,
+				COALESCE(AVG(NULLIF(u.request_location->>'longitude', '')::double precision), 0) AS c_lng,
+				COALESCE(p.location->>'city', '')         AS p_city,
+				COALESCE(p.location->>'region', '')       AS p_region,
+				COALESCE(p.location->>'region_code', '')  AS p_region_code,
+				COALESCE(p.location->>'country', '')      AS p_country,
+				COALESCE(p.location->>'country_code', '') AS p_country_code,
+				COALESCE(AVG(NULLIF(p.location->>'latitude',  '')::double precision), 0) AS p_lat,
+				COALESCE(AVG(NULLIF(p.location->>'longitude', '')::double precision), 0) AS p_lng,
+				COUNT(*)                              AS requests,
+				COALESCE(SUM(u.prompt_tokens), 0)     AS prompt_tokens,
+				COALESCE(SUM(u.completion_tokens), 0) AS completion_tokens
+			 FROM usage u
+			 JOIN providers p ON p.id = u.provider_id
+			 WHERE u.request_location IS NOT NULL
+			   AND p.location IS NOT NULL
+			   AND u.created_at >= $1
+			 GROUP BY c_city, c_region, c_region_code, c_country, c_country_code,
+			          p_city, p_region, p_region_code, p_country, p_country_code
+			 ORDER BY requests DESC
+			 LIMIT 50`

--- a/coordinator/store/analytics_flows_test.go
+++ b/coordinator/store/analytics_flows_test.go
@@ -1,0 +1,195 @@
+package store
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestUsageFlowBucketsMatchesOriginalAggregate(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	since := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	origin := `{"city":"North","region":"Region","region_code":"R","country":"United States","country_code":"US","latitude":"10","longitude":"20"}`
+	destination := strings.Replace(origin, `"North"`, `"South"`, 1)
+	for id, location := range map[string]any{
+		"p1":             destination,
+		"p2":             strings.ReplaceAll(strings.ReplaceAll(destination, `"10"`, `"30"`), `"20"`, `"40"`),
+		"p3":             strings.ReplaceAll(strings.ReplaceAll(destination, `"10"`, `""`), `"20"`, `"60"`),
+		"other-region":   strings.Replace(destination, `"R"`, `"S"`, 1),
+		"unlocated":      nil,
+		"json-null":      `null`,
+		"empty-location": `{}`,
+		"":               destination,
+	} {
+		insertFlowProvider(t, s, id, location)
+	}
+	insert := func(provider string, location any, prompt, completion int, at time.Time) {
+		t.Helper()
+		_, err := s.pool.Exec(ctx, `INSERT INTO usage
+ (provider_id, consumer_key_hash, model, prompt_tokens, completion_tokens, created_at, request_location)
+ VALUES ($1, 'flow-consumer', 'flow-model', $2, $3, $4, $5::jsonb)`, provider, prompt, completion, at, location)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	for range 3 {
+		insert("p1", origin, 10, 20, since.Add(time.Hour))
+	}
+	insert("p2", strings.ReplaceAll(strings.ReplaceAll(origin, `"10"`, `"30"`), `"20"`, `"40"`), 7, 9, since.Add(time.Hour))
+	insert("p2", strings.ReplaceAll(strings.ReplaceAll(origin, `"10"`, `""`), `"20"`, `""`), 0, 1, since.Add(time.Hour))
+	insert("p3", strings.ReplaceAll(strings.ReplaceAll(origin, `"10"`, `null`), `"20"`, `"50"`), 5, 6, since) // inclusive cutoff
+	insert("p1", strings.Replace(origin, `"R"`, `"S"`, 1), 6, 7, since)
+	insert("other-region", origin, 8, 9, since)
+	insert("p1", `null`, 2, 3, since) // JSON null is located; SQL NULL is not.
+	insert("p1", `{}`, 4, 5, since)
+	insert("json-null", origin, 2, 3, since)
+	insert("empty-location", origin, 4, 5, since)
+	insert("", strings.Replace(origin, `"North"`, `"Empty provider ID"`, 1), 2, 3, since)
+	insert("p1", `{"city":"Zero","latitude":0,"longitude":0}`, 1, 2, since)
+	insert("p1", origin, 9999, 9999, since.Add(-time.Nanosecond))
+	insert("p1", nil, 9999, 9999, since)
+	insert("missing-provider", origin, 9999, 9999, since)
+	insert("unlocated", origin, 9999, 9999, since)
+
+	got := assertUsageFlowsMatchOriginal(t, s, since)
+	if len(got) != 7 {
+		t.Fatalf("got %d flow buckets, want 7", len(got))
+	}
+	main := got[0]
+	if main.ConsumerCity != "North" || main.ProviderCity != "South" ||
+		main.Requests != 6 || main.PromptTokens != 42 || main.CompletionTokens != 76 {
+		t.Fatalf("weighted fixture totals: %+v", main)
+	}
+	if main.ConsumerLatitude != 15 || main.ConsumerLongitude != 30 ||
+		main.ProviderLatitude != 18 || math.Abs(main.ProviderLongitude-100.0/3) > 1e-10 {
+		t.Fatalf("weighted fixture coordinates: %+v", main)
+	}
+	if empty, err := s.UsageFlowBuckets(since.Add(2*time.Hour), nil); err != nil || len(empty) != 0 {
+		t.Fatalf("empty window: buckets=%+v err=%v", empty, err)
+	}
+}
+
+func TestUsageFlowBucketsTop50AfterCombiningProviders(t *testing.T) {
+	s := testPostgresStore(t)
+	since := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	for _, id := range []string{"p1", "p2"} {
+		insertFlowProvider(t, s, id, `{"city":"South","latitude":10,"longitude":20}`)
+	}
+	// Two providers per flow, with unequal counts. Limiting provider groups
+	// before combining flows would lose contributors or choose the wrong top 50.
+	_, err := s.pool.Exec(context.Background(), `INSERT INTO usage
+ (provider_id, consumer_key_hash, model, prompt_tokens, completion_tokens, created_at, request_location)
+ SELECT CASE WHEN sample=1 THEN 'p1' ELSE 'p2' END, 'flow-consumer', 'flow-model', 2, 3, $1,
+        jsonb_build_object('city', 'Origin ' || flow, 'latitude', sample, 'longitude', sample*2)
+ FROM generate_series(1,60) AS flow
+ CROSS JOIN LATERAL generate_series(1,flow+1) AS sample`, since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := assertUsageFlowsMatchOriginal(t, s, since)
+	if len(got) != 50 || got[0].Requests != 61 || got[49].Requests != 12 {
+		t.Fatalf("top 50 contract: %+v", got)
+	}
+}
+
+func TestUsageFlowPlanChoiceDoesNotLeakToPool(t *testing.T) {
+	s, tracer := testPostgresStoreWithTracer(t, func(cfg *pgxpool.Config) {
+		cfg.MaxConns = 1
+		cfg.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_generic_plan"
+	})
+	tracer.reset()
+	if _, err := s.UsageFlowBuckets(time.Now().Add(time.Hour), nil); err != nil {
+		t.Fatal(err)
+	}
+	events := tracer.snapshot()
+	assertAnalyticsTx(t, events, "WITH located_usage AS MATERIALIZED")
+	custom := -1
+	for i, event := range events {
+		if event.sql == "SET LOCAL plan_cache_mode = force_custom_plan" {
+			custom = i
+		}
+		if strings.Contains(event.sql, "WITH located_usage AS MATERIALIZED") &&
+			(custom < 0 || events[custom].pid != event.pid) {
+			t.Fatal("flow query did not select a custom plan on its transaction connection")
+		}
+	}
+	var mode string
+	if err := s.pool.QueryRow(context.Background(), "SHOW plan_cache_mode").Scan(&mode); err != nil {
+		t.Fatal(err)
+	}
+	if mode != "force_generic_plan" {
+		t.Fatalf("flow query leaked plan_cache_mode=%q into the pool", mode)
+	}
+}
+
+func insertFlowProvider(t *testing.T, s *PostgresStore, id string, location any) {
+	t.Helper()
+	_, err := s.pool.Exec(context.Background(), `INSERT INTO providers (id, hardware, models, backend, location)
+ VALUES ($1, '{}', '[]', 'mlx-swift', $2::jsonb)`, id, location)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertUsageFlowsMatchOriginal(t *testing.T, s *PostgresStore, since time.Time) []UsageFlowBucket {
+	t.Helper()
+	got, err := s.UsageFlowBuckets(since, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := s.pool.Query(context.Background(), originalFlowAggregateSQL, since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	key := func(b UsageFlowBucket) string {
+		return strings.Join([]string{b.ConsumerCity, b.ConsumerRegion, b.ConsumerRegionCode,
+			b.ConsumerCountry, b.ConsumerCountryCode, b.ProviderCity, b.ProviderRegion,
+			b.ProviderRegionCode, b.ProviderCountry, b.ProviderCountryCode}, "\x00")
+	}
+	want := make(map[string]UsageFlowBucket)
+	for rows.Next() {
+		var b UsageFlowBucket
+		if err := rows.Scan(&b.ConsumerCity, &b.ConsumerRegion, &b.ConsumerRegionCode,
+			&b.ConsumerCountry, &b.ConsumerCountryCode, &b.ConsumerLatitude, &b.ConsumerLongitude,
+			&b.ProviderCity, &b.ProviderRegion, &b.ProviderRegionCode, &b.ProviderCountry,
+			&b.ProviderCountryCode, &b.ProviderLatitude, &b.ProviderLongitude,
+			&b.Requests, &b.PromptTokens, &b.CompletionTokens); err != nil {
+			t.Fatal(err)
+		}
+		want[key(b)] = b
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("flow count: got %d, want %d", len(got), len(want))
+	}
+	for i, b := range got {
+		expected, ok := want[key(b)]
+		if !ok {
+			t.Fatalf("unexpected flow: %+v", b)
+		}
+		if math.Abs(b.ConsumerLatitude-expected.ConsumerLatitude) > 1e-10 ||
+			math.Abs(b.ConsumerLongitude-expected.ConsumerLongitude) > 1e-10 ||
+			math.Abs(b.ProviderLatitude-expected.ProviderLatitude) > 1e-10 ||
+			math.Abs(b.ProviderLongitude-expected.ProviderLongitude) > 1e-10 {
+			t.Fatalf("coordinates differ: got %+v, want %+v", b, expected)
+		}
+		b.ConsumerLatitude, b.ConsumerLongitude = expected.ConsumerLatitude, expected.ConsumerLongitude
+		b.ProviderLatitude, b.ProviderLongitude = expected.ProviderLatitude, expected.ProviderLongitude
+		if !reflect.DeepEqual(b, expected) {
+			t.Fatalf("flow differs: got %+v, want %+v", b, expected)
+		}
+		if i > 0 && got[i-1].Requests < b.Requests {
+			t.Fatal("flows are not sorted by descending request count")
+		}
+	}
+	return got
+}

--- a/coordinator/store/analytics_workmem_test.go
+++ b/coordinator/store/analytics_workmem_test.go
@@ -198,7 +198,7 @@ func TestUsageAnalyticsRunInWorkMemTransaction(t *testing.T) {
 	if len(flows) != 1 || flows[0].Requests != 3 || flows[0].ProviderCity != "San Francisco" {
 		t.Fatalf("flow buckets = %+v, want one NY->SF flow with 3 requests", flows)
 	}
-	assertAnalyticsTx(t, tracer.snapshot(), "JOIN providers p ON p.id = u.provider_id")
+	assertAnalyticsTx(t, tracer.snapshot(), "WITH located_usage AS MATERIALIZED")
 
 	tracer.reset()
 	totals, err := s.NetworkTotals(since)

--- a/coordinator/store/postgres_analytics.go
+++ b/coordinator/store/postgres_analytics.go
@@ -99,36 +99,12 @@ func (s *PostgresStore) UsageFlowBuckets(since time.Time, _ map[string]*Provider
 
 	var buckets []UsageFlowBucket
 	err := s.withAnalyticsTx(ctx, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx,
-			`SELECT
-				COALESCE(u.request_location->>'city', '')         AS c_city,
-				COALESCE(u.request_location->>'region', '')       AS c_region,
-				COALESCE(u.request_location->>'region_code', '')  AS c_region_code,
-				COALESCE(u.request_location->>'country', '')      AS c_country,
-				COALESCE(u.request_location->>'country_code', '') AS c_country_code,
-				COALESCE(AVG(NULLIF(u.request_location->>'latitude',  '')::double precision), 0) AS c_lat,
-				COALESCE(AVG(NULLIF(u.request_location->>'longitude', '')::double precision), 0) AS c_lng,
-				COALESCE(p.location->>'city', '')         AS p_city,
-				COALESCE(p.location->>'region', '')       AS p_region,
-				COALESCE(p.location->>'region_code', '')  AS p_region_code,
-				COALESCE(p.location->>'country', '')      AS p_country,
-				COALESCE(p.location->>'country_code', '') AS p_country_code,
-				COALESCE(AVG(NULLIF(p.location->>'latitude',  '')::double precision), 0) AS p_lat,
-				COALESCE(AVG(NULLIF(p.location->>'longitude', '')::double precision), 0) AS p_lng,
-				COUNT(*)                              AS requests,
-				COALESCE(SUM(u.prompt_tokens), 0)     AS prompt_tokens,
-				COALESCE(SUM(u.completion_tokens), 0) AS completion_tokens
-			 FROM usage u
-			 JOIN providers p ON p.id = u.provider_id
-			 WHERE u.request_location IS NOT NULL
-			   AND p.location IS NOT NULL
-			   AND u.created_at >= $1
-			 GROUP BY c_city, c_region, c_region_code, c_country, c_country_code,
-			          p_city, p_region, p_region_code, p_country, p_country_code
-			 ORDER BY requests DESC
-			 LIMIT 50`,
-			since,
-		)
+		// A generic cutoff plan overestimates the rolling window and can sort
+		// millions of rows. Keep the plan choice inside this read-only transaction.
+		if _, err := tx.Exec(ctx, "SET LOCAL plan_cache_mode = force_custom_plan"); err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx, usageFlowBucketsSQL, since)
 		if err != nil {
 			return err
 		}

--- a/coordinator/store/postgres_analytics_flows.go
+++ b/coordinator/store/postgres_analytics_flows.go
@@ -1,0 +1,65 @@
+package store
+
+// Aggregate request origins per provider before joining provider locations.
+// Joining and sorting every raw usage row exceeded the 10-second refresh
+// deadline at production scale. Both grouping stages can hash; the provider
+// join and final aggregation process only the reduced input. Coordinate sums
+// retain their non-null sample counts,
+// and provider coordinates are weighted by requests, matching the raw-row AVG.
+//
+// MATERIALIZED keeps the reduction before the provider lookup. The correlated
+// OFFSET 0 keeps that lookup on the provider primary key even when PostgreSQL
+// overestimates the number of groups and would otherwise scan all historical
+// provider rows. Neither boundary changes which requests contribute to a flow.
+// The cutoff, null-location handling, and top-50 contract are unchanged.
+const usageFlowBucketsSQL = `WITH located_usage AS MATERIALIZED (
+    SELECT COALESCE(request_location->>'city', '') AS city,
+           COALESCE(request_location->>'region', '') AS region,
+           COALESCE(request_location->>'region_code', '') AS region_code,
+           COALESCE(request_location->>'country', '') AS country,
+           COALESCE(request_location->>'country_code', '') AS country_code,
+           provider_id,
+           SUM(NULLIF(request_location->>'latitude', '')::double precision) AS latitude_sum,
+           COUNT(NULLIF(request_location->>'latitude', '')::double precision) AS latitude_count,
+           SUM(NULLIF(request_location->>'longitude', '')::double precision) AS longitude_sum,
+           COUNT(NULLIF(request_location->>'longitude', '')::double precision) AS longitude_count,
+           COUNT(*) AS requests,
+           SUM(prompt_tokens) AS prompt_tokens,
+           SUM(completion_tokens) AS completion_tokens
+    FROM usage
+    WHERE request_location IS NOT NULL AND created_at >= $1
+    GROUP BY city, region, region_code, country, country_code, provider_id
+)
+SELECT u.city AS c_city,
+       u.region AS c_region,
+       u.region_code AS c_region_code,
+       u.country AS c_country,
+       u.country_code AS c_country_code,
+       COALESCE(SUM(u.latitude_sum) / NULLIF(SUM(u.latitude_count), 0), 0) AS c_lat,
+       COALESCE(SUM(u.longitude_sum) / NULLIF(SUM(u.longitude_count), 0), 0) AS c_lng,
+       COALESCE(p.location->>'city', '') AS p_city,
+       COALESCE(p.location->>'region', '') AS p_region,
+       COALESCE(p.location->>'region_code', '') AS p_region_code,
+       COALESCE(p.location->>'country', '') AS p_country,
+       COALESCE(p.location->>'country_code', '') AS p_country_code,
+       COALESCE(
+           SUM(NULLIF(p.location->>'latitude', '')::double precision * u.requests) /
+           NULLIF(SUM(u.requests) FILTER (WHERE NULLIF(p.location->>'latitude', '') IS NOT NULL), 0),
+           0) AS p_lat,
+       COALESCE(
+           SUM(NULLIF(p.location->>'longitude', '')::double precision * u.requests) /
+           NULLIF(SUM(u.requests) FILTER (WHERE NULLIF(p.location->>'longitude', '') IS NOT NULL), 0),
+           0) AS p_lng,
+       SUM(u.requests)::bigint AS requests,
+       COALESCE(SUM(u.prompt_tokens), 0) AS prompt_tokens,
+       COALESCE(SUM(u.completion_tokens), 0) AS completion_tokens
+FROM located_usage u
+JOIN LATERAL (
+    SELECT location FROM providers
+    WHERE id = u.provider_id AND location IS NOT NULL
+    OFFSET 0
+) p ON true
+GROUP BY u.city, u.region, u.region_code, u.country, u.country_code,
+         p_city, p_region, p_region_code, p_country, p_country_code
+ORDER BY requests DESC
+LIMIT 50`


### PR DESCRIPTION
The Stats page returns 503 when its request-flow geography query exceeds the 10-second store deadline. The query joined and sorted millions of usage rows before aggregating; repeated failures prevented the complete Stats snapshot from refreshing and eventually exhausted its five-minute cached copy.

Aggregate request origins per provider first, then perform indexed provider-location lookups and aggregate the resulting flows. Keep the rolling cutoff's custom plan local to the existing read-only analytics transaction. Preserve request/token counts, request-weighted coordinates, null-location semantics, and the top-50 result contract. The query lives in a focused helper; the handler, timeout, cache policy, and JSON shape are unchanged.

### Before

```mermaid
flowchart TD
    A[Stats page requests snapshot] --> B[handleStats and computeStats]
    B --> C[UsageFlowBuckets]
    C --> D[Join raw usage rows to provider locations]
    D --> E[Sort wide rows and aggregate flows]
    E --> F[Query exceeds 10-second deadline]
    F --> G[Stats refresh fails]
    G --> H[Cached snapshot expires after five minutes]
    H --> I[Coordinator and console return 503]
```

### After

```mermaid
flowchart TD
    A[Stats page requests snapshot] --> B[handleStats and computeStats]
    B --> C[UsageFlowBuckets selects transaction-local custom plan]
    C --> D[usageFlowBucketsSQL groups origins per provider]
    D --> E[Indexed lookup of locations for grouped providers]
    E --> F[Combine flow counts and weighted coordinates]
    F --> G[Return the same top 50 flows]
    G --> H[Successful computeStats refreshes snapshot]
    H --> I[Coordinator and console serve Stats data]
```

### Production-data evidence

Read-only investigation on September 5 at approximately 7:22–7:28 p.m. PDT, against coordinator build `4d9811f7c240b37f2915a6475f8476d7db01340e`. The affected store files were unchanged between that build and this PR's base, `bbf6f83d4`.

| Query trial | Execution | Temporary writes |
|---|---:|---:|
| Original SQL, explicitly using a custom plan | 11.032 s | 3.17 GiB |
| SQL included in this change | 3.107 s | 0 |

The candidate reduced approximately 5.2 million located usage rows to 58,465 provider/origin groups before provider lookups. Both trials used the existing transaction-local 1 GiB `work_mem` and `hash_mem_multiplier=1.0`, with a fixed lower cutoff and a 25-second diagnostic statement timeout. These are single query executions; new records arrived between trials, and this is not a deployed endpoint or sustained-load benchmark. The checked-in SQL matches the tested candidate apart from whitespace.

A separate comparison executed both queries in one statement on the same database snapshot: 50 buckets each, no missing/extra buckets, exact request and token counts, and maximum coordinate difference `2.43e-11` from floating-point aggregation order.

### Validation

- New PostgreSQL regression tests compare against the independent original query: unequal request weights, missing/null coordinates and locations, empty provider IDs, unmatched providers, cutoff boundaries, zero coordinates, empty windows, and top-50 selection after combining providers.
- A single-connection test verifies the custom plan runs in the read-only analytics transaction and does not leak into the pool.
- `go test -race ./coordinator/...` with a dedicated local PostgreSQL 16 database: passed, including the new regression tests.
- Coordinator build, `go vet ./coordinator/...`, and `golangci-lint` v2.1.6: passed.
- Release integrity, installer parity, production-env refresh tests, docs lint, and whitespace checks: passed.

No production mutation, deployment, schema migration, or timeout increase is included. After an approved deployment, verify both `/v1/stats` and the console `/api/stats` return complete snapshots and continue refreshing past the cache TTL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791254322&installation_model_id=21733&pr_number=850&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F850&signature=aadc368fe6d95f82c032a6a99c31304f0943bbebbcc33fef37065f8b6af78b36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->