### PR TITLE
fix(provider): scale SSD cache disk policy with available space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased — provider SSD cache disk policy
 
 - Size the shared SSD cache at half of currently available disk space without a fixed 100 GiB ceiling. Keep a fixed 20 GiB low-disk write reserve instead of reserving 5% of the whole disk, so large disks with ample free space can cache. Preserve encryption, eviction, daily write limits and ENOSPC handling.
+- Check the full pending SSD donation against free space above the reserve before writing, so a donation cannot pass merely because free space starts above 20 GiB.
+
 ## Unreleased: prediction decisions and backup deadlines
 
 - Record the coordinator's prediction policy, reservation ceiling and encoded deadline budget alongside each provider's returned prediction and decision. Distinguish refusals from acceptance followed by expiry without changing error codes or prediction policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — provider SSD cache disk policy
+
+- Size the shared SSD cache at half of currently available disk space without a fixed 100 GiB ceiling. Keep a fixed 20 GiB low-disk write reserve instead of reserving 5% of the whole disk, so large disks with ample free space can cache. Preserve encryption, eviction, daily write limits and ENOSPC handling.
+
 ## Unreleased — stats request-flow refresh
 
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.

--- a/docs/provider/hardware-requirements.md
+++ b/docs/provider/hardware-requirements.md
@@ -1,6 +1,6 @@
 # Provider hardware requirements
 
-> Last updated: 2026-09-05 · commit `169b342e6`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 Reference for what a Mac needs to run the `darkbloom` provider: the minimum
 requirements, the chip families the provider distinguishes, which catalog
@@ -18,7 +18,7 @@ and are not repeated here.
 | Architecture | `arm64` only; the installer refuses Intel Macs | `coordinator/api/install.sh` |
 | RAM | At least 8 GB to start at all ([`../architecture/hardware-support.md#context`](../architecture/hardware-support.md#context)); per-model needs below | `provider-swift/Sources/darkbloom/StartCommand+Preflight.swift` (`hardware.memoryGb < 8`) |
 | macOS | 14 (Sonoma) or later, the build floor; `darkbloom doctor` warns below macOS 26 (`recommendedMacOSMajorVersion`, [`../architecture/hardware-support.md#context`](../architecture/hardware-support.md#context)) but does not block | `provider-swift/Package.swift` (`.macOS(.v14)`), `provider-swift/Sources/ProviderCore/Security/BootSecurity.swift` |
-| Storage | Weights per model (catalog `size_gb`) under the Hugging Face hub cache, plus the SSD prefix-cache budget (`defaultSSDDiskBudgetBytes`, [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules)) when that cache is active | `provider-swift/Sources/ProviderCoreFoundation/ModelScanner.swift` (`defaultCacheDirectory`), `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` |
+| Storage | Weights per model (catalog `size_gb`) under the Hugging Face hub cache, plus the SSD prefix-cache budget (`ssdDiskBudgetBytes`, [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules)) when that cache is active | `provider-swift/Sources/ProviderCoreFoundation/ModelScanner.swift` (`defaultCacheDirectory`), `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` |
 | Network | Outbound `wss://api.darkbloom.dev/ws/provider` and HTTPS on 443; a heartbeat every `heartbeat_interval_secs` ([`cli-reference.md`](./cli-reference.md#providertoml-keys-read-by-the-cli)); no inbound port | `provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift` |
 | Security posture | SIP enabled and Full Security boot; a logged-in GUI session for APNs code-identity attestation | [`attestation.md`](./attestation.md) |
 
@@ -88,7 +88,7 @@ with less than `minimumLoadKVBytes` of KV headroom is unloaded again
 | Rule | Where it is specified | Code |
 |---|---|---|
 | Location | [`../reference/ssd-kv-cache.md#paths`](../reference/ssd-kv-cache.md#paths) | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift` |
-| Box-wide budget (`defaultSSDDiskBudgetBytes`, halved when the volume is short on free space), the `DARKBLOOM_PREFIX_CACHE_DISK_GB` override, LRU eviction | [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules) | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) |
+| Box-wide budget (`ssdDiskBudgetBytes`, based on currently available space), the `DARKBLOOM_PREFIX_CACHE_DISK_GB` override, LRU eviction | [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules) | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) |
 | Low-disk write stop (`lowDiskFloorBytes`; reads continue) and the daily write cap (`defaultMaxWriteBytesPerDay`) | [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules) | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift` |
 | When it is used at all | Eligible Qwen uses complete SSD on native contiguous or segmented paged storage; historical GPT-OSS/Gemma complete checkpoints require paged storage. Loaded capability, identity and key gates apply; resident RAM is opt-in | [`../architecture/prefix-cache.md`](../architecture/prefix-cache.md) |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -396,7 +396,7 @@ Internals and file format: [`ssd-kv-cache.md`](ssd-kv-cache.md).
 | `DARKBLOOM_PREFIX_CACHE` | affirmative opts in; non-affirmative nonempty disables | on for exact Qwen cohort, off otherwise | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift` (`isEnabled`) | Unset/empty uses the [model default](../design/release-090-paged-qwen-cache.md). Explicit affirmative values permit other models subject to capability/identity gates; resident payloads require the separate memory opt-in. |
 | `DARKBLOOM_PREFIX_CACHE_MEMORY` | affirmative (`1`, `true`, `yes`, `on`) | off | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift` (`isMemoryEnabled`) | Explicit opt-in for both paged resident blocks and the recurrent RAM bank; global disable wins. Forwarded by LaunchAgent. |
 | `DARKBLOOM_PREFIX_CACHE_STATS_INTERVAL_SECS` | seconds (`0` off) | `120` | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` | Cadence of the local SSD stats line and typed per-store heartbeat observation; `0` omits the observation. Sample age still advances between ticks; see [telemetry](../architecture/telemetry.md#durable-prefix-cache-observations). |
-| `DARKBLOOM_PREFIX_CACHE_DISK_GB` | GiB | `100`, clamped to half the currently available space | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) | Box-wide on-disk budget across all models. A valid positive override is used verbatim; the free-space clamp applies to the default. |
+| `DARKBLOOM_PREFIX_CACHE_DISK_GB` | GiB | Half the currently available space; `20` if space cannot be measured | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) | Box-wide on-disk budget across all models, with no fixed default ceiling. A valid positive override is used verbatim. The separate 20 GiB free-space write reserve still applies. |
 | `DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL` | affirmative | off | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift` | Allows an in-memory KEK fallback and the isolated test root. Ephemeral ciphertext cannot be reused after process exit. |
 | `DARKBLOOM_PREFIX_CACHE_TEST_ROOT` | directory | unset | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift` | Isolated payload root, accepted only with `DARKBLOOM_PREFIX_CACHE_ALLOW_EPHEMERAL`; normally forces an ephemeral key. |
 | `DARKBLOOM_PREFIX_CACHE_TEST_PERSISTENT_KEY` | exactly `1` | off | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift` (`forceEphemeralKey`) | Benchmark-only: use the normal persistent KEK path within an accepted test root. Fallback is still possible; the benchmark SPI defaults to requiring actual persistent mode. Not forwarded to LaunchAgents. |

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -1,6 +1,6 @@
 # SSD KV cache reference
 
-> Last updated: 2026-09-06 · commit `e21e4cc75`
+> Last updated: 2026-09-07 · commit `0b46b1618`
 
 Exact on-disk format, paths, identity binding, environment knobs, size and
 eviction rules, and per-family reuse capability of the provider's encrypted SSD
@@ -187,12 +187,12 @@ All constants are code constants of `SSDPrefixCachePolicy` and
 
 | Rule | Constant | Code |
 |---|---|---|
-| Disk budget | `defaultSSDDiskBudgetBytes = 100 * 1_073_741_824` (100 GiB); default `max(1, min(defaultSSDDiskBudgetBytes, volumeFree / 2))`, re-evaluated during enforcement across all models. Unknown free space uses the fixed default; a valid positive environment override wins verbatim. | `PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) |
+| Disk budget | Default `max(1, volumeFree / 2)`, with no fixed ceiling, re-evaluated during enforcement across all models. Unknown free space uses `fallbackSSDDiskBudgetBytes = 20 * 1_073_741_824` (20 GiB); a valid positive environment override wins verbatim. The separate low-disk write stop still applies. | `PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) |
 | Eviction order | LRU by last hit across the whole `kv3/` root; eviction is `unlink` + index removal | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDBlockIndex.swift` |
 | Maintenance sweep | `SSDWholeRootMaintainer`, `intervalSeconds = 60`: TTL expiry, budget eviction, crash-temp cleanup | `SSDPrefixCacheFactory.swift` (`startWholeRootMaintenance`), `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWholeRootMaintainer.swift` |
 | TTL | `defaultTTLSeconds = 900`, `maxTTLSeconds = 900`, sliding on hit | `SSDPrefixCachePolicy.swift` |
 | Daily write cap | `defaultMaxWriteBytesPerDay = 150 * 1_000_000_000` | `SSDPrefixCachePolicy.swift` |
-| Low-disk write stop | `lowDiskFloorBytes = max(lowDiskAbsoluteFloorBytes = 20 * 1_073_741_824, lowDiskCapacityFraction = 0.05 × volume)`; reads continue; ENOSPC starts `enospcCooldownSeconds = 600` | `SSDPrefixCachePolicy.swift` |
+| Low-disk write stop | `lowDiskFloorBytes = lowDiskAbsoluteFloorBytes = 20 * 1_073_741_824` (20 GiB), independent of total disk capacity; reads continue; ENOSPC starts `enospcCooldownSeconds = 600` | `SSDPrefixCachePolicy.swift` |
 | Payload/staging cap | `defaultMaxStageBytes = 1024 * 1_048_576`; `defaultMaxStageMillis = 1000` at `conservativeStageBytesPerSecond = 1_500_000_000` | `SSDPrefixCachePolicy.swift` |
 | Attention donation floor | `prefixTokens > adoptionBoundTokens + minEffectiveTokens`, whole blocks only; `defaultMinEffectiveTokens = 1024`, raised to 1_536 for `.frozenFullReplay` with bound ≥ 25_600 | `SSDPrefixCache.swift` (`donate`), `PrefixCachePolicy.swift` |
 | Write-behind queue | `writeQueueMaxJobs = 2`, `writeQueueMaxBytes = 512 * 1_048_576`, `writeQueueSlackBytes = 256 * 1_048_576`; overflow drops the donation | `SSDPrefixCachePolicy.swift`, `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift` |

--- a/docs/threat-model.yaml
+++ b/docs/threat-model.yaml
@@ -6,8 +6,10 @@ created: "2026-05-14"
 # disk) — see docs/architecture/security/encryption.md and identity-binding.md.
 # Every other entry still reflects the 2026-05-14 review and has not been
 # re-verified.
-# SSD disk-budget values updated 2026-09-05 against commit 30bdf8e7a;
-# this does not re-verify the surrounding cache threat claims.
+# SSD disk policy re-checked 2026-09-08 against PR #866 (base 4be02331e):
+# default available-disk/2 without a fixed ceiling, 20 GiB unknown-space
+# budget fallback, and a fixed 20 GiB pre-write reserve including the pending
+# donation payload. This does not re-verify the surrounding cache threat claims.
 methodology: STRIDE
 description: >
   Runtime threat model for the EigenInference / darkbloom decentralized GPU inference
@@ -1695,9 +1697,13 @@ threats:
         (b) The at-rest window is bounded by a 15-MINUTE sliding TTL
             (DARKBLOOM_PREFIX_CACHE_SSD_TTL_SECONDS can only shorten it;
             sliding on hit; opportunistic sweep on write + periodic task);
-            a default 100 GiB box-wide LRU disk budget, limited to half the
-            currently available disk space, unlinks oldest-by-last-hit.
+            a default box-wide LRU disk budget of half the currently available
+            disk space, with no fixed ceiling, unlinks oldest-by-last-hit.
+            Unknown available space uses a 20 GiB budget fallback.
             DARKBLOOM_PREFIX_CACHE_DISK_GB overrides that default budget.
+            The separate fixed 20 GiB pre-write free-space reserve includes
+            the pending donation payload; it does not reserve OS disk blocks
+            against unrelated concurrent writers.
         (c) File crypto is the reviewed legacy scheme unchanged: per-file
             random DEK wrapped AES-256-GCM under the SE-rooted KEK,
             HKDF-derived per-chunk nonces ("dbkv-chunk-v3"), canonical
@@ -1772,8 +1778,10 @@ threats:
         status: implemented
       - description: >
           SSD tier at-rest window bound: 15-minute sliding TTL (env can only
-          shorten), default min(100 GiB, available-disk/2) box-wide LRU disk
-          budget (DARKBLOOM_PREFIX_CACHE_DISK_GB overrides), verified weightHash in
+          shorten), default available-disk/2 box-wide LRU disk budget without
+          a fixed ceiling (20 GiB fallback when unavailable;
+          DARKBLOOM_PREFIX_CACHE_DISK_GB overrides), a fixed 20 GiB pre-write
+          free-space reserve including the pending donation payload, verified weightHash in
           coordinator mode (model-ID fallback in standalone) + layoutEpoch
           fail-closed bindings, and KEK-wipe purge (files become unreadable AND
           unfindable — K_lookup derives from the KEK).

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
@@ -84,15 +84,14 @@ enum PrefixCachePolicy {
     /// retired `BatchScheduler+PrefixCacheSizing` resolver).
     static let diskBudgetEnvironmentFlag = "DARKBLOOM_PREFIX_CACHE_DISK_GB"
 
-    /// Box-wide SSD ceiling across all models, clamped to half the volume's
-    /// currently available space.
-    static let defaultSSDDiskBudgetBytes = 100 * 1_073_741_824
+    /// Conservative fallback only when available disk space cannot be measured.
+    static let fallbackSSDDiskBudgetBytes = 20 * 1_073_741_824
 
     /// Resolved box-wide SSD disk budget (bytes). A valid positive env
-    /// override wins verbatim; otherwise `min(100 GiB, free/2)`,
+    /// override wins verbatim; otherwise `free/2`, without a fixed ceiling,
     /// re-evaluated per enforcement so the
     /// ceiling shrinks as the volume fills. Unknown free space ⇒ the
-    /// fixed default.
+    /// conservative fallback. The separate low-disk write guard remains active.
     static func ssdDiskBudgetBytes(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         freeBytes: Int?
@@ -101,8 +100,8 @@ enum PrefixCachePolicy {
         if let gb = envGB, gb > 0, gb.isFinite, gb < gbToBytesCeiling {
             return Int(gb * 1_073_741_824)
         }
-        guard let free = freeBytes else { return defaultSSDDiskBudgetBytes }
-        return max(1, min(defaultSSDDiskBudgetBytes, free / 2))
+        guard let free = freeBytes else { return fallbackSSDDiskBudgetBytes }
+        return max(1, free / 2)
     }
 
     /// Best-effort free capacity (bytes) of the volume containing `url`

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift
@@ -154,14 +154,14 @@ enum SSDPrefixCachePolicy {
 
     // MARK: - Low-disk guard
 
-    /// Writes stop when volume free space drops under
-    /// `max(20 GiB, 5% of capacity)`. Reads are unaffected.
+    /// Writes stop below a fixed 20 GiB free-space reserve. The reserve does
+    /// not grow with the physical disk: large volumes with ample free bytes
+    /// must not lose caching solely because their free percentage is small.
+    /// Reads are unaffected.
     static let lowDiskAbsoluteFloorBytes = 20 * 1_073_741_824
-    static let lowDiskCapacityFraction = 0.05
 
-    static func lowDiskFloorBytes(volumeCapacityBytes: Int) -> Int {
-        let fromFraction = Int(Double(max(0, volumeCapacityBytes)) * lowDiskCapacityFraction)
-        return max(lowDiskAbsoluteFloorBytes, fromFraction)
+    static func lowDiskFloorBytes(volumeCapacityBytes _: Int) -> Int {
+        lowDiskAbsoluteFloorBytes
     }
 
     /// Cooldown after an ENOSPC mid-write before writes are retried.

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -309,10 +309,12 @@ final class SSDWriteBehind: @unchecked Sendable {
             settleAll(job, dropped: job.blocks.count)
             return
         }
-        // Low-disk guard: stop writing under the fixed free-space reserve.
+        // Admit the whole donation above the reserve, not just its first
+        // block. Like the hybrid checkpoint writer, account for the pending
+        // payload before any I/O. This is not an OS disk-space reservation.
         if let space = config.volumeSpace() {
             let floor = SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: space.capacity)
-            if space.free < floor {
+            if space.free < floor || job.totalBytes > space.free - floor {
                 diskUnavailable = true
                 settleAll(job, dropped: job.blocks.count)
                 return

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDWriteBehind.swift
@@ -309,7 +309,7 @@ final class SSDWriteBehind: @unchecked Sendable {
             settleAll(job, dropped: job.blocks.count)
             return
         }
-        // Low-disk guard: stop writing under max(20 GiB, 5% capacity) free.
+        // Low-disk guard: stop writing under the fixed free-space reserve.
         if let space = config.volumeSpace() {
             let floor = SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: space.capacity)
             if space.free < floor {

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -670,7 +670,7 @@ struct SSDPrefixCacheModeTests {
             == PrefixCacheReadyResult.maxStageMs)
     }
 
-    @Test("box-wide disk budget: env override wins; default = min(100 GiB, free/2)")
+    @Test("box-wide disk budget: env override wins; default follows half of free space")
     func diskBudgetResolver() {
         let gib = 1_073_741_824
         #expect(
@@ -681,22 +681,24 @@ struct SSDPrefixCacheModeTests {
             PrefixCachePolicy.ssdDiskBudgetBytes(
                 environment: ["DARKBLOOM_PREFIX_CACHE_DISK_GB": "150"], freeBytes: 10 * gib)
                 == 150 * gib)
-        // The automatic ceiling applies when at least 200 GiB is available.
+        // Large volumes are no longer limited by a fixed 100 GiB ceiling.
         #expect(
             PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: 800 * gib)
-                == 100 * gib)
+                == 400 * gib)
         #expect(
             PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: 200 * gib)
                 == 100 * gib)
-        // Below that, the automatic budget follows currently available space.
+        // The automatic budget follows currently available space.
         #expect(
             PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: 100 * gib)
                 == 50 * gib)
         #expect(
             PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: 10 * gib)
                 == 5 * gib)
-        // Preserve the fixed fallback when free space is unknown.
-        #expect(PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: nil) == 100 * gib)
+        // Unknown capacity keeps a conservative bounded fallback.
+        #expect(PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: nil) == 20 * gib)
+        #expect(PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: 0) == 1)
+        #expect(PrefixCachePolicy.ssdDiskBudgetBytes(environment: [:], freeBytes: Int.max) == Int.max / 2)
         // Malformed env degrades to the default (never crashes, never 0).
         #expect(
             PrefixCachePolicy.ssdDiskBudgetBytes(
@@ -728,6 +730,10 @@ struct SSDPrefixCacheModeTests {
         #expect(SSDPrefixCachePolicy.maxStageBytes(environment: [:]) == 1024 * 1_048_576)
         #expect(SSDPrefixCachePolicy.maxStageMillis(environment: [:]) == 1000)
         #expect(SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: 0)
+            == 20 * 1_073_741_824)
+        #expect(SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: 1_995_165_736_960)
+            == 20 * 1_073_741_824)
+        #expect(SSDPrefixCachePolicy.lowDiskFloorBytes(volumeCapacityBytes: Int.max)
             == 20 * 1_073_741_824)
     }
 }
@@ -1624,6 +1630,28 @@ struct SSDReadyWriteBarrierTests {
             stats: SSDPrefixCacheStatsBox(),
             onBlockSettled: onBlockSettled,
             sweepExpired: {})
+    }
+
+    @Test("a large disk with 95 GB free can donate below five percent free")
+    func largeVolumeDonation() async throws {
+        let dir = tempDir("large-volume-donation")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writes = Counter()
+        let durable = Counter()
+        let outcome = OutcomeBox()
+        let writer = pipeline(
+            dir: dir,
+            volumeSpace: { (free: 94_941_983_360, capacity: 1_995_165_736_960) },
+            writeBlock: { _, _ in writes.increment(); return 1 })
+        #expect(writer.submit(.init(
+            blocks: [block(1)], totalBytes: 1,
+            onDurable: { durable.increment(); return true },
+            onOutcome: outcome.set)))
+        await writer.waitUntilDrained()
+        writer.close()
+        #expect(writes.count == 1)
+        #expect(durable.count == 1)
+        #expect(outcome.outcome == .donated)
     }
 
     @Test("low disk, generic write error, ENOSPC, and shutdown never cross durable barrier")

--- a/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDPrefixCacheTests.swift
@@ -1654,6 +1654,37 @@ struct SSDReadyWriteBarrierTests {
         #expect(outcome.outcome == .donated)
     }
 
+    @Test("pending donation must fit above the free-space reserve", arguments: [0, 1, 2])
+    func pendingDonationReserve(headroom: Int) async throws {
+        let dir = tempDir("pending-donation-reserve-\(headroom)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let writes = Counter()
+        let settled = Counter()
+        let durable = Counter()
+        let outcome = OutcomeBox()
+        let writer = pipeline(
+            dir: dir,
+            volumeSpace: {
+                (free: SSDPrefixCachePolicy.lowDiskAbsoluteFloorBytes + headroom,
+                 capacity: 2_000_000_000_000)
+            },
+            writeBlock: { _, _ in writes.increment(); return 1 },
+            onBlockSettled: { _ in settled.increment() })
+        // Each block fits in one byte; the complete two-byte donation must fit.
+        #expect(writer.submit(.init(
+            blocks: [block(1), block(2)], totalBytes: 2,
+            onDurable: { durable.increment(); return true },
+            onOutcome: outcome.set)))
+        await writer.waitUntilDrained()
+        writer.close()
+        let fits = headroom >= 2
+        #expect(writes.count == (fits ? 2 : 0))
+        #expect(settled.count == 2)
+        #expect(durable.count == (fits ? 1 : 0))
+        #expect(outcome.outcome == (fits ? .donated : .diskUnavailable))
+        #expect(outcome.count == 1)
+    }
+
     @Test("low disk, generic write error, ENOSPC, and shutdown never cross durable barrier")
     func failureMatrix() async throws {
         let dir = tempDir("ready-write-failures")


### PR DESCRIPTION
A 2 TB provider with about 95 GB available refused even its first Qwen checkpoint because the low-disk guard reserved 5% of total capacity (about 100 GB). Use a fixed 20 GiB free-space reserve and size the shared cache at half the currently available space without a fixed 100 GiB ceiling.

The positive `DARKBLOOM_PREFIX_CACHE_DISK_GB` override keeps its existing semantics. Unknown available space uses a conservative 20 GiB cache-budget fallback. Attention-cache donation admission now checks that the full pending payload fits above the 20 GiB reserve, matching the existing hybrid-checkpoint guard. This is a pre-write free-space check, not an OS reservation against concurrent filesystem writers. The threat-model bounds and scoped review record now match the new policy. Encryption, TTL/LRU eviction, daily write limits, model eligibility and ENOSPC handling are unchanged. This requires a provider release; it does not change production coordinator settings.

### Before

```mermaid
flowchart LR
    A[Provider has 95 GB free on 2 TB disk] --> B[PrefixCachePolicy.ssdDiskBudgetBytes]
    B --> C[Budget min of 100 GiB and half free space]
    A --> D[SSDPrefixCachePolicy.lowDiskFloorBytes]
    D --> E[Reserve max of 20 GiB and 5 percent total capacity]
    E --> F[SSDWriteBehind or SSDHybridCheckpointStore.performWrite]
    C --> F
    F --> G[Donation refused as disk_unavailable]
```

### After

```mermaid
flowchart LR
    A[Provider has 95 GB free on 2 TB disk] --> B[PrefixCachePolicy.ssdDiskBudgetBytes]
    B --> C[Budget half of available space]
    A --> D[SSDPrefixCachePolicy.lowDiskFloorBytes]
    D --> E[Fixed 20 GiB reserve]
    E --> F[SSDWriteBehind or SSDHybridCheckpointStore.performWrite]
    C --> F
    F --> J[Require free space minus reserve to cover pending payload]
    J --> G[Donation can proceed through existing safety checks]
    H[Free space below 20 GiB] --> F
    F --> I[Low-disk donations still refused]
```

### Validation

- PASS: clean Swift 6.3.3 build with pinned dependencies; 11 tests in `SSDPrefixCacheModeTests` and `SSDReadyWriteBarrierTests`, including the actual M5 volume/free-space values, override/fallback behavior, low-disk refusal and ENOSPC handling.
- Reproduced the near-reserve donation failure before the fix; all three boundary cases now pass, including full-job accounting and no ready receipt after refusal.
- `make docs-check`, threat-model YAML parsing and `git diff --check`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791419143&installation_model_id=21733&pr_number=866&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F866&signature=62b8663b291b61737cbeae077e137795848aed68cf18da0ed67f38990dcf6d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->