### PR TITLE
fix(provider): stop doctor failing model-fit on boxes the daemon serves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased — doctor model-fit verdict
+
+- Stop `darkbloom doctor` reporting "model fits in RAM" as a failure on boxes the daemon serves. The check sampled memory once from outside the daemon, while the load gate unloads idle models and drops the MLX buffer cache before refusing, so a resident model's footprint was charged against the verdict despite being memory the gate reclaims. A requirement that lands between the sample and what that reclaim could reach is now a warning naming both figures, and no longer advises narrowing `enabled_models` on a capable machine. Requirements beyond the reclaim ceiling still fail, and now cite the ceiling rather than the sample.
+- Operator-visible: that case exits 0 instead of 1. `darkbloom doctor --strict` still exits non-zero. Suggested alternative models are judged against the same ceiling, so a box is no longer steered to a smaller model than it can serve.
+
 ## Unreleased — stats request-flow refresh
 
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.

--- a/docs/architecture/hardware-support.md
+++ b/docs/architecture/hardware-support.md
@@ -1,6 +1,6 @@
 # Hardware support and the provider memory model
 
-> Last updated: 2026-09-05 · commit `02f6af71a`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 What hardware the provider runs on and how it decides, in bytes, whether a
 model may load and how much KV cache each resident model may use. Read this to
@@ -113,16 +113,30 @@ freeForLoadGb(total, systemAvailable, gpuActive, gpuCache, reserve, outstanding)
     committed = reserve + outstanding
     = max(0, realFree − committed) / 2^30                    -- no multiplicative discount
 
+freeForLoadAfterReclaimGb(total, systemAvailable, mlxUsed, reserve, outstanding)
+    reclaimable = min(total, systemAvailable + mlxUsed)   -- unloading returns MLX memory to the OS
+    committed   = reserve + outstanding
+    = max(0, reclaimable − committed) / 2^30              -- GROSS of headroom, like freeForLoadGb
+
 maxLoadableWeightGb(total, systemAvailable, mlxUsed, reserve, headroomGb, outstanding)
-    reclaimable = min(total, systemAvailable + mlxUsed)
-    usable      = reclaimable − (reserve + outstanding)
-    = max(0, usable / 2^30 − max(0, headroomGb))
+    = max(0, freeForLoadAfterReclaimGb(...) − max(0, headroomGb))   -- a WEIGHT budget
 
 requiredToLoadGb(weightsGb, headroomGb) = max(0, weightsGb) + max(0, headroomGb)
 evictionCanReach(available, reclaimable, required) = available + reclaimable ≥ required
 fitsAtAllocation(availableNetOfLedger, ownReservation, required) = availableNetOfLedger + ownReservation / 2^30 ≥ required
 canLoad(...) = requiredToLoadGb ≤ freeForLoadGb
 ```
+
+The two reclaim-aware figures differ only by the load headroom, and confusing them
+charges it twice: `freeForLoadAfterReclaimGb` is comparable to `requiredToLoadGb`
+(weights plus headroom), while `maxLoadableWeightGb` is comparable to weights alone —
+which is why the heartbeat's `free_for_load_gb` is populated from the latter and
+`CapacityQuoteEngine` compares model weights against it directly.
+
+`doctor` consumes `freeForLoadGb` and `freeForLoadAfterReclaimGb` as a floor and a ceiling; it never calls `maxLoadableWeightGb`. Its single non-reclaiming sample
+cannot see the reclaim the load gate performs before it refuses, so a requirement that
+lands between the two is reported as a warning rather than a refusal; only past the
+ceiling is it a failure. See `ModelFitDiagnostic`, `memoryBasis`.
 
 `weightsGb` is the scanner's padded estimate (`sizeBytes / 2^30 ×
 memoryOverheadFactor`), so a load needs `weights × memoryOverheadFactor +

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -1,6 +1,6 @@
 # Provider CLI reference
 
-> Last updated: 2026-09-06 · commit `2eebb5412`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 Reference for the `darkbloom` command-line tool: every subcommand and flag, the
 files and identifiers it creates, the `provider.toml` keys it reads with their
@@ -406,6 +406,16 @@ darkbloom doctor [--strict] [--coordinator <url>] [--support] [--clear-backend-g
 `darkbloom doctor` is read-only except for the subprocess calls used by public
 ProviderCore checks and the explicit `--clear-backend-guard` action
 (`provider-swift/Sources/darkbloom/DoctorCommand.swift`, `runClearBackendGuard`).
+
+The operator diagnosis above those checks includes `model fits in RAM`. It is
+reported as a pair of bounds rather than a single verdict: `doctor` runs in its own
+process and takes one non-reclaiming memory sample, while the daemon's load gate
+unloads idle models and drops the MLX buffer cache before it refuses. A requirement
+below the sample passes; one above what that reclaim could reach fails; one between
+them is a warning that names both figures and states that `doctor` cannot settle it
+from outside the daemon (`provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift`,
+`memoryBasis`). Only the failure exits non-zero; the warning exits non-zero only
+under `--strict`.
 
 Two of the detailed checks cover the KV-backend rollout:
 

--- a/docs/provider/troubleshooting.md
+++ b/docs/provider/troubleshooting.md
@@ -1,6 +1,6 @@
 # Provider troubleshooting
 
-> Last updated: 2026-09-06 · commit `615d96328`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 Symptom → check → fix for the `darkbloom` provider: installer exits, `doctor`
 check names, service lifecycle, coordinator connection, updates, models and the
@@ -138,7 +138,8 @@ are tabulated in [`cli-reference.md`](./cli-reference.md#runtime-constants).
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `model fit` ✗ / `recent model load` shows admission refused | `ModelLoadAdmission` (`provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift`) found less free-for-load memory than the model's padded weights plus headroom ([load gate](../architecture/hardware-support.md#load-gate-modelloadadmission)) | Close other apps; lower `max_model_slots`; pick a smaller quantisation ([hardware requirements](./hardware-requirements.md)) |
+| `model fit` ✗ / `recent model load` shows admission refused | `ModelLoadAdmission` (`provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift`) found less memory than the model's padded weights plus headroom, even after the load gate evicts every idle model ([load gate](../architecture/hardware-support.md#load-gate-modelloadadmission)) | Close other apps; lower `max_model_slots`; pick a smaller quantisation ([hardware requirements](./hardware-requirements.md)) |
+| `model fits in RAM` ⚠ "cannot settle whether this model loads" | The requirement lands between what `doctor` can sample and what the daemon's load gate could reach by unloading idle models and dropping the MLX buffer cache. `doctor` runs in a separate process, so it can neither perform that reclaim nor see in-flight work (`provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift`, `memoryBasis`) | Nothing to change in `provider.toml`. If loads are actually failing, the daemon records the refusal — check `recent model load` and `darkbloom logs` |
 | Model missing from `darkbloom models list` | Not in `~/.cache/huggingface/hub`, or filtered by `enabled_models` | `darkbloom models download <id>`; `darkbloom models list --all` |
 | Load fails after a catalog update | New build published for the alias | `darkbloom models remove <id>` then `darkbloom models download <id>` |
 | `Skipping <id>: model_type … has no engine-v2 adapter` | Family not served by CBv2 | Use a supported family; the model is never advertised |

--- a/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
+++ b/provider-swift/Sources/ProviderCore/Diagnostics/ModelFitDiagnostic.swift
@@ -6,11 +6,30 @@ import Foundation
 /// assigned model doesn't fit its RAM ("Insufficient memory (X GB free, need Y
 /// GB)"). This turns the raw numbers into an operator-facing verdict.
 ///
-/// Delegates to `ModelLoadAdmission` — the SAME arithmetic the running provider
-/// uses in `ProviderLoop.availableMemoryGb()` / `ensureModelLoaded` — so the
-/// verdict `doctor` prints can never drift from what the daemon enforces at load
-/// time. (Before, this modelled an older `weights × 2.0` / `free × 0.7` gate
-/// that no longer matches the runtime.)
+/// Delegates to `ModelLoadAdmission` — the SAME per-sample arithmetic the running
+/// provider uses in `ProviderLoop.availableMemoryGb()` / `ensureModelLoaded`.
+/// (Before, this modelled an older `weights × 2.0` / `free × 0.7` gate that no
+/// longer matches the runtime.)
+///
+/// Sharing the arithmetic is NOT the same as sharing the decision, and this
+/// docstring used to claim it was. `doctor` runs outside the daemon: it takes ONE
+/// non-reclaiming sample, while the daemon's gate is a loop that LRU-evicts idle
+/// models, drops the MLX buffer cache and RE-SAMPLES before refusing
+/// (`ProviderLoop.evictUntilAvailable`). On a box holding a resident model the two
+/// disagree by roughly that model's footprint — which is why `doctor` failed boxes
+/// the daemon serves, and told their operators to shrink `enabled_models`.
+///
+/// So the verdict is bounded, not asserted: `usableGb` is the floor a CLI can
+/// see, `usableAfterReclaimGb` is the ceiling the reclaim loop could reach, and a
+/// requirement landing between them is reported as a WARN that says so. The
+/// ceiling only ever WITHHOLDS a failure — it never grants a pass. That asymmetry
+/// is what lets it over-credit safely: it assumes every resident byte is
+/// evictable, which is looser than the daemon's own feasibility credit, and
+/// clearing the eviction loop is not the last gate anyway (`claimPendingLoad`,
+/// then the post-load serveability probe). `DaemonState.inferenceActive` could
+/// narrow it, but gating on a signal that is both staler and strictly narrower
+/// than `ProviderLoop.hasInflightWork` would reintroduce false refusals without
+/// preventing a single false pass, since there are none to prevent.
 public enum ModelFitDiagnostic {
     private static let gib = 1024.0 * 1024.0 * 1024.0
 
@@ -37,10 +56,12 @@ public enum ModelFitDiagnostic {
                 / (1024.0 * 1024.0 * 1024.0))
     }
 
-    /// The memory (GB) the provider would actually have free to load a model,
-    /// via `ModelLoadAdmission.freeForLoadGb`: real free RAM (clamped to what the
+    /// The FLOOR only — `MemoryBasis.usableGb`. Real free RAM (clamped to what the
     /// OS reports available when known) minus the OS reserve and resident MLX
-    /// memory. Shared with `ProviderLoop.availableMemoryGb()` so they agree.
+    /// memory, via `ModelLoadAdmission.freeForLoadGb`. The same per-sample
+    /// arithmetic as `ProviderLoop.availableMemoryGb()`, but not the same
+    /// decision — that method runs inside a reclaim loop and this does not.
+    /// Prefer `memoryBasis` where the ceiling matters.
     ///
     /// - Parameters:
     ///   - systemAvailableGb: real OS-reported available memory (doctor reads it
@@ -53,19 +74,65 @@ public enum ModelFitDiagnostic {
         gpuActiveGb: Double = 0,
         gpuCacheGb: Double = 0
     ) -> Double {
+        memoryBasis(
+            totalGb: totalGb, reserveGb: reserveGb, systemAvailableGb: systemAvailableGb,
+            gpuActiveGb: gpuActiveGb, gpuCacheGb: gpuCacheGb
+        ).usableGb
+    }
+
+    /// The two bounds a diagnostic run outside the daemon can honestly establish.
+    /// Returned as a pair so the floor and the ceiling are always computed from
+    /// one set of inputs and cannot drift apart at the call site.
+    public struct MemoryBasis: Sendable, Equatable {
+        /// What one non-reclaiming sample sees — resident MLX memory subtracted
+        /// as consumed. Identical to what `doctor` has always reported.
+        public let usableGb: Double
+        /// The ceiling the daemon's load gate could reach by evicting idle models
+        /// and dropping the MLX buffer cache. Equal to `usableGb` when nothing is
+        /// resident, so an offline run is unchanged.
+        public let afterReclaimGb: Double
+        public init(usableGb: Double, afterReclaimGb: Double) {
+            self.usableGb = usableGb
+            self.afterReclaimGb = afterReclaimGb
+        }
+    }
+
+    /// Both bounds for one box. See `MemoryBasis`.
+    public static func memoryBasis(
+        totalGb: Double,
+        reserveGb: Double,
+        systemAvailableGb: Double? = nil,
+        gpuActiveGb: Double = 0,
+        gpuCacheGb: Double = 0
+    ) -> MemoryBasis {
         let totalBytes = bytes(totalGb)
         // Same cap-implied reserve the running gate uses (max(configReserve,
         // physical − 90% cap)), so the doctor verdict matches what the daemon
         // actually enforces and never reports "fits" for a model the cap refuses.
         let reserve = UnifiedMemoryCap.loadReserveBytes(
             physicalBytes: totalBytes, configReserveBytes: bytes(reserveGb))
-        return ModelLoadAdmission.freeForLoadGb(
+        let systemAvailableBytes = systemAvailableGb.map(bytes) ?? .max
+        let gpuActive = bytes(gpuActiveGb)
+        let gpuCache = bytes(gpuCacheGb)
+        let usable = ModelLoadAdmission.freeForLoadGb(
             totalBytes: totalBytes,
-            systemAvailableBytes: systemAvailableGb.map(bytes) ?? .max,
-            gpuActiveBytes: bytes(gpuActiveGb),
-            gpuCacheBytes: bytes(gpuCacheGb),
+            systemAvailableBytes: systemAvailableBytes,
+            gpuActiveBytes: gpuActive,
+            gpuCacheBytes: gpuCache,
             reserveBytes: reserve,
             outstandingReservationBytes: 0)
+        // The load gate's own reclaim, priced the way it prices it: our resident
+        // MLX memory returns to the OS when an idle model is unloaded, so it is
+        // ADDED BACK to system-available rather than merely not subtracted.
+        let (sumUsed, usedOverflow) = gpuActive.addingReportingOverflow(gpuCache)
+        let mlxUsed = usedOverflow ? UInt64.max : sumUsed
+        let afterReclaim = ModelLoadAdmission.freeForLoadAfterReclaimGb(
+            totalBytes: totalBytes,
+            systemAvailableBytes: systemAvailableBytes,
+            mlxUsedBytes: mlxUsed,
+            reserveBytes: reserve,
+            outstandingReservationBytes: 0)
+        return MemoryBasis(usableGb: usable, afterReclaimGb: max(usable, afterReclaim))
     }
 
     /// A candidate model the operator could serve instead, with its size.
@@ -85,14 +152,24 @@ public enum ModelFitDiagnostic {
     /// floor over that whole set, not the target's own) — pass it so the
     /// verdict matches what the daemon enforces; nil falls back to the target
     /// alone (a single-model box, where the two coincide).
+    ///
+    /// `usableAfterReclaimGb` is `MemoryBasis.afterReclaimGb` — the ceiling the
+    /// daemon's eviction loop could reach. nil means no ceiling is known and the
+    /// verdict collapses to the single-bound behaviour. It is used only to
+    /// WITHHOLD a failure, never to grant a pass.
     public static func diagnose(
         modelID: String,
         weightGb: Double,
         usableGb: Double,
+        usableAfterReclaimGb: Double? = nil,
         alternatives: [ModelOption] = [],
         servingSetIDs: [String]? = nil
     ) -> Diagnostic {
-        guard weightGb > 0, usableGb > 0 else {
+        // A zero sample is not "unknown" when a reclaim ceiling is known: an
+        // OS-available reading below the reserve floors the sample at 0 on
+        // exactly the boxes this check exists for. Fall through on the ceiling
+        // rather than discarding a bound we actually have.
+        guard weightGb > 0, max(usableGb, usableAfterReclaimGb ?? 0) > 0 else {
             return Diagnostic(
                 section: .traffic, name: "model fits in RAM", level: .warn,
                 message: "couldn't determine the model size or available memory; skipping the fit check.",
@@ -120,10 +197,42 @@ public enum ModelFitDiagnostic {
                 message: "\(modelID) needs ~\(fmt(needed)) GB; \(fmt(usableGb)) GB usable.",
                 fix: nil)
         }
+        // #721: `usableGb` is ONE non-reclaiming sample taken from outside the
+        // daemon. The daemon's load gate is a loop — evict idle models, drop the
+        // MLX buffer cache, RE-SAMPLE (ProviderLoop.evictUntilAvailable) — and
+        // reaches up to `usableAfterReclaimGb`. Between the two a CLI has no
+        // evidence either way, and asserting a refusal there is what made doctor
+        // FAIL boxes the daemon demonstrably serves, with a fix line that shrinks
+        // a capable box's serving set.
+        //
+        // WARN, never PASS: this ceiling is looser than the daemon's own eviction
+        // feasibility credit (evictionCanReach counts evictable slot weights plus
+        // the MLX cache, not all resident memory), and clearing the loop is not
+        // the last gate anyway (claimPendingLoad, the post-load serveability
+        // probe). Only the daemon can prove a load succeeds.
+        let ceilingGb = max(usableGb, usableAfterReclaimGb ?? usableGb)
+        if needed <= ceilingGb {
+            return Diagnostic(
+                section: .traffic, name: "model fits in RAM", level: .warn,
+                message: "\(modelID) needs ~\(fmt2(needed)) GB. This check sees \(fmt2(usableGb)) GB "
+                    + "usable, but the daemon's load gate reclaims its own MLX memory first — "
+                    + "evicting idle models and dropping the MLX buffer cache, then re-sampling — "
+                    + "which raises the ceiling to at most \(fmt2(ceilingGb)) GB. `doctor` runs "
+                    + "outside the daemon: it can neither perform that reclaim nor see what is in "
+                    + "flight, so it cannot settle whether this model loads.",
+                fix: "no `provider.toml` change is indicated by this check. If loads are actually "
+                    + "failing, the daemon records the refusal — see `recent model load` below and "
+                    + "`darkbloom logs`. `darkbloom doctor --strict` still exits non-zero here.")
+        }
         // Each alternative is judged with ITS OWN activation floor — the
         // suggestion models what `enabled_models = [candidate]` would require.
+        // Judged against the CEILING, not the current sample: the suggestion
+        // models `enabled_models = [candidate]`, where the resident set this box
+        // holds today is gone. Filtering against the sample would recommend a
+        // smaller model than the box can serve — the same downgrade this check
+        // exists to stop. With no ceiling known the two are equal.
         let fits = alternatives
-            .filter { requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id) <= usableGb }
+            .filter { requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id) <= ceilingGb }
             .sorted { $0.weightGb > $1.weightGb }
         let suggestion: String
         if fits.isEmpty {
@@ -132,13 +241,23 @@ public enum ModelFitDiagnostic {
             let list = fits.prefix(3).map { "\($0.id) (~\(fmt(requiredGb(estimatedMemoryGb: $0.weightGb, modelID: $0.id))) GB)" }.joined(separator: ", ")
             suggestion = "set `enabled_models` in provider.toml to a model that fits: \(list)."
         }
+        let ceilingClause = ceilingGb > usableGb
+            ? "at most \(fmt(ceilingGb)) GB is reachable even after the daemon evicts every idle model"
+            : "only \(fmt(usableGb)) GB is usable"
         return Diagnostic(
             section: .traffic, name: "model fits in RAM", level: .fail,
-            message: "\(modelID) needs ~\(fmt(needed)) GB but only \(fmt(usableGb)) GB is usable — it will show online but every request fails to load.",
+            message: "\(modelID) needs ~\(fmt(needed)) GB but \(ceilingClause) — it will show online but every request fails to load.",
             fix: suggestion)
     }
 
     private static func fmt(_ v: Double) -> String {
         String(format: "%.1f", v)
+    }
+
+    /// The WARN prints three figures that can lie within 0.1 GB of one another,
+    /// where one decimal renders them identically and the message reads as a
+    /// contradiction ("needs 18.0, sees 18.0, can reach 18.0 — why warn?").
+    private static func fmt2(_ v: Double) -> String {
+        String(format: "%.2f", v)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ModelLoadAdmission.swift
@@ -66,6 +66,43 @@ public enum ModelLoadAdmission {
         return Double(usable) / bytesPerGb
     }
 
+    /// Physical memory (GB) available to load a model AFTER the reclaim the load
+    /// path performs before it gives up: `ProviderLoop.evictUntilAvailable`
+    /// LRU-evicts idle resident models and calls `MLX.Memory.clearCache()`, then
+    /// RE-SAMPLES. Unloading hands our MLX memory back to the OS, so the pool is
+    /// `min(total, systemAvailable + mlxUsed)`, less the reserve and any
+    /// outstanding unmaterialized KV commitment.
+    ///
+    /// GROSS of the load headroom — like `freeForLoadGb` and UNLIKE
+    /// `maxLoadableWeightGb`, which is exactly this value MINUS `headroomGb` (a
+    /// model-WEIGHT budget, which is why the wire field `free_for_load_gb` is
+    /// populated from that one and not from `freeForLoadGb`). Compare this
+    /// against `requiredToLoadGb`; comparing a weight budget against it charges
+    /// the headroom twice (`CapacityQuoteEngine` compares weights DIRECTLY
+    /// against the wire figure for exactly that reason).
+    ///
+    /// The OPTIMISTIC bound. It assumes every resident byte is evictable, which
+    /// is looser than the eviction loop's own feasibility credit
+    /// (`Σ evictable slot weights + MLX cache`, which excludes a slot that is
+    /// serving). Callers that must not over-promise pass `mlxUsedBytes: 0` while
+    /// work is in flight — the heartbeat does exactly that for
+    /// `free_for_load_gb`, gated on `ProviderLoop.hasInflightWork`.
+    ///
+    /// A caller that only ever uses this to WITHHOLD a refusal does not need
+    /// that gate: over-crediting cannot turn into a false "fits".
+    public static func freeForLoadAfterReclaimGb(
+        totalBytes: UInt64,
+        systemAvailableBytes: UInt64 = .max,
+        mlxUsedBytes: UInt64,
+        reserveBytes: UInt64,
+        outstandingReservationBytes: UInt64 = 0
+    ) -> Double {
+        let reclaimable = min(totalBytes, saturatingAdd(systemAvailableBytes, mlxUsedBytes))
+        let committed = saturatingAdd(reserveBytes, outstandingReservationBytes)
+        let usable = reclaimable > committed ? reclaimable - committed : 0
+        return Double(usable) / bytesPerGb
+    }
+
     /// Maximum model-WEIGHT footprint (GB) this machine could load right now,
     /// assuming idle/evictable resident models are unloaded to make room. This is
     /// the number the coordinator needs for COLD-LOAD routing: it answers "if I
@@ -80,6 +117,8 @@ public enum ModelLoadAdmission {
     /// value on the idle path (totalPending == 0), where every resident model is
     /// in fact evictable, so the full-eviction assumption holds. The result is the
     /// loadable headroom MINUS the load headroom, i.e. weights only; clamped >= 0.
+    /// Concretely: the same reclaimable pool as `freeForLoadAfterReclaimGb`,
+    /// minus the load headroom.
     ///
     /// - Parameters:
     ///   - reserveBytes: OS/operator reserve to hold back, i.e.
@@ -104,10 +143,12 @@ public enum ModelLoadAdmission {
         // reclaimable pool is current OS-available plus our own MLX usage, capped
         // at total physical. Hold back the load reserve and any outstanding KV
         // reservation, then the load headroom.
-        let reclaimable = min(totalBytes, saturatingAdd(systemAvailableBytes, mlxUsedBytes))
-        let committed = saturatingAdd(reserveBytes, outstandingReservationBytes)
-        let usable = reclaimable > committed ? reclaimable - committed : 0
-        let freeGb = Double(usable) / bytesPerGb
+        let freeGb = freeForLoadAfterReclaimGb(
+            totalBytes: totalBytes,
+            systemAvailableBytes: systemAvailableBytes,
+            mlxUsedBytes: mlxUsedBytes,
+            reserveBytes: reserveBytes,
+            outstandingReservationBytes: outstandingReservationBytes)
         return max(0, freeGb - max(0, headroomGb))
     }
 

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -917,8 +917,12 @@ extension ProviderLoop {
     ///      or count their already materialized backing twice.
     ///
     /// `doctor`'s model-fit check shares the SAME arithmetic via
-    /// `ModelLoadAdmission`, so the operator-facing verdict can never drift from
-    /// what this method enforces at load time.
+    /// `ModelLoadAdmission`, but NOT the same decision: this method is called
+    /// inside `evictUntilAvailable`'s reclaim loop, which unloads idle models,
+    /// drops the MLX buffer cache and re-samples before refusing, while `doctor`
+    /// takes one sample from a separate process and can do neither. So the two
+    /// agree per-sample and diverge by whatever is reclaimable. `doctor` handles
+    /// that by bounding rather than asserting — see `ModelFitDiagnostic`.
     ///
     /// `internal` (not `private`): also the admission probe for the startup
     /// preload (`ProviderLoop+StartupPreload`), which must skip — never evict

--- a/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
+++ b/provider-swift/Sources/ProviderCore/Service/DaemonStateFile.swift
@@ -101,9 +101,11 @@ public struct DaemonState: Codable, Sendable, Equatable {
         public var gpuMemoryActiveGb: Double
         /// Live MLX GPU cache (buffer pool) memory. Optional for backward
         /// compatibility with state files written before this field existed; the
-        /// model-fit diagnostic subtracts it so `doctor` exactly mirrors
-        /// `ProviderLoop.availableMemoryGb()` even when the OS-available reading
-        /// is unavailable.
+        /// model-fit diagnostic subtracts it to match
+        /// `ProviderLoop.availableMemoryGb()` per-sample even when the
+        /// OS-available reading is unavailable. It also ADDS it back as the
+        /// reclaim ceiling, because the daemon's load gate drops this pool and
+        /// re-samples before refusing — see `ModelFitDiagnostic.memoryBasis`.
         public var gpuMemoryCacheGb: Double?
         public init(totalMemoryGb: Double, gpuMemoryActiveGb: Double, gpuMemoryCacheGb: Double? = nil) {
             self.totalMemoryGb = totalMemoryGb

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -85,16 +85,24 @@ enum DoctorRunner {
             // When the daemon is up and fresh, subtract its live GPU-active
             // memory too (the min() inside ModelLoadAdmission keeps it conservative
             // without double-counting against the OS-available figure).
+            //
+            // #721: that single sample is the FLOOR, not the decision. The daemon
+            // reclaims its own MLX memory before refusing, so `basis` also carries
+            // the ceiling that reclaim could reach; a requirement between the two
+            // is undecidable from out here and must not be reported as a refusal.
+            // With no fresh daemon both GPU figures are 0 and the two bounds are
+            // equal, so the offline verdict is unchanged.
             let gpuActiveGb = (stateFresh ? state?.capacity?.gpuMemoryActiveGb : nil) ?? 0
             let gpuCacheGb = (stateFresh ? state?.capacity?.gpuMemoryCacheGb : nil) ?? 0
             let bytesPerGb = 1024.0 * 1024.0 * 1024.0
             let systemAvailableGb = SystemMemory.availableBytes().map { Double($0) / bytesPerGb }
-            let usableGb = ModelFitDiagnostic.usableInferenceGb(
+            let basis = ModelFitDiagnostic.memoryBasis(
                 totalGb: Double(hw.memoryGb),
                 reserveGb: Double(snapshot.config.provider.memoryReserveGB),
                 systemAvailableGb: systemAvailableGb,
                 gpuActiveGb: gpuActiveGb,
                 gpuCacheGb: gpuCacheGb)
+            let usableGb = basis.usableGb
 
             // Prefer the live loaded model ONLY when the daemon is up and fresh;
             // otherwise diagnose the CONFIGURED model. A stale state file (daemon
@@ -154,7 +162,8 @@ enum DoctorRunner {
             if let targetID, let target = allModels.first(where: { $0.id == targetID }) {
                 out.append(ModelFitDiagnostic.diagnose(
                     modelID: targetID, weightGb: target.estimatedMemoryGb,
-                    usableGb: usableGb, alternatives: alternatives,
+                    usableGb: usableGb, usableAfterReclaimGb: basis.afterReclaimGb,
+                    alternatives: alternatives,
                     // A LIVE empty set is authoritative (the daemon retired
                     // everything) and must reach the verdict as [] — the
                     // open-world default floor — not collapse to nil, which
@@ -168,7 +177,8 @@ enum DoctorRunner {
                 if let biggest = alternatives.max(by: { $0.weightGb < $1.weightGb }) {
                     out.append(ModelFitDiagnostic.diagnose(
                         modelID: biggest.id, weightGb: biggest.weightGb,
-                        usableGb: usableGb, alternatives: alternatives))
+                        usableGb: usableGb, usableAfterReclaimGb: basis.afterReclaimGb,
+                        alternatives: alternatives))
                 }
             }
         }
@@ -189,7 +199,9 @@ enum DoctorRunner {
             if let err = state.lastModelLoadError {
                 out.append(Diagnostic(section: .runtime, name: "recent model load", level: .warn,
                                       message: "FAILED for \(err.model): \(err.message)",
-                                      fix: "see the model-fit check above; serve a model that fits this box's RAM."))
+                                      fix: "this is the daemon's own record of a refused load — it is "
+                                          + "authoritative where the model-fit check above is only a bound. "
+                                          + "Read the message for the reason before changing `enabled_models`."))
             }
             // ---- Billing ----
             if state.stats.usageGaps > 0 {

--- a/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/DiagnosticsTests.swift
@@ -131,6 +131,92 @@ import Testing
     #expect(bad.level == .fail)
 }
 
+// MARK: - #721: the reclaim band (doctor's floor vs the load gate's ceiling)
+
+/// The two bounds on the #721 reporter's box. `doctor` subtracts resident MLX
+/// memory as consumed; the daemon's load gate unloads idle models and drops the
+/// MLX buffer cache, handing those bytes back to the OS, then re-samples.
+@Test func memoryBasisReportsBothTheSampleAndTheReclaimCeiling() {
+    // 32 GB box, 4 GB reserve, OS-available 15, resident MLX 14 active + 1 cache.
+    // floor   = min(32 − 15, 15) − 4 = min(17, 15) − 4 = 11.0
+    // ceiling = min(32, 15 + 15)  − 4 = min(32, 30) − 4 = 26.0
+    let basis = ModelFitDiagnostic.memoryBasis(
+        totalGb: 32, reserveGb: 4, systemAvailableGb: 15, gpuActiveGb: 14, gpuCacheGb: 1)
+    #expect(abs(basis.usableGb - 11.0) < 0.01, "floor (got \(basis.usableGb))")
+    #expect(abs(basis.afterReclaimGb - 26.0) < 0.01, "ceiling (got \(basis.afterReclaimGb))")
+}
+
+/// With nothing resident the ceiling collapses onto the sample, so a run with no
+/// fresh daemon — where DoctorRunner passes 0 for both GPU figures — is unchanged.
+@Test func memoryBasisCollapsesToOneBoundWhenNothingIsResident() {
+    let basis = ModelFitDiagnostic.memoryBasis(totalGb: 32, reserveGb: 4, systemAvailableGb: 22)
+    #expect(abs(basis.usableGb - basis.afterReclaimGb) < 0.01)
+    #expect(abs(basis.usableGb - 18.0) < 0.01)
+}
+
+/// THE #721 REGRESSION. gpt-oss-20b needs 13.53 + 3.5 (its measured floor) + 1.0
+/// (min serveable KV) = 18.03. The sample says 11.0 — a refusal — but the gate can
+/// reach 26.0, so the requirement lands inside the band doctor cannot settle from
+/// outside the daemon. Before the fix this was a FAIL telling the operator to
+/// shrink `enabled_models` on a box that serves the model.
+@Test func modelFitWarnsInsteadOfFailingInsideTheReclaimBand() {
+    let d = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 13.53,
+        usableGb: 11.0, usableAfterReclaimGb: 26.0,
+        servingSetIDs: ["gpt-oss-20b"])
+    #expect(d.level == .warn, "a shortfall inside the reclaim band is undecidable, not a refusal")
+    #expect(d.message.contains("18.0"), "must still state the requirement")
+    #expect(d.message.contains("11.0") && d.message.contains("26.0"), "must name BOTH bounds")
+    #expect(d.fix?.contains("enabled_models") != true,
+        "must not tell the operator to downgrade a box the daemon can serve")
+}
+
+/// The ceiling only ever WITHHOLDS a failure. Past it, the verdict is still FAIL —
+/// and the message now names the ceiling rather than the sample, so the operator
+/// sees the number that actually decides it.
+@Test func modelFitStillFailsBeyondTheReclaimCeiling() {
+    // 25 GB weights + 4.5 headroom (3.5 activation floor + 1.0 min KV) = 29.5 > 26.0.
+    let d = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 25.0,
+        usableGb: 11.0, usableAfterReclaimGb: 26.0,
+        servingSetIDs: ["gpt-oss-20b"])
+    #expect(d.level == .fail)
+    #expect(d.message.contains("26.0"), "the FAIL must cite the ceiling, not the sample")
+    #expect(d.message.contains("evicts every idle model"))
+}
+
+/// A nil ceiling means "no ceiling known" and must reproduce the pre-#721 verdict
+/// exactly — this is what keeps all 14 existing call sites and their assertions
+/// byte-identical.
+@Test func modelFitWithoutACeilingReproducesTheSingleBoundVerdict() {
+    let withoutCeiling = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 13.53, usableGb: 11.0,
+        servingSetIDs: ["gpt-oss-20b"])
+    #expect(withoutCeiling.level == .fail)
+    #expect(withoutCeiling.message.contains("only 11.0 GB is usable"))
+    // Passing the sample as its own ceiling is the same thing.
+    let echoed = ModelFitDiagnostic.diagnose(
+        modelID: "gpt-oss-20b", weightGb: 13.53,
+        usableGb: 11.0, usableAfterReclaimGb: 11.0,
+        servingSetIDs: ["gpt-oss-20b"])
+    #expect(echoed == withoutCeiling)
+}
+
+/// Suggestions model `enabled_models = [candidate]`, i.e. the resident set this
+/// box holds today is gone — so they are judged against the ceiling. Filtering
+/// against the sample would recommend a smaller model than the box can serve,
+/// which is the downgrade this check exists to stop.
+@Test func modelFitAlternativesAreJudgedAgainstTheCeiling() {
+    // "mid" needs 12.0 + 6.5 = 18.5: above the 11.0 sample, under the 26.0 ceiling.
+    let alts = [ModelFitDiagnostic.ModelOption(id: "mid", weightGb: 12.0)]
+    let d = ModelFitDiagnostic.diagnose(
+        modelID: "huge", weightGb: 40.0,
+        usableGb: 11.0, usableAfterReclaimGb: 26.0,
+        alternatives: alts, servingSetIDs: ["huge"])
+    #expect(d.level == .fail, "40 GB weights exceed even the ceiling")
+    #expect(d.fix?.contains("mid") == true, "a model reachable after reclaim must still be offered")
+}
+
 @Test func modelFitSuggestsFittingAlternatives() {
     let alts = [
         ModelFitDiagnostic.ModelOption(id: "small", weightGb: 5.0),

--- a/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelLoadAdmissionTests.swift
@@ -134,6 +134,49 @@ private let gib: UInt64 = 1024 * 1024 * 1024
     #expect(ok, "the core fix must still hold under the OOM-safety clamps")
 }
 
+// MARK: - freeForLoadAfterReclaimGb (the reclaim-aware pool, GROSS of headroom)
+
+// The two reclaim-aware figures differ by exactly the load headroom, and by
+// nothing else. This is the invariant that keeps `doctor` from charging the
+// headroom twice: `freeForLoadAfterReclaimGb` is comparable to
+// `requiredToLoadGb` (weights + headroom), `maxLoadableWeightGb` is comparable
+// to weights alone.
+@Test func freeForLoadAfterReclaimIsMaxLoadableWeightPlusHeadroom() {
+    let total: UInt64 = 64 * gib
+    let sysAvail: UInt64 = 20 * gib
+    let mlx: UInt64 = 12 * gib
+    let reserve: UInt64 = 4 * gib
+    let headroom = 6.5
+    // min(64, 20+12) = 32; minus 4 reserve = 28 gross.
+    let gross = ModelLoadAdmission.freeForLoadAfterReclaimGb(
+        totalBytes: total, systemAvailableBytes: sysAvail,
+        mlxUsedBytes: mlx, reserveBytes: reserve)
+    #expect(abs(gross - 28.0) < 0.001, "gross reclaim pool (got \(gross))")
+    let net = ModelLoadAdmission.maxLoadableWeightGb(
+        totalBytes: total, systemAvailableBytes: sysAvail,
+        mlxUsedBytes: mlx, reserveBytes: reserve, headroomGb: headroom)
+    #expect(abs(gross - headroom - net) < 0.001,
+        "the weight budget must be the gross pool minus the headroom, exactly once")
+}
+
+// With nothing resident the reclaim-aware pool collapses onto the
+// non-reclaiming one, so the refactor cannot move any existing verdict on an
+// idle box and `doctor`'s offline path stays bit-identical.
+@Test func freeForLoadAfterReclaimEqualsFreeForLoadWhenNothingIsResident() {
+    let total: UInt64 = 32 * gib
+    let sysAvail: UInt64 = 22 * gib
+    let reserve: UInt64 = 4 * gib
+    let reclaimAware = ModelLoadAdmission.freeForLoadAfterReclaimGb(
+        totalBytes: total, systemAvailableBytes: sysAvail,
+        mlxUsedBytes: 0, reserveBytes: reserve)
+    let plain = ModelLoadAdmission.freeForLoadGb(
+        totalBytes: total, systemAvailableBytes: sysAvail,
+        gpuActiveBytes: 0, gpuCacheBytes: 0, reserveBytes: reserve)
+    #expect(abs(reclaimAware - plain) < 0.001,
+        "at mlxUsed == 0 the two bounds must agree (got \(reclaimAware) vs \(plain))")
+    #expect(abs(reclaimAware - 18.0) < 0.001)
+}
+
 // MARK: - maxLoadableWeightGb (heartbeat free_for_load_gb the coordinator consumes)
 
 // Idle resident models are reclaimable: the provider LRU-evicts them on a cold


### PR DESCRIPTION
## Summary

`darkbloom doctor` reports `model fits in RAM` as a **failure on boxes the daemon serves**, and tells the operator to shrink `enabled_models` on hardware that is not actually too small. Doctor samples memory once from its own process; the daemon's load gate unloads idle models and drops the MLX buffer cache, then re-samples, before it refuses. So a resident model's footprint is charged against the verdict even though it is memory the gate would reclaim.

This makes the check report what it can prove. It keeps the sample as a floor, adds the reclaim ceiling the load gate could reach, and reports a requirement between the two as a warning that names both figures instead of a refusal.

## Linked issue

Closes #721

## Before / after

### Behaviour

```mermaid
flowchart TB
  subgraph Before
    direction TB
    B1["darkbloom doctor"] --> B2["one non-reclaiming sample<br/>usable = 11.0 GB"]
    B2 --> B3{"needed 18.0<br/>&le; 11.0 ?"}
    B3 -- no --> B4["FAIL: 'every request fails to load'<br/>fix: set enabled_models to a smaller model<br/>exit 1"]
    B4 --> B5["operator downgrades a box<br/>that serves the model fine"]
  end
  subgraph After
    direction TB
    A1["darkbloom doctor"] --> A2["floor 11.0 GB (sample)<br/>ceiling 26.0 GB (after reclaim)"]
    A2 --> A3{"needed 18.0<br/>vs the band"}
    A3 -- "&le; floor" --> A4["PASS (unchanged)"]
    A3 -- "in band" --> A5["WARN: names both figures,<br/>says doctor cannot settle it<br/>no enabled_models advice, exit 0"]
    A3 -- "&gt; ceiling" --> A6["FAIL, now citing the ceiling<br/>exit 1"]
  end
  Before ~~~ After
```

### Code

```mermaid
flowchart TB
  subgraph BeforeCode["Before"]
    direction TB
    C1["DoctorRunner<br/>buildOperatorDiagnosis"] --> C2["ModelFitDiagnostic<br/>usableInferenceGb"]
    C2 --> C3["ModelLoadAdmission<br/>freeForLoadGb<br/>(MLX = consumed)"]
    C3 --> C4["diagnose(usableGb:)"]
    C4 --> C5["pass / fail"]
    C6["maxLoadableWeightGb<br/>(own inline reclaim math)"]
  end
  subgraph AfterCode["After"]
    direction TB
    D1["DoctorRunner<br/>buildOperatorDiagnosis"] --> D2["ModelFitDiagnostic<br/>memoryBasis -> MemoryBasis"]
    D2 --> D3["freeForLoadGb<br/>(floor, MLX consumed)"]
    D2 --> D4["freeForLoadAfterReclaimGb<br/>(ceiling, MLX reclaimable)"]
    D3 --> D5["diagnose(usableGb:usableAfterReclaimGb:)"]
    D4 --> D5
    D5 --> D6["pass / warn / fail"]
    D4 --> D7["maxLoadableWeightGb<br/>= freeForLoadAfterReclaimGb - headroom"]
  end
  BeforeCode ~~~ AfterCode
```

## What changed

- **`ModelLoadAdmission`** — new `freeForLoadAfterReclaimGb`, the reclaimable pool **gross** of the load headroom. `maxLoadableWeightGb` is now that minus `headroomGb`; its arithmetic is byte-identical, the two are just no longer duplicated. This is deliberate: the two figures differ only by the headroom, and confusing them charges it twice — the trap `CapacityQuoteEngine` already documents.
- **`ModelFitDiagnostic`** — `memoryBasis` returns floor and ceiling together so they cannot drift apart at the call site. `diagnose` takes `usableAfterReclaimGb: Double? = nil`; `nil` collapses the ceiling onto the floor, so all 14 existing call sites keep their exact verdict and strings. New WARN branch between the bounds. Alternative suggestions are judged against the ceiling — filtering them against the sample recommends a smaller model than the box can serve, which is the same downgrade this fixes.
- **`DoctorRunner`** — computes the pair, passes the ceiling at both `diagnose` call sites.
- **Three docstrings** corrected. `ModelFitDiagnostic`, `ProviderLoop+ModelLoading.availableMemoryGb` and `DaemonStateFile.Capacity` all asserted the doctor verdict "can never drift from what the daemon enforces at load time". True of the per-sample arithmetic, false of the decision — that claim is what made this bug easy to miss.

## The numbers

Reporter's box: 32 GiB, `memory_reserve_gb = 4`, OS-available 15 GiB, resident MLX 15 GiB.

```
floor   = min(32 - 15, 15) - 4 = 11.0 GB   <- what doctor sampled
ceiling = min(32, 15 + 15)  - 4 = 26.0 GB   <- what the load gate can reach
gap                             = 15.0 GB   = the resident MLX set
```

`gpt-oss-20b` needs `13.53 + 3.5 + 1.0 = 18.03`. Was FAIL at exit 1; now WARN at exit 0.

## Test plan

- [x] `swift build --target ProviderCore` — clean
- [x] `swift test --filter "modelFit|memoryBasis|freeForLoadAfterReclaim|maxLoadableWeight|usableInferenceGb"`
- [x] Existing assertions unchanged, including `DiagnosticsTests` `usableInferenceGbMatchesProviderAccounting` (`gpuActiveGb: 5 -> 23.0`), which pins the current `usableInferenceGb` semantics, and `maxLoadableWeightMirrorsCanLoadWhenIdle`
- [x] `make docs-check` — 262 files OK
- [x] New regression test fails without the fix: with no ceiling the verdict is FAIL, which is exactly the pre-fix behaviour the band test asserts against

New tests: `memoryBasisReportsBothTheSampleAndTheReclaimCeiling`, `memoryBasisCollapsesToOneBoundWhenNothingIsResident`, `modelFitWarnsInsteadOfFailingInsideTheReclaimBand`, `modelFitStillFailsBeyondTheReclaimCeiling`, `modelFitWithoutACeilingReproducesTheSingleBoundVerdict`, `modelFitAlternativesAreJudgedAgainstTheCeiling`, `freeForLoadAfterReclaimIsMaxLoadableWeightPlusHeadroom`, `freeForLoadAfterReclaimEqualsFreeForLoadWhenNothingIsResident`.

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [x] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [ ] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes

No wire fields, no state-file schema change, no config keys. The new `diagnose` parameter is defaulted and `ModelFitDiagnostic` has exactly one production caller.

**One user-visible behaviour change worth calling out:** a shortfall doctor cannot prove now exits 0 instead of 1. `darkbloom doctor --strict` still exits non-zero on it. `darkbloom verify` is unaffected — it never calls `buildOperatorDiagnosis`.

## Notes for reviewers

**What this proves and what it does not.** It is proven that the two gates disagree, so the FAIL is wrong. It is *not* proven that the daemon always succeeds afterwards — `claimPendingLoad` and the post-load serveability guard still run after eviction. That is why the band is a WARN and never a PASS, and why the message makes no success claim.

**Why the ceiling can safely over-credit.** It assumes every resident byte is evictable, which is looser than the gate's own feasibility credit (`evictionCanReach` counts evictable slot weights plus the MLX cache). That is deliberate: the ceiling only ever *withholds* a failure, never grants a pass, so over-crediting cannot manufacture a false "fits". It also means doctor never needs `hasInflightWork`, which is actor-isolated and unavailable to a separate process.

**Considered and rejected:** publishing the daemon's own `free_for_load_gb` into the state file. It is gated on `hasInflightWork`, so it collapses to today's wrong number the moment anything is being served — it would fix an idle box and nothing else.

**Not addressed:** there is still no test for `DoctorRunner` itself; `buildOperatorDiagnosis` is `async` and reads the state file, `SystemMemory`, `ModelScanner` and network directly with no seam. All the arithmetic and the whole verdict live in the pure, tested layer, so what remains there is one call plus two argument pairs. Happy to add a closure seam as a follow-up if you want it.

**Two bounds on the fix, stated plainly.** It is inert when the daemon's state file is stale (>90 s) or the daemon is down — both GPU figures fall back to 0, the ceiling collapses onto the floor, and the old FAIL returns. That is deliberate: with no fresh reading there is no evidence for a ceiling. And the ceiling is looser than the gate's own pre-eviction feasibility credit (`evictionCanReach` counts evictable slot weights plus the MLX cache, not all resident memory), so it is an upper bound — the message says "at most" for that reason.

Also corrected in passing, because the new prose sits beside them: `troubleshooting.md` and `cli-reference.md` claimed `darkbloom verify` runs the doctor checks. It does not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791362323&installation_model_id=21733&pr_number=858&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F858&signature=1aacc91c3f6f3637ce47dc06dc3c042692870f938090e777204b6facd611cc9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->