### PR TITLE
Add experimental provider continuity key primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
+      - name: Test provider continuity primitives
+        run: swift test --package-path provider-swift/Packages/BootContinuity --skip BootKeyHardwareTests
       - name: Restore SwiftPM cache
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:

--- a/provider-swift/Packages/BootContinuity/Package.swift
+++ b/provider-swift/Packages/BootContinuity/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "BootContinuity",
+    platforms: [.macOS(.v14)],
+    products: [.library(name: "BootContinuity", targets: ["BootContinuity"])],
+    targets: [
+        .target(name: "BootContinuity"),
+        .testTarget(name: "BootContinuityTests", dependencies: ["BootContinuity"]),
+    ]
+)

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuationTranscript.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuationTranscript.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum BootContinuationTranscript {
+    static func encode(context: BootContinuityContext, publicKey: Data,
+                       challenge: BootContinuationChallenge) -> Data {
+        var result = Data("darkbloom/boot-continuation/v1\0".utf8)
+        for value in [context.accountID, context.deviceID, context.coordinatorOrigin, context.releaseID] {
+            append(Data(value.utf8), to: &result)
+        }
+        var generation = context.policyGeneration.bigEndian
+        withUnsafeBytes(of: &generation) { result.append(contentsOf: $0) }
+        append(publicKey, to: &result)
+        append(challenge.nonce, to: &result)
+        append(challenge.processPublicKey, to: &result)
+        return result
+    }
+
+    private static func append(_ value: Data, to result: inout Data) {
+        var size = UInt32(value.count).bigEndian
+        withUnsafeBytes(of: &size) { result.append(contentsOf: $0) }
+        result.append(value)
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuityTypes.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuityTypes.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Explicit development opt-in. No environment variable enables this package.
+public enum BootContinuityActivation: Sendable {
+    case disabled
+    case experimental
+}
+
+public enum BootContinuityError: Error, Equatable, Sendable {
+    case disabled
+    case secureEnclaveUnavailable
+    case invalidContext
+    case invalidChallenge
+    case invalidRecord
+    case unsupportedRecordVersion
+    case contextMismatch
+    case publicKeyMismatch
+    /// Reboot, unavailable hardware, and damaged handles can all cause this.
+    /// This local result does not attest a boot transition to a remote party.
+    case keyUnavailable
+    case possessionCheckFailed
+}
+
+/// Exact recovery namespace. Changing any field requires a new bootstrap.
+public struct BootContinuityContext: Codable, Equatable, Sendable {
+    public let accountID: String
+    public let deviceID: String
+    public let coordinatorOrigin: String
+    public let releaseID: String
+    public let policyGeneration: UInt64
+
+    public init(accountID: String, deviceID: String, coordinatorOrigin: String,
+                releaseID: String, policyGeneration: UInt64) throws {
+        self.accountID = accountID
+        self.deviceID = deviceID
+        self.coordinatorOrigin = coordinatorOrigin
+        self.releaseID = releaseID
+        self.policyGeneration = policyGeneration
+        try validate()
+    }
+
+    func validate() throws {
+        for value in [accountID, deviceID, coordinatorOrigin, releaseID] {
+            guard !value.isEmpty, value.utf8.count <= 512,
+                  !value.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) }) else {
+                throw BootContinuityError.invalidContext
+            }
+        }
+        guard let origin = URLComponents(string: coordinatorOrigin),
+              origin.scheme == "https", origin.host?.isEmpty == false,
+              origin.user == nil, origin.password == nil,
+              origin.query == nil, origin.fragment == nil,
+              origin.path.isEmpty else { throw BootContinuityError.invalidContext }
+    }
+}
+
+public struct BootContinuationChallenge: Sendable {
+    public let nonce: Data
+    public let processPublicKey: Data
+
+    public init(nonce: Data, processPublicKey: Data) throws {
+        guard nonce.count == 32, processPublicKey.count == 32 else {
+            throw BootContinuityError.invalidChallenge
+        }
+        self.nonce = nonce
+        self.processPublicKey = processPublicKey
+    }
+}
+
+/// A domain-separated local possession proof; not hardware attestation or authorization.
+public struct BootContinuationProof: Sendable {
+    public let publicKey: Data
+    public let signatureDER: Data
+    public let transcript: Data
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeyRecord.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeyRecord.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Internal storage representation. Never expose the handle over a CLI or protocol.
+struct BootKeyRecord: Codable {
+    static let currentVersion = 1
+    static let maximumSize = 32 * 1024
+
+    let version: Int
+    let context: BootContinuityContext
+    let publicKey: Data
+    let opaqueHandle: Data
+
+    init(context: BootContinuityContext, key: any BootHardwareKey) {
+        version = Self.currentVersion
+        self.context = context
+        publicKey = key.publicKey
+        opaqueHandle = key.opaqueHandle
+    }
+
+    static func decode(_ data: Data, expecting context: BootContinuityContext) throws -> Self {
+        guard data.count <= maximumSize else { throw BootContinuityError.invalidRecord }
+        let record: Self
+        do { record = try JSONDecoder().decode(Self.self, from: data) }
+        catch { throw BootContinuityError.invalidRecord }
+        guard record.version == currentVersion else { throw BootContinuityError.unsupportedRecordVersion }
+        try record.context.validate()
+        guard record.context == context else { throw BootContinuityError.contextMismatch }
+        guard record.publicKey.count == 64, !record.opaqueHandle.isEmpty,
+              record.opaqueHandle.count <= 16 * 1024 else { throw BootContinuityError.invalidRecord }
+        return record
+    }
+
+    func encode() throws -> Data {
+        let encoded = try JSONEncoder().encode(self)
+        guard encoded.count <= Self.maximumSize else { throw BootContinuityError.invalidRecord }
+        return encoded
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeySession.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeySession.swift
@@ -1,0 +1,68 @@
+import CryptoKit
+import Foundation
+
+protocol BootHardwareKey {
+    var publicKey: Data { get }
+    var opaqueHandle: Data { get }
+    func sign(_ message: Data) throws -> Data
+}
+
+protocol BootKeyEngine {
+    var isAvailable: Bool { get }
+    func create() throws -> any BootHardwareKey
+    func recover(handle: Data) throws -> any BootHardwareKey
+}
+
+/// IO-independent lifecycle. Recovery never creates a replacement key.
+final class BootKeySession {
+    let context: BootContinuityContext
+    private let key: any BootHardwareKey
+    var publicKey: Data { key.publicKey }
+
+    private init(context: BootContinuityContext, key: any BootHardwareKey) throws {
+        self.context = context
+        self.key = key
+        // Recovery can return a public key before the enclave accepts an operation.
+        // Challenge the private half before reporting a usable session.
+        var random = SystemRandomNumberGenerator()
+        let challenge = try BootContinuationChallenge(
+            nonce: Data((0..<32).map { _ in UInt8.random(in: .min ... .max, using: &random) }),
+            processPublicKey: Data(repeating: 0, count: 32))
+        _ = try provePossession(challenge)
+    }
+
+    static func create(context: BootContinuityContext, activation: BootContinuityActivation,
+                       engine: any BootKeyEngine) throws -> BootKeySession {
+        try preflight(context: context, activation: activation, engine: engine)
+        return try BootKeySession(context: context, key: engine.create())
+    }
+
+    static func recover(record data: Data, context: BootContinuityContext,
+                        activation: BootContinuityActivation, engine: any BootKeyEngine) throws -> BootKeySession {
+        try preflight(context: context, activation: activation, engine: engine)
+        let record = try BootKeyRecord.decode(data, expecting: context)
+        let key = try engine.recover(handle: record.opaqueHandle)
+        guard key.publicKey == record.publicKey else { throw BootContinuityError.publicKeyMismatch }
+        return try BootKeySession(context: context, key: key)
+    }
+
+    private static func preflight(context: BootContinuityContext,
+                                  activation: BootContinuityActivation, engine: any BootKeyEngine) throws {
+        guard activation == .experimental else { throw BootContinuityError.disabled }
+        try context.validate()
+        guard engine.isAvailable else { throw BootContinuityError.secureEnclaveUnavailable }
+    }
+
+    func storageRecord() throws -> Data { try BootKeyRecord(context: context, key: key).encode() }
+
+    func provePossession(_ challenge: BootContinuationChallenge) throws -> BootContinuationProof {
+        let transcript = BootContinuationTranscript.encode(context: context, publicKey: publicKey, challenge: challenge)
+        let signature = try key.sign(transcript)
+        guard let publicKey = try? P256.Signing.PublicKey(rawRepresentation: publicKey),
+              let parsed = try? P256.Signing.ECDSASignature(derRepresentation: signature),
+              publicKey.isValidSignature(parsed, for: transcript) else {
+            throw BootContinuityError.possessionCheckFailed
+        }
+        return BootContinuationProof(publicKey: self.publicKey, signatureDER: signature, transcript: transcript)
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/SecureEnclaveBootKey.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/SecureEnclaveBootKey.swift
@@ -1,0 +1,49 @@
+import CryptoKit
+import Foundation
+import LocalAuthentication
+import Security
+
+struct SecureEnclaveBootKeyEngine: BootKeyEngine {
+    var isAvailable: Bool { SecureEnclave.isAvailable }
+
+    func create() throws -> any BootHardwareKey {
+        let context = noInteractionContext()
+        var error: Unmanaged<CFError>?
+        // Class F is private SPI (SecItemPriv.h), not a public SDK guarantee.
+        // Do not substitute another protection if the platform rejects it.
+        guard let access = SecAccessControlCreateWithFlags(nil, "f" as CFString, .privateKeyUsage, &error) else {
+            _ = error?.takeRetainedValue()
+            throw BootContinuityError.keyUnavailable
+        }
+        do {
+            return EnclaveKey(try SecureEnclave.P256.Signing.PrivateKey(
+                accessControl: access, authenticationContext: context))
+        } catch { throw BootContinuityError.keyUnavailable }
+    }
+
+    func recover(handle: Data) throws -> any BootHardwareKey {
+        do {
+            return EnclaveKey(try SecureEnclave.P256.Signing.PrivateKey(
+                dataRepresentation: handle, authenticationContext: noInteractionContext()))
+        } catch { throw BootContinuityError.keyUnavailable }
+    }
+
+    private func noInteractionContext() -> LAContext {
+        let context = LAContext()
+        context.interactionNotAllowed = true
+        return context
+    }
+}
+
+private struct EnclaveKey: BootHardwareKey {
+    let key: SecureEnclave.P256.Signing.PrivateKey
+
+    init(_ key: SecureEnclave.P256.Signing.PrivateKey) { self.key = key }
+    var publicKey: Data { key.publicKey.rawRepresentation }
+    var opaqueHandle: Data { key.dataRepresentation }
+
+    func sign(_ message: Data) throws -> Data {
+        do { return try key.signature(for: message).derRepresentation }
+        catch { throw BootContinuityError.keyUnavailable }
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeyHardwareTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeyHardwareTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import XCTest
+@testable import BootContinuity
+
+final class BootKeyHardwareTests: XCTestCase {
+    func testExplicitlyRequestedHardwareRoundTrip() throws {
+        guard ProcessInfo.processInfo.environment["DARKBLOOM_TEST_BOOT_KEY_HARDWARE"] == "1" else {
+            throw XCTSkip("Requires explicit local hardware-test opt-in")
+        }
+        let engine = SecureEnclaveBootKeyEngine()
+        let context = try makeContext()
+        let original = try BootKeySession.create(context: context, activation: .experimental, engine: engine)
+        // The record stays in test memory. No Keychain or filesystem persistence.
+        let recovered = try BootKeySession.recover(record: original.storageRecord(), context: context, activation: .experimental, engine: engine)
+        XCTAssertEqual(original.publicKey, recovered.publicKey)
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 7, count: 32), processPublicKey: Data(repeating: 8, count: 32))
+        _ = try recovered.provePossession(challenge)
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeySessionTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeySessionTests.swift
@@ -1,0 +1,149 @@
+import CryptoKit
+import Foundation
+import XCTest
+@testable import BootContinuity
+
+final class BootKeySessionTests: XCTestCase {
+    func testDisabledAndUnavailableNeverCreateOrRecover() throws {
+        let engine = MemoryEngine()
+        let context = try makeContext()
+        assertError(.disabled) { _ = try BootKeySession.create(context: context, activation: .disabled, engine: engine) }
+        assertError(.disabled) { _ = try BootKeySession.recover(record: Data(), context: context, activation: .disabled, engine: engine) }
+        engine.isAvailable = false
+        assertError(.secureEnclaveUnavailable) { _ = try BootKeySession.create(context: context, activation: .experimental, engine: engine) }
+        XCTAssertEqual(engine.creates, 0)
+        XCTAssertEqual(engine.recovers, 0)
+    }
+
+    func testRecoveryProvesSamePrivateKeyAndBindsEachContextField() throws {
+        let engine = MemoryEngine()
+        let context = try makeContext()
+        let original = try BootKeySession.create(context: context, activation: .experimental, engine: engine)
+        let record = try original.storageRecord()
+        let recovered = try BootKeySession.recover(record: record, context: context, activation: .experimental, engine: engine)
+        XCTAssertEqual(original.publicKey, recovered.publicKey)
+        XCTAssertEqual(engine.creates, 1)
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 1, count: 32), processPublicKey: Data(repeating: 2, count: 32))
+        let proof = try recovered.provePossession(challenge)
+        let key = try P256.Signing.PublicKey(rawRepresentation: proof.publicKey)
+        let signature = try P256.Signing.ECDSASignature(derRepresentation: proof.signatureDER)
+        XCTAssertTrue(key.isValidSignature(signature, for: proof.transcript))
+        for other in try [makeContext(account: "other"), makeContext(device: "other"),
+                          makeContext(origin: "https://other.example"), makeContext(release: "other"), makeContext(generation: 2)] {
+            assertError(.contextMismatch) {
+                _ = try BootKeySession.recover(record: record, context: other, activation: .experimental, engine: engine)
+            }
+            let otherTranscript = BootContinuationTranscript.encode(context: other, publicKey: proof.publicKey, challenge: challenge)
+            XCTAssertFalse(key.isValidSignature(signature, for: otherTranscript))
+        }
+        XCTAssertEqual(engine.recovers, 1, "Context rejection must precede hardware access")
+    }
+
+    func testUnusableHandleNeverCreatesReplacement() throws {
+        let engine = MemoryEngine()
+        let context = try makeContext()
+        let session = try BootKeySession.create(context: context, activation: .experimental, engine: engine)
+        let record = try session.storageRecord()
+        engine.keys.removeAll()
+        assertError(.keyUnavailable) {
+            _ = try BootKeySession.recover(record: record, context: context, activation: .experimental, engine: engine)
+        }
+        XCTAssertEqual(engine.creates, 1)
+    }
+
+    func testRestoredPublicKeyMustMatchAndPrivateOperationMustWork() throws {
+        let engine = MemoryEngine()
+        let context = try makeContext()
+        let session = try BootKeySession.create(context: context, activation: .experimental, engine: engine)
+        let data = try session.storageRecord()
+        engine.replacement = MemoryKey()
+        assertError(.publicKeyMismatch) {
+            _ = try BootKeySession.recover(record: data, context: context, activation: .experimental, engine: engine)
+        }
+        engine.replacement = nil
+        engine.keys.values.first?.refuseSigning = true
+        assertError(.keyUnavailable) {
+            _ = try BootKeySession.recover(record: data, context: context, activation: .experimental, engine: engine)
+        }
+    }
+
+    func testMalformedOversizedAndUnknownRecordsNeverReachHardware() throws {
+        let engine = MemoryEngine()
+        let context = try makeContext()
+        for data in [Data("{}".utf8), Data(repeating: 0, count: BootKeyRecord.maximumSize + 1)] {
+            assertError(.invalidRecord) {
+                _ = try BootKeySession.recover(record: data, context: context, activation: .experimental, engine: engine)
+            }
+        }
+        let session = try BootKeySession.create(context: context, activation: .experimental, engine: engine)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: session.storageRecord()) as? [String: Any])
+        object["version"] = 99
+        let data = try JSONSerialization.data(withJSONObject: object)
+        assertError(.unsupportedRecordVersion) {
+            _ = try BootKeySession.recover(record: data, context: context, activation: .experimental, engine: engine)
+        }
+        XCTAssertEqual(engine.recovers, 0)
+    }
+
+    func testTranscriptRejectsFieldAmbiguityAndChallengeSubstitution() throws {
+        let engine = MemoryEngine()
+        let a = try makeContext(account: "ab", device: "c")
+        let b = try makeContext(account: "a", device: "bc")
+        let session = try BootKeySession.create(context: a, activation: .experimental, engine: engine)
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 1, count: 32), processPublicKey: Data(repeating: 2, count: 32))
+        let proof = try session.provePossession(challenge)
+        XCTAssertNotEqual(proof.transcript, BootContinuationTranscript.encode(context: b, publicKey: session.publicKey, challenge: challenge))
+        let key = try P256.Signing.PublicKey(rawRepresentation: proof.publicKey)
+        let signature = try P256.Signing.ECDSASignature(derRepresentation: proof.signatureDER)
+        for changed in try [BootContinuationChallenge(nonce: Data(repeating: 3, count: 32), processPublicKey: challenge.processPublicKey),
+                            BootContinuationChallenge(nonce: challenge.nonce, processPublicKey: Data(repeating: 4, count: 32))] {
+            XCTAssertFalse(key.isValidSignature(signature, for: BootContinuationTranscript.encode(context: a, publicKey: session.publicKey, challenge: changed)))
+        }
+        assertError(.invalidChallenge) { _ = try BootContinuationChallenge(nonce: Data(), processPublicKey: Data()) }
+        assertError(.invalidContext) { _ = try makeContext(origin: "https://example.test/path") }
+    }
+}
+
+func makeContext(account: String = "account", device: String = "device", origin: String = "https://example.test",
+                 release: String = "release-sha256", generation: UInt64 = 1) throws -> BootContinuityContext {
+    try BootContinuityContext(accountID: account, deviceID: device, coordinatorOrigin: origin, releaseID: release, policyGeneration: generation)
+}
+
+func assertError(_ error: BootContinuityError, file: StaticString = #filePath, line: UInt = #line, _ operation: () throws -> Void) {
+    XCTAssertThrowsError(try operation(), file: file, line: line) {
+        XCTAssertEqual($0 as? BootContinuityError, error, file: file, line: line)
+    }
+}
+
+final class MemoryEngine: BootKeyEngine {
+    var isAvailable = true
+    var creates = 0
+    var recovers = 0
+    var keys: [Data: MemoryKey] = [:]
+    var replacement: MemoryKey?
+
+    func create() throws -> any BootHardwareKey {
+        creates += 1
+        let key = MemoryKey()
+        keys[key.opaqueHandle] = key
+        return key
+    }
+
+    func recover(handle: Data) throws -> any BootHardwareKey {
+        recovers += 1
+        if let replacement { return replacement }
+        guard let key = keys[handle] else { throw BootContinuityError.keyUnavailable }
+        return key
+    }
+}
+
+final class MemoryKey: BootHardwareKey {
+    let key = P256.Signing.PrivateKey()
+    let opaqueHandle = Data(UUID().uuidString.utf8)
+    var refuseSigning = false
+    var publicKey: Data { key.publicKey.rawRepresentation }
+    func sign(_ message: Data) throws -> Data {
+        guard !refuseSigning else { throw BootContinuityError.keyUnavailable }
+        return try key.signature(for: message).derRepresentation
+    }
+}


### PR DESCRIPTION
Adds an isolated, explicitly experimental provider continuity package with typed context-bound possession proofs, strict recovery validation, and a Secure Enclave key backend. Production provider startup and coordinator authorization remain unchanged. The package rejects unavailable or mismatched state without creating replacement credentials.

Stacked on #862. This is a preparation layer; physical lifecycle and signed-app validation are still release gates.

### Before

```mermaid
flowchart LR
  A[Provider startup] --> B[Existing process identity]
  C[Continuity experiments] --> D[No reusable lifecycle module]
```

### After

```mermaid
flowchart LR
  A[Provider startup] --> B[Existing process identity]
  C[Explicit experimental caller] --> D[BootKeySession preflight]
  D --> E[Validate context and record]
  E --> F[SecureEnclaveBootKeyEngine]
  F --> G[Verify private possession]
  G --> H[Typed continuation proof]
  E --> I[Reject unusable or mismatched state]
```

Validation: the full CI workflow and end-to-end integration workflow passed at 4f58beab70e3471f8337d70016d2bf29a595a906, including the provider build/tests and deterministic package suite. A local hardware round-trip and same-boot recovery across separate processes also passed. Hardware tests require explicit opt-in; signed-app and physical reboot validation remain pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418009&installation_model_id=21733&pr_number=863&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F863&signature=5670310901672dfa3fd5019de0aed4b12c0986562e418bff9409eeba47a434c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->