### PR TITLE
fix(release): make validation signing identity discoverable

### DIFF
--- a/.github/workflows/provider-signing-validation.yml
+++ b/.github/workflows/provider-signing-validation.yml
@@ -126,6 +126,8 @@ jobs:
           security import "$RUNNER_TEMP/signing-certificate.p12" -k "$keychain" \
             -P "$P12_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple: -s -k "$keychain_password" "$keychain"
+          python3 tooling/scripts/provider-signing-validation.py keychain \
+            --keychain "$keychain" --identity "$DEVELOPER_ID"
           rm -f "$RUNNER_TEMP/signing-certificate.p12"
           app="$RUNNER_TEMP/signing-stage/Darkbloom.app"
           printf '%s' "$PROFILE_BASE64" | base64 --decode > "$app/Contents/embedded.provisionprofile"

--- a/scripts/provider-signing-validation.py
+++ b/scripts/provider-signing-validation.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import plistlib
+import shlex
 import shutil
 import subprocess
 import tarfile
@@ -42,6 +43,22 @@ def write_json(path, value):
     with path.open("x") as destination:
         json.dump(value, destination, indent=2)
         destination.write("\n")
+
+
+def configure_keychain(arguments):
+    keychain = str(arguments.keychain.resolve(strict=True))
+    existing = shlex.split(subprocess.check_output(
+        ["security", "list-keychains", "-d", "user"], text=True))
+    # codesign --keychain narrows identity selection; it does not add the
+    # keychain to the search list used for identity/certificate-chain lookup.
+    if keychain not in existing:
+        subprocess.run(["security", "list-keychains", "-d", "user", "-s",
+                        keychain, *existing], check=True)
+    identities = subprocess.check_output(
+        ["security", "find-identity", "-v", "-p", "codesigning", keychain], text=True)
+    if '"' + arguments.identity + '"' not in identities:
+        raise ValueError("Required Developer ID identity is unavailable in the signing keychain")
+    print("Verified signing identity: " + arguments.identity)
 
 
 def stage(arguments):
@@ -195,6 +212,9 @@ def receipt(arguments):
 def main():
     parser = argparse.ArgumentParser()
     commands = parser.add_subparsers(dest="command", required=True)
+    keychain_parser = commands.add_parser("keychain")
+    keychain_parser.add_argument("--keychain", type=Path, required=True)
+    keychain_parser.add_argument("--identity", required=True)
     stage_parser = commands.add_parser("stage")
     for name in ["source", "bin", "metallib", "output"]:
         stage_parser.add_argument("--" + name, type=Path, required=True)
@@ -212,7 +232,7 @@ def main():
     for name in ["output", "notary"]:
         receipt_parser.add_argument("--" + name, type=Path, required=True)
     arguments = parser.parse_args()
-    {"stage": stage, "unpack": unpack, "profile": profile,
+    {"keychain": configure_keychain, "stage": stage, "unpack": unpack, "profile": profile,
      "cli-entitlements": cli_entitlements, "receipt": receipt}[arguments.command](arguments)
 
 

--- a/scripts/test-provider-signing-validation.py
+++ b/scripts/test-provider-signing-validation.py
@@ -19,6 +19,43 @@ SPEC.loader.exec_module(VALIDATION)
 
 
 class SigningValidationTests(unittest.TestCase):
+    def test_signing_keychain_preserves_search_paths_with_spaces_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            keychain = Path(temporary, "signing validation.keychain-db")
+            keychain.touch()
+            path = str(keychain.resolve())
+            login = "/Users/runner/Library/Keychains/login keychain-db"
+            identity = "Developer ID Application: Example (TESTTEAM)"
+            arguments = argparse.Namespace(keychain=keychain, identity=identity)
+            for already_present in [False, True]:
+                with self.subTest(already_present=already_present):
+                    paths = [path, login] if already_present else [login]
+                    listing = "\n".join(json.dumps(value) for value in paths)
+                    with mock.patch.object(VALIDATION.subprocess, "check_output", side_effect=[
+                            listing, '1) ' + 'a' * 40 + ' "' + identity + '"\n1 valid identities found']), \
+                            mock.patch.object(VALIDATION.subprocess, "run") as run, \
+                            mock.patch("builtins.print"):
+                        VALIDATION.configure_keychain(arguments)
+                    if already_present:
+                        run.assert_not_called()
+                    else:
+                        run.assert_called_once_with(
+                            ["security", "list-keychains", "-d", "user", "-s", path, login], check=True)
+
+    def test_signing_keychain_refuses_missing_or_wrong_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            keychain = Path(temporary, "signing.keychain-db")
+            keychain.touch()
+            for identities in ["0 valid identities found", '1) abc "Developer ID Application: Other"']:
+                with self.subTest(identities=identities), \
+                        mock.patch.object(VALIDATION.subprocess, "check_output", side_effect=[
+                            json.dumps(str(keychain.resolve())), identities]), \
+                        mock.patch.object(VALIDATION.subprocess, "run") as run:
+                    with self.assertRaisesRegex(ValueError, "identity is unavailable"):
+                        VALIDATION.configure_keychain(argparse.Namespace(
+                            keychain=keychain, identity="Developer ID Application: Expected"))
+                    run.assert_not_called()
+
     def test_workflow_has_no_environment_or_publication_route(self):
         workflow = (ROOT / ".github/workflows/provider-signing-validation.yml").read_text()
         self.assertNotRegex(workflow, r"(?m)^\s+environment:")


### PR DESCRIPTION
Manual provider signing validation imports the Developer ID identity but fails on its first codesign invocation with `no identity found` ([failed run](https://github.com/Layr-Labs/d-inference/actions/runs/34093289404)). The temporary keychain was missing from the user search list required by codesign.

Add the imported keychain to the search list while preserving existing entries, including paths containing spaces. Verify that the expected Developer ID is available before signing. Repeated configuration leaves an already-correct list untouched, and an absent or different identity fails early. This affects the isolated validation workflow; the release workflow already configures its keychain search list.

Before:
```mermaid
flowchart LR
  A[Manual validation] --> B[Import signing identity]
  B --> C[Keychain absent from search list]
  C --> D[codesign: no identity found]
  D --> E[No signed candidate]
```

After:
```mermaid
flowchart LR
  A[Manual validation] --> B[Import signing identity]
  B --> C[configure_keychain: preserve and extend search list]
  C --> D[Check exact Developer ID]
  D -->|Available| E[Sign and verify candidate]
  D -->|Missing| F[Fail before signing]
```

Validation: 11 signing-validation helper tests and 4 release-resolution tests pass. The added cases cover preserving paths with spaces, idempotence and refusal of missing or unrelated identities. The [real validation rerun](https://github.com/Layr-Labs/d-inference/actions/runs/34094334149) passes signing, static verification, Apple notarization and stapling against source `0b46b1618d43cae3ae3d8e0fde1a9cc6d974e9d0`. This validation workflow did not publish a provider release.
