### PR TITLE
ci: enable reviewed-branch provider signing validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,20 @@ on:
   push:
     branches: [master, main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Reviewed full commit SHA to build
+        required: true
+        type: string
+      version:
+        description: Exact existing source version; does not change source
+        required: true
+        type: string
 
 jobs:
   release-integrity:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Release Integrity
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -18,6 +29,7 @@ jobs:
           ./scripts/test-prod-env-refresh.sh
 
   docs:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Docs Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -26,6 +38,7 @@ jobs:
         run: ./scripts/docs-check.sh
 
   test-coordinator:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Coordinator Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
     services:
@@ -65,6 +78,7 @@ jobs:
           fi
 
   lint-coordinator:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Coordinator Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -78,6 +92,7 @@ jobs:
           golangci-lint run
 
   test-prompt-sidecar:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Prompt Sidecar Tests
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -111,6 +126,7 @@ jobs:
           ./scripts/verify-prompt-sidecar-linux.sh "$RUNNER_TEMP/promptsidecar-linux"
 
   test-provider:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Provider Tests
     runs-on: blacksmith-12vcpu-macos-latest
     steps:
@@ -299,7 +315,7 @@ jobs:
   cache-swift:
     name: Swift Build + Cache
     runs-on: blacksmith-12vcpu-macos-latest
-    if: github.event_name == 'push'
+    if: ${{ github.event_name != 'workflow_dispatch' && (github.event_name == 'push') }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -348,6 +364,7 @@ jobs:
           key: spm-v3-${{ runner.os }}-${{ github.sha }}-${{ hashFiles('provider-swift/Package.resolved', 'libs/mlx-swift/Package.swift', 'libs/mlx-swift-lm/Package.swift') }}
 
   lint-console:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     name: Console UI Lint & Build
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -363,3 +380,20 @@ jobs:
         run: cd console-ui && npx eslint src/
       - name: Build
         run: cd console-ui && npm run build
+
+  provider-signing-validation:
+    name: Provider signing validation (manual only)
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/provider-signing-validation.yml
+    permissions:
+      contents: read
+      actions: read
+    with:
+      source_sha: ${{ inputs.source_sha }}
+      version: ${{ inputs.version }}
+    secrets:
+      APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,8 @@ jobs:
       - name: Run Swift tests
         working-directory: provider-swift
         # NOTE: do NOT pass --build-tests-relinking flags; the bundle is already
-        # built above, so `swift test` reuses it (and our colocated metallib).
-        run: swift test
+        # built above. Reuse it and isolate process-global environment changes.
+        run: ../scripts/run-provider-tests.sh
       - name: Verify production prompt parity
         run: ./scripts/verify-prompt-parity.sh
       # FLAKE-ORDERING GUARD (audit fix, v0.8.0): every nested step below runs

--- a/.github/workflows/provider-signing-validation.yml
+++ b/.github/workflows/provider-signing-validation.yml
@@ -108,7 +108,6 @@ jobs:
     runs-on: blacksmith-12vcpu-macos-latest
     timeout-minutes: 35
     env:
-      DEVELOPER_ID: 'Developer ID Application: Eigen Labs, Inc. (SLDQ2GJ6TL)'
       APPLE_TEAM_ID: SLDQ2GJ6TL
     steps:
       - name: Checkout reviewed signing tooling only
@@ -140,11 +139,15 @@ jobs:
           umask 077
           test -n "$P12_BASE64" && test -n "$P12_PASSWORD" && test -n "$PROFILE_BASE64"
           keychain="$RUNNER_TEMP/signing-validation.keychain-db"
+          python3 tooling/scripts/provider_signing_identity.py capture \
+            --snapshot "$RUNNER_TEMP/signing-search-list-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.json" --keychain "$keychain"
           keychain_password=$(openssl rand -hex 24)
           printf '%s' "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/signing-certificate.p12"
           security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 3600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
+          python3 tooling/scripts/provider_signing_identity.py activate \
+            --snapshot "$RUNNER_TEMP/signing-search-list-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.json"
           security import "$RUNNER_TEMP/signing-certificate.p12" -k "$keychain" \
             -P "$P12_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
@@ -153,27 +156,33 @@ jobs:
           printf '%s' "$PROFILE_BASE64" | base64 --decode > "$app/Contents/embedded.provisionprofile"
           security cms -D -i "$app/Contents/embedded.provisionprofile" > "$RUNNER_TEMP/profile.plist"
           python3 tooling/scripts/provider-signing-validation.py profile --profile "$RUNNER_TEMP/profile.plist"
+      - name: Select unique valid Developer ID Application identity
+        run: |
+          python3 tooling/scripts/provider_signing_identity.py select \
+            --snapshot "$RUNNER_TEMP/signing-search-list-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.json" --team "$APPLE_TEAM_ID" \
+            --output "$RUNNER_TEMP/signing-identity.json" --github-env "$GITHUB_ENV"
       - name: Sign and statically verify the app
         run: |
           set -euo pipefail
           app="$RUNNER_TEMP/signing-stage/Darkbloom.app"
           keychain="$RUNNER_TEMP/signing-validation.keychain-db"
           codesign --force --options runtime --timestamp --identifier io.darkbloom.fan-helper \
-            --keychain "$keychain" --sign "$DEVELOPER_ID" "$app/Contents/Helpers/darkbloom-fan-helper"
-          codesign --verify --strict -R="anchor apple generic and identifier \"io.darkbloom.fan-helper\" and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" \
+            --keychain "$keychain" --sign "$SIGNING_IDENTITY_SHA1" "$app/Contents/Helpers/darkbloom-fan-helper"
+          codesign --verify --strict -R="$SIGNING_REQUIREMENT and identifier \"io.darkbloom.fan-helper\"" \
             "$app/Contents/Helpers/darkbloom-fan-helper"
           codesign --force --options runtime --timestamp --keychain "$keychain" \
-            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/mlx.metallib"
+            --sign "$SIGNING_IDENTITY_SHA1" "$app/Contents/MacOS/mlx.metallib"
           codesign --force --options runtime --timestamp --keychain "$keychain" \
             --entitlements tooling/provider-swift/entitlements-enclave.plist \
-            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/darkbloom-enclave"
+            --sign "$SIGNING_IDENTITY_SHA1" "$app/Contents/MacOS/darkbloom-enclave"
           codesign --force --options runtime --timestamp --keychain "$keychain" \
             --entitlements tooling/provider-swift/entitlements.plist \
-            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/darkbloom"
+            --sign "$SIGNING_IDENTITY_SHA1" "$app/Contents/MacOS/darkbloom"
           codesign --force --options runtime --timestamp --keychain "$keychain" \
-            --entitlements tooling/provider-swift/entitlements.plist --sign "$DEVELOPER_ID" "$app"
-          codesign --verify --deep --strict --verbose=2 "$app"
-          codesign --verify --strict --verbose=2 "$app/Contents/MacOS/darkbloom"
+            --entitlements tooling/provider-swift/entitlements.plist --sign "$SIGNING_IDENTITY_SHA1" "$app"
+          codesign --verify --deep --strict --verbose=2 \
+            -R="$SIGNING_REQUIREMENT and identifier \"io.darkbloom.provider\"" "$app"
+          codesign --verify --strict --verbose=2 -R="$SIGNING_REQUIREMENT" "$app/Contents/MacOS/darkbloom"
           codesign -d --entitlements - --xml "$app/Contents/MacOS/darkbloom" > "$RUNNER_TEMP/cli-entitlements.plist"
           python3 tooling/scripts/provider-signing-validation.py cli-entitlements --plist "$RUNNER_TEMP/cli-entitlements.plist"
           ditto -c -k --keepParent "$app" "$RUNNER_TEMP/notarization-input.zip"
@@ -192,7 +201,8 @@ jobs:
           xcrun stapler staple "$app"
           xcrun stapler validate "$app"
           spctl --assess --type execute --verbose=4 "$app"
-          codesign --verify --deep --strict --verbose=2 "$app"
+          codesign --verify --deep --strict --verbose=2 \
+            -R="$SIGNING_REQUIREMENT and identifier \"io.darkbloom.provider\"" "$app"
           python3 tooling/scripts/provider-signing-validation.py receipt \
             --output "$RUNNER_TEMP/signing-stage" --notary "$RUNNER_TEMP/notary-result.json"
           tar czf "$RUNNER_TEMP/signed-validation.tar.gz" -C "$RUNNER_TEMP/signing-stage" .
@@ -200,8 +210,9 @@ jobs:
       - name: Remove temporary signing material
         if: always()
         run: |
-          security delete-keychain "$RUNNER_TEMP/signing-validation.keychain-db" 2>/dev/null || true
-          rm -f "$RUNNER_TEMP/signing-certificate.p12" "$RUNNER_TEMP/profile.plist"
+          python3 tooling/scripts/provider_signing_identity.py cleanup \
+            --snapshot "$RUNNER_TEMP/signing-search-list-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT.json" \
+            --output "$RUNNER_TEMP/signing-keychain-cleanup.json"
       - name: Retain signing-validation artifact only
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -210,6 +221,8 @@ jobs:
             ${{ runner.temp }}/signed-validation.tar.gz
             ${{ runner.temp }}/signed-validation.sha256
             ${{ runner.temp }}/notary-result.json
+            ${{ runner.temp }}/signing-identity.json
+            ${{ runner.temp }}/signing-keychain-cleanup.json
           retention-days: 3
           if-no-files-found: error
       - name: Retain non-secret notarization diagnostics
@@ -217,6 +230,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: provider-signing-validation-diagnostics
-          path: ${{ runner.temp }}/notary-result.json
+          path: |
+            ${{ runner.temp }}/notary-result.json
+            ${{ runner.temp }}/signing-identity.json
+            ${{ runner.temp }}/signing-keychain-cleanup.json
           retention-days: 3
           if-no-files-found: ignore

--- a/.github/workflows/provider-signing-validation.yml
+++ b/.github/workflows/provider-signing-validation.yml
@@ -1,0 +1,200 @@
+name: Provider Signing Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Reviewed full commit SHA to build
+        required: true
+        type: string
+      version:
+        description: Exact existing source version; does not change source
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    name: Build unsigned validation input
+    runs-on: blacksmith-12vcpu-macos-latest
+    timeout-minutes: 60
+    steps:
+      - name: Validate explicit source identity
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA" --jq .commit.verification.verified)" = true
+      - name: Checkout reviewed workflow tooling
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          path: tooling
+          persist-credentials: false
+      - name: Checkout candidate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.source_sha }}
+          path: candidate
+          submodules: recursive
+          persist-credentials: false
+      - name: Validate packaging and workflow isolation guards
+        run: python3 tooling/scripts/test-provider-signing-validation.py
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+        with:
+          go-version-file: candidate/go.mod
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.88.0 --profile minimal
+      - name: Build exact source and stage unsigned app
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+          EXPECTED_SOURCE: ${{ inputs.source_sha }}
+          RUSTUP_TOOLCHAIN: 1.88.0
+          MLX_METALLIB_DEPLOYMENT_TARGET: '26.2'
+        run: |
+          set -euo pipefail
+          test "$(git -C candidate rev-parse HEAD)" = "$EXPECTED_SOURCE"
+          candidate/scripts/check-release-version.sh "$EXPECTED_VERSION"
+          command -v cmake >/dev/null 2>&1 || brew install cmake
+          cd candidate/provider-swift
+          swift build -c release --scratch-path "$RUNNER_TEMP/provider-build" --product darkbloom
+          swift build -c release --scratch-path "$RUNNER_TEMP/provider-build" --product darkbloom-enclave
+          swift build -c release --scratch-path "$RUNNER_TEMP/provider-build" --product darkbloom-fan-helper
+          bin_dir=$(swift build -c release --scratch-path "$RUNNER_TEMP/provider-build" --show-bin-path)
+          cd "$GITHUB_WORKSPACE"
+          METALLIB_CACHE_DIR="$RUNNER_TEMP/metallib-cache" candidate/scripts/fetch-metallib.sh "$RUNNER_TEMP/metallib"
+          python3 tooling/scripts/provider-signing-validation.py stage \
+            --source "$GITHUB_WORKSPACE/candidate" --bin "$bin_dir" \
+            --metallib "$RUNNER_TEMP/metallib/mlx.metallib" \
+            --output "$RUNNER_TEMP/unsigned-stage" --version "$EXPECTED_VERSION"
+          tar czf "$RUNNER_TEMP/unsigned-validation.tar.gz" -C "$RUNNER_TEMP/unsigned-stage" .
+      - name: Retain unsigned input for the separate signing job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: provider-signing-input
+          path: ${{ runner.temp }}/unsigned-validation.tar.gz
+          retention-days: 3
+          if-no-files-found: error
+
+  signing:
+    name: Validate signing and notarization without publication
+    needs: build
+    runs-on: blacksmith-12vcpu-macos-latest
+    timeout-minutes: 35
+    env:
+      DEVELOPER_ID: 'Developer ID Application: Eigen Labs, Inc. (SLDQ2GJ6TL)'
+      APPLE_TEAM_ID: SLDQ2GJ6TL
+    steps:
+      - name: Checkout reviewed signing tooling only
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ github.sha }}
+          path: tooling
+          persist-credentials: false
+      - name: Read this run's unsigned artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SOURCE: ${{ inputs.source_sha }}
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name provider-signing-input --dir "$RUNNER_TEMP/incoming"
+          python3 tooling/scripts/provider-signing-validation.py unpack \
+            --archive "$RUNNER_TEMP/incoming/unsigned-validation.tar.gz" \
+            --output "$RUNNER_TEMP/signing-stage" \
+            --source-sha "$EXPECTED_SOURCE" --version "$EXPECTED_VERSION"
+      - name: Import repository-scoped signing material
+        env:
+          P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          P12_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          test -n "$P12_BASE64" && test -n "$P12_PASSWORD" && test -n "$PROFILE_BASE64"
+          keychain="$RUNNER_TEMP/signing-validation.keychain-db"
+          keychain_password=$(openssl rand -hex 24)
+          printf '%s' "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/signing-certificate.p12"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 3600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$RUNNER_TEMP/signing-certificate.p12" -k "$keychain" \
+            -P "$P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+          rm -f "$RUNNER_TEMP/signing-certificate.p12"
+          app="$RUNNER_TEMP/signing-stage/Darkbloom.app"
+          printf '%s' "$PROFILE_BASE64" | base64 --decode > "$app/Contents/embedded.provisionprofile"
+          security cms -D -i "$app/Contents/embedded.provisionprofile" > "$RUNNER_TEMP/profile.plist"
+          python3 tooling/scripts/provider-signing-validation.py profile --profile "$RUNNER_TEMP/profile.plist"
+      - name: Sign and statically verify the app
+        run: |
+          set -euo pipefail
+          app="$RUNNER_TEMP/signing-stage/Darkbloom.app"
+          keychain="$RUNNER_TEMP/signing-validation.keychain-db"
+          codesign --force --options runtime --timestamp --identifier io.darkbloom.fan-helper \
+            --keychain "$keychain" --sign "$DEVELOPER_ID" "$app/Contents/Helpers/darkbloom-fan-helper"
+          codesign --verify --strict -R="anchor apple generic and identifier \"io.darkbloom.fan-helper\" and certificate leaf[subject.OU] = \"$APPLE_TEAM_ID\"" \
+            "$app/Contents/Helpers/darkbloom-fan-helper"
+          codesign --force --options runtime --timestamp --keychain "$keychain" \
+            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/mlx.metallib"
+          codesign --force --options runtime --timestamp --keychain "$keychain" \
+            --entitlements tooling/provider-swift/entitlements-enclave.plist \
+            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/darkbloom-enclave"
+          codesign --force --options runtime --timestamp --keychain "$keychain" \
+            --entitlements tooling/provider-swift/entitlements.plist \
+            --sign "$DEVELOPER_ID" "$app/Contents/MacOS/darkbloom"
+          codesign --force --options runtime --timestamp --keychain "$keychain" \
+            --entitlements tooling/provider-swift/entitlements.plist --sign "$DEVELOPER_ID" "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          codesign --verify --strict --verbose=2 "$app/Contents/MacOS/darkbloom"
+          codesign -d --entitlements - --xml "$app/Contents/MacOS/darkbloom" > "$RUNNER_TEMP/cli-entitlements.plist"
+          python3 tooling/scripts/provider-signing-validation.py cli-entitlements --plist "$RUNNER_TEMP/cli-entitlements.plist"
+          ditto -c -k --keepParent "$app" "$RUNNER_TEMP/notarization-input.zip"
+      - name: Validate Apple notarization and stapled ticket
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_ID" && test -n "$APPLE_APP_PASSWORD"
+          xcrun notarytool submit "$RUNNER_TEMP/notarization-input.zip" \
+            --apple-id "$APPLE_ID" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 15m --output-format json > "$RUNNER_TEMP/notary-result.json"
+          python3 -c 'import json,sys; result=json.load(open(sys.argv[1])); assert result.get("status")=="Accepted" and result.get("id")' "$RUNNER_TEMP/notary-result.json"
+          app="$RUNNER_TEMP/signing-stage/Darkbloom.app"
+          xcrun stapler staple "$app"
+          xcrun stapler validate "$app"
+          spctl --assess --type execute --verbose=4 "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          python3 tooling/scripts/provider-signing-validation.py receipt \
+            --output "$RUNNER_TEMP/signing-stage" --notary "$RUNNER_TEMP/notary-result.json"
+          tar czf "$RUNNER_TEMP/signed-validation.tar.gz" -C "$RUNNER_TEMP/signing-stage" .
+          shasum -a 256 "$RUNNER_TEMP/signed-validation.tar.gz" > "$RUNNER_TEMP/signed-validation.sha256"
+      - name: Remove temporary signing material
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/signing-validation.keychain-db" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/signing-certificate.p12" "$RUNNER_TEMP/profile.plist"
+      - name: Retain signing-validation artifact only
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: provider-signing-validation
+          path: |
+            ${{ runner.temp }}/signed-validation.tar.gz
+            ${{ runner.temp }}/signed-validation.sha256
+            ${{ runner.temp }}/notary-result.json
+          retention-days: 3
+          if-no-files-found: error
+      - name: Retain non-secret notarization diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: provider-signing-validation-diagnostics
+          path: ${{ runner.temp }}/notary-result.json
+          retention-days: 3
+          if-no-files-found: ignore

--- a/.github/workflows/provider-signing-validation.yml
+++ b/.github/workflows/provider-signing-validation.yml
@@ -12,6 +12,28 @@ on:
         required: true
         type: string
 
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Reviewed full commit SHA to build
+        required: true
+        type: string
+      version:
+        description: Exact existing source version; does not change source
+        required: true
+        type: string
+    secrets:
+      APPLE_CERTIFICATE_P12:
+        required: true
+      APPLE_CERTIFICATE_PASSWORD:
+        required: true
+      PROVISIONING_PROFILE_BASE64:
+        required: true
+      APPLE_ID:
+        required: true
+      APPLE_APP_PASSWORD:
+        required: true
+
 permissions:
   contents: read
   actions: read

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ provider-test: ## Build and run Swift provider tests with source-matched metalli
 	    done; \
 	    [ "$$found" -eq 1 ] || { echo "provider test runner bundle not found in $$bin_path" >&2; exit 1; }; \
 	    trap - EXIT HUP INT TERM
-	cd provider-swift && swift test --skip-build
+	cd provider-swift && ../scripts/run-provider-tests.sh
 
 provider: provider-build provider-test ## Build + test provider
 

--- a/console-ui/vercel.json
+++ b/console-ui/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "release/signing-validation-enable": false
+    }
+  }
+}

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-05 · commit `4d9811f7c`
+> Last updated: 2026-09-06 · commit `9c107e7b2`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -10,6 +10,11 @@ of it; the per-component steps below explain what each target runs.
 Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
 `scripts/publish-model.sh` to registration. See the
 [model publishing procedure](../operations/model-migration.md).
+
+The [manual signing-validation workflow](../operations/provider-release.md#environment-free-signing-validation)
+builds a reviewed, signed source revision and packages its existing version for
+Apple signing and notarization checks. It retains an Actions artifact for isolated
+validation; the unsigned build and signing run in separate jobs.
 
 ## Prerequisites
 

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-06 · commit `f3b2ee6a6`
+> Last updated: 2026-09-06 · commit `8cc56074a`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -18,7 +18,9 @@ validation; the unsigned build and signing run in separate jobs. CI's explicit
 manual entrypoint calls the reusable signing workflow at the same commit and
 maps only its five required secrets. Ordinary push/PR builds retain their prior
 job definitions and runners; a real signing dispatch requires separate review
-and authorization.
+and authorization. The signer selects a unique valid Developer ID Application
+identity from its isolated keychain, binds its team and certificate kind, signs by
+fingerprint, and restores the original keychain search list on cleanup.
 
 ## Prerequisites
 

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-06 · commit `9c107e7b2`
+> Last updated: 2026-09-06 · commit `f3b2ee6a6`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -14,7 +14,11 @@ Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
 The [manual signing-validation workflow](../operations/provider-release.md#environment-free-signing-validation)
 builds a reviewed, signed source revision and packages its existing version for
 Apple signing and notarization checks. It retains an Actions artifact for isolated
-validation; the unsigned build and signing run in separate jobs.
+validation; the unsigned build and signing run in separate jobs. CI's explicit
+manual entrypoint calls the reusable signing workflow at the same commit and
+maps only its five required secrets. Ordinary push/PR builds retain their prior
+job definitions and runners; a real signing dispatch requires separate review
+and authorization.
 
 ## Prerequisites
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-06 · commit `f3b2ee6a6`
+> Last updated: 2026-09-06 · commit `8cc56074a`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -21,10 +21,13 @@ signing workflow and its artifact, identity, entitlement and archive checks.
 Run `python3 scripts/test-provider-signing-routing.py` for parsed YAML job-graph
 checks and mutation fixtures. The routing test uses Ruby's standard YAML parser
 and a canonical baseline from the pre-entrypoint PR commit: it verifies that all
-eight ordinary CI job definitions and both signing job definitions are preserved,
+eight ordinary CI job definitions and the unsigned build job are preserved,
 that push/PR routing is unchanged, and that manual CI expands only to the unsigned
-build and dependent signer with exactly five mapped secrets. These CPU fixtures
-do not execute pipeline commands, provider binaries or use signing credentials.
+build and dependent signer with exactly five mapped secrets. The signer contract separately records the bounded identity/search-list revision.
+Run `python3 scripts/test-provider-signing-identity.py` for synthetic public-identity
+parsing, exact-team/kind and ambiguity refusals, mocked keychain lifecycle/cleanup,
+and the platform `csreq` requirement parser. These fixtures never operate on real
+keychains, signing credentials, provider binaries or models.
 See the [signing-validation procedure](../operations/provider-release.md#environment-free-signing-validation)
 for the separate signed artifact validation.
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-05 · commit `efc4e301b`
+> Last updated: 2026-09-06 · commit `9c107e7b2`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -15,6 +15,12 @@ checksum rejection, fallback, and cancellation. `scripts/test-publish-model.sh`
 checks the artifact workflow payload. `TestHuggingFaceArtifactPostgresAndCache`
 in `coordinator/store/hugging_face_artifact_test.go` uses a disposable
 `DATABASE_URL` to check storage and cache invalidation.
+
+Run `python3 scripts/test-provider-signing-validation.py` to verify the manual
+signing workflow and its artifact, identity, entitlement and archive checks.
+These CPU fixtures do not execute provider binaries or use signing credentials.
+See the [signing-validation procedure](../operations/provider-release.md#environment-free-signing-validation)
+for the separate signed artifact validation.
 
 ## Prerequisites
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-06 · commit `dcf764a0d`
+> Last updated: 2026-09-06 · commit `f3b2ee6a6`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -18,7 +18,13 @@ in `coordinator/store/hugging_face_artifact_test.go` uses a disposable
 
 Run `python3 scripts/test-provider-signing-validation.py` to verify the manual
 signing workflow and its artifact, identity, entitlement and archive checks.
-These CPU fixtures do not execute provider binaries or use signing credentials.
+Run `python3 scripts/test-provider-signing-routing.py` for parsed YAML job-graph
+checks and mutation fixtures. The routing test uses Ruby's standard YAML parser
+and a canonical baseline from the pre-entrypoint PR commit: it verifies that all
+eight ordinary CI job definitions and both signing job definitions are preserved,
+that push/PR routing is unchanged, and that manual CI expands only to the unsigned
+build and dependent signer with exactly five mapped secrets. These CPU fixtures
+do not execute pipeline commands, provider binaries or use signing credentials.
 See the [signing-validation procedure](../operations/provider-release.md#environment-free-signing-validation)
 for the separate signed artifact validation.
 
@@ -363,7 +369,7 @@ token IDs are accepted.
 
 | Workflow | Trigger | Jobs (name → what runs) |
 |---|---|---|
-| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) | push, PR | **Release Integrity** — `scripts/check-release-version.sh`, `scripts/sync-install-embed.sh check`, `scripts/test-prod-env-refresh.sh` · **Docs Lint** — `scripts/docs-check.sh` · **Coordinator Tests** — `go test -race $(go list ./... \| grep -v /e2e)` with `postgres:16` service + `gofmt -l .` · **Coordinator Lint** — `golangci-lint run` (v2.1.6) · **Prompt Sidecar Tests** — cargo fmt/check/clippy/test on Rust 1.88.0, static musl Docker stage, `verify-prompt-sidecar-linux.sh` · **Provider Tests** (macOS 12-vcpu) — `swift build --build-tests`, metallib staging, `swift test`, `verify-prompt-parity.sh`, six nested suites via `run-nested-suite.sh` (each its own step, `if: !cancelled()`), `test-install-atomic.sh` · **Swift Build + Cache** — release build of `darkbloom` + `darkbloom-fan-helper`, warms the SwiftPM cache · **Console UI Lint & Build** — Node 22, `npm ci`, `npx eslint src/`, `npm run build` |
+| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) | push, PR; explicit manual signing validation | **Release Integrity** — `scripts/check-release-version.sh`, `scripts/sync-install-embed.sh check`, `scripts/test-prod-env-refresh.sh` · **Docs Lint** — `scripts/docs-check.sh` · **Coordinator Tests** — `go test -race $(go list ./... \| grep -v /e2e)` with `postgres:16` service + `gofmt -l .` · **Coordinator Lint** — `golangci-lint run` (v2.1.6) · **Prompt Sidecar Tests** — cargo fmt/check/clippy/test on Rust 1.88.0, static musl Docker stage, `verify-prompt-sidecar-linux.sh` · **Provider Tests** (macOS 12-vcpu) — `swift build --build-tests`, metallib staging, `swift test`, `verify-prompt-parity.sh`, six nested suites via `run-nested-suite.sh` (each its own step, `if: !cancelled()`), `test-install-atomic.sh` · **Swift Build + Cache** — release build of `darkbloom` + `darkbloom-fan-helper`, warms the SwiftPM cache · **Console UI Lint & Build** — Node 22, `npm ci`, `npx eslint src/`, `npm run build` · **Manual only:** relative reusable signing workflow, unsigned build → signer; all ordinary CI jobs skipped |
 | [`.github/workflows/integration.yml`](../../.github/workflows/integration.yml) | push to `master`/`main`, PR | **E2E Integration Tests** (macOS, 120 min budget): install Postgres 16, `swift build -c debug`, cargo sidecar build, metallib staging, HF snapshot downloads; lanes: paged @ 8 blocking gate (`TestIntegration\|TestProfile` minus exact-cache) → exact-cache routing paged @ 8 (expected red, `continue-on-error`) → default-posture smoke (`EXPECT_KV_BACKEND=contiguous`) → current coordinator vs released v0.7.12 provider (`scripts/fetch-v0712-provider.sh`, `DARKBLOOM_MIXED_VERSION_EXPECT=artifact`, fails unless `MIXED_VERSION_TIER_ARTIFACT_OK` appears) → released v0.7.12 coordinator (`git worktree add … v0.7.12`) vs candidate provider (`NonStreamingInference`, `StreamingInference`) |
 | [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml) | PR, gated by the `benchmarks` environment (manual approval) | **E2E Benchmarks** — `go test ./e2e/ -count=1 -v -timeout 40m -p=1 -run 'TestBenchmark'`, posts `BENCHMARK_MD_PATH` as a PR comment |
 | [`.github/workflows/release-swift.yml`](../../.github/workflows/release-swift.yml) | tag `v*`, manual | Provider release; see [`../operations/provider-release.md`](../operations/provider-release.md) |

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-06 · commit `9c107e7b2`
+> Last updated: 2026-09-06 · commit `dcf764a0d`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -82,13 +82,25 @@ production prompt vectors against it with
 
 ### 4. Provider (Swift) — unit tests with a source-matched metallib
 
+`scripts/run-provider-tests.sh` passes `--no-parallel` explicitly for the general
+suite because unrelated Swift Testing cases share process-wide MLX state and
+executor capacity. Concurrency tests retain their own tasks and interleavings.
+The real process-environment projection case (`defaultApplyProjectsSettings`)
+and bounded SSD stage-deadline case (`stageDelta`) run in separate processes
+through `scripts/run-nested-suite.sh`, including its nonempty/no-skips guards.
+A failure in the general suite does not silence either isolated gate. No test
+assertion, timeout or inference-concurrency setting changes.
+
 ```bash
 make provider-test
 # = cd provider-swift && swift build --build-tests
 #   ./scripts/fetch-metallib.sh <bin-path>            (build mlx.metallib from libs/mlx-swift source)
 #   cp mlx.metallib into every <bin-path>/*PackageTests.xctest/Contents/MacOS/
-#   cd provider-swift && swift test --skip-build
+#   cd provider-swift && ../scripts/run-provider-tests.sh
 ```
+
+Run `python3 scripts/test-run-provider-tests.py` to check this shell routing with
+a fake Swift command. These CPU tests do not build or run Swift, MLX or a model.
 
 The metallib staging is not optional: MLX loads `mlx.metallib` from beside the
 running executable, and for tests the executable is the `.xctest` runner.

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-06 · commit `9c107e7b2`
+> Last updated: 2026-09-06 · commit `2feef1249`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -33,11 +33,15 @@ signing and when the final receipt is written.
 The signing job uses repository-scoped `APPLE_CERTIFICATE_P12`,
 `APPLE_CERTIFICATE_PASSWORD`, `PROVISIONING_PROFILE_BASE64`, `APPLE_ID` and
 `APPLE_APP_PASSWORD`. It imports an isolated temporary keychain, validates the
-profile's team/access group/push entitlement/expiry, signs the normal app
-components, then checks the signed CLI's keychain group, APNs entitlement and
-disabled debug-task entitlement. It checks Apple notarization and a stapled
-ticket, and emits post-sign
-file hashes. Keychain material is removed even on failure. Only explicit Actions
+profile's team, keychain group, production APNs grant, expiry and declared
+application identity (`scripts/provider-signing-validation.py`, `profile`). Both
+`com.apple.application-identifier` and `application-identifier` are checked when
+present: each must name the exact provider team/app or a wildcard that covers
+it. Profiles may omit those declarations; conflicting, malformed or unrelated
+declarations fail validation. The job signs the normal app components, then
+checks the signed CLI's keychain group, APNs entitlement and disabled debug-task
+entitlement. It checks Apple notarization and a stapled ticket, and emits
+post-sign file hashes. Keychain material is removed even on failure. Only explicit Actions
 artifacts and non-secret notarization diagnostics are retained for three days.
 
 The normal APNs entitlement retains its required `production` value; this is a

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-06 · commit `f3b2ee6a6`
+> Last updated: 2026-09-06 · commit `8cc56074a`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -40,17 +40,36 @@ signing and when the final receipt is written.
 
 The signing job uses repository-scoped `APPLE_CERTIFICATE_P12`,
 `APPLE_CERTIFICATE_PASSWORD`, `PROVISIONING_PROFILE_BASE64`, `APPLE_ID` and
-`APPLE_APP_PASSWORD`. It imports an isolated temporary keychain, validates the
+`APPLE_APP_PASSWORD`. Before creating the isolated temporary keychain, it records
+the original user keychain search list. It then activates the temporary keychain
+while preserving all prior entries and their order. After import it validates the
 profile's team, keychain group, production APNs grant, expiry and declared
 application identity (`scripts/provider-signing-validation.py`, `profile`). Both
 `com.apple.application-identifier` and `application-identifier` are checked when
 present: each must name the exact provider team/app or a wildcard that covers
 it. Profiles may omit those declarations; conflicting, malformed or unrelated
-declarations fail validation. The job signs the normal app components, then
-checks the signed CLI's keychain group, APNs entitlement and disabled debug-task
-entitlement. It checks Apple notarization and a stapled ticket, and emits
-post-sign file hashes. Keychain material is removed even on failure. Only explicit Actions
-artifacts and non-secret notarization diagnostics are retained for three days.
+declarations fail validation.
+
+`scripts/provider_signing_identity.py` queries only the isolated keychain with
+`security find-identity -v -p codesigning`. Exactly one valid certificate/private-key
+identity must be present. Its kind must be Developer ID Application and its team
+must equal `SLDQ2GJ6TL`; zero, ambiguous, wrong-kind, wrong-team or malformed results
+fail before signing. The selected public SHA-1 identity fingerprint is passed to
+`codesign`, avoiding dependence on a company's display-name spelling. There is no
+global identity fallback and no new certificate/trust-anchor installation.
+
+Static signed-code requirements retain Apple's generic anchor and the exact team,
+add the Developer ID Application leaf marker, and preserve the helper/app identifiers.
+The marker `1.2.840.113635.100.6.1.13` is documented in Apple's
+[Security policy definitions](https://github.com/apple-oss-distributions/Security/blob/db15acbe6a7f257a859ad9a3bb86097bfe0679d9/trust/headers/SecPolicyPriv.h).
+The job checks the CLI's keychain group, APNs entitlement and disabled debug-task
+entitlement, then Apple notarization, the stapled ticket and post-sign file hashes.
+
+Cleanup always restores and verifies the original user search list, then removes
+the captured temporary keychain and material. Restore failure still attempts
+private-material deletion and fails the job; it is not reported as successful cleanup.
+Only existing Actions artifacts plus non-secret identity, cleanup and notarization
+receipts are retained for three days. No private key or secret value is exported.
 
 The normal APNs entitlement retains its required `production` value; this is a
 static signing entitlement, not a GitHub environment or a provider registration.
@@ -74,11 +93,21 @@ After explicit authorization, the registered entrypoint is selected with
 `gh workflow run ci.yml --ref <reviewed-branch> -f source_sha=<verified-full-sha> -f version=<exact-source-version>`.
 The build rechecks the published signature, exact checkout and existing version;
 secret-name availability alone does not establish credential validity.
+The first authorized signing run, [34030878981](https://github.com/Layr-Labs/d-inference/actions/runs/34030878981),
+built and validated its unsigned artifact but failed its first hard-coded identity
+lookup after importing one identity and validating the profile. No certificate
+subject or valid-identity listing was retained, so a display-name change is unproven.
+The release workflow already added the temporary keychain to the search list; the
+initial isolated workflow omitted that step. The scoped search-list lifecycle and
+strict fingerprint selection address both lookup causes without weakening a gate.
+Any retry requires review of the changed definition; there is no cross-run artifact input.
+
 Source preparation and the CPU helper tests do not claim a completed signing run:
 
 ```bash
 python3 scripts/test-provider-signing-validation.py
 python3 scripts/test-provider-signing-routing.py
+python3 scripts/test-provider-signing-identity.py
 ```
 
 ## When to use

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-04 · commit `ac60c5ada`
+> Last updated: 2026-09-06 · commit `9c107e7b2`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -8,6 +8,51 @@ environment, and let [`.github/workflows/release-swift.yml`](../../.github/workf
 build, sign, notarize, hash, upload, and register the bundle. The coordinator
 verifies every registered artifact by re-downloading it, so a release either
 lands fully or not at all.
+
+## Environment-free signing validation
+
+[`provider-signing-validation.yml`](../../.github/workflows/provider-signing-validation.yml)
+is a separate manual workflow for a reviewed full `source_sha` and its existing
+`version`. It has no GitHub `environment` field or environment selector and no
+coordinator registration, R2 upload, GitHub Release, tag or deployment step.
+Its token has only `contents: read` and `actions: read`.
+
+The build job has no signing secrets. It checks the source's verified commit
+signature and version parity, builds the exact provider and metallib, then stages
+an unsigned app with the existing SwiftPM resource helper. A new runner downloads
+that same run's artifact, verifies its inventory/source/version, rejects unsafe
+archive paths and links, and checks the candidate entitlements against the
+reviewed workflow tooling (`scripts/provider-signing-validation.py`).
+
+Unpacking limits the compressed archive and total declared member bytes to
+2 GiB, each member to 512 MiB, and the archive to 16,384 members. Normalized
+duplicate paths, including case aliases, are refused. The app's bundle ID,
+executable name and both version fields must match the expected source before
+signing and when the final receipt is written.
+
+The signing job uses repository-scoped `APPLE_CERTIFICATE_P12`,
+`APPLE_CERTIFICATE_PASSWORD`, `PROVISIONING_PROFILE_BASE64`, `APPLE_ID` and
+`APPLE_APP_PASSWORD`. It imports an isolated temporary keychain, validates the
+profile's team/access group/push entitlement/expiry, signs the normal app
+components, then checks the signed CLI's keychain group, APNs entitlement and
+disabled debug-task entitlement. It checks Apple notarization and a stapled
+ticket, and emits post-sign
+file hashes. Keychain material is removed even on failure. Only explicit Actions
+artifacts and non-secret notarization diagnostics are retained for three days.
+
+The normal APNs entitlement retains its required `production` value; this is a
+static signing entitlement, not a GitHub environment or a provider registration.
+The workflow never executes the candidate CLI, helper, model or inference server.
+Signed runtime smoke, installation, model correctness and release approval remain
+separate gates. The original release workflow's `validation_only` option still
+selects a deployment environment and is not this isolated path.
+
+Review and make the new manual workflow available before authorizing a dispatch.
+Source preparation and the CPU helper tests do not claim a completed signing run:
+
+```bash
+python3 scripts/test-provider-signing-validation.py
+```
 
 ## When to use
 

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-06 · commit `2feef1249`
+> Last updated: 2026-09-06 · commit `f3b2ee6a6`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -12,10 +12,18 @@ lands fully or not at all.
 ## Environment-free signing validation
 
 [`provider-signing-validation.yml`](../../.github/workflows/provider-signing-validation.yml)
-is a separate manual workflow for a reviewed full `source_sha` and its existing
-`version`. It has no GitHub `environment` field or environment selector and no
+accepts a reviewed full `source_sha` and its existing `version` through both
+`workflow_dispatch` and `workflow_call`. The registered [CI workflow](../../.github/workflows/ci.yml)
+provides the signing-validation manual entrypoint: its manual event skips the
+ordinary CI jobs and calls this reusable workflow with a relative path at the
+same commit. Push/PR triggers and all ordinary job definitions remain unchanged,
+including the push-only Swift cache job and provider test isolation.
+
+The CI caller maps exactly the five signing secrets named below; it does not
+inherit the repository's entire secret set. Both caller and reusable workflow
+keep only `contents: read` and `actions: read`. The standalone manual entrypoint
+is retained. This path has no GitHub `environment` field or environment selector and no
 coordinator registration, R2 upload, GitHub Release, tag or deployment step.
-Its token has only `contents: read` and `actions: read`.
 
 The build job has no signing secrets. It checks the source's verified commit
 signature and version parity, builds the exact provider and metallib, then stages
@@ -51,11 +59,26 @@ Signed runtime smoke, installation, model correctness and release approval remai
 separate gates. The original release workflow's `validation_only` option still
 selects a deployment environment and is not this isolated path.
 
-Review and make the new manual workflow available before authorizing a dispatch.
+Review the exact caller/reusable workflow commit, expanded build/signing job
+graph, source SHA and version before separately authorizing a real dispatch.
+The registered CI path can select the reviewed branch before a master merge:
+[harmless probe run 34029318546](https://github.com/Layr-Labs/d-inference/actions/runs/34029318546)
+executed one identity-only Ubuntu job from that branch while master CI lacked
+`workflow_dispatch`. That probe did not exercise signing or reusable jobs. Its
+branch creation used an existing account exception to restricted ref creation;
+normal repository access and source-review rules still apply.
+
+GitHub documents [branch selection for a manual workflow](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow)
+and [same-commit relative reusable calls](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#calling-a-reusable-workflow).
+After explicit authorization, the registered entrypoint is selected with
+`gh workflow run ci.yml --ref <reviewed-branch> -f source_sha=<verified-full-sha> -f version=<exact-source-version>`.
+The build rechecks the published signature, exact checkout and existing version;
+secret-name availability alone does not establish credential validity.
 Source preparation and the CPU helper tests do not claim a completed signing run:
 
 ```bash
 python3 scripts/test-provider-signing-validation.py
+python3 scripts/test-provider-signing-routing.py
 ```
 
 ## When to use

--- a/scripts/fixtures/provider-signing-routing-baseline.json
+++ b/scripts/fixtures/provider-signing-routing-baseline.json
@@ -73,7 +73,13 @@
     },
     "jobs": {
       "build": "dd03264284f2b0b5cce952e23b3f937e5eda813396731597f5db3039405fc48e",
-      "signing": "42410c40012a6abd9ed3853aceeee4d80c4adcad49a8ca5c3d9c5e59b289001a"
+      "signing": "04744fe53cb51c62cabf9f081ee76fbc534466091b9a2d7b2162146e945f72fa"
+    },
+    "identity_revision": {
+      "parent_workflow_sha": "8cc56074ae7a6dd6553fe3cd3692af1ba58ed9a2",
+      "previous_signing_job_sha256": "42410c40012a6abd9ed3853aceeee4d80c4adcad49a8ca5c3d9c5e59b289001a",
+      "new_signing_job_sha256": "04744fe53cb51c62cabf9f081ee76fbc534466091b9a2d7b2162146e945f72fa",
+      "scope": "Only signer identity lookup/search-list lifecycle, Developer ID requirements and non-secret diagnostics; normal CI and unsigned build unchanged."
     }
   },
   "preserved_files": {

--- a/scripts/fixtures/provider-signing-routing-baseline.json
+++ b/scripts/fixtures/provider-signing-routing-baseline.json
@@ -1,0 +1,92 @@
+{
+  "source_commit": "f3b2ee6a69cc83a03ffc70ae860dfb6a903799a7",
+  "canonical_hash": "SHA256 of UTF-8 json.dumps(value, sort_keys=True, separators=(comma, colon))",
+  "ci": {
+    "top": {
+      "name": "CI"
+    },
+    "events": {
+      "push": {
+        "branches": [
+          "master",
+          "main"
+        ]
+      },
+      "pull_request": null
+    },
+    "jobs": {
+      "release-integrity": {
+        "sha256": "c64c6bc9065aaf9b80891d6a5a2b64b2e7eaebcfa53869201b703b697df91878",
+        "if": null
+      },
+      "docs": {
+        "sha256": "44f693c77ade7327dff38e91240f37d18dbcd98401927fd242c0a7184be0b008",
+        "if": null
+      },
+      "test-coordinator": {
+        "sha256": "c93838458ef79504df0b3fc7ba2a09cd0a45b419819630796fca8c985c9b508b",
+        "if": null
+      },
+      "lint-coordinator": {
+        "sha256": "aae791c29939f40e9e401afa24994bafa3f43ed8bdcbfcb3f02e68b10de0cb12",
+        "if": null
+      },
+      "test-prompt-sidecar": {
+        "sha256": "e221aa285798e7d992800f3ce6e51acf29b1a791ef1ac80378e161856728536f",
+        "if": null
+      },
+      "test-provider": {
+        "sha256": "9fe8ff598c04f196ee46211ca090a1d1aff751c11a9f8feaf1d71b324efcbdbf",
+        "if": null
+      },
+      "cache-swift": {
+        "sha256": "bf405c85b593d47e11462b31786354bcf04b146319fa27efae75dc9b5bf30373",
+        "if": "github.event_name == 'push'"
+      },
+      "lint-console": {
+        "sha256": "7caac2b5c8dd633dda47a243d042a33ff37edc6a448c5eabd2e7d3a47517f34c",
+        "if": null
+      }
+    }
+  },
+  "signing": {
+    "top": {
+      "name": "Provider Signing Validation",
+      "permissions": {
+        "contents": "read",
+        "actions": "read"
+      }
+    },
+    "manual_event": {
+      "inputs": {
+        "source_sha": {
+          "description": "Reviewed full commit SHA to build",
+          "required": true,
+          "type": "string"
+        },
+        "version": {
+          "description": "Exact existing source version; does not change source",
+          "required": true,
+          "type": "string"
+        }
+      }
+    },
+    "jobs": {
+      "build": "dd03264284f2b0b5cce952e23b3f937e5eda813396731597f5db3039405fc48e",
+      "signing": "42410c40012a6abd9ed3853aceeee4d80c4adcad49a8ca5c3d9c5e59b289001a"
+    }
+  },
+  "preserved_files": {
+    "scripts/run-provider-tests.sh": "fe00e82ef515fee3caae91ae53593927e1a13f3be0ca8ec89bbd4df8043b077c",
+    "scripts/run-nested-suite.sh": "14ecf2a47a07c07b2bdc535ac1a6fdd64c674763963a2fa9b86cb07d8feeda48",
+    "scripts/provider-signing-validation.py": "e8bbead2713264ef53eb8917ddf8b2f25f79a5105b7966daef44d92c81a315c4",
+    "scripts/test-provider-signing-validation.py": "fe96f0fb8769aa8033fae0908a2cf5224faddb5d0f590bfdec3cfb54b57ac281",
+    "scripts/stage-swiftpm-resource-bundles.sh": "1151d2a1ea15096b81425a163b911831134ac0aaef58a0e10d22c316b13de0b1",
+    "provider-swift/entitlements.plist": "3da35936c7b5bde0a37436771f8cbe54b0ea5273ce66082e0c0b0cf541677d11",
+    "provider-swift/entitlements-enclave.plist": "526f1d7d729bc609f4b6c06a57a69ff74c6c5c2f08fc7d1269c6815dc9abed28",
+    ".github/workflows/release-swift.yml": "7dd094b6e975344d7ff665fe5163232d9c4ae431cac1bab1933a4ef4dfc1fd69",
+    ".github/workflows/register-model.yml": "b908ab2cabb5136ff940fa5cab84a6cb88b588b66707abf77bae3a1c1eae5596",
+    "vercel.json": "e2ac0c0120a7ef800398c5ee3de046482346fe79dfe8d406d46f6ff472e36caf",
+    "console-ui/vercel.json": "e2ac0c0120a7ef800398c5ee3de046482346fe79dfe8d406d46f6ff472e36caf"
+  }
+}

--- a/scripts/provider-signing-validation.py
+++ b/scripts/provider-signing-validation.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import plistlib
+import shutil
+import subprocess
+import tarfile
+import unicodedata
+
+TEAM = "SLDQ2GJ6TL"
+APP_ID = "io.darkbloom.provider"
+MAX_ARCHIVE_BYTES = 2 << 30
+MAX_MEMBER_BYTES = 512 << 20
+MAX_TOTAL_BYTES = 2 << 30
+MAX_ARCHIVE_MEMBERS = 16_384
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def inventory(root):
+    files = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError(f"Unexpected package symlink: {path}")
+        if path.is_file():
+            files[str(path.relative_to(root))] = {
+                "sha256": sha256(path), "bytes": path.stat().st_size,
+            }
+    return files
+
+
+def write_json(path, value):
+    with path.open("x") as destination:
+        json.dump(value, destination, indent=2)
+        destination.write("\n")
+
+
+def stage(arguments):
+    root = arguments.output
+    root.mkdir(parents=True, exist_ok=False)
+    app = root / "Darkbloom.app"
+    binaries = app / "Contents/MacOS"
+    helpers = app / "Contents/Helpers"
+    resources = app / "Contents/Resources/darkbloom-runtime-capabilities"
+    for path in [binaries, helpers, resources, root / "validation-inputs"]:
+        path.mkdir(parents=True)
+    for name in ["darkbloom", "darkbloom-enclave"]:
+        shutil.copy2(arguments.bin / name, binaries / name)
+    shutil.copy2(arguments.bin / "darkbloom-fan-helper", helpers / "darkbloom-fan-helper")
+    shutil.copy2(arguments.metallib, binaries / "mlx.metallib")
+    (resources / "fan-helper-v1").write_text("1\n")
+    info = {
+        "CFBundleIdentifier": APP_ID, "CFBundleExecutable": "darkbloom",
+        "CFBundleName": "Darkbloom", "CFBundleVersion": arguments.version,
+        "CFBundleShortVersionString": arguments.version,
+        "CFBundlePackageType": "APPL", "LSMinimumSystemVersion": "14.0",
+    }
+    with (app / "Contents/Info.plist").open("wb") as output:
+        plistlib.dump(info, output)
+    for name in ["entitlements.plist", "entitlements-enclave.plist"]:
+        shutil.copy2(arguments.source / "provider-swift" / name, root / "validation-inputs" / name)
+    subprocess.run([
+        "bash", str(Path(__file__).resolve().parent / "stage-swiftpm-resource-bundles.sh"),
+        str(arguments.bin), str(app), str(root / "validation-inputs/resource-bundles.txt"),
+    ], check=True)
+    source_sha = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=arguments.source, text=True).strip()
+    submodules = subprocess.check_output(
+        ["git", "submodule", "status", "--recursive"], cwd=arguments.source, text=True).splitlines()
+    write_json(root / "unsigned-files.json", {
+        "schema": 1, "source_sha": source_sha, "version": arguments.version,
+        "submodules": submodules, "files": inventory(root),
+    })
+
+
+def unpack(arguments):
+    if arguments.archive.stat().st_size > MAX_ARCHIVE_BYTES:
+        raise ValueError("Archive size exceeds the validation limit")
+    arguments.output.mkdir(parents=True, exist_ok=False)
+    with tarfile.open(arguments.archive, "r:gz") as archive:
+        members, names, total_bytes = [], set(), 0
+        for member in archive:
+            name = PurePosixPath(member.name)
+            if name.is_absolute() or ".." in name.parts or not (member.isfile() or member.isdir()):
+                raise ValueError(f"Unsafe package member: {member.name}")
+            canonical = unicodedata.normalize("NFC", name.as_posix()).casefold()
+            if canonical in names:
+                raise ValueError(f"Duplicate package member: {member.name}")
+            names.add(canonical)
+            if member.size < 0 or member.size > MAX_MEMBER_BYTES:
+                raise ValueError(f"Package member size exceeds the validation limit: {member.name}")
+            total_bytes += member.size
+            if total_bytes > MAX_TOTAL_BYTES:
+                raise ValueError("Package total size exceeds the validation limit")
+            if len(members) >= MAX_ARCHIVE_MEMBERS:
+                raise ValueError("Package member count exceeds the validation limit")
+            member.mode &= 0o777
+            members.append(member)
+        archive.extractall(arguments.output, members=members)
+    manifest = json.loads((arguments.output / "unsigned-files.json").read_text())
+    if manifest["source_sha"] != arguments.source_sha or manifest["version"] != arguments.version:
+        raise ValueError("Unsigned artifact source/version differs from the dispatch inputs")
+    actual = inventory(arguments.output)
+    actual.pop("unsigned-files.json")
+    if actual != manifest["files"]:
+        raise ValueError("Unsigned artifact inventory changed")
+    check_info(arguments.output, arguments.version)
+    tooling = Path(__file__).resolve().parent.parent
+    for name in ["entitlements.plist", "entitlements-enclave.plist"]:
+        if sha256(arguments.output / "validation-inputs" / name) != sha256(tooling / "provider-swift" / name):
+            raise ValueError("Candidate signing entitlements differ from reviewed workflow tooling")
+
+
+def check_info(root, version):
+    with (root / "Darkbloom.app/Contents/Info.plist").open("rb") as source:
+        info = plistlib.load(source)
+    required = {"CFBundleIdentifier": APP_ID, "CFBundleVersion": version,
+                "CFBundleShortVersionString": version, "CFBundleExecutable": "darkbloom"}
+    if not isinstance(info, dict) or any(info.get(key) != value for key, value in required.items()):
+        raise ValueError("App Info.plist identity/version does not match the expected source")
+
+
+def cli_entitlements(arguments):
+    with arguments.plist.open("rb") as source:
+        value = plistlib.load(source)
+    if not isinstance(value, dict):
+        raise ValueError("Signed CLI entitlements are not a dictionary")
+    groups = value.get("keychain-access-groups", [])
+    if not isinstance(groups, list) or TEAM + "." + APP_ID not in groups:
+        raise ValueError("Signed CLI lacks the required keychain access group")
+    if value.get("com.apple.developer.aps-environment") != "production":
+        raise ValueError("Signed CLI lacks the required APNs entitlement")
+    for key in ["get-task-allow", "com.apple.security.get-task-allow"]:
+        if value.get(key, False) is not False:
+            raise ValueError("Signed CLI enables or malforms get-task-allow")
+
+
+def profile(arguments):
+    with arguments.profile.open("rb") as source:
+        value = plistlib.load(source)
+    entitlements = value.get("Entitlements", {})
+    groups = entitlements.get("keychain-access-groups", [])
+    if TEAM not in value.get("TeamIdentifier", []):
+        raise ValueError("Provisioning profile team mismatch")
+    if TEAM + "." + APP_ID not in groups and TEAM + ".*" not in groups:
+        raise ValueError("Provisioning profile does not authorize the provider access group")
+    if entitlements.get("aps-environment", entitlements.get("com.apple.developer.aps-environment")) != "production":
+        raise ValueError("Provisioning profile lacks the required APNs entitlement")
+    app_id = entitlements.get("application-identifier", "")
+    if app_id and not (app_id.endswith(APP_ID) or app_id.endswith("*")):
+        raise ValueError("Provisioning profile application identifier mismatch")
+    expiration = value.get("ExpirationDate")
+    if expiration is None or (expiration.replace(tzinfo=timezone.utc) - datetime.now(timezone.utc)).days < 30:
+        raise ValueError("Provisioning profile expires in fewer than 30 days")
+
+
+def receipt(arguments):
+    root = arguments.output
+    notarization = json.loads(arguments.notary.read_text())
+    if notarization.get("status") != "Accepted" or not notarization.get("id"):
+        raise ValueError("Notarization did not produce an accepted ticket")
+    unsigned = json.loads((root / "unsigned-files.json").read_text())
+    check_info(root, unsigned["version"])
+    app = root / "Darkbloom.app"
+    (root / "bin").mkdir()
+    for name in ["darkbloom", "darkbloom-enclave", "mlx.metallib"]:
+        shutil.copy2(app / "Contents/MacOS" / name, root / "bin" / name)
+    write_json(root / "signing-validation.json", {
+        "schema": 1, "scope": "signing_and_notarization_validation_only",
+        "source_sha": unsigned["source_sha"], "version": unsigned["version"],
+        "submodules": unsigned["submodules"], "notarization_id": notarization["id"],
+        "notarization_status": notarization["status"], "files": inventory(root),
+        "model_execution": False, "runtime_smoke": False, "release_published": False,
+    })
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    stage_parser = commands.add_parser("stage")
+    for name in ["source", "bin", "metallib", "output"]:
+        stage_parser.add_argument("--" + name, type=Path, required=True)
+    stage_parser.add_argument("--version", required=True)
+    unpack_parser = commands.add_parser("unpack")
+    for name in ["archive", "output"]:
+        unpack_parser.add_argument("--" + name, type=Path, required=True)
+    unpack_parser.add_argument("--source-sha", required=True)
+    unpack_parser.add_argument("--version", required=True)
+    profile_parser = commands.add_parser("profile")
+    profile_parser.add_argument("--profile", type=Path, required=True)
+    entitlements_parser = commands.add_parser("cli-entitlements")
+    entitlements_parser.add_argument("--plist", type=Path, required=True)
+    receipt_parser = commands.add_parser("receipt")
+    for name in ["output", "notary"]:
+        receipt_parser.add_argument("--" + name, type=Path, required=True)
+    arguments = parser.parse_args()
+    {"stage": stage, "unpack": unpack, "profile": profile,
+     "cli-entitlements": cli_entitlements, "receipt": receipt}[arguments.command](arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/provider-signing-validation.py
+++ b/scripts/provider-signing-validation.py
@@ -155,9 +155,18 @@ def profile(arguments):
         raise ValueError("Provisioning profile does not authorize the provider access group")
     if entitlements.get("aps-environment", entitlements.get("com.apple.developer.aps-environment")) != "production":
         raise ValueError("Provisioning profile lacks the required APNs entitlement")
-    app_id = entitlements.get("application-identifier", "")
-    if app_id and not (app_id.endswith(APP_ID) or app_id.endswith("*")):
-        raise ValueError("Provisioning profile application identifier mismatch")
+    expected_app_id = TEAM + "." + APP_ID
+    # macOS uses the long key; other profiles may use the short spelling.
+    # Developer ID profiles may omit it, but every declared value must cover
+    # this exact team/app. A wildcard grants only its own prefix, not any app.
+    for key in ["com.apple.application-identifier", "application-identifier"]:
+        if key not in entitlements:
+            continue
+        app_id = entitlements[key]
+        if not isinstance(app_id, str) or not (app_id == expected_app_id or (
+                app_id.startswith(TEAM + ".") and app_id.endswith("*")
+                and app_id.count("*") == 1 and expected_app_id.startswith(app_id[:-1]))):
+            raise ValueError("Provisioning profile application identifier mismatch: " + key)
     expiration = value.get("ExpirationDate")
     if expiration is None or (expiration.replace(tzinfo=timezone.utc) - datetime.now(timezone.utc)).days < 30:
         raise ValueError("Provisioning profile expires in fewer than 30 days")

--- a/scripts/provider_signing_identity.py
+++ b/scripts/provider_signing_identity.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Isolated-keychain lifecycle and public Developer ID identity selection.
+
+This helper never imports/exports a private key, reads a signing secret, changes
+trust settings, or selects from a global identity search. The workflow owns
+secret import; this helper records public metadata and fails closed.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+MAX_METADATA_BYTES = 64 * 1024
+MAX_IDENTITIES = 16
+KEYCHAIN_NAME = "signing-validation.keychain-db"
+DEVELOPER_ID_APPLICATION_OID = "1.2.840.113635.100.6.1.13"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def security(*arguments):
+    return subprocess.run(["security", *arguments], check=True, capture_output=True, text=True, timeout=30).stdout
+
+
+def path_string(value):
+    require(isinstance(value, str) and value and Path(value).is_absolute()
+            and all(character.isprintable() for character in value), "invalid keychain path")
+    return value
+
+
+def search_list(text):
+    require(len(text.encode()) <= MAX_METADATA_BYTES, "keychain search-list metadata limit")
+    values = shlex.split(text)
+    require(len(values) <= 64 and len(set(values)) == len(values), "invalid keychain search list")
+    return [path_string(value) for value in values]
+
+
+def write_json(path, value, exclusive=False):
+    payload = json.dumps(value, indent=2, ensure_ascii=True) + "\n"
+    if exclusive:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w") as output:
+            output.write(payload)
+    else:
+        temporary = path.with_name(path.name + ".tmp")
+        temporary.write_text(payload)
+        temporary.chmod(0o600)
+        temporary.replace(path)
+
+
+def snapshot(path):
+    require(path.stat().st_size <= MAX_METADATA_BYTES, "keychain snapshot metadata limit")
+    value = json.loads(path.read_text())
+    require(set(value) == {"schema", "domain", "temporary_keychain", "original_search_list"}
+            and value["schema"] == 1 and value["domain"] == "user", "invalid keychain snapshot")
+    temporary = Path(path_string(value["temporary_keychain"]))
+    require(temporary.name == KEYCHAIN_NAME and temporary.parent == path.parent,
+            "temporary keychain is outside the captured scope")
+    original = value["original_search_list"]
+    require(isinstance(original, list) and len(original) <= 64 and len(set(original)) == len(original),
+            "invalid original search list")
+    for entry in original:
+        path_string(entry)
+    require(str(temporary) not in original, "temporary keychain was not new")
+    return value
+
+
+def capture_search_list(path, keychain):
+    path_string(str(keychain))
+    require(keychain.name == KEYCHAIN_NAME and keychain.parent == path.parent,
+            "temporary keychain must share the snapshot directory")
+    require(not path.exists() and not keychain.exists(), "refusing existing keychain/snapshot")
+    original = search_list(security("list-keychains", "-d", "user"))
+    require(str(keychain) not in original, "temporary keychain is already in the search list")
+    write_json(path, {"schema": 1, "domain": "user", "temporary_keychain": str(keychain),
+                      "original_search_list": original}, exclusive=True)
+
+
+def activate_search_list(path):
+    state = snapshot(path)
+    require(Path(state["temporary_keychain"]).is_file(), "temporary keychain was not created")
+    expected = [state["temporary_keychain"], *state["original_search_list"]]
+    security("list-keychains", "-d", "user", "-s", *expected)
+    require(search_list(security("list-keychains", "-d", "user")) == expected,
+            "temporary keychain search-list activation failed")
+
+
+def parse_valid_identities(text):
+    require(len(text.encode()) <= MAX_METADATA_BYTES, "identity metadata limit")
+    identities, reported = [], None
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        match = re.fullmatch(r'\s*(\d+)\)\s+([0-9A-Fa-f]{40})\s+"([^"\r\n]+)"\s*', line)
+        if match:
+            require(reported is None and int(match[1]) == len(identities) + 1,
+                    "identity listing order is inconsistent")
+            require(all(c.isprintable() for c in match[3]), "identity name contains control characters")
+            identities.append({"sha1": match[2].upper(), "name": match[3]})
+            require(len(identities) <= MAX_IDENTITIES, "too many identities")
+            continue
+        count = re.fullmatch(r'\s*(\d+) valid identit(?:y|ies) found\s*', line)
+        require(count is not None and reported is None, "unrecognized identity listing")
+        reported = int(count[1])
+    require(reported is not None and reported == len(identities), "identity count mismatch")
+    require(len({entry["sha1"] for entry in identities}) == len(identities), "duplicate identity fingerprint")
+    return identities
+
+
+def code_requirement(team):
+    require(re.fullmatch(r'[A-Z0-9]{10}', team) is not None, "invalid expected team")
+    return ('anchor apple generic and certificate leaf[field.' + DEVELOPER_ID_APPLICATION_OID
+            + '] exists and certificate leaf[subject.OU] = "' + team + '"')
+
+
+def select_identity(identities, team):
+    code_requirement(team)
+    require(len(identities) == 1, "expected exactly one valid codesigning identity in the isolated keychain")
+    selected = identities[0]
+    match = re.fullmatch(r'Developer ID Application: (.+) \(([A-Z0-9]{10})\)', selected["name"])
+    require(match is not None and match[1].strip(), "identity is not Developer ID Application")
+    require(match[2] == team, "Developer ID Application identity has the wrong team")
+    return selected
+
+
+def record_identity(path, team, output, github_env):
+    state = snapshot(path)
+    receipt = {"schema": 1, "expected_team": team, "status": "rejected", "valid_identities": []}
+    try:
+        current = search_list(security("list-keychains", "-d", "user"))
+        require(current == [state["temporary_keychain"], *state["original_search_list"]],
+                "isolated keychain search list was not activated")
+        text = security("find-identity", "-v", "-p", "codesigning", state["temporary_keychain"])
+        receipt["valid_identities"] = parse_valid_identities(text)
+        selected = select_identity(receipt["valid_identities"], team)
+        requirement = code_requirement(team)
+        receipt.update(status="selected", selected=selected, signed_code_requirement=requirement,
+                       private_key_check="security find-identity -v -p codesigning",
+                       identity_scope="isolated imported keychain only")
+        # Only public, validated ASCII fingerprint and fixed-policy requirement
+        # enter the environment; no subject, password or key data is exported.
+        with github_env.open("a") as stream:
+            stream.write("SIGNING_IDENTITY_SHA1=" + selected["sha1"] + "\n")
+            stream.write("SIGNING_REQUIREMENT=" + requirement + "\n")
+    except Exception as error:
+        receipt["status"] = "rejected"
+        receipt["error"] = str(error)
+        raise
+    finally:
+        write_json(output, receipt)
+
+
+def cleanup_keychain(path, output):
+    receipt = {"schema": 1, "status": "not_created", "search_list_restored": False,
+               "temporary_keychain_deleted": False}
+    if not path.exists():
+        write_json(output, receipt)
+        return
+    errors = []
+    temporary = path.parent / KEYCHAIN_NAME
+    try:
+        state = snapshot(path)
+        security("list-keychains", "-d", "user", "-s", *state["original_search_list"])
+        require(search_list(security("list-keychains", "-d", "user")) == state["original_search_list"],
+                "original keychain search list was not restored")
+        receipt["search_list_restored"] = True
+    except Exception as error:
+        errors.append("search-list restore: " + str(error))
+    try:
+        # This is the fixed temporary name in the captured workflow directory,
+        # never a deletion target accepted from malformed snapshot data.
+        if temporary.exists():
+            security("delete-keychain", str(temporary))
+        require(not temporary.exists(), "temporary keychain still exists")
+        receipt["temporary_keychain_deleted"] = True
+    except Exception as error:
+        errors.append("temporary-keychain deletion: " + str(error))
+    finally:
+        for name in ("signing-certificate.p12", "profile.plist"):
+            try:
+                (path.parent / name).unlink(missing_ok=True)
+            except Exception as error:
+                errors.append("temporary-file removal: " + str(error))
+        receipt.update(status="cleaned" if not errors else "failed", errors=errors)
+        write_json(output, receipt)
+    require(not errors, "signing keychain cleanup failed; see the non-secret cleanup receipt")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    capture = commands.add_parser("capture")
+    capture.add_argument("--snapshot", type=Path, required=True)
+    capture.add_argument("--keychain", type=Path, required=True)
+    activate = commands.add_parser("activate")
+    activate.add_argument("--snapshot", type=Path, required=True)
+    select = commands.add_parser("select")
+    for name in ("snapshot", "output", "github-env"):
+        select.add_argument("--" + name, type=Path, required=True)
+    select.add_argument("--team", required=True)
+    cleanup = commands.add_parser("cleanup")
+    cleanup.add_argument("--snapshot", type=Path, required=True)
+    cleanup.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.command == "capture": capture_search_list(args.snapshot, args.keychain)
+    elif args.command == "activate": activate_search_list(args.snapshot)
+    elif args.command == "select": record_identity(args.snapshot, args.team, args.output, args.github_env)
+    else: cleanup_keychain(args.snapshot, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/provider_signing_workflow_graph.py
+++ b/scripts/provider_signing_workflow_graph.py
@@ -142,7 +142,8 @@ def snapshot(root=ROOT):
             "status": "validated", "event_job_graphs": graphs,
             "workflow_call_path": CALL_PATH, "secret_names": list(SIGNING_SECRETS),
             "secret_values_read": False, "normal_job_definitions_preserved": True,
-            "signing_job_definitions_preserved": True}
+            "signing_build_job_preserved": True,
+            "signing_identity_revision": baseline["signing"].get("identity_revision")}
 
 
 if __name__ == "__main__":

--- a/scripts/provider_signing_workflow_graph.py
+++ b/scripts/provider_signing_workflow_graph.py
@@ -1,0 +1,149 @@
+"""Parsed, fail-closed contract for CI's manual signing-validation route.
+
+Ruby's standard-library YAML parser avoids reimplementing YAML or installing a
+parser during this CPU-only source check. No workflow command is executed.
+"""
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+
+ROOT = Path(__file__).resolve().parent.parent
+CALL_JOB = "provider-signing-validation"
+CALL_PATH = "./.github/workflows/provider-signing-validation.yml"
+SIGNING_SECRETS = (
+    "APPLE_CERTIFICATE_P12", "APPLE_CERTIFICATE_PASSWORD", "PROVISIONING_PROFILE_BASE64",
+    "APPLE_ID", "APPLE_APP_PASSWORD",
+)
+MANUAL = "${{ github.event_name == 'workflow_dispatch' }}"
+ORDINARY = "${{ github.event_name != 'workflow_dispatch' }}"
+CACHE = "${{ github.event_name != 'workflow_dispatch' && (github.event_name == 'push') }}"
+READ_ONLY = {"contents": "read", "actions": "read"}
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def parsed_yaml(path):
+    program = "v = YAML.safe_load(File.read(ARGV[0])); v['on'] = v.delete(true) if v.key?(true); puts JSON.generate(v)"
+    result = subprocess.run(["ruby", "-ryaml", "-rjson", "-e", program, str(path)],
+                            check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def canonical_sha256(value):
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def load_contract(root=ROOT):
+    baseline = json.loads((root / "scripts/fixtures/provider-signing-routing-baseline.json").read_text())
+    return (parsed_yaml(root / ".github/workflows/ci.yml"),
+            parsed_yaml(root / ".github/workflows/provider-signing-validation.yml"), baseline)
+
+
+def secret_references(value):
+    return set(re.findall(r"secrets\.([A-Z][A-Z0-9_]*)", json.dumps(value)))
+
+
+def validate(ci, signing, baseline):
+    require({k: v for k, v in ci.items() if k not in ("on", "jobs")} == baseline["ci"]["top"],
+            "CI top-level behavior changed")
+    events = dict(ci["on"])
+    manual = events.pop("workflow_dispatch", None)
+    require(events == baseline["ci"]["events"], "normal CI triggers changed")
+    require(manual == baseline["signing"]["manual_event"], "manual inputs changed or gained defaults")
+    require(set(ci["jobs"]) == set(baseline["ci"]["jobs"]) | {CALL_JOB}, "CI job graph changed")
+    for name, expected in baseline["ci"]["jobs"].items():
+        job = copy.deepcopy(ci["jobs"][name])
+        old_if = expected["if"]
+        require(old_if in (None, "github.event_name == 'push'"), "unsupported baseline condition")
+        guard = ORDINARY if old_if is None else CACHE
+        require(job.get("if") == guard, "manual isolation guard changed: " + name)
+        if old_if is None:
+            del job["if"]
+        else:
+            job["if"] = old_if
+        require(canonical_sha256(job) == expected["sha256"], "normal job definition changed: " + name)
+
+    expected_call = {
+        "name": "Provider signing validation (manual only)", "if": MANUAL, "uses": CALL_PATH,
+        "permissions": READ_ONLY,
+        "with": {key: "${{ inputs." + key + " }}" for key in ("source_sha", "version")},
+        "secrets": {name: "${{ secrets." + name + " }}" for name in SIGNING_SECRETS},
+    }
+    require(ci["jobs"][CALL_JOB] == expected_call, "reusable caller route, inputs, permissions or secrets changed")
+    require({k: v for k, v in signing.items() if k not in ("on", "jobs")} == baseline["signing"]["top"],
+            "signing workflow top-level behavior changed")
+    require(signing.get("permissions") == READ_ONLY, "signing permission escalation")
+    require(set(signing["on"]) == {"workflow_dispatch", "workflow_call"}, "unexpected signing trigger")
+    require(signing["on"]["workflow_dispatch"] == baseline["signing"]["manual_event"],
+            "standalone manual entrypoint changed")
+    require(signing["on"]["workflow_call"] == {
+        "inputs": manual["inputs"], "secrets": {name: {"required": True} for name in SIGNING_SECRETS}},
+        "reusable workflow inputs or five-secret contract changed")
+    require(set(signing["jobs"]) == {"build", "signing"}, "unexpected signing job graph")
+    for name, expected in baseline["signing"]["jobs"].items():
+        require(canonical_sha256(signing["jobs"][name]) == expected, "signing job definition changed: " + name)
+    require(not secret_references(signing["jobs"]["build"]), "signing secret reached build job")
+    require(secret_references(signing["jobs"]["signing"]) == set(SIGNING_SECRETS),
+            "signer secret allowlist changed")
+    require(signing["jobs"]["signing"]["needs"] == "build", "signer no longer depends on unsigned build")
+
+
+def condition_active(condition, event):
+    """Only the three exact conditions accepted by validate are supported."""
+    if condition == MANUAL:
+        return event == "workflow_dispatch"
+    if condition == ORDINARY:
+        return event != "workflow_dispatch"
+    if condition == CACHE:
+        return event != "workflow_dispatch" and event == "push"
+    raise ValueError("unsupported routing condition")
+
+
+def expanded_ci_graph(ci, signing, baseline, event):
+    validate(ci, signing, baseline)
+    if event not in ci["on"]:
+        return {}
+    graph = {}
+    for name, job in ci["jobs"].items():
+        if not condition_active(job["if"], event):
+            continue
+        if name != CALL_JOB:
+            graph[name] = copy.deepcopy(job)
+        else:
+            for child_name, child in signing["jobs"].items():
+                node = copy.deepcopy(child)
+                needs = node.get("needs")
+                if needs is not None:
+                    needs = [needs] if isinstance(needs, str) else needs
+                    node["needs"] = [CALL_JOB + "/" + value for value in needs]
+                graph[CALL_JOB + "/" + child_name] = node
+    return graph
+
+
+def preserved_files(root, baseline):
+    for relative, expected in baseline["preserved_files"].items():
+        require(hashlib.sha256((root / relative).read_bytes()).hexdigest() == expected,
+                "preserved source changed: " + relative)
+
+
+def snapshot(root=ROOT):
+    ci, signing, baseline = load_contract(root)
+    validate(ci, signing, baseline)
+    preserved_files(root, baseline)
+    graphs = {event: expanded_ci_graph(ci, signing, baseline, event)
+              for event in ("push", "pull_request", "workflow_dispatch")}
+    return {"schema": 1, "baseline_commit": baseline["source_commit"],
+            "status": "validated", "event_job_graphs": graphs,
+            "workflow_call_path": CALL_PATH, "secret_names": list(SIGNING_SECRETS),
+            "secret_values_read": False, "normal_job_definitions_preserved": True,
+            "signing_job_definitions_preserved": True}
+
+
+if __name__ == "__main__":
+    print(json.dumps(snapshot(), indent=2))

--- a/scripts/run-provider-tests.sh
+++ b/scripts/run-provider-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run from provider-swift after building tests and staging the matched metallib.
+# Keep failures visible while every process-sensitive case still gets its run.
+set -uo pipefail
+provider_test_status=0
+isolated_filters=(
+  defaultApplyProjectsSettings
+  stageDelta
+)
+isolated_pattern=$(IFS='|'; printf '%s' "${isolated_filters[*]}")
+# Unrelated Swift Testing cases otherwise share process-wide MLX state and
+# executor capacity. Tests retain their own tasks and controlled interleavings.
+swift test --skip-build --no-parallel --skip "$isolated_pattern" || provider_test_status=$?
+for test_filter in "${isolated_filters[@]}"; do
+  ../scripts/run-nested-suite.sh "$test_filter" || provider_test_status=$?
+done
+exit "$provider_test_status"

--- a/scripts/test-provider-signing-identity.py
+++ b/scripts/test-provider-signing-identity.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Synthetic metadata/lifecycle tests: no secrets, real keychains or app execution."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import provider_signing_identity as identity
+
+TEAM = "SLDQ2GJ6TL"
+HASH = "A" * 40
+NAME = "Developer ID Application: A Different Legal Display Name, Inc. (" + TEAM + ")"
+
+
+def listing(name=NAME, fingerprint=HASH):
+    return '  1) ' + fingerprint + ' "' + name + '"\n     1 valid identities found\n'
+
+
+class FakeSecurity:
+    def __init__(self, keychains, text=None):
+        self.current = list(keychains)
+        self.text = listing() if text is None else text
+        self.calls = []
+        self.fail_restore = False
+        self.original = list(keychains)
+
+    def __call__(self, *args):
+        self.calls.append(args)
+        if args == ("list-keychains", "-d", "user"):
+            return "\n".join(json.dumps(path) for path in self.current)
+        if args[:4] == ("list-keychains", "-d", "user", "-s"):
+            if self.fail_restore and list(args[4:]) == self.original:
+                raise subprocess.CalledProcessError(1, ["security", *args])
+            self.current = list(args[4:])
+            return ""
+        if args[:4] == ("find-identity", "-v", "-p", "codesigning"):
+            if len(args) != 5: raise AssertionError("identity lookup was not keychain-scoped")
+            return self.text
+        if args[0] == "delete-keychain":
+            Path(args[1]).unlink()
+            self.current = [value for value in self.current if value != args[1]]
+            return ""
+        raise AssertionError("unexpected security command: " + repr(args))
+
+
+class SigningIdentityTests(unittest.TestCase):
+    def test_unique_valid_developer_id_uses_fingerprint_without_company_name_pin(self):
+        rows = identity.parse_valid_identities(listing(fingerprint=HASH.lower()))
+        self.assertEqual(identity.select_identity(rows, TEAM), {"sha1": HASH, "name": NAME})
+        requirement = identity.code_requirement(TEAM)
+        self.assertIn("anchor apple generic", requirement)
+        self.assertIn("certificate leaf[field.1.2.840.113635.100.6.1.13] exists", requirement)
+        self.assertIn('certificate leaf[subject.OU] = "' + TEAM + '"', requirement)
+
+    def test_zero_ambiguous_wrong_team_and_wrong_kind_fail_closed(self):
+        cases = [[], [{"sha1": HASH, "name": NAME}, {"sha1": "B" * 40, "name": NAME}],
+                 [{"sha1": HASH, "name": NAME.replace(TEAM, "OTHERTEAM1")}],
+                 [{"sha1": HASH, "name": "Apple Development: Person (" + TEAM + ")"}],
+                 [{"sha1": HASH, "name": "Developer ID Installer: Org (" + TEAM + ")"}]]
+        for rows in cases:
+            with self.subTest(rows=rows), self.assertRaises(ValueError): identity.select_identity(rows, TEAM)
+
+    def test_malformed_invalid_or_inconsistent_listings_are_not_ignored(self):
+        invalid = [listing().replace(HASH, "not-a-fingerprint"), listing().replace("1 valid", "2 valid"),
+                   listing().replace('"\n', '" (CSSMERR_TP_CERT_EXPIRED)\n'),
+                   listing() + "unexpected trailing line\n", listing().replace("1)", "2)"),
+                   listing().replace("Different", "Different\x1b[31m"),
+                   '1) ' + HASH + ' "' + NAME + '"\n2) ' + HASH + ' "' + NAME + '"\n2 valid identities found\n']
+        for text in invalid:
+            with self.subTest(text=text), self.assertRaises(ValueError): identity.parse_valid_identities(text)
+        self.assertEqual(identity.parse_valid_identities("0 valid identities found\n"), [])
+
+    def test_quoted_search_paths_are_preserved_without_shell_splitting(self):
+        value = '    "/Users/runner/Library/Keychains/login.keychain-db"\n    "/tmp/Path With Spaces/other.keychain-db"\n'
+        self.assertEqual(identity.search_list(value), ["/Users/runner/Library/Keychains/login.keychain-db",
+                                                     "/tmp/Path With Spaces/other.keychain-db"])
+        for text in ['"relative.keychain-db"', '"/tmp/a"\n"/tmp/a"']:
+            with self.assertRaises(ValueError): identity.search_list(text)
+
+    def test_capture_activate_select_and_cleanup_restore_exact_original_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); keychain = root / identity.KEYCHAIN_NAME
+            snap, out, env = root / "snapshot.json", root / "identity.json", root / "env"
+            original = ["/Users/runner/Library/Keychains/login.keychain-db", "/tmp/Other Keys/custom.keychain-db"]
+            fake = FakeSecurity(original)
+            with mock.patch.object(identity, "security", side_effect=fake):
+                identity.capture_search_list(snap, keychain)
+                keychain.write_text("synthetic placeholder, not a keychain")
+                identity.activate_search_list(snap)
+                self.assertEqual(fake.current, [str(keychain), *original])
+                identity.record_identity(snap, TEAM, out, env)
+                self.assertEqual(json.loads(out.read_text())["selected"]["sha1"], HASH)
+                self.assertEqual(env.read_text(), "SIGNING_IDENTITY_SHA1=" + HASH + "\nSIGNING_REQUIREMENT="
+                                 + identity.code_requirement(TEAM) + "\n")
+                for name in ["signing-certificate.p12", "profile.plist"]: (root / name).write_text("synthetic")
+                identity.cleanup_keychain(snap, root / "cleanup.json")
+                identity.cleanup_keychain(snap, root / "cleanup.json")
+                self.assertEqual(fake.current, original)
+                self.assertFalse(keychain.exists())
+                self.assertFalse((root / "signing-certificate.p12").exists())
+                self.assertFalse((root / "profile.plist").exists())
+                receipt = json.loads((root / "cleanup.json").read_text())
+                self.assertEqual(receipt["status"], "cleaned")
+                self.assertTrue(receipt["search_list_restored"])
+                self.assertIn(("find-identity", "-v", "-p", "codesigning", str(keychain)), fake.calls)
+
+    def test_rejected_identity_writes_diagnostics_without_exporting_a_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); keychain = root / identity.KEYCHAIN_NAME; snap = root / "snapshot.json"
+            fake = FakeSecurity([], "0 valid identities found\n")
+            with mock.patch.object(identity, "security", side_effect=fake):
+                identity.capture_search_list(snap, keychain); keychain.write_text("synthetic")
+                identity.activate_search_list(snap)
+                with self.assertRaises(ValueError):
+                    identity.record_identity(snap, TEAM, root / "identity.json", root / "env")
+                self.assertFalse((root / "env").exists())
+                self.assertEqual(json.loads((root / "identity.json").read_text())["status"], "rejected")
+                identity.cleanup_keychain(snap, root / "cleanup.json")
+                self.assertEqual(fake.current, [])
+
+    def test_restore_failure_still_deletes_owned_material_and_fails_cleanup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); keychain = root / identity.KEYCHAIN_NAME; snap = root / "snapshot.json"
+            fake = FakeSecurity(["/tmp/original.keychain-db"])
+            with mock.patch.object(identity, "security", side_effect=fake):
+                identity.capture_search_list(snap, keychain); keychain.write_text("synthetic")
+                identity.activate_search_list(snap)
+                (root / "signing-certificate.p12").write_text("synthetic")
+                fake.fail_restore = True
+                with self.assertRaises(ValueError): identity.cleanup_keychain(snap, root / "cleanup.json")
+                self.assertFalse(keychain.exists())
+                self.assertFalse((root / "signing-certificate.p12").exists())
+                receipt = json.loads((root / "cleanup.json").read_text())
+                self.assertEqual(receipt["status"], "failed")
+                self.assertFalse(receipt["search_list_restored"])
+                self.assertTrue(receipt["temporary_keychain_deleted"])
+
+    def test_absent_snapshot_does_not_touch_keychains_and_capture_refuses_reuse(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); keychain = root / identity.KEYCHAIN_NAME; snap = root / "snapshot.json"
+            fake = FakeSecurity([])
+            with mock.patch.object(identity, "security", side_effect=fake):
+                identity.cleanup_keychain(snap, root / "cleanup.json")
+                self.assertEqual(fake.calls, [])
+                keychain.write_text("preexisting synthetic fixture")
+                with self.assertRaises(ValueError): identity.capture_search_list(snap, keychain)
+                self.assertFalse(snap.exists())
+                self.assertTrue(keychain.exists())
+
+    @unittest.skipUnless(shutil.which("csreq"), "Apple csreq is unavailable")
+    def test_apple_requirement_parser_accepts_team_kind_and_identifier_bindings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for index, suffix in enumerate(["", ' and identifier "io.darkbloom.provider"',
+                                            ' and identifier "io.darkbloom.fan-helper"']):
+                output = Path(tmp) / str(index)
+                result = subprocess.run(["csreq", "-r-", "-b", str(output)],
+                                        input=identity.code_requirement(TEAM) + suffix,
+                                        text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertGreater(output.stat().st_size, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-provider-signing-routing.py
+++ b/scripts/test-provider-signing-routing.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""CPU-only parsed workflow preservation, routing and mutation tests."""
+import copy
+import unittest
+
+from provider_signing_workflow_graph import (
+    ROOT, CALL_JOB, CALL_PATH, SIGNING_SECRETS, load_contract, validate,
+    expanded_ci_graph, preserved_files,
+)
+
+
+class SigningWorkflowRoutingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ci, cls.signing, cls.baseline = load_contract()
+
+    def test_all_eight_normal_jobs_keep_every_definition_and_existing_condition(self):
+        validate(self.ci, self.signing, self.baseline)
+        self.assertEqual(len(self.baseline["ci"]["jobs"]), 8)
+        preserved_files(ROOT, self.baseline)
+
+    def test_push_and_pr_keep_their_original_job_sets(self):
+        original = set(self.baseline["ci"]["jobs"])
+        self.assertEqual(set(expanded_ci_graph(self.ci, self.signing, self.baseline, "push")), original)
+        self.assertEqual(set(expanded_ci_graph(self.ci, self.signing, self.baseline, "pull_request")),
+                         original - {"cache-swift"})
+        self.assertEqual(expanded_ci_graph(self.ci, self.signing, self.baseline, "workflow_run"), {})
+
+    def test_manual_graph_is_only_unsigned_build_then_signer(self):
+        graph = expanded_ci_graph(self.ci, self.signing, self.baseline, "workflow_dispatch")
+        self.assertEqual(set(graph), {CALL_JOB + "/build", CALL_JOB + "/signing"})
+        self.assertNotIn("needs", graph[CALL_JOB + "/build"])
+        self.assertEqual(graph[CALL_JOB + "/signing"]["needs"], [CALL_JOB + "/build"])
+        self.assertEqual(self.ci["jobs"][CALL_JOB]["uses"], CALL_PATH)
+        self.assertNotIn("@", CALL_PATH)
+        self.assertTrue(all("environment" not in node for node in graph.values()))
+
+    def test_reusable_contract_and_standalone_manual_inputs_match_exactly(self):
+        call = self.signing["on"]["workflow_call"]
+        self.assertEqual(call["inputs"], self.signing["on"]["workflow_dispatch"]["inputs"])
+        self.assertEqual(set(call["inputs"]), {"source_sha", "version"})
+        self.assertTrue(all(v == {"required": True} for v in call["secrets"].values()))
+        self.assertEqual(set(call["secrets"]), set(SIGNING_SECRETS))
+        self.assertEqual(self.ci["jobs"][CALL_JOB]["permissions"], {"contents": "read", "actions": "read"})
+
+    def test_guard_removal_or_runner_command_drift_is_rejected(self):
+        for change in ("guard", "runner", "provider-isolation", "cache-condition", "extra-job"):
+            ci = copy.deepcopy(self.ci)
+            if change == "guard": del ci["jobs"]["test-provider"]["if"]
+            elif change == "runner": ci["jobs"]["test-provider"]["runs-on"] = "self-hosted"
+            elif change == "provider-isolation":
+                step = next(s for s in ci["jobs"]["test-provider"]["steps"] if "run-provider-tests.sh" in s.get("run", ""))
+                step["run"] = "swift test"
+            elif change == "cache-condition": ci["jobs"]["cache-swift"]["if"] = ci["jobs"]["docs"]["if"]
+            else: ci["jobs"]["extra-model"] = {"runs-on": "self-hosted", "steps": []}
+            with self.subTest(change=change), self.assertRaises(ValueError): validate(ci, self.signing, self.baseline)
+
+    def test_inherit_all_extra_missing_or_wrong_secret_mapping_is_rejected(self):
+        for change in ("inherit", "extra", "missing", "wrong"):
+            ci = copy.deepcopy(self.ci)
+            if change == "inherit": ci["jobs"][CALL_JOB]["secrets"] = "inherit"
+            elif change == "extra": ci["jobs"][CALL_JOB]["secrets"]["DEV_RELEASE_KEY"] = "${{ secrets.DEV_RELEASE_KEY }}"
+            elif change == "missing": del ci["jobs"][CALL_JOB]["secrets"][SIGNING_SECRETS[0]]
+            else: ci["jobs"][CALL_JOB]["secrets"][SIGNING_SECRETS[0]] = "${{ secrets.DEV_RELEASE_KEY }}"
+            with self.subTest(change=change), self.assertRaises(ValueError): validate(ci, self.signing, self.baseline)
+
+    def test_wrong_ref_write_permission_or_environment_caller_is_rejected(self):
+        for key, value in (("uses", CALL_PATH + "@master"), ("permissions", {"contents": "write"}),
+                           ("environment", "dev"), ("if", "${{ always() }}")):
+            ci = copy.deepcopy(self.ci); ci["jobs"][CALL_JOB][key] = value
+            with self.subTest(key=key), self.assertRaises(ValueError): validate(ci, self.signing, self.baseline)
+
+    def test_inputs_cannot_be_optional_defaulted_or_redirected(self):
+        for change in ("optional", "default", "redirect", "selector"):
+            ci = copy.deepcopy(self.ci)
+            if change == "optional": ci["on"]["workflow_dispatch"]["inputs"]["source_sha"]["required"] = False
+            elif change == "default": ci["on"]["workflow_dispatch"]["inputs"]["version"]["default"] = "0.9.0"
+            elif change == "redirect": ci["jobs"][CALL_JOB]["with"]["source_sha"] = "${{ github.sha }}"
+            else: ci["on"]["workflow_dispatch"]["inputs"]["environment"] = {"type": "string"}
+            with self.subTest(change=change), self.assertRaises(ValueError): validate(ci, self.signing, self.baseline)
+
+    def test_signing_jobs_cannot_gain_candidate_execution_or_lose_cleanup(self):
+        for change in ("execute", "cleanup", "secret-in-build", "new-trigger", "extra-secret"):
+            signing = copy.deepcopy(self.signing)
+            if change == "execute": signing["jobs"]["signing"]["steps"].append({"run": "candidate/darkbloom --version"})
+            elif change == "cleanup":
+                step = next(s for s in signing["jobs"]["signing"]["steps"] if s.get("name") == "Remove temporary signing material")
+                step["if"] = "success()"
+            elif change == "secret-in-build": signing["jobs"]["build"]["env"] = {"KEY": "${{ secrets.APPLE_CERTIFICATE_P12 }}"}
+            elif change == "new-trigger": signing["on"]["push"] = None
+            else: signing["on"]["workflow_call"]["secrets"]["DEV_RELEASE_KEY"] = {"required": True}
+            with self.subTest(change=change), self.assertRaises(ValueError): validate(self.ci, signing, self.baseline)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test-provider-signing-routing.py
+++ b/scripts/test-provider-signing-routing.py
@@ -43,6 +43,30 @@ class SigningWorkflowRoutingTests(unittest.TestCase):
         self.assertEqual(set(call["secrets"]), set(SIGNING_SECRETS))
         self.assertEqual(self.ci["jobs"][CALL_JOB]["permissions"], {"contents": "read", "actions": "read"})
 
+    def test_signer_requires_scoped_identity_search_restore_and_code_requirements(self):
+        job = self.signing["jobs"]["signing"]
+        self.assertEqual(job["env"], {"APPLE_TEAM_ID": "SLDQ2GJ6TL"})
+        steps = {step.get("name"): step for step in job["steps"]}
+        imported = steps["Import repository-scoped signing material"]["run"]
+        self.assertLess(imported.index("provider_signing_identity.py capture"), imported.index("security create-keychain"))
+        self.assertLess(imported.index("provider_signing_identity.py activate"), imported.index("security import"))
+        selection = steps["Select unique valid Developer ID Application identity"]["run"]
+        self.assertIn('provider_signing_identity.py select', selection)
+        self.assertIn('--team "$APPLE_TEAM_ID"', selection)
+        sign = steps["Sign and statically verify the app"]["run"]
+        self.assertNotIn("$DEVELOPER_ID", sign)
+        self.assertEqual(sign.count('--sign "$SIGNING_IDENTITY_SHA1"'), 5)
+        self.assertIn('$SIGNING_REQUIREMENT and identifier', sign)
+        self.assertIn('-R="$SIGNING_REQUIREMENT"', sign)
+        cleanup = steps["Remove temporary signing material"]
+        self.assertEqual(cleanup["if"], "always()")
+        self.assertIn("provider_signing_identity.py cleanup", cleanup["run"])
+        self.assertIn("signing-keychain-cleanup.json", cleanup["run"])
+        diagnostic = steps["Retain non-secret notarization diagnostics"]
+        self.assertEqual(diagnostic["if"], "always()")
+        self.assertIn("signing-identity.json", diagnostic["with"]["path"])
+        self.assertIn("signing-keychain-cleanup.json", diagnostic["with"]["path"])
+
     def test_guard_removal_or_runner_command_drift_is_rejected(self):
         for change in ("guard", "runner", "provider-isolation", "cache-condition", "extra-job"):
             ci = copy.deepcopy(self.ci)

--- a/scripts/test-provider-signing-validation.py
+++ b/scripts/test-provider-signing-validation.py
@@ -159,6 +159,37 @@ class SigningValidationTests(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         VALIDATION.profile(argparse.Namespace(profile=path))
 
+    def test_profile_app_identifier_must_authorize_the_exact_team_and_app(self):
+        expected = VALIDATION.TEAM + "." + VALIDATION.APP_ID
+        cases = [
+            ({}, True),  # Developer ID may omit this entitlement.
+            ({"com.apple.application-identifier": expected}, True),
+            ({"application-identifier": expected}, True),
+            ({"com.apple.application-identifier": VALIDATION.TEAM + ".*"}, True),
+            ({"com.apple.application-identifier": VALIDATION.TEAM + ".io.darkbloom.*"}, True),
+            ({"com.apple.application-identifier": VALIDATION.TEAM + ".io.darkbloom.other"}, False),
+            ({"application-identifier": "OTHERTEAM." + VALIDATION.APP_ID}, False),
+            ({"application-identifier": VALIDATION.TEAM + ".unrelated.*"}, False),
+            ({"application-identifier": "*"}, False),
+            ({"application-identifier": ""}, False),
+            ({"application-identifier": [expected]}, False),
+            ({"com.apple.application-identifier": expected,
+              "application-identifier": VALIDATION.TEAM + ".other"}, False),
+        ]
+        for app_ids, valid in cases:
+            with self.subTest(app_ids=app_ids), tempfile.TemporaryDirectory() as temporary:
+                value = {"TeamIdentifier": [VALIDATION.TEAM],
+                    "ExpirationDate": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=60),
+                    "Entitlements": {"keychain-access-groups": [expected],
+                        "com.apple.developer.aps-environment": "production", **app_ids}}
+                path = Path(temporary) / "profile.plist"
+                path.write_bytes(plistlib.dumps(value))
+                if valid:
+                    VALIDATION.profile(argparse.Namespace(profile=path))
+                else:
+                    with self.assertRaisesRegex(ValueError, "application identifier mismatch"):
+                        VALIDATION.profile(argparse.Namespace(profile=path))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test-provider-signing-validation.py
+++ b/scripts/test-provider-signing-validation.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import argparse
+from datetime import datetime, timedelta, timezone
+import importlib.util
+import io
+import json
+from pathlib import Path
+import plistlib
+import shutil
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location("signing_validation", ROOT / "scripts/provider-signing-validation.py")
+VALIDATION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATION)
+
+
+class SigningValidationTests(unittest.TestCase):
+    def test_workflow_has_no_environment_or_publication_route(self):
+        workflow = (ROOT / ".github/workflows/provider-signing-validation.yml").read_text()
+        self.assertNotRegex(workflow, r"(?m)^\s+environment:")
+        self.assertIn("  workflow_dispatch:", workflow)
+        self.assertNotRegex(workflow, r"(?m)^  (push|pull_request|workflow_run):")
+        self.assertIn("  contents: read", workflow)
+        for forbidden in ["contents: write", "secrets.DEV_", "secrets.PROD_", "R2_", "gh release", "aws ", "resolve-provider-release.sh"]:
+            self.assertNotIn(forbidden, workflow)
+        build_job = workflow.split("  signing:", 1)[0]
+        self.assertNotIn("secrets.", build_job)
+        self.assertIn("provider-signing-validation.py cli-entitlements", workflow)
+
+    def make_archive(self, directory, mutate=False, info_updates=None):
+        source = directory / "source"
+        (source / "validation-inputs").mkdir(parents=True)
+        app_contents = source / "Darkbloom.app/Contents"
+        app_contents.mkdir(parents=True)
+        info = {"CFBundleIdentifier": VALIDATION.APP_ID, "CFBundleVersion": "test-version",
+                "CFBundleShortVersionString": "test-version", "CFBundleExecutable": "darkbloom"}
+        info.update(info_updates or {})
+        with (app_contents / "Info.plist").open("wb") as output:
+            plistlib.dump(info, output)
+        for name in ["entitlements.plist", "entitlements-enclave.plist"]:
+            shutil.copy2(ROOT / "provider-swift" / name, source / "validation-inputs" / name)
+        (source / "fixture.txt").write_text("synthetic unsigned archive fixture")
+        manifest = {"source_sha": "test-source", "version": "test-version", "files": VALIDATION.inventory(source)}
+        (source / "unsigned-files.json").write_text(json.dumps(manifest))
+        if mutate:
+            (source / "fixture.txt").write_text("changed after manifest")
+        archive = directory / "unsigned.tar.gz"
+        with tarfile.open(archive, "w:gz") as output:
+            output.add(source, arcname=".")
+        return archive
+
+    def test_unpack_requires_exact_inventory_and_source(self):
+        for scenario in ["valid", "mutated", "wrong-source"]:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                archive = self.make_archive(root, mutate=scenario == "mutated")
+                arguments = argparse.Namespace(archive=archive, output=root / "output",
+                    source_sha="other-source" if scenario == "wrong-source" else "test-source", version="test-version")
+                if scenario == "valid":
+                    VALIDATION.unpack(arguments)
+                else:
+                    with self.assertRaises(ValueError):
+                        VALIDATION.unpack(arguments)
+
+    def test_unpack_refuses_path_escape_and_links(self):
+        for name, member_type in [("../escape", tarfile.REGTYPE), ("link", tarfile.SYMTYPE), ("hardlink", tarfile.LNKTYPE)]:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                archive = root / "invalid.tar.gz"
+                with tarfile.open(archive, "w:gz") as output:
+                    member = tarfile.TarInfo(name)
+                    member.type = member_type
+                    member.linkname = "../escape"
+                    output.addfile(member, io.BytesIO())
+                with self.assertRaises(ValueError):
+                    VALIDATION.unpack(argparse.Namespace(archive=archive, output=root / "output", source_sha="unused", version="unused"))
+                self.assertFalse((root / "escape").exists())
+
+    def test_unpack_refuses_mismatched_bundle_identity_and_versions(self):
+        for key in ["CFBundleIdentifier", "CFBundleVersion", "CFBundleShortVersionString", "CFBundleExecutable"]:
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                archive = self.make_archive(root, info_updates={key: "wrong-value"})
+                with self.assertRaisesRegex(ValueError, "Info.plist"):
+                    VALIDATION.unpack(argparse.Namespace(archive=archive, output=root / "output",
+                        source_sha="test-source", version="test-version"))
+
+    def test_unpack_bounds_members_total_size_and_count(self):
+        cases = [
+            ({"MAX_ARCHIVE_BYTES": 0}, [], "Archive size"),
+            ({"MAX_MEMBER_BYTES": 4}, [("large", 5)], "member size"),
+            ({"MAX_TOTAL_BYTES": 4}, [("first", 3), ("second", 3)], "total size"),
+            ({"MAX_ARCHIVE_MEMBERS": 1}, [("first", 0), ("second", 0)], "member count"),
+        ]
+        for limits, entries, message in cases:
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                archive = root / "bounded.tar.gz"
+                with tarfile.open(archive, "w:gz") as output:
+                    for name, size in entries:
+                        member = tarfile.TarInfo(name)
+                        member.size = size
+                        output.addfile(member, io.BytesIO(b"x" * size))
+                with mock.patch.multiple(VALIDATION, **limits), self.assertRaisesRegex(ValueError, message):
+                    VALIDATION.unpack(argparse.Namespace(archive=archive, output=root / "output",
+                        source_sha="unused", version="unused"))
+
+    def test_unpack_refuses_duplicate_and_case_aliased_members(self):
+        for names in [("member", "member"), ("member", "./member"), ("Member", "member")]:
+            with self.subTest(names=names), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                archive = root / "duplicate.tar.gz"
+                with tarfile.open(archive, "w:gz") as output:
+                    for name in names:
+                        output.addfile(tarfile.TarInfo(name), io.BytesIO())
+                with self.assertRaisesRegex(ValueError, "Duplicate"):
+                    VALIDATION.unpack(argparse.Namespace(archive=archive, output=root / "output",
+                        source_sha="unused", version="unused"))
+
+    def test_signed_cli_entitlements_require_group_push_and_no_debug_task(self):
+        for scenario in ["valid", "missing-group", "wrong-aps", "debug", "legacy-debug", "malformed-debug"]:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary:
+                value = {"keychain-access-groups": [VALIDATION.TEAM + "." + VALIDATION.APP_ID],
+                         "com.apple.developer.aps-environment": "production"}
+                if scenario == "missing-group": value.pop("keychain-access-groups")
+                if scenario == "wrong-aps": value["com.apple.developer.aps-environment"] = "development"
+                if scenario == "debug": value["com.apple.security.get-task-allow"] = True
+                if scenario == "legacy-debug": value["get-task-allow"] = True
+                if scenario == "malformed-debug": value["get-task-allow"] = "false"
+                path = Path(temporary) / "entitlements.plist"
+                with path.open("wb") as output:
+                    plistlib.dump(value, output)
+                if scenario == "valid":
+                    VALIDATION.cli_entitlements(argparse.Namespace(plist=path))
+                else:
+                    with self.assertRaises(ValueError):
+                        VALIDATION.cli_entitlements(argparse.Namespace(plist=path))
+
+    def test_profile_requires_team_access_group_push_and_expiry(self):
+        for scenario in ["valid", "team", "group", "push", "expiry"]:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary:
+                value = {"TeamIdentifier": [VALIDATION.TEAM],
+                    "ExpirationDate": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=60),
+                    "Entitlements": {"keychain-access-groups": [VALIDATION.TEAM + "." + VALIDATION.APP_ID], "aps-environment": "production"}}
+                if scenario == "team": value["TeamIdentifier"] = ["OTHER"]
+                if scenario == "group": value["Entitlements"]["keychain-access-groups"] = []
+                if scenario == "push": value["Entitlements"].pop("aps-environment")
+                if scenario == "expiry": value["ExpirationDate"] = datetime.now(timezone.utc).replace(tzinfo=None)
+                path = Path(temporary) / "profile.plist"
+                with path.open("wb") as output:
+                    plistlib.dump(value, output)
+                if scenario == "valid":
+                    VALIDATION.profile(argparse.Namespace(profile=path))
+                else:
+                    with self.assertRaises(ValueError):
+                        VALIDATION.profile(argparse.Namespace(profile=path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-run-provider-tests.py
+++ b/scripts/test-run-provider-tests.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Exercise the real provider/nested shell routing without invoking Swift or MLX."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parent.parent
+FILTERS = ["defaultApplyProjectsSettings", "stageDelta"]
+
+
+class ProviderTestRoutingTests(unittest.TestCase):
+    def invoke(self, mode="pass"):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            for name in ["scripts", "provider-swift", "bin"]:
+                (root / name).mkdir()
+            for name in ["run-provider-tests.sh", "run-nested-suite.sh"]:
+                shutil.copy2(ROOT / "scripts" / name, root / "scripts" / name)
+            swift = root / "bin/swift"
+            swift.write_text("#!" + sys.executable + "\n" + '''
+import json, os, sys
+arguments = sys.argv[1:]
+name = arguments[arguments.index("--filter") + 1] if "--filter" in arguments else "general"
+with open(os.environ["PROVIDER_ROUTE_LOG"], "a") as output:
+    output.write(json.dumps({"name": name, "arguments": arguments}) + "\\n")
+mode = os.environ["PROVIDER_ROUTE_MODE"]
+if mode == "fail:" + name:
+    print("Synthetic Swift command failure")
+    sys.exit(7 if name == "general" else 9)
+if mode == "zero:" + name:
+    print("Test run with 0 tests passed after 0.001 seconds.")
+elif mode == "skip:" + name:
+    print("Test syntheticCase() skipped: missing fixture")
+    print("Test run with 1 tests passed after 0.001 seconds.")
+else:
+    print("Test run with 1 tests passed after 0.001 seconds.")
+''')
+            swift.chmod(0o755)
+            log = root / "calls.jsonl"
+            environment = dict(os.environ, PATH=str(root / "bin") + os.pathsep + os.environ["PATH"],
+                               PROVIDER_ROUTE_LOG=str(log), PROVIDER_ROUTE_MODE=mode)
+            process = subprocess.run(["bash", str(root / "scripts/run-provider-tests.sh")],
+                                     cwd=root / "provider-swift", env=environment,
+                                     capture_output=True, text=True)
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            self.assertEqual([call["name"] for call in calls], ["general", *FILTERS])
+            return process, calls
+
+    def test_general_suite_is_serial_and_each_excluded_case_runs_separately(self):
+        process, calls = self.invoke()
+        self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+        self.assertEqual(calls[0]["arguments"],
+                         ["test", "--skip-build", "--no-parallel", "--skip", "|".join(FILTERS)])
+        for call, name in zip(calls[1:], FILTERS):
+            self.assertEqual(call["arguments"], ["test", "--skip-build", "--filter", name])
+
+    def test_general_failure_does_not_silence_isolated_gates_or_turn_green(self):
+        process, _ = self.invoke("fail:general")
+        self.assertEqual(process.returncode, 7)
+
+    def test_each_isolated_failure_survives_later_success(self):
+        for name in FILTERS:
+            with self.subTest(name=name):
+                process, _ = self.invoke("fail:" + name)
+                self.assertEqual(process.returncode, 9)
+
+    def test_zero_count_isolated_gate_cannot_pass(self):
+        for name in FILTERS:
+            with self.subTest(name=name):
+                process, _ = self.invoke("zero:" + name)
+                self.assertNotEqual(process.returncode, 0)
+                self.assertIn("executed ZERO tests", process.stdout)
+
+    def test_skipped_isolated_gate_cannot_pass(self):
+        for name in FILTERS:
+            with self.subTest(name=name):
+                process, _ = self.invoke("skip:" + name)
+                self.assertNotEqual(process.returncode, 0)
+                self.assertIn("skipped one or more tests", process.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "release/signing-validation-enable": false
+    }
+  }
+}


### PR DESCRIPTION
This draft enables provider signing validation through the registered CI workflow without a master merge, and now includes a bounded correction from the first authorized run. An explicit reviewed source SHA and existing version are built without signing credentials; a separate signer validates the artifact, selects a valid isolated Developer ID identity, signs and verifies the app, and checks notarization/stapling. Nothing is released or registered.

### Observed run and diagnosis

[Run 34030878981](https://github.com/Layr-Labs/d-inference/actions/runs/34030878981) used workflow `8cc56074ae7a6dd6553fe3cd3692af1ba58ed9a2` and candidate `f91fe843b0cb22e2d1b2a85c0652982f3a8ff146` / `0.8.16`. Its unsigned build and artifact verification succeeded. The signer imported one identity and passed profile checks, then its first `codesign` command failed with `Developer ID Application: Eigen Labs, Inc. (SLDQ2GJ6TL): no identity found`. Cleanup succeeded; notarization did not run and no signed artifact was produced.

The retained log contains no actual certificate subject or valid-identity enumeration, so a company-name change is **unproven**. The release workflow uses the same display name but adds the temporary keychain to the user search list and logs valid identities; the initial isolated workflow omitted those steps. The correction addresses both lookup causes without guessing a new display name or relaxing a runtime gate.

### Bounded signer correction

- Capture the original user search list before creating the temporary keychain, activate that keychain with all prior entries preserved, then restore and verify the original list during cleanup. The snapshot path is specific to this run/attempt. No trust setting or certificate anchor is installed.
- Query only the imported keychain using `security find-identity -v -p codesigning`. Require exactly one valid certificate/private-key identity, Developer ID Application kind, and exact team `SLDQ2GJ6TL`. Zero, multiple, wrong-kind, wrong-team or malformed results fail closed; there is no arbitrary fallback.
- Sign by the selected public SHA-1 identity fingerprint. Static requirements bind Apple's generic anchor, the Developer ID Application leaf marker, exact team, and the existing app/helper identifiers. Requirements are checked before notarization and after stapling.
- Always attempt restoration and deletion of temporary signing material. Restore failure still attempts private-material deletion and fails cleanup. Only public identity/requirement and cleanup metadata join the existing diagnostic artifacts; no secret value or private key is exported.

### Preserved behavior

CI's manual entrypoint still requires only `source_sha` and `version`, expands to unsigned build → signer, and maps exactly `APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `PROVISIONING_PROFILE_BASE64`, `APPLE_ID` and `APPLE_APP_PASSWORD`. Caller/callee permissions remain `contents: read` and `actions: read`; the relative reusable call uses the caller commit and the standalone manual trigger remains.

All ordinary push/PR CI job definitions, guards, runner isolation, nested tests and timeouts are unchanged by this correction. The unsigned build job, source/version checks, artifact bounds, profile/entitlement validation, resource staging, dependency pins, release/register workflows and both Vercel suppressions are unchanged. There is no cross-run artifact input, candidate binary/model execution, deployment environment, tag, release, R2 upload or registration path.

### Before

```mermaid
flowchart LR
  Manual[Reviewed manual CI dispatch] --> Build[Secret-free source/version-checked build]
  Build --> Artifact[This run's unsigned artifact]
  Artifact --> Import[Import temporary keychain and validate profile]
  Import --> Name[Hard-coded display-name lookup]
  Name --> Failure[No identity found before first signature]
  Failure --> Cleanup[Delete temporary signing material]
```

### After

```mermaid
flowchart LR
  Manual[Reviewed manual CI dispatch] --> Build[Same unsigned build and artifact checks]
  Build --> Capture[Capture search list and activate isolated keychain]
  Capture --> Import[Import and unchanged profile validation]
  Import --> Select[Unique valid Developer ID Application for exact team]
  Select -->|reject| Cleanup[Restore list and delete material; retain public diagnostics]
  Select -->|accept| Sign[Sign by fingerprint and verify Apple/type/team/identifier requirements]
  Sign --> Apple[Notarize, staple and verify again]
  Apple --> Result[Validation artifact and public receipts]
  Sign --> Cleanup
  Apple --> Cleanup
```

### Validation and pending authorization

- 9 identity/lifecycle tests and 10 routing tests pass normally and under `python -O`; existing 9 packaging/profile and 5 fake-Swift isolation tests also pass: **33 unique CPU test functions**. Identity tests mock all keychain operations; 3 static requirement variants compile with Apple's `csreq`. No real keychain, signing credential, provider or model is exercised by these fixtures.
- Parsed hashes preserve all 8 ordinary CI jobs and the unsigned build. Routing/mutation checks retain the two-job manual graph, five-secret allowlist, read-only permissions, source/version inputs and rejection/cleanup gates. The fixture explicitly records the intentional signer revision from `8cc56074ae7a6dd6553fe3cd3692af1ba58ed9a2`.
- Actionlint and documentation/diff checks pass. The branch mechanism remains backed by harmless [probe 34029318546](https://github.com/Layr-Labs/d-inference/actions/runs/34029318546); branch/ref writes use the account's existing repository policy exceptions, without force or access-rule changes.
- The first run and unsigned artifact `9988664285` remain immutable. The downloaded tar is `100239202` bytes with SHA-256 `18ebc43b207a54343f7b6ba459da5f98ebfc192a0c1c9baac137215ff5f10f45`; its source/version, 15-file inventory, submodule identities and entitlements verify. It is not a signed or notarized artifact.

**No retry has been issued or authorized for this changed definition.** An authorized reviewer must approve the exact workflow diff/job graph and separately authorize any fresh run. Actual identity validity, signing, notarization and signed runtime restart remain pending. The prior unrelated Threat Model Review failure was an Anthropic HTTP 401 credential error; no credential or review gate was changed.

Current source: `f9423f94ef41ced998009f4d503919e038c35175`, a signed bounded append to `8cc56074ae7a6dd6553fe3cd3692af1ba58ed9a2`. The unsigned build still requires a fresh same-run artifact; the correction does not reuse the failed run's artifact as an input.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791282089&installation_model_id=21733&pr_number=853&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F853&signature=c5ef250939a7a997a45ec902c99e78557c2dfe320efa712adc88652f0ba009f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->