### PR TITLE
Add scoped custody for provider continuity candidates

### DIFF
--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -586,6 +586,7 @@ jobs:
             exit 1
           fi
           echo "Entitlement verification passed: $EXPECTED_ACCESS_GROUP authorized via embedded provisioning profile"
+          python3 scripts/check-provider-keychain-scope.py "$APP"
 
           # Flat layout alongside the .app bundle. Coordinator's release
           # artifact verifier (release_handlers.go:413) requires bin/darkbloom

--- a/provider-swift/Package.swift
+++ b/provider-swift/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .executable(name: "darkbloom-publish", targets: ["darkbloom-publish"]),
     ],
     dependencies: [
+        .package(path: "Packages/BootContinuity"),
         .package(path: "../libs/mlx-swift"),
         .package(path: "../libs/mlx-swift-lm"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
@@ -112,6 +113,7 @@ let package = Package(
         .target(
             name: "ProviderCore",
             dependencies: [
+                .product(name: "BootContinuity", package: "BootContinuity"),
                 "ProviderCoreFoundation",
                 "ProviderMetallibControl",
                 .product(name: "MLX", package: "mlx-swift"),

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootApplicationPolicy.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootApplicationPolicy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct BootApplicationPolicy {
+    static let identifier = "io.darkbloom.provider"
+    static let teamID = "SLDQ2GJ6TL"
+    static let applicationID = "\(teamID).\(identifier)"
+    static let forbiddenEntitlements = [
+        "get-task-allow", "com.apple.security.get-task-allow",
+        "com.apple.security.cs.disable-library-validation",
+        "com.apple.security.cs.allow-dyld-environment-variables",
+        "com.apple.security.cs.allow-unsigned-executable-memory",
+        "com.apple.security.cs.disable-executable-page-protection",
+        "com.apple.security.cs.allow-jit",
+    ]
+
+    static func validate(identifier: String, teamID: String, hardenedRuntime: Bool,
+                         entitlements: [String: Any], executable: URL, bundle: URL,
+                         bundleExecutable: URL?) throws {
+        guard identifier == Self.identifier, teamID == Self.teamID, hardenedRuntime,
+              entitlements["com.apple.application-identifier"] as? String == applicationID,
+              let groups = entitlements["keychain-access-groups"] as? [String],
+              groups.contains(DataProtectionBootIdentityStore.accessGroup),
+              bundle.pathExtension == "app",
+              executable.resolvingSymlinksInPath() == bundleExecutable?.resolvingSymlinksInPath(),
+              executable.resolvingSymlinksInPath() == bundle.appendingPathComponent("Contents/MacOS/darkbloom").resolvingSymlinksInPath()
+        else { throw BootCustodyError.applicationNotPermitted }
+        for name in forbiddenEntitlements {
+            // Entitlement presence with any unexpected shape is rejected too.
+            if let value = entitlements[name] {
+                guard CFGetTypeID(value as CFTypeRef) == CFBooleanGetTypeID(),
+                      (value as? Bool) == false else {
+                    throw BootCustodyError.applicationNotPermitted
+                }
+            }
+        }
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuationTranscript.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuationTranscript.swift
@@ -4,14 +4,20 @@ enum BootContinuationTranscript {
     static func encode(context: BootContinuityContext, publicKey: Data,
                        challenge: BootContinuationChallenge) -> Data {
         var result = Data("darkbloom/boot-continuation/v1\0".utf8)
+        result.append(contextFields(context))
+        append(publicKey, to: &result)
+        append(challenge.nonce, to: &result)
+        append(challenge.processPublicKey, to: &result)
+        return result
+    }
+
+    static func contextFields(_ context: BootContinuityContext) -> Data {
+        var result = Data()
         for value in [context.accountID, context.deviceID, context.coordinatorOrigin, context.releaseID] {
             append(Data(value.utf8), to: &result)
         }
         var generation = context.policyGeneration.bigEndian
         withUnsafeBytes(of: &generation) { result.append(contentsOf: $0) }
-        append(publicKey, to: &result)
-        append(challenge.nonce, to: &result)
-        append(challenge.processPublicKey, to: &result)
         return result
     }
 

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuityCustodian.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootContinuityCustodian.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Experimental, local preparation seam. This actor never grants authorization,
+/// persists request secrets, or changes the provider's live request key.
+public actor BootContinuityCustodian {
+    private let activation: BootContinuityActivation
+    private let store: any BootIdentityStore
+    private let engine: any BootKeyEngine
+    private let application: any BootApplicationScope
+    private var session: BootKeySession?
+
+    public init(activation: BootContinuityActivation = .disabled) {
+        self.activation = activation
+        store = DataProtectionBootIdentityStore()
+        engine = SecureEnclaveBootKeyEngine()
+        application = SignedBootApplicationScope()
+        // These constructors perform no Security or Keychain IO.
+    }
+
+    init(activation: BootContinuityActivation, store: any BootIdentityStore,
+         engine: any BootKeyEngine, application: any BootApplicationScope) {
+        self.activation = activation
+        self.store = store
+        self.engine = engine
+        self.application = application
+    }
+
+    /// Context uses actual signed executable identity, never a claimed release.
+    public func makeContext(accountID: String, deviceID: String, coordinatorOrigin: String,
+                            policyGeneration: UInt64) throws -> BootContinuityContext {
+        guard activation == .experimental else { throw BootContinuityError.disabled }
+        return try BootContinuityContext(accountID: accountID, deviceID: deviceID,
+                                         coordinatorOrigin: coordinatorOrigin,
+                                         releaseID: application.currentReleaseID(),
+                                         policyGeneration: policyGeneration)
+    }
+
+    public func recover(context: BootContinuityContext) throws -> BootContinuityRecovery {
+        session = nil
+        guard activation == .experimental else { return .disabled }
+        try validateCaller(context)
+        guard let data = try store.read(context: context) else { return .absent }
+        let recovered = try BootKeySession.recover(record: data, context: context,
+                                                  activation: activation, engine: engine)
+        session = recovered
+        return .recovered(descriptor(recovered))
+    }
+
+    /// Explicitly creates a *candidate*, not a trusted or authorized identity.
+    /// Existing, stale, locked, and corrupt records require separate resolution;
+    /// none causes automatic rotation. The future bootstrap owns that policy.
+    public func prepareCandidateForBootstrap(context: BootContinuityContext) throws -> BootContinuityDescriptor {
+        session = nil
+        guard activation == .experimental else { throw BootContinuityError.disabled }
+        try validateCaller(context)
+        guard try store.read(context: context) == nil else { throw BootCustodyError.recordAlreadyExists }
+        let candidate = try BootKeySession.create(context: context, activation: activation, engine: engine)
+        // A competing process may have inserted since read. Insert-only semantics
+        // reject that race; the losing candidate never becomes the active session.
+        try store.insert(candidate.storageRecord(), context: context)
+        session = candidate
+        return descriptor(candidate)
+    }
+
+    public func provePossession(challenge: BootContinuationChallenge) throws -> BootContinuationProof {
+        guard activation == .experimental else { throw BootContinuityError.disabled }
+        guard let session else { throw BootCustodyError.noRecoveredSession }
+        try validateCaller(session.context)
+        return try session.provePossession(challenge)
+    }
+
+    /// Clears only process memory. It never deletes Keychain state.
+    public func forgetRecoveredSession() { session = nil }
+
+    private func validateCaller(_ context: BootContinuityContext) throws {
+        try context.validate()
+        guard try application.currentReleaseID() == context.releaseID else { throw BootCustodyError.releaseMismatch }
+    }
+
+    private func descriptor(_ session: BootKeySession) -> BootContinuityDescriptor {
+        BootContinuityDescriptor(context: session.context, publicKey: session.publicKey)
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootCustodyTypes.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootCustodyTypes.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public enum BootCustodyError: Error, Equatable, Sendable {
+    case applicationNotPermitted
+    case releaseMismatch
+    case recordAlreadyExists
+    case noRecoveredSession
+    case keychainFailure(Int32)
+}
+
+public struct BootContinuityDescriptor: Sendable {
+    public let context: BootContinuityContext
+    public let publicKey: Data
+}
+
+public enum BootContinuityRecovery: Sendable {
+    case disabled
+    case absent
+    /// Possession was checked locally. A coordinator must authorize its use.
+    case recovered(BootContinuityDescriptor)
+}
+
+protocol BootIdentityStore: Sendable {
+    func read(context: BootContinuityContext) throws -> Data?
+    /// Insert-only. Existing records are never replaced by this operation.
+    func insert(_ data: Data, context: BootContinuityContext) throws
+}
+
+protocol BootApplicationScope: Sendable {
+    /// Validates the current caller and returns the signed executable CDHash.
+    func currentReleaseID() throws -> String
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeyRecord.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeyRecord.swift
@@ -1,20 +1,24 @@
+import CryptoKit
 import Foundation
 
-/// Internal storage representation. Never expose the handle over a CLI or protocol.
+/// Internal representation from authenticated custody and caller-owned context.
+/// Never import external records or expose handles over a CLI or protocol.
 struct BootKeyRecord: Codable {
-    static let currentVersion = 1
+    static let currentVersion = 2
     static let maximumSize = 32 * 1024
 
     let version: Int
     let context: BootContinuityContext
     let publicKey: Data
     let opaqueHandle: Data
+    let bindingSignatureDER: Data
 
-    init(context: BootContinuityContext, key: any BootHardwareKey) {
+    init(context: BootContinuityContext, key: any BootHardwareKey) throws {
         version = Self.currentVersion
         self.context = context
         publicKey = key.publicKey
         opaqueHandle = key.opaqueHandle
+        bindingSignatureDER = try key.sign(Self.binding(context: context, publicKey: key.publicKey, handle: key.opaqueHandle))
     }
 
     static func decode(_ data: Data, expecting context: BootContinuityContext) throws -> Self {
@@ -27,7 +31,22 @@ struct BootKeyRecord: Codable {
         guard record.context == context else { throw BootContinuityError.contextMismatch }
         guard record.publicKey.count == 64, !record.opaqueHandle.isEmpty,
               record.opaqueHandle.count <= 16 * 1024 else { throw BootContinuityError.invalidRecord }
+        guard let key = try? P256.Signing.PublicKey(rawRepresentation: record.publicKey),
+              let signature = try? P256.Signing.ECDSASignature(derRepresentation: record.bindingSignatureDER),
+              key.isValidSignature(signature, for: binding(context: record.context, publicKey: record.publicKey, handle: record.opaqueHandle)) else {
+            throw BootContinuityError.invalidRecord
+        }
         return record
+    }
+
+    // Local integrity only. Someone who already possesses the usable handle can
+    // make another binding; this is neither hardware policy nor server approval.
+    private static func binding(context: BootContinuityContext, publicKey: Data, handle: Data) -> Data {
+        var result = Data("darkbloom/boot-record/v2\0".utf8)
+        result.append(BootContinuationTranscript.contextFields(context))
+        result.append(publicKey)
+        result.append(contentsOf: SHA256.hash(data: handle))
+        return result
     }
 
     func encode() throws -> Data {

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeySession.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/BootKeySession.swift
@@ -7,7 +7,7 @@ protocol BootHardwareKey {
     func sign(_ message: Data) throws -> Data
 }
 
-protocol BootKeyEngine {
+protocol BootKeyEngine: Sendable {
     var isAvailable: Bool { get }
     func create() throws -> any BootHardwareKey
     func recover(handle: Data) throws -> any BootHardwareKey

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/DataProtectionBootIdentityStore.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/DataProtectionBootIdentityStore.swift
@@ -1,0 +1,60 @@
+import CryptoKit
+import Foundation
+import LocalAuthentication
+import Security
+
+struct DataProtectionBootIdentityStore: BootIdentityStore {
+    static let accessGroup = "SLDQ2GJ6TL.io.darkbloom.provider"
+    static let service = "io.darkbloom.provider.boot-continuity.v1"
+
+    func read(context: BootContinuityContext) throws -> Data? {
+        var query = Self.baseQuery(context: context)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var value: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &value)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else { throw BootCustodyError.keychainFailure(status) }
+        guard let data = value as? Data, data.count <= BootKeyRecord.maximumSize else {
+            throw BootContinuityError.invalidRecord
+        }
+        return data
+    }
+
+    func insert(_ data: Data, context: BootContinuityContext) throws {
+        guard data.count <= BootKeyRecord.maximumSize else { throw BootContinuityError.invalidRecord }
+        var query = Self.baseQuery(context: context)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        query[kSecValueData as String] = data
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status == errSecDuplicateItem { throw BootCustodyError.recordAlreadyExists }
+        guard status == errSecSuccess else { throw BootCustodyError.keychainFailure(status) }
+    }
+
+    static func baseQuery(context: BootContinuityContext) -> [String: Any] {
+        let authentication = LAContext()
+        authentication.interactionNotAllowed = true
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: accountLocator(context: context),
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrSynchronizable as String: false,
+            kSecUseAuthenticationContext as String: authentication,
+        ]
+    }
+
+    static func accountLocator(context: BootContinuityContext) -> String {
+        var data = Data("darkbloom/boot-custody-location/v1\0".utf8)
+        for value in [context.accountID, context.deviceID, context.coordinatorOrigin, context.releaseID] {
+            let bytes = Data(value.utf8)
+            var count = UInt32(bytes.count).bigEndian
+            withUnsafeBytes(of: &count) { data.append(contentsOf: $0) }
+            data.append(bytes)
+        }
+        var generation = context.policyGeneration.bigEndian
+        withUnsafeBytes(of: &generation) { data.append(contentsOf: $0) }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Sources/BootContinuity/SignedBootApplicationScope.swift
+++ b/provider-swift/Packages/BootContinuity/Sources/BootContinuity/SignedBootApplicationScope.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Security
+
+struct SignedBootApplicationScope: BootApplicationScope {
+    func currentReleaseID() throws -> String {
+        var code: SecCode?
+        guard SecCodeCopySelf(SecCSFlags(), &code) == errSecSuccess, let code else {
+            throw BootCustodyError.applicationNotPermitted
+        }
+        var requirement: SecRequirement?
+        let expression = "anchor apple generic and identifier \"io.darkbloom.provider\" and certificate leaf[subject.OU] = \"SLDQ2GJ6TL\""
+        guard SecRequirementCreateWithString(expression as CFString, SecCSFlags(), &requirement) == errSecSuccess,
+              let requirement,
+              SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), requirement) == errSecSuccess else {
+            throw BootCustodyError.applicationNotPermitted
+        }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, SecCSFlags(), &staticCode) == errSecSuccess, let staticCode else {
+            throw BootCustodyError.applicationNotPermitted
+        }
+        var raw: CFDictionary?
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &raw) == errSecSuccess,
+              let info = raw as? [String: Any],
+              let identifier = info[kSecCodeInfoIdentifier as String] as? String,
+              let team = info[kSecCodeInfoTeamIdentifier as String] as? String,
+              let flags = info[kSecCodeInfoFlags as String] as? UInt32,
+              let entitlements = info[kSecCodeInfoEntitlementsDict as String] as? [String: Any],
+              let executable = info[kSecCodeInfoMainExecutable as String] as? URL,
+              let hash = info[kSecCodeInfoUnique as String] as? Data, !hash.isEmpty else {
+            throw BootCustodyError.applicationNotPermitted
+        }
+        try BootApplicationPolicy.validate(identifier: identifier, teamID: team,
+                                            hardenedRuntime: flags & 0x10000 != 0, // CS_RUNTIME (Security/CSCommon.h)
+                                            entitlements: entitlements, executable: executable,
+                                            bundle: Bundle.main.bundleURL, bundleExecutable: Bundle.main.executableURL)
+        return "cdhash:" + hash.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootApplicationPolicyTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootApplicationPolicyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import LocalAuthentication
+import Security
+import XCTest
+@testable import BootContinuity
+
+final class BootApplicationPolicyTests: XCTestCase {
+    private let app = URL(fileURLWithPath: "/Applications/Darkbloom.app")
+    private var executable: URL { app.appendingPathComponent("Contents/MacOS/darkbloom") }
+    private var allowed: [String: Any] {
+        ["com.apple.application-identifier": BootApplicationPolicy.applicationID,
+         "keychain-access-groups": [DataProtectionBootIdentityStore.accessGroup]]
+    }
+
+    func testOnlyExpectedMainAppScopePasses() throws {
+        try check()
+        XCTAssertThrowsError(try check(identifier: "darkbloom-enclave"))
+        XCTAssertThrowsError(try check(team: "OTHERTEAM"))
+        XCTAssertThrowsError(try check(runtime: false))
+        XCTAssertThrowsError(try check(entitlements: [:]))
+        XCTAssertThrowsError(try check(path: app.appendingPathComponent("Contents/MacOS/darkbloom-enclave")))
+        var otherGroup = allowed
+        otherGroup["keychain-access-groups"] = ["OTHERTEAM.io.darkbloom.provider"]
+        XCTAssertThrowsError(try check(entitlements: otherGroup))
+        for entitlement in BootApplicationPolicy.forbiddenEntitlements {
+            var unsafe = allowed
+            unsafe[entitlement] = true
+            XCTAssertThrowsError(try check(entitlements: unsafe))
+            unsafe[entitlement] = "unexpected"
+            XCTAssertThrowsError(try check(entitlements: unsafe))
+            unsafe[entitlement] = 0
+            XCTAssertThrowsError(try check(entitlements: unsafe))
+            unsafe[entitlement] = false
+            try check(entitlements: unsafe)
+        }
+    }
+
+    func testLiveTestBinaryIsRejectedBeforeCustody() {
+        XCTAssertThrowsError(try SignedBootApplicationScope().currentReleaseID()) {
+            XCTAssertEqual($0 as? BootCustodyError, .applicationNotPermitted)
+        }
+    }
+
+    func testKeychainQueryCannotFallBackToLegacyOrSynchronizableStorage() throws {
+        let query = DataProtectionBootIdentityStore.baseQuery(context: try makeContext())
+        XCTAssertEqual(query[kSecUseDataProtectionKeychain as String] as? Bool, true)
+        XCTAssertEqual(query[kSecAttrSynchronizable as String] as? Bool, false)
+        XCTAssertEqual(query[kSecAttrAccessGroup as String] as? String, DataProtectionBootIdentityStore.accessGroup)
+        XCTAssertEqual((query[kSecUseAuthenticationContext as String] as? LAContext)?.interactionNotAllowed, true)
+        XCTAssertNil(query[kSecAttrAccess as String], "No legacy keychain ACL path")
+    }
+
+    func testLocatorBindsEveryAuthoritativeContextField() throws {
+        let original = DataProtectionBootIdentityStore.accountLocator(context: try makeContext())
+        for context in try [makeContext(account: "other"), makeContext(device: "other"),
+                            makeContext(origin: "https://other.example"), makeContext(release: "other"), makeContext(generation: 2)] {
+            XCTAssertNotEqual(original, DataProtectionBootIdentityStore.accountLocator(context: context))
+        }
+    }
+
+    private func check(identifier: String = BootApplicationPolicy.identifier, team: String = BootApplicationPolicy.teamID,
+                       runtime: Bool = true, entitlements: [String: Any]? = nil, path: URL? = nil) throws {
+        try BootApplicationPolicy.validate(identifier: identifier, teamID: team, hardenedRuntime: runtime,
+                                            entitlements: entitlements ?? allowed, executable: path ?? executable,
+                                            bundle: app, bundleExecutable: executable)
+    }
+}

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootCustodianTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootCustodianTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import XCTest
+@testable import BootContinuity
+
+final class BootCustodianTests: XCTestCase, @unchecked Sendable {
+    func testDisabledPerformsNoApplicationHardwareOrStorageIO() async throws {
+        let fixture = Fixture(activation: .disabled)
+        let result = try await fixture.custodian.recover(context: makeContext())
+        guard case .disabled = result else { return XCTFail("Expected disabled") }
+        do { _ = try await fixture.custodian.prepareCandidateForBootstrap(context: makeContext()); XCTFail("must reject") }
+        catch { XCTAssertEqual(error as? BootContinuityError, .disabled) }
+        XCTAssertEqual(fixture.store.reads, 0)
+        XCTAssertEqual(fixture.store.inserts, 0)
+        XCTAssertEqual(fixture.application.checks, 0)
+        XCTAssertEqual(fixture.engine.creates, 0)
+        XCTAssertEqual(fixture.engine.recovers, 0)
+    }
+
+    func testApplicationAndReleaseMismatchRejectBeforeKeychainAccess() async throws {
+        let fixture = Fixture()
+        fixture.application.failure = .applicationNotPermitted
+        await assertCustodyError(.applicationNotPermitted) { _ = try await fixture.custodian.recover(context: makeContext()) }
+        fixture.application.failure = nil
+        await assertCustodyError(.releaseMismatch) { _ = try await fixture.custodian.recover(context: makeContext(release: "claimed")) }
+        XCTAssertEqual(fixture.store.reads, 0)
+        XCTAssertEqual(fixture.engine.creates, 0)
+    }
+
+    func testContextUsesVerifiedReleaseAndAbsentRecoveryDoesNotCreate() async throws {
+        let fixture = Fixture()
+        let context = try await fixture.custodian.makeContext(accountID: "account", deviceID: "device", coordinatorOrigin: "https://example.test", policyGeneration: 1)
+        XCTAssertEqual(context.releaseID, fixture.application.release)
+        guard case .absent = try await fixture.custodian.recover(context: context) else { return XCTFail("Expected absent") }
+        XCTAssertEqual(fixture.engine.creates, 0)
+        XCTAssertEqual(fixture.store.inserts, 0)
+    }
+
+    func testExplicitCandidateCanRecoverAcrossCustodianInstances() async throws {
+        let fixture = Fixture()
+        let context = try makeContext()
+        let candidate = try await fixture.custodian.prepareCandidateForBootstrap(context: context)
+        await fixture.custodian.forgetRecoveredSession()
+        let next = BootContinuityCustodian(activation: .experimental, store: fixture.store, engine: fixture.engine, application: fixture.application)
+        guard case let .recovered(descriptor) = try await next.recover(context: context) else { return XCTFail("Expected recovered") }
+        XCTAssertEqual(candidate.publicKey, descriptor.publicKey)
+        XCTAssertEqual(fixture.engine.creates, 1)
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 1, count: 32), processPublicKey: Data(repeating: 2, count: 32))
+        let proof = try await next.provePossession(challenge: challenge)
+        XCTAssertEqual(proof.publicKey, candidate.publicKey)
+    }
+
+    func testLockedStorageAndUnusableKeysPreserveRecordsAndNeverRotate() async throws {
+        let fixture = Fixture()
+        let context = try makeContext()
+        _ = try await fixture.custodian.prepareCandidateForBootstrap(context: context)
+        let retained = fixture.store.records
+        fixture.store.failure = .keychainFailure(-25308)
+        await assertCustodyError(.keychainFailure(-25308)) { _ = try await fixture.custodian.recover(context: context) }
+        await assertCustodyError(.keychainFailure(-25308)) { _ = try await fixture.custodian.prepareCandidateForBootstrap(context: context) }
+        fixture.store.failure = nil
+        fixture.engine.keys.removeAll()
+        do { _ = try await fixture.custodian.recover(context: context); XCTFail("must reject") }
+        catch { XCTAssertEqual(error as? BootContinuityError, .keyUnavailable) }
+        await assertCustodyError(.recordAlreadyExists) { _ = try await fixture.custodian.prepareCandidateForBootstrap(context: context) }
+        XCTAssertEqual(fixture.store.records, retained)
+        XCTAssertEqual(fixture.engine.creates, 1)
+        XCTAssertEqual(fixture.store.inserts, 1)
+    }
+
+    func testInsertRaceCannotActivateLosingCandidate() async throws {
+        let fixture = Fixture()
+        fixture.store.insertFailure = .recordAlreadyExists
+        await assertCustodyError(.recordAlreadyExists) { _ = try await fixture.custodian.prepareCandidateForBootstrap(context: makeContext()) }
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 1, count: 32), processPublicKey: Data(repeating: 2, count: 32))
+        await assertCustodyError(.noRecoveredSession) { _ = try await fixture.custodian.provePossession(challenge: challenge) }
+        XCTAssertTrue(fixture.store.records.isEmpty)
+    }
+
+    func testRecordCopyAndMetadataRewriteCannotChangeContext() async throws {
+        let fixture = Fixture()
+        let original = try makeContext()
+        _ = try await fixture.custodian.prepareCandidateForBootstrap(context: original)
+        let foreign = try makeContext(account: "different-account")
+        let record = try XCTUnwrap(fixture.store.records[DataProtectionBootIdentityStore.accountLocator(context: original)])
+        let locator = DataProtectionBootIdentityStore.accountLocator(context: foreign)
+        fixture.store.records[locator] = record
+        do { _ = try await fixture.custodian.recover(context: foreign); XCTFail("must reject copied record") }
+        catch { XCTAssertEqual(error as? BootContinuityError, .contextMismatch) }
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: record) as? [String: Any])
+        var rewritten = try XCTUnwrap(object["context"] as? [String: Any])
+        rewritten["accountID"] = foreign.accountID
+        object["context"] = rewritten
+        fixture.store.records[locator] = try JSONSerialization.data(withJSONObject: object)
+        do { _ = try await fixture.custodian.recover(context: foreign); XCTFail("must reject rewritten record") }
+        catch { XCTAssertEqual(error as? BootContinuityError, .invalidRecord) }
+        XCTAssertEqual(fixture.engine.recovers, 0)
+        XCTAssertEqual(fixture.engine.creates, 1)
+    }
+
+    func testRejectedRecoveryClearsEarlierInMemorySession() async throws {
+        let fixture = Fixture()
+        _ = try await fixture.custodian.prepareCandidateForBootstrap(context: makeContext())
+        fixture.application.failure = .applicationNotPermitted
+        await assertCustodyError(.applicationNotPermitted) { _ = try await fixture.custodian.recover(context: makeContext()) }
+        fixture.application.failure = nil
+        let challenge = try BootContinuationChallenge(nonce: Data(repeating: 1, count: 32), processPublicKey: Data(repeating: 2, count: 32))
+        await assertCustodyError(.noRecoveredSession) { _ = try await fixture.custodian.provePossession(challenge: challenge) }
+    }
+}
+
+private struct Fixture {
+    let store = MemoryStore()
+    let engine = MemoryEngine()
+    let application = MemoryApplication()
+    let custodian: BootContinuityCustodian
+    init(activation: BootContinuityActivation = .experimental) {
+        custodian = BootContinuityCustodian(activation: activation, store: store, engine: engine, application: application)
+    }
+}
+
+private final class MemoryStore: BootIdentityStore, @unchecked Sendable {
+    var records: [String: Data] = [:]
+    var reads = 0
+    var inserts = 0
+    var failure: BootCustodyError?
+    var insertFailure: BootCustodyError?
+    func read(context: BootContinuityContext) throws -> Data? {
+        reads += 1
+        if let failure { throw failure }
+        return records[DataProtectionBootIdentityStore.accountLocator(context: context)]
+    }
+    func insert(_ data: Data, context: BootContinuityContext) throws {
+        inserts += 1
+        if let failure = insertFailure ?? failure { throw failure }
+        let key = DataProtectionBootIdentityStore.accountLocator(context: context)
+        guard records[key] == nil else { throw BootCustodyError.recordAlreadyExists }
+        records[key] = data
+    }
+}
+
+private final class MemoryApplication: BootApplicationScope, @unchecked Sendable {
+    var release = "release-sha256"
+    var checks = 0
+    var failure: BootCustodyError?
+    func currentReleaseID() throws -> String {
+        checks += 1
+        if let failure { throw failure }
+        return release
+    }
+}
+
+private func assertCustodyError(_ error: BootCustodyError, file: StaticString = #filePath, line: UInt = #line,
+                                _ operation: () async throws -> Void) async {
+    do { try await operation(); XCTFail("Expected \(error)", file: file, line: line) }
+    catch let caught { XCTAssertEqual(caught as? BootCustodyError, error, file: file, line: line) }
+}

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeyHardwareTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeyHardwareTests.swift
@@ -1,8 +1,49 @@
 import Foundation
+import Security
 import XCTest
 @testable import BootContinuity
 
 final class BootKeyHardwareTests: XCTestCase {
+    func testExplicitlyRequestedSignedAppStaticPolicy() throws {
+        guard ProcessInfo.processInfo.environment["DARKBLOOM_TEST_BOOT_KEY_HARDWARE"] == "1",
+              let path = ProcessInfo.processInfo.environment["DARKBLOOM_TEST_SIGNED_APP_PATH"] else {
+            throw XCTSkip("Requires explicit installed signed-app path")
+        }
+        let app = URL(fileURLWithPath: path)
+        let executable = app.appendingPathComponent("Contents/MacOS/darkbloom")
+        var code: SecStaticCode?
+        XCTAssertEqual(SecStaticCodeCreateWithPath(executable as CFURL, SecCSFlags(), &code), errSecSuccess)
+        let candidate = try XCTUnwrap(code)
+        var requirement: SecRequirement?
+        let expression = "anchor apple generic and identifier \"io.darkbloom.provider\" and certificate leaf[subject.OU] = \"SLDQ2GJ6TL\""
+        XCTAssertEqual(SecRequirementCreateWithString(expression as CFString, SecCSFlags(), &requirement), errSecSuccess)
+        XCTAssertEqual(SecStaticCodeCheckValidity(candidate, SecCSFlags(rawValue: kSecCSStrictValidate), requirement), errSecSuccess)
+        var raw: CFDictionary?
+        XCTAssertEqual(SecCodeCopySigningInformation(candidate, SecCSFlags(rawValue: kSecCSSigningInformation), &raw), errSecSuccess)
+        let info = try XCTUnwrap(raw as? [String: Any])
+        try BootApplicationPolicy.validate(
+            identifier: XCTUnwrap(info[kSecCodeInfoIdentifier as String] as? String),
+            teamID: XCTUnwrap(info[kSecCodeInfoTeamIdentifier as String] as? String),
+            hardenedRuntime: XCTUnwrap(info[kSecCodeInfoFlags as String] as? UInt32) & 0x10000 != 0,
+            entitlements: XCTUnwrap(info[kSecCodeInfoEntitlementsDict as String] as? [String: Any]),
+            executable: XCTUnwrap(info[kSecCodeInfoMainExecutable as String] as? URL),
+            bundle: app, bundleExecutable: executable)
+        // This validates stored signature metadata, not execution of our new
+        // currentReleaseID() function inside the released main process.
+    }
+
+    func testExplicitlyRequestedUnentitledKeychainRead() throws {
+        guard ProcessInfo.processInfo.environment["DARKBLOOM_TEST_BOOT_KEY_HARDWARE"] == "1" else {
+            throw XCTSkip("Requires explicit local hardware-test opt-in")
+        }
+        // Test binaries are not signed/provisioned for the provider access group.
+        // This is read-only, uses a test-only namespace, and must not show UI.
+        let context = try makeContext(account: "unentitled-read-control")
+        XCTAssertThrowsError(try DataProtectionBootIdentityStore().read(context: context)) {
+            XCTAssertEqual($0 as? BootCustodyError, .keychainFailure(errSecMissingEntitlement))
+        }
+    }
+
     func testExplicitlyRequestedHardwareRoundTrip() throws {
         guard ProcessInfo.processInfo.environment["DARKBLOOM_TEST_BOOT_KEY_HARDWARE"] == "1" else {
             throw XCTSkip("Requires explicit local hardware-test opt-in")

--- a/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeySessionTests.swift
+++ b/provider-swift/Packages/BootContinuity/Tests/BootContinuityTests/BootKeySessionTests.swift
@@ -115,7 +115,7 @@ func assertError(_ error: BootContinuityError, file: StaticString = #filePath, l
     }
 }
 
-final class MemoryEngine: BootKeyEngine {
+final class MemoryEngine: BootKeyEngine, @unchecked Sendable {
     var isAvailable = true
     var creates = 0
     var recovers = 0

--- a/provider-swift/Sources/ProviderCore/Security/ProviderBootContinuity.swift
+++ b/provider-swift/Sources/ProviderCore/Security/ProviderBootContinuity.swift
@@ -1,0 +1,38 @@
+import BootContinuity
+import Foundation
+
+/// An inactive protocol-development seam. ProviderLoop does not instantiate it.
+/// A future handshake must independently authorize this identity and any new
+/// process key; a local recovery result must never restore coordinator trust.
+public actor ProviderBootContinuity {
+    private let custodian: BootContinuityCustodian
+    private let processPublicKey: Data
+
+    public init(nodeKeyPair: NodeKeyPair, activation: BootContinuityActivation = .disabled) {
+        // Capture the live endpoint from local provider state. A challenge cannot
+        // ask this adapter to endorse a different externally supplied endpoint.
+        processPublicKey = nodeKeyPair.publicKeyBytes
+        custodian = BootContinuityCustodian(activation: activation)
+    }
+
+    public func makeContext(accountID: String, deviceID: String, coordinatorOrigin: String,
+                            policyGeneration: UInt64) async throws -> BootContinuityContext {
+        try await custodian.makeContext(accountID: accountID, deviceID: deviceID,
+                                        coordinatorOrigin: coordinatorOrigin, policyGeneration: policyGeneration)
+    }
+
+    public func recover(context: BootContinuityContext) async throws -> BootContinuityRecovery {
+        try await custodian.recover(context: context)
+    }
+
+    public func prepareCandidateForBootstrap(context: BootContinuityContext) async throws -> BootContinuityDescriptor {
+        try await custodian.prepareCandidateForBootstrap(context: context)
+    }
+
+    public func provePossession(serverNonce: Data) async throws -> BootContinuationProof {
+        let challenge = try BootContinuationChallenge(nonce: serverNonce, processPublicKey: processPublicKey)
+        return try await custodian.provePossession(challenge: challenge)
+    }
+
+    public func forgetRecoveredSession() async { await custodian.forgetRecoveredSession() }
+}

--- a/scripts/check-provider-keychain-scope.py
+++ b/scripts/check-provider-keychain-scope.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Read-only validation of the signed provider's Keychain access scope."""
+
+import pathlib
+import plistlib
+import re
+import subprocess
+import sys
+
+
+APP_ID = "SLDQ2GJ6TL.io.darkbloom.provider"
+FORBIDDEN = (
+    "get-task-allow",
+    "com.apple.security.get-task-allow",
+    "com.apple.security.cs.disable-library-validation",
+    "com.apple.security.cs.allow-dyld-environment-variables",
+    "com.apple.security.cs.allow-unsigned-executable-memory",
+    "com.apple.security.cs.disable-executable-page-protection",
+    "com.apple.security.cs.allow-jit",
+)
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(args, check=True, capture_output=True)
+
+
+def entitlements(path: pathlib.Path) -> dict:
+    result = run("codesign", "-d", "--entitlements", "-", "--xml", str(path))
+    return plistlib.loads(result.stdout)
+
+
+def validate(app: pathlib.Path) -> None:
+    main = app / "Contents/MacOS/darkbloom"
+    run("codesign", "--verify", "--deep", "--strict", str(app))
+    requirement = (
+        'anchor apple generic and identifier "io.darkbloom.provider" '
+        'and certificate leaf[subject.OU] = "SLDQ2GJ6TL"'
+    )
+    run("codesign", "--verify", "--strict", "-R=" + requirement, str(main))
+    current = entitlements(main)
+    if current.get("com.apple.application-identifier") != APP_ID:
+        raise ValueError("main application identifier mismatch")
+    if APP_ID not in current.get("keychain-access-groups", []):
+        raise ValueError("main Keychain access group is missing")
+    for name in FORBIDDEN:
+        if name in current and current[name] is not False:
+            raise ValueError("main runtime exception is not permitted: " + name)
+    details = run("codesign", "-dv", str(main)).stderr.decode()
+    flags = re.search(r"flags=0x([0-9a-fA-F]+)", details)
+    if not flags or not int(flags.group(1), 16) & 0x10000:
+        raise ValueError("main hardened runtime is missing")
+    for relative in ("Contents/MacOS/darkbloom-enclave", "Contents/Helpers/darkbloom-fan-helper"):
+        helper = app / relative
+        if not helper.is_file():
+            raise ValueError("required helper missing: " + relative)
+        run("codesign", "--verify", "--strict", str(helper))
+        # An empty entitlement result is valid for a helper; malformed output is not.
+        output = run("codesign", "-d", "--entitlements", "-", "--xml", str(helper)).stdout
+        helper_entitlements = plistlib.loads(output) if output.strip() else {}
+        for name in ("keychain-access-groups", "com.apple.application-identifier", "application-identifier"):
+            if name in helper_entitlements:
+                raise ValueError("helper has application Keychain scope: " + relative)
+
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) != 2:
+            raise ValueError("usage: check-provider-keychain-scope.py APP")
+        validate(pathlib.Path(sys.argv[1]))
+    except (ValueError, OSError, subprocess.CalledProcessError, plistlib.InvalidFileException) as error:
+        print("provider-keychain-scope: failed: " + str(error), file=sys.stderr)
+        sys.exit(1)
+    print("provider-keychain-scope: ok")


### PR DESCRIPTION
Adds application-scoped Data Protection Keychain custody and an inactive provider adapter for the experimental continuity package. Recovery validates signed application scope and exact context, while explicit candidate creation is insert-only. Disabled mode performs no Keychain work, and failures preserve existing records.

Stacked on #863, which is stacked on #862. Provider startup and coordinator authorization remain unchanged. The adapter binds proof construction to its captured local process key; signed-app runtime and lifecycle validation remain release gates.

### Before

```mermaid
flowchart LR
  A[Experimental caller] --> B[BootKeySession]
  B --> C[Internal opaque record]
  D[Provider startup] --> E[Existing process identity]
```

### After

```mermaid
flowchart LR
  A[Explicit provider adapter] --> B[BootContinuityCustodian]
  B --> C[Validate signed app and context]
  C --> D[Data Protection Keychain read or insert]
  D --> E[BootKeySession possession check]
  E --> F[Proof using captured process key]
  C --> G[Reject and preserve stored state]
  H[Default disabled] --> I[No Keychain IO]
  J[Provider startup] --> K[Existing process identity]
```

Validation: the full CI and end-to-end integration workflows passed at 6e91d54d38e16634979217c2e636b1c846da772e, including the full provider build/tests and coordinator compatibility checks. All 18 deterministic package tests passed, as did three opt-in local hardware/artifact checks and the installed-app release-scope check. New signed-app runtime, custody and physical reboot validation remain separate gates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418535&installation_model_id=21733&pr_number=864&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F864&signature=936e16474ab20eb3dbd719654ea10ccc14ae352a293f96b356acd438f8caa739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->