### PR TITLE
fix(console): prevent earnings navigation flash before Mac setup

### DIFF
--- a/console-ui/src/components/console-entry/workspaces.test.ts
+++ b/console-ui/src/components/console-entry/workspaces.test.ts
@@ -20,4 +20,14 @@ describe("Workspace routing", () => {
     expect(accountItems("provider").some((item) => item.href === "/billing")).toBe(false);
     expect(accountItems("consumer").some((item) => item.href === "/billing")).toBe(true);
   });
+  it.each(["loading", "guest", "new", "error"] as const)("hides earnings for %s accounts while keeping setup and the calculator available", (status) => {
+    const items = navigationGroups("provider", { status, total: 0, online: 0 }).flatMap((group) => group.items);
+    expect(items.some((item) => item.href === "/providers/earnings")).toBe(false);
+    expect(items.some((item) => item.href === "/providers/setup")).toBe(true);
+    expect(items.some((item) => item.href === "/earn")).toBe(true);
+  });
+  it("keeps earnings available when a linked Mac is offline", () => {
+    const items = navigationGroups("provider", { status: "linked", total: 1, online: 0 }).flatMap((group) => group.items);
+    expect(items.some((item) => item.href === "/providers/earnings")).toBe(true);
+  });
 });

--- a/console-ui/src/components/navigation/items.ts
+++ b/console-ui/src/components/navigation/items.ts
@@ -19,7 +19,7 @@ const ACCOUNT_ITEMS: NavigationItem[] = [
 ];
 export function navigationGroups(mode: Workspace, account: ProviderAccount) {
   if (mode === "consumer") return CONSUMER_GROUPS;
-  const existing = account.status !== "new" && account.status !== "guest";
+  const existing = account.status === "linked";
   return [
     { label: "Provider workspace", items: [
       { href: "/providers", icon: Server, label: "Your fleet" },

--- a/console-ui/src/components/navigation/provider-earnings.test.tsx
+++ b/console-ui/src/components/navigation/provider-earnings.test.tsx
@@ -1,0 +1,55 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Sidebar } from "@/components/Sidebar";
+import { ConsoleExperienceProvider } from "../console-entry/ConsoleExperience";
+import { useStore } from "@/lib/store";
+
+const auth = vi.hoisted(() => ({
+  ready: false, authenticated: false, user: { id: "account-a" },
+  getAccessToken: vi.fn().mockResolvedValue("test-session"),
+}));
+vi.mock("next/navigation", () => ({ usePathname: () => "/earn", useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@/components/providers/PrivyClientProvider", () => ({ useAuthContext: () => auth }));
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => ({ ...auth, login: vi.fn(), logout: vi.fn() }) }));
+vi.mock("@/components/providers/ThemeProvider", () => ({ useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }) }));
+
+beforeEach(() => {
+  auth.ready = false;
+  auth.authenticated = false;
+  localStorage.clear();
+  vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() })));
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
+
+describe.each([true, false])("Provider earnings navigation (sidebar open: %s)", (sidebarOpen) => {
+  it("never shows earnings while auth loads or after resolving a guest", () => {
+    useStore.setState({ sidebarOpen });
+    const view = render(<ConsoleExperienceProvider><Sidebar /></ConsoleExperienceProvider>);
+    expect(screen.queryByRole("link", { name: "Your earnings" })).not.toBeInTheDocument();
+    auth.ready = true;
+    view.rerender(<ConsoleExperienceProvider><Sidebar /></ConsoleExperienceProvider>);
+    expect(screen.queryByRole("link", { name: "Your earnings" })).not.toBeInTheDocument();
+  });
+
+  it.each(["empty", "linked", "error"])("waits for provider discovery before rendering the %s result", async (outcome) => {
+    useStore.setState({ sidebarOpen });
+    auth.ready = true;
+    auth.authenticated = true;
+    let respond!: (response: Response) => void;
+    vi.stubGlobal("fetch", vi.fn(() => new Promise<Response>((resolve) => { respond = resolve; })));
+    render(<ConsoleExperienceProvider><Sidebar /></ConsoleExperienceProvider>);
+    await act(async () => {});
+    expect(screen.queryByRole("link", { name: "Your earnings" })).not.toBeInTheDocument();
+    await act(async () => {
+      respond(outcome === "error" ? new Response(null, { status: 503 }) : Response.json({
+        providers: outcome === "linked" ? [{ id: "mac-a", online: false }] : [],
+      }));
+    });
+    if (outcome === "linked") {
+      expect(screen.getByRole("link", { name: "Your earnings" })).toHaveAttribute("href", "/providers/earnings");
+    } else {
+      expect(screen.queryByRole("link", { name: "Your earnings" })).not.toBeInTheDocument();
+    }
+    expect(screen.getByRole("link", { name: "Earnings calculator" })).toHaveAttribute("href", "/earn");
+  });
+});


### PR DESCRIPTION
## Summary
Fix the brief “Your earnings” navigation flash when opening `/earn` without a Mac set up. `navigationGroups` now includes earnings only when provider discovery confirms a `linked` account, including linked Macs that are offline.

Previously, excluding only `new` and `guest` also exposed earnings during `loading` and `error`. Both expanded and collapsed navigation share the corrected condition.

## Before and after

```mermaid
flowchart TD
  subgraph Before
    A[useProviderAccount: loading or error] --> B[navigationGroups: neither new nor guest]
    B --> C[Sidebar shows Your earnings]
    C --> D[Discovery resolves guest or empty]
    D --> E[Earnings disappears]
  end
  subgraph After
    F[useProviderAccount: loading or error] --> G[navigationGroups: require linked]
    G --> H[Sidebar hides Your earnings]
    H --> I[Discovery resolves]
    I --> J[Guest or empty: stays hidden]
    I --> K[Linked Mac, online or offline: show earnings]
  end
```

## Test plan

- [x] Reproduced the initial link and its disappearance on the live `/earn` page.
- [x] Added tests before the fix: 10 failed on the original condition, including real Sidebar + ConsoleExperienceProvider + useProviderAccount transitions with delayed mocked discovery.
- [x] `bun run test src/components/console-entry src/components/navigation` — 35 tests passed.
- [x] `bunx eslint src/components/navigation/items.ts src/components/navigation/provider-earnings.test.tsx src/components/console-entry/workspaces.test.ts` — no errors; 3 duplicate-string warnings.
- [x] Local browser verification at `/earn`; setup and calculator remain available, earnings stays hidden. Local auth uses the repository's unconfigured mock; guest/loading/linked/error transitions are covered by component tests.
- [x] `git diff --check`.
- [ ] `bunx tsc --noEmit` — blocked by errors outside the changed files (provider dashboard fixtures, EarningsContent fetch headers, DatadogRUM, PrivyRealProvider, and vitest.config.ts).

![Local earnings calculator with earnings navigation hidden](https://raw.githubusercontent.com/prasiddhnaik/d-inference/c6db4b697c5fc81734e393fd3e499686c2b4d24a/earnings-fixed.png)

## Components touched

- [x] console-ui (Next.js)

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

Production change is one condition in `navigationGroups`; the remaining changes are regression tests. No production deployment performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791270526&installation_model_id=21733&pr_number=852&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F852&signature=2762b52481ad0445b436b404ed061d3933d23f1732425502bf72c04a5edd9792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->