### PR TITLE
feat(observability): report cache outcomes and saved tokens by model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — per-model cache reporting
+
+- Add internal model breakdowns for provider-reported cache hits/misses, cached and avoided-prefill tokens, accepted V2 proofs, cache-selected terminals and timing samples. Keep invalid/missing usage distinct from misses and retain the aggregate public status.
+
 ## Unreleased — cache evidence and coordinator reconnect recovery
 
 - Preserve unchanged models' cache holders and receipts when another model loads or changes, and keep proof-mismatch fences across unrelated capability updates. Report bounded receipt rejection reasons and separate proof mismatch from ordinary holder changes.

--- a/coordinator/api/cache_model_telemetry.go
+++ b/coordinator/api/cache_model_telemetry.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"math"
+	"strings"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+// Model breakdowns are internal operational metrics. The public status and
+// existing exact_cache metrics retain their aggregate-only contract. Never use
+// a caller's alias, provider identity, request ID, receipt nonce or prompt hash.
+func (s *Server) cacheModelLabel(model string) string {
+	if s.registry != nil {
+		if id, ok := s.registry.CatalogModelID(model); ok && id != "" && len(id) <= 200 && !strings.ContainsAny(id, ",|\n\r\x00") {
+			return id
+		}
+	}
+	return "unknown"
+}
+
+func (s *Server) cacheModelCount(name string, value int64, labels ...MetricLabel) {
+	if s.metrics != nil {
+		s.metrics.AddCounter("cache_model_"+name+"_total", value, labels...)
+	}
+	tags := make([]string, 0, len(labels))
+	for _, label := range labels {
+		tags = append(tags, label.Name+":"+label.Value)
+	}
+	s.ddCount("routing.cache_model."+name, value, tags)
+}
+
+// Sum/sample counters work with both Datadog HTTPS and DogStatsD. The admin
+// histogram preserves milliseconds for percentiles; the estimate is not a
+// measured counterfactual or a claim of successful end-to-end delivery.
+func (s *Server) cacheModelTiming(name string, ms float64, labels ...MetricLabel) {
+	if ms < 0 || math.IsNaN(ms) || math.IsInf(ms, 0) || ms >= float64(math.MaxInt64)/1000 {
+		return
+	}
+	s.cacheModelCount(name+"_us", int64(math.Round(ms*1000)), labels...)
+	s.cacheModelCount(name+"_samples", 1, labels...)
+	if s.metrics != nil {
+		s.metrics.ObserveHistogram("cache_model_"+name+"_ms", ms, labels...)
+	}
+}
+
+// Same terminal-completion population as aggregate provider usage; includes
+// parked completions, excludes unknown/duplicate/abandoned terminals. Invalid
+// and absent usage are visible coverage gaps, never counted as cache misses.
+func (s *Server) emitModelCacheUsage(pr *registry.PendingRequest, usage protocol.UsageInfo, valid, present bool) {
+	if pr == nil {
+		return
+	}
+	model := MetricLabel{"model", s.cacheModelLabel(pr.Model)}
+	outcome, tier := "unreported", "none"
+	if present && !valid {
+		outcome = "invalid"
+	} else if valid {
+		outcome, tier = usage.CacheOutcome, lowCardinalityCacheTier(usage.CacheTier)
+	}
+	labels := []MetricLabel{model, {"outcome", outcome}, {"tier", tier}}
+	s.cacheModelCount("usage", 1, labels...)
+	if !valid {
+		return
+	}
+	s.cacheModelCount("cached_tokens", int64(usage.CachedTokens), model, MetricLabel{"tier", tier})
+	s.cacheModelCount("prefill_tokens_saved", int64(usage.PrefillTokensSaved), model, MetricLabel{"tier", tier})
+	s.cacheModelTiming("provider_stage", usage.CacheStageMs, labels...)
+}
+
+// Called only after V2 proof acceptance. ModelID has then been checked against
+// both the issued request and the provider capability, before catalog labeling.
+func (s *Server) emitModelCacheLookup(msg *protocol.PrefixCacheLookupV2Message, receipt registry.CacheReceiptResult) {
+	if msg == nil || !receipt.Accepted {
+		return
+	}
+	s.cacheModelCount("lookup", 1,
+		MetricLabel{"model", s.cacheModelLabel(msg.ModelID)},
+		MetricLabel{"outcome", msg.Outcome},
+		MetricLabel{"tier", lowCardinalityCacheTier(msg.Tier)})
+}
+
+func (s *Server) emitModelCacheDonation(msg *protocol.PrefixCacheReadyV2Message, receipt registry.CacheReceiptResult) {
+	if msg == nil || !receipt.Accepted {
+		return
+	}
+	s.cacheModelCount("donation", 1,
+		MetricLabel{"model", s.cacheModelLabel(msg.ModelID)},
+		MetricLabel{"tier", lowCardinalityCacheTier(msg.Tier)})
+}
+
+// Runs inside the existing exactly-once cache terminal claim. "result" is the
+// provider's cache outcome, not consumer request success; an unreported error
+// terminal remains distinguishable from a provider-reported hit or miss.
+func (s *Server) emitModelCacheSelection(pr *registry.PendingRequest, tags []string) {
+	labels := s.cacheModelSelectionLabels(pr.Model, tags)
+	s.cacheModelCount("selection", 1, labels...)
+	if ms := pr.CacheSelectionEstimatedTTFTSavedMs; ms > 0 {
+		s.cacheModelTiming("estimated_ttft_saved", ms, labels...)
+	}
+}
+
+func (s *Server) cacheModelSelectionLabels(model string, tags []string) []MetricLabel {
+	labels := []MetricLabel{{"model", s.cacheModelLabel(model)}}
+	for _, tag := range tags {
+		name, value, _ := strings.Cut(tag, ":")
+		labels = append(labels, MetricLabel{name, value})
+	}
+	return labels
+}

--- a/coordinator/api/cache_model_telemetry_test.go
+++ b/coordinator/api/cache_model_telemetry_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func modelCacheTestCatalog(s *Server) {
+	s.registry.SetModelCatalog([]registry.CatalogEntry{
+		{ID: "qwen3.5-35b-a3b"}, {ID: "qwen3.6-35b-a3b-vl-mtp-mxfp8"}, {ID: "EigenLabs/Qwen3.8-27B-4bit-mtp"},
+	})
+}
+
+func TestModelCacheCompletionsSeparateModelsAndPreserveUsage(t *testing.T) {
+	srv, _, _ := billingTestServer(t)
+	t.Cleanup(srv.Close)
+	modelCacheTestCatalog(srv)
+	collector := newUDPCollector(t)
+	defer collector.Close()
+	dd := newTestDD(t, collector)
+	defer dd.Close()
+	srv.SetDatadog(dd)
+	const a = "qwen3.5-35b-a3b"
+	const b = "qwen3.6-35b-a3b-vl-mtp-mxfp8"
+	const c = "EigenLabs/Qwen3.8-27B-4bit-mtp"
+	hit := protocol.UsageInfo{PromptTokens: 4096, CompletionTokens: 10, CacheOutcome: "hit", CacheTier: "ssd", CachedTokens: 3072, PrefillTokensSaved: 2048, CacheStageMs: 40.25}
+	miss := protocol.UsageInfo{PromptTokens: 4096, CompletionTokens: 10, CacheOutcome: "miss_absent", CacheTier: "ssd"}
+	invalid := hit
+	invalid.CachedTokens = 5000
+	for i, tc := range []struct {
+		model  string
+		usage  protocol.UsageInfo
+		parked bool
+	}{
+		{a, hit, false}, {b, miss, false}, {c, hit, true}, {a, invalid, false},
+		{b, protocol.UsageInfo{PromptTokens: 4096, CompletionTokens: 10}, false},
+	} {
+		provider := registerHeartbeatedProvider(t, srv, fmt.Sprintf("private-provider-%d", i), tc.model, nil)
+		pr := completedPendingRequest(t, srv, provider, fmt.Sprintf("private-request-%d", i), tc.model, tc.usage)
+		pr.PublicModel = "private-caller-alias"
+		if tc.parked {
+			srv.holdForSettlement(pr)
+			provider.RemovePending(pr.RequestID)
+		}
+		msg := protocol.InferenceCompleteMessage{Type: protocol.TypeInferenceComplete, RequestID: pr.RequestID, Usage: tc.usage}
+		srv.handleComplete(provider.ID, provider, &msg)
+		// Replayed provider terminals must not inflate model counts or tokens.
+		srv.handleComplete(provider.ID, provider, &msg)
+		if !tc.parked {
+			got := <-pr.CompleteCh
+			if validCacheUsage(tc.usage) && got.CachedTokens != tc.usage.CachedTokens {
+				t.Fatalf("telemetry changed response cached tokens: %+v", got)
+			}
+		}
+	}
+	snap := srv.metrics.Snapshot()
+	for _, tc := range []struct{ model, outcome, tier string }{
+		{a, "hit", "ssd"}, {b, "miss_absent", "ssd"}, {c, "hit", "ssd"}, {a, "invalid", "none"}, {b, "unreported", "none"},
+	} {
+		key := metricKey("cache_model_usage_total", []MetricLabel{{"model", tc.model}, {"outcome", tc.outcome}, {"tier", tc.tier}})
+		if snap.Counters[key] != 1 {
+			t.Fatalf("%s = %d, want 1", key, snap.Counters[key])
+		}
+	}
+	for _, model := range []string{a, c} {
+		labels := []MetricLabel{{"model", model}, {"tier", "ssd"}}
+		if got := snap.Counters[metricKey("cache_model_prefill_tokens_saved_total", labels)]; got != 2048 {
+			t.Fatalf("saved tokens for %s = %d", model, got)
+		}
+		if got := snap.Counters[metricKey("cache_model_cached_tokens_total", labels)]; got != 3072 {
+			t.Fatalf("cached tokens for %s = %d", model, got)
+		}
+	}
+	if snap.Counters["exact_cache_usage_total{outcome=hit,tier=ssd}"] != 2 || snap.Counters["exact_cache_prefill_tokens_saved_total{tier=ssd}"] != 4096 {
+		t.Fatal("aggregate usage changed or invalid/duplicate usage was counted")
+	}
+	stageLabels := []MetricLabel{{"model", a}, {"tier", "ssd"}, {"outcome", "hit"}}
+	if snap.Counters[metricKey("cache_model_provider_stage_us_total", stageLabels)] != 40250 || snap.Counters[metricKey("cache_model_provider_stage_samples_total", stageLabels)] != 1 {
+		t.Fatal("provider stage sum/sample counters are wrong")
+	}
+	for key := range snap.Counters {
+		if strings.HasPrefix(key, "cache_model_lookup_total") {
+			t.Fatal("provider usage fabricated proof-backed hits")
+		}
+	}
+	_ = dd.Statsd.Flush()
+	packets := collector.drain()
+	if !hasMetric(findMetrics(packets, "routing.cache_model.usage"), "model:"+a) || !hasMetric(findMetrics(packets, "routing.cache_model.prefill_tokens_saved"), "model:"+c) {
+		t.Fatalf("model metrics absent from Datadog: %v", packets)
+	}
+	modelPackets := findMetrics(packets, "routing.cache_model.")
+	for _, secret := range []string{"private-caller-alias", "private-provider-", "private-request-"} {
+		if strings.Contains(strings.Join(modelPackets, "\n"), secret) {
+			t.Fatalf("model metrics leaked %s", secret)
+		}
+	}
+}
+
+func TestModelCacheProofAndSelectionPopulationsStaySeparate(t *testing.T) {
+	srv := &Server{registry: registry.New(quietLogger()), metrics: NewMetrics()}
+	modelCacheTestCatalog(srv)
+	model := "qwen3.5-35b-a3b"
+	lookup := &protocol.PrefixCacheLookupV2Message{ModelID: model, Tier: "ssd", Outcome: "hit", CacheReceiptNonce: "private-nonce"}
+	ready := &protocol.PrefixCacheReadyV2Message{ModelID: model, Tier: "ssd"}
+	srv.emitModelCacheLookup(lookup, registry.CacheReceiptResult{Reason: registry.CacheReceiptPromptMismatch})
+	srv.emitModelCacheDonation(ready, registry.CacheReceiptResult{Reason: registry.CacheReceiptLookupNotSeen})
+	if len(srv.metrics.Snapshot().Counters) != 0 {
+		t.Fatal("rejected proof counted as accepted")
+	}
+	accepted := registry.CacheReceiptResult{Accepted: true, Reason: registry.CacheReceiptAccepted}
+	srv.emitModelCacheLookup(lookup, accepted)
+	srv.emitModelCacheDonation(ready, accepted)
+	hit := protocol.UsageInfo{PromptTokens: 4096, CacheOutcome: "hit", CacheTier: "ssd", CachedTokens: 2048, PrefillTokensSaved: 2048}
+	for i, selected := range []bool{false, true} {
+		pr := cacheTelemetryPending(fmt.Sprintf("private-receipt-%d", i))
+		pr.Model = model
+		pr.PublicModel = "private-alias"
+		pr.CacheSelectionSelected = selected
+		pr.CacheSelectionEstimatedTTFTSavedMs = 150.25
+		if !selected {
+			pr.CacheSelectionEstimatedTTFTSavedMs = 0
+		}
+		srv.emitCacheSelectionTerminal(pr, hit, true, true)
+		srv.emitCacheSelectionTerminal(pr, hit, true, true)
+		srv.emitCacheSelectionTTFT(pr, hit, true, 200)
+		srv.emitCacheSelectionTTFT(pr, hit, false, 200) // invalid usage cannot produce a timing sample
+	}
+	missing := cacheTelemetryPending("private-disconnected")
+	missing.Model = model
+	srv.emitCacheSelectionTerminal(missing, protocol.UsageInfo{}, false, false)
+	srv.emitCacheSelectionTerminal(missing, hit, true, true)
+	snap := srv.metrics.Snapshot()
+	counts := map[string]int64{}
+	var estimatedUS, samples, ttftUS, ttftSamples int64
+	for key, value := range snap.Counters {
+		for _, prefix := range []string{"cache_model_lookup_total", "cache_model_donation_total", "cache_model_selection_total"} {
+			if strings.HasPrefix(key, prefix) {
+				counts[prefix] += value
+			}
+		}
+		if strings.HasPrefix(key, "cache_model_ttft_us_total") {
+			ttftUS += value
+		}
+		if strings.HasPrefix(key, "cache_model_ttft_samples_total") {
+			ttftSamples += value
+		}
+		if strings.HasPrefix(key, "cache_model_estimated_ttft_saved_us_total") {
+			estimatedUS += value
+		}
+		if strings.HasPrefix(key, "cache_model_estimated_ttft_saved_samples_total") {
+			samples += value
+		}
+	}
+	if counts["cache_model_lookup_total"] != 1 || counts["cache_model_donation_total"] != 1 || counts["cache_model_selection_total"] != 3 || estimatedUS != 150250 || samples != 1 {
+		t.Fatalf("counts=%v estimatedUS=%d samples=%d", counts, estimatedUS, samples)
+	}
+	if ttftUS != 400000 || ttftSamples != 2 {
+		t.Fatalf("TTFT sum=%d samples=%d", ttftUS, ttftSamples)
+	}
+	raw, _ := json.Marshal(snap)
+	if !strings.Contains(string(raw), "selected=false") || !strings.Contains(string(raw), "lookup_outcome=unreported") {
+		t.Fatal("selection coverage populations collapsed")
+	}
+	for _, secret := range []string{"private-", "secret-route"} {
+		if strings.Contains(string(raw), secret) {
+			t.Fatalf("metrics leaked %s", secret)
+		}
+	}
+}
+
+func TestModelCacheLabelsRequireExplicitCatalogMembership(t *testing.T) {
+	srv := &Server{registry: registry.New(quietLogger()), metrics: NewMetrics()}
+	const secret = "private-off-catalog-model"
+	if srv.cacheModelLabel(secret) != "unknown" {
+		t.Fatal("nil catalog allowed arbitrary labels")
+	}
+	modelCacheTestCatalog(srv)
+	if srv.cacheModelLabel(secret) != "unknown" {
+		t.Fatal("off-catalog label leaked")
+	}
+	if srv.cacheModelLabel("EigenLabs/Qwen3.8-27B-4bit-mtp") != "EigenLabs/Qwen3.8-27B-4bit-mtp" {
+		t.Fatal("catalog identity lost")
+	}
+	for _, id := range []string{"bad|tag", "bad,tag", "bad\ntag", strings.Repeat("x", 201)} {
+		srv.registry.SetModelCatalog([]registry.CatalogEntry{{ID: id}})
+		if srv.cacheModelLabel(id) != "unknown" {
+			t.Fatal("unsafe label allowed")
+		}
+	}
+	for _, ms := range []float64{math.NaN(), math.Inf(1), -1, math.MaxFloat64} {
+		srv.cacheModelTiming("provider_stage", ms)
+	}
+	if len(srv.metrics.Snapshot().Counters) != 0 {
+		t.Fatal("invalid timing recorded")
+	}
+}

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -706,6 +706,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			receipt := s.registry.ApplyPrefixCacheLookupV2Result(providerID, lookupMsg)
 			s.emitCacheReceiptResult("lookup_v2", receipt)
 			if receipt.Accepted {
+				s.emitModelCacheLookup(lookupMsg, receipt)
 				s.ddIncr("routing.cache_lookup_receipt", []string{
 					"protocol:v2",
 					"outcome:" + lookupMsg.Outcome,
@@ -723,6 +724,7 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			receipt := s.registry.ApplyPrefixCacheReadyV2Result(providerID, readyMsg)
 			s.emitCacheReceiptResult("ready_v2", receipt)
 			if receipt.Accepted {
+				s.emitModelCacheDonation(readyMsg, receipt)
 				s.ddIncr("routing.cache_ready_receipt", []string{
 					"protocol:v2",
 					"tier:" + lowCardinalityCacheTier(readyMsg.Tier),
@@ -897,6 +899,7 @@ func (s *Server) emitCacheSelectionTerminal(pr *registry.PendingRequest, usage p
 		return false
 	}
 	tags := cacheSelectionTerminalTags(pr, usage, usageValid, usagePresent)
+	s.emitModelCacheSelection(pr, tags)
 	s.ddIncr("routing.cache_selection_terminal", tags)
 	if pr.CacheSelectionDiscountMs > 0 {
 		s.ddHistogram("routing.cache_selection_discount_ms", pr.CacheSelectionDiscountMs, tags)
@@ -923,6 +926,7 @@ func (s *Server) emitCacheSelectionTTFT(pr *registry.PendingRequest, usage proto
 	if !ok {
 		return
 	}
+	s.cacheModelTiming("ttft", value, s.cacheModelSelectionLabels(pr.Model, tags)...)
 	s.ddHistogram("routing.cache_selection_ttft_ms", value, tags)
 }
 
@@ -2304,6 +2308,7 @@ func (s *Server) handleCompleteAt(
 		s.emitExactCacheUsage(msg.Usage.CacheOutcome, lowCardinalityCacheTier(msg.Usage.CacheTier),
 			msg.Usage.CachedTokens, msg.Usage.PrefillTokensSaved, msg.Usage.CacheStageMs)
 	}
+	s.emitModelCacheUsage(pr, msg.Usage, cacheUsageValid, cacheUsagePresent)
 	cacheTerminalClaimed := s.emitCacheSelectionTerminal(pr, msg.Usage, cacheUsageValid, cacheUsagePresent)
 	s.reconcileOutputAdmission(pr, msg.Usage.CompletionTokens)
 

--- a/coordinator/registry/model_catalog.go
+++ b/coordinator/registry/model_catalog.go
@@ -70,6 +70,15 @@ func (r *Registry) IsModelInCatalog(model string) bool {
 	return ok
 }
 
+// CatalogModelID returns only an explicitly registered model ID. Unlike
+// IsModelInCatalog, a nil catalog never admits arbitrary telemetry labels.
+func (r *Registry) CatalogModelID(model string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.modelCatalog[model]
+	return entry.ID, ok
+}
+
 // CatalogWeightHash returns the expected weight hash for a model, or empty
 // string if not set or not in catalog.
 func (r *Registry) CatalogWeightHash(model string) string {

--- a/docs/architecture/cache-aware-routing.md
+++ b/docs/architecture/cache-aware-routing.md
@@ -1,6 +1,6 @@
 # Exact Prefix Cache Routing
 
-> Last updated: 2026-09-07 · commit `efcde6334`
+> Last updated: 2026-09-08 · commit `ada6fcea1`
 
 Exact prefix cache routing lets the scheduler prefer a provider that has
 *proven* it holds a reusable exact token prefix in an advertised resident
@@ -594,6 +594,14 @@ The closed reasons come from `coordinator/registry/cache_receipt_result.go`;
 `exact_cache.receipt` and `exact_cache_receipt_total` label type, outcome and reason.
 Provider-reported usage remains separate from accepted proof-backed lookup hits.
 No nonce, scope, prompt or prefix hash is emitted by these counters.
+
+Per-model internal metrics use `routing.cache_model.*` / `cache_model_*`.
+They keep provider-reported reuse, accepted V2 proofs and cache-selected
+terminals separate. `selected=true` is an expected routing benefit, not proof
+of reuse; the terminal must also report `result=hit`. Missing/invalid usage is
+not a miss, and cache usage is not a consumer-success verdict. See the
+[metric inventory](../reference/telemetry-inventory.md#cache-results-by-model-internal)
+and `coordinator/api/cache_model_telemetry.go`.
 
 ## Code map
 

--- a/docs/architecture/telemetry.md
+++ b/docs/architecture/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-> Last updated: 2026-09-07 · commit `efcde6334`
+> Last updated: 2026-09-08 · commit `ada6fcea1`
 
 How operational data leaves a provider, what the coordinator does with it, and
 why nothing on that path can carry a prompt or slow a request. The heartbeat is
@@ -288,6 +288,14 @@ distinguish rejected evidence from provider-reported hits. APNs recovery emits
 `code_attest.proof_verified{kind:apns|resume}` and
 `code_attest.coverage_persist{outcome:success|error}`. These are aggregate
 operational metrics; they add no fields to the provider telemetry wire schema.
+
+Per-model cache reporting is a separate internal `routing.cache_model.*`
+family, mirrored by `cache_model_*` admin metrics. It distinguishes reported
+usage, accepted proofs and cache-selected terminals without altering the public
+aggregate cache response. Model IDs must be present in the active catalog;
+other IDs use `unknown`. Timing sums and sample counts work over HTTPS as well
+as DogStatsD. See the [metric inventory](../reference/telemetry-inventory.md#cache-results-by-model-internal)
+for populations, labels and reset semantics (`coordinator/api/cache_model_telemetry.go`).
 
 ## Code map
 

--- a/docs/operations/cache-routing-rollout.md
+++ b/docs/operations/cache-routing-rollout.md
@@ -1,6 +1,6 @@
 # Cache-aware routing: activation, ramp and rollback
 
-> Last updated: 2026-09-06 · commit `2eebb5412`
+> Last updated: 2026-09-08 · commit `ada6fcea1`
 
 How to turn provider-confirmed prefix-cache routing on for the production
 coordinator, widen its activation bounds one at a time, and turn it off again.
@@ -219,6 +219,36 @@ Compare with the snapshot from step 1 when in doubt:
 diff <(jq -S . /tmp/darkbloom-cache-rollout.before.json) <(curl -fsS localhost:8080/v1/cache/status | jq -S \
   '{routing_mode, activation, sidecar: {enabled: .sidecar.enabled, ready: .sidecar.ready, restarts: .sidecar.restarts}, providers, holders, attempts}')
 ```
+
+### Per-model rollout evidence
+
+After deploying model metrics, query the same time window for each series:
+
+```text
+sum:d_inference.routing.cache_model.usage{env:production,outcome:hit} by {model}.as_count()
+sum:d_inference.routing.cache_model.usage{env:production,outcome:miss_absent} by {model}.as_count()
+sum:d_inference.routing.cache_model.usage{env:production,outcome:miss_corrupt} by {model}.as_count()
+sum:d_inference.routing.cache_model.prefill_tokens_saved{env:production} by {model}.as_count()
+sum:d_inference.routing.cache_model.lookup{env:production,outcome:hit} by {model}.as_count()
+sum:d_inference.routing.cache_model.selection{env:production,selected:true,result:hit} by {model}.as_count()
+```
+
+Reported hit rate is `hits / (hits + miss_absent + miss_corrupt)`. Track
+`invalid`, `unreported` and `skipped_*` usage separately; their presence is not
+proof of a lookup miss. Compare accepted `lookup` and `selection` evidence
+alongside reported reuse; do not add those populations together. Request success
+and first-content latency still come from the existing request-outcome/profile
+metrics. `selection.result=hit` does not itself prove a successful response.
+
+Mean stage milliseconds is `provider_stage_us / provider_stage_samples / 1000`
+with identical model/outcome/tier filters. Mean observed first-content milliseconds
+is `ttft_us / ttft_samples / 1000`, grouped by model and terminal cache outcome.
+Estimated savings in seconds is
+`estimated_ttft_saved_us / 1000000`; filter `selected:true,result:hit` for the
+cache-selected reported-hit subset. This remains a scheduler estimate, not a
+measured uncached comparison. Admin metrics expose the same counters and timing
+histograms. See the [metric inventory](../reference/telemetry-inventory.md#cache-results-by-model-internal).
+These breakdowns start at deployment and cannot reconstruct prior model counts.
 
 ## Rollback
 

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,6 +1,6 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-07 · commit `efcde6334`
+> Last updated: 2026-09-08 · commit `ada6fcea1`
 
 The complete public HTTP surface of the coordinator, derived from the 108 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
@@ -258,6 +258,12 @@ The exact-cache lifecycle `holder_removed` map includes `proof_mismatch`, separa
 from `capability_change`. Updating one model preserves unchanged models' holders,
 pending receipts and proof fences. See `coordinator/registry/cache_model_changes.go`
 and `coordinator/registry/cache_receipt_result.go`.
+
+Per-model cache usage, accepted lookup and selection metrics are available only
+through the existing authenticated `GET /v1/admin/metrics` endpoint and Datadog.
+They add no model identifiers or fields to `GET /v1/cache/status`. See the
+[internal cache metric inventory](telemetry-inventory.md#cache-results-by-model-internal)
+for `cache_model_*` labels and populations (`coordinator/api/cache_model_telemetry.go`).
 
 ## Provider capacity observations
 

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-07 · commit `5ce1d0cd0`
+> Last updated: 2026-09-08 · commit `ada6fcea1`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -130,6 +130,37 @@ lists every name).
 | `routing.ttft_calibration_ratio` | gauge | `model` | each TTFT observation (`coordinator/api/settlement.go`) |
 | `routing.unservable_reclassified`, `routing.first_chunk_timeout_reclassified`, `routing.client_error_passthrough`, `routing.oversized_request_rejected`, `routing.deadline_unreachable_rejected`, `routing.invalid_ttft`, `routing.dispatch_client_error_stop`, `routing.first_chunk_timeout_ladder_capped`, `routing.hedge_governor_suppressed`, `routing.pending_load_backoff`, `routing.scan_admission_timeout`, `routing.ttft_admission`, `routing.ttft_spread`, `routing.provider_selected`, `routing.load_model_rejects` | count | mostly `model` | routing edge cases |
 | `http.requests` (count), `http.latency_ms` (histogram) | — | `method`, `path`, `status_code` | every HTTP request (`loggingMiddleware`, `coordinator/api/server.go`) |
+
+### Cache results by model (internal)
+
+`coordinator/api/cache_model_telemetry.go` emits the following Datadog counters
+under `d_inference.routing.cache_model.`. Their admin counterparts are
+`cache_model_<suffix>_total` in `GET /v1/admin/metrics`. The `model` label is the
+resolved active catalog ID (`coordinator/registry/model_catalog.go`,
+`CatalogModelID`), never the requested alias or a provider-supplied arbitrary
+model. Off-catalog/removed IDs, an unconfigured catalog and malformed labels
+collapse to `unknown`. No account, provider, request, cache scope, nonce, weight
+hash or prompt-derived identity is attached. Existing `exact_cache.*` metrics
+and the public cache status retain their aggregate-only contract.
+
+| Suffix | Labels besides `model` | Population / interpretation |
+|---|---|---|
+| `usage` | `outcome`, `tier` | Completion terminals with retained pending/parked ownership, at the same seam as aggregate cache usage. Outcome is `hit`, `miss_absent`, `miss_corrupt`, `skipped_capacity`, `skipped_cost`, `skipped_policy`, `invalid` or `unreported`. `invalid`/`unreported` use tier `none`; they are coverage gaps, not misses. Duplicate and unknown terminals do not count. |
+| `cached_tokens`, `prefill_tokens_saved` | `tier` | Validated provider-reported token totals. Cached tokens may exceed saved prefill tokens when replay is required. Neither count requires an accepted routing proof. |
+| `provider_stage_us`, `provider_stage_samples` | `outcome`, `tier` | Sum of provider-reported staging microseconds (rounded per sample) and sample count for valid usage. Divide to obtain mean stage time. This is overhead, not time saved. |
+| `lookup` | `outcome`, `tier` | Only coordinator-accepted V2 lookup proofs; distinct from terminal provider usage. Rejected proofs remain in aggregate reason counters. |
+| `donation` | `tier` | Accepted V2 ready receipts, not number of files, unique prefixes or requests. |
+| `selection` | `mode`, `tier`, `selected`, `result`, `lookup_outcome`, `cache_read` | Existing exactly-once cache terminal population. `selected=true` identifies cache-favored routing; combine with `result=hit` for reported reuse. `result` describes cache usage, not consumer request success. Here `tier` is the selected routing tier (`none` for an unselected provider); `usage.tier` instead describes actual reported reuse. Error terminals can be `unreported`. |
+| `ttft_us`, `ttft_samples` | Same as `selection` | Coordinator-measured first-content latency for valid reported usage in active cache routing. Compare hit/miss and selected/unselected populations; this is observed latency, not estimated savings. |
+| `estimated_ttft_saved_us`, `estimated_ttft_saved_samples` | Same as `selection` | Positive finite scheduler estimates, split by the terminal cache outcome. These are not measured counterfactual savings or success-only totals. |
+
+Timing sums/sample counters work with both HTTPS and DogStatsD. The admin
+registry additionally exposes `cache_model_provider_stage_ms` and
+`cache_model_ttft_ms` and `cache_model_estimated_ttft_saved_ms` histograms with the corresponding labels.
+Admin counters reset on coordinator restart; all model breakdowns begin only
+when this instrumentation is deployed. Historical aggregate hits cannot be
+backfilled into models. Provider usage, receipt counts and selection counts
+have different populations and must not be summed together.
 
 ### Telemetry pipeline and platform gauges
 


### PR DESCRIPTION
Cache hits and saved-prefill tokens were only available as network aggregates. A request profile’s cache discount could identify the chosen model, but could not establish that it actually hit cache. Add internal per-model reporting before expanding cache routing.

The new `routing.cache_model.*` Datadog counters and `cache_model_*` admin metrics separate three populations: validated provider terminal usage, accepted V2 cache proofs, and cache-selected terminal outcomes. They report hits/misses/skips, invalid or missing usage, cached tokens, avoided-prefill tokens, accepted lookups/donations, and selected versus unselected reported reuse. Timing sum/sample counters cover SSD staging, observed first-content latency and estimated TTFT savings; sums work with the production Datadog HTTPS transport. Admin histograms retain percentile buckets.

Model labels come from the resolved active catalog ID, not caller aliases. Missing/off-catalog IDs and unsafe labels collapse to `unknown`, including when catalog filtering is disabled. No provider, account, request, nonce, scope or prompt-derived identity is added to metrics. Existing aggregate metrics, public cache status, API cached-token responses, routing, billing and provider wire types are unchanged. No database migration or provider release is required for this telemetry.

### Before

```mermaid
flowchart TD
  C[Provider completion] --> H[handleComplete validates usage]
  H --> U[Aggregate usage and saved-token metrics]
  P[V2 lookup or ready receipt] --> V[Registry validates proof]
  V --> A[Aggregate accepted-proof metrics]
  T[Cache terminal claim] --> S[emitCacheSelectionTerminal]
  S --> O[Aggregate selection and savings estimates]
  U --> Q[Operator cannot rank cache results by model]
  A --> Q
  O --> Q
```

### After

```mermaid
flowchart TD
  C[Provider completion] --> H[handleComplete validates usage and retains terminal ownership]
  H --> U[emitModelCacheUsage: hit miss skipped invalid unreported]
  P[V2 lookup or ready receipt] --> V[Registry accepts proof]
  V --> A[emitModelCacheLookup or Donation]
  T[Exactly-once cache terminal claim] --> S[emitModelCacheSelection]
  F[Valid observed first-content timing] --> M[cacheModelTiming: observed TTFT]
  U --> L[CatalogModelID: canonical ID or unknown]
  A --> L
  S --> L
  M --> L
  L --> D[Datadog and authenticated admin metrics]
  D --> Q[Operator compares model hit rates tokens and latency by population]
```

### Validation

- Focused race tests cover three model IDs, separate cached versus avoided-prefill token totals, hit/miss/invalid/unreported usage, parked completion, duplicate terminal handling, accepted versus rejected proofs, selected/unselected/disconnected terminals, timing sums, catalog-only labels and preservation of API response usage.
- Existing cache terminal idempotence, selection, aggregate privacy and cached-token response tests pass with the additions.
- Full coordinator suite: `env -u DATABASE_URL -u EIGENINFERENCE_DATABASE_URL go test -p 1 ./coordinator/...`.
- `make docs-check`, Go formatting and `git diff --check`.

### Reading the numbers

- Provider usage is sanity-checked reporting; it is not an accepted routing proof or a consumer-success guarantee. Its completion population matches the existing aggregate usage seam. Unknown, duplicate, discarded deadline-late and speculative-losing completions are not added to that population.
- `selection.result=hit` describes reported cache reuse, not successful end-to-end request delivery. Use request-outcome telemetry for success/error rates.
- Hit rate is `hit / (hit + miss_absent + miss_corrupt)`. Missing/invalid/skipped usage is tracked separately.
- Estimates remain estimates, even when grouped by model. Observed TTFT is a separate metric and needs comparable workloads for causal latency claims.
- Model breakdowns start after deployment. Historical aggregate hits cannot be backfilled, and in-process admin counters reset on coordinator restart.
- This PR does not change rollout settings. It can be included with #868 in the next coordinator upgrade before the proposed 100% eligibility / 5-plan-per-second rollout. Queries and timing formulas are in `docs/operations/cache-routing-rollout.md` and `docs/reference/telemetry-inventory.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791504418&installation_model_id=21733&pr_number=871&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F871&signature=e9b5a42b3e338183bf3b7b1d9e882c82d9380b1729d3586c6408a1d2ea538cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->