### PR TITLE
fix(provider): preserve terminals and valid cache checkpoints

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEvidenceEnqueueGate.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEvidenceEnqueueGate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The cache can stop admitting proofs without closing request delivery. Both
+/// use the same sequence so a terminal racing shutdown cannot overtake a proof
+/// that the finalizer has already enqueued.
+final class PrefixCacheEvidenceEnqueueGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var nextID: UInt64 = 1
+    private var closed = false
+
+    var isOpen: Bool { lock.withLock { !closed } }
+
+    func claim(terminal: Bool) -> UInt64? {
+        lock.withLock {
+            guard !closed || terminal else { return nil }
+            // Wrapping avoids ever exhausting terminal delivery. IDs only need
+            // to be unique among pending commands, not over the model lifetime.
+            defer { nextID &+= 1 }
+            return nextID
+        }
+    }
+
+    func close() {
+        lock.withLock { closed = true }
+    }
+}
+
+/// Owned by one request's callback rather than the model-wide actor, so duplicate
+/// or racing terminal callbacks are suppressed even after that actor deallocates.
+final class PrefixCacheTerminalDeliveryGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+
+    func claim() -> Bool {
+        lock.withLock {
+            guard !claimed else { return false }
+            claimed = true
+            return true
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEvidenceSequencer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCacheEvidenceSequencer.swift
@@ -17,24 +17,6 @@ actor PrefixCacheEvidenceSequencer {
         let hasExpiry: Bool
     }
 
-    private final class EnqueueGate: @unchecked Sendable {
-        private let lock = NSLock()
-        private var nextID: UInt64 = 1
-        private var closed = false
-
-        func claim() -> UInt64? {
-            lock.withLock {
-                guard !closed, nextID < UInt64.max else { return nil }
-                defer { nextID += 1 }
-                return nextID
-            }
-        }
-
-        func close() {
-            lock.withLock { closed = true }
-        }
-    }
-
     private struct Context: Sendable, Equatable {
         let requestID: String
         let nonce: String
@@ -65,7 +47,7 @@ actor PrefixCacheEvidenceSequencer {
     private let receiptTier: PrefixCacheTier
     private let capabilityProvider: @Sendable () -> PrefixCacheV2Capability?
     private let sequenceProvider: (@Sendable (String) -> UInt64?)?
-    private nonisolated let enqueueGate = EnqueueGate()
+    private nonisolated let enqueueGate = PrefixCacheEvidenceEnqueueGate()
     private var activeCapability: PrefixCacheV2Capability?
     private var nextSequence: UInt64 = 1
     private var nextCommandID: UInt64 = 1
@@ -96,6 +78,9 @@ actor PrefixCacheEvidenceSequencer {
     }
 
     nonisolated func shutdown() {
+        // Recovery may close the cache before an outer inference handler sends
+        // its final completion/error. Stop accepting optional evidence, but let
+        // terminal messages follow all commands accepted before this boundary.
         enqueueGate.close()
     }
 
@@ -106,7 +91,7 @@ actor PrefixCacheEvidenceSequencer {
         forwardTerminal: Bool = true,
         readyBoundaryMode: String? = nil
     ) -> PrefixCacheV2EvidenceCallbacks? {
-        guard let capability = capabilityProvider() else { return nil }
+        guard enqueueGate.isOpen, let capability = capabilityProvider() else { return nil }
         // The echo is absent on old coordinators. Local SSD reuse may still
         // proceed, but its checkpoint receipts must not be misread as legacy
         // durable coverage through the full prompt floor.
@@ -119,6 +104,7 @@ actor PrefixCacheEvidenceSequencer {
             nonce: nonce,
             capability: capability,
             forwardTerminal: forwardTerminal)
+        let terminalGate = PrefixCacheTerminalDeliveryGate()
         return PrefixCacheV2EvidenceCallbacks(
             lookup: { [weak self] result in
                 self?.enqueue(.lookup(context, result, send))
@@ -127,14 +113,26 @@ actor PrefixCacheEvidenceSequencer {
                 self?.enqueue(.ready(context, result, send))
             },
             terminal: { [weak self] message in
-                self?.enqueue(.terminal(context, message, send))
+                guard terminalGate.claim() else { return }
+                if let self {
+                    self.enqueue(.terminal(context, message, send))
+                } else if context.forwardTerminal {
+                    // Accepted commands retain the sequencer until they have
+                    // drained, so deallocation means there is no queued proof
+                    // left for this direct fallback to overtake.
+                    send.send(message)
+                }
             })
     }
 
     private nonisolated func enqueue(_ command: Command) {
-        guard let id = enqueueGate.claim() else { return }
-        Task { [weak self] in
-            await self?.receive(id: id, command: command)
+        let terminal: Bool
+        if case .terminal = command { terminal = true } else { terminal = false }
+        guard let id = enqueueGate.claim(terminal: terminal) else { return }
+        // Do not let model/bridge teardown drop an already accepted command or
+        // leave a hole that prevents later command IDs from draining.
+        Task {
+            await self.receive(id: id, command: command)
         }
     }
 
@@ -142,7 +140,7 @@ actor PrefixCacheEvidenceSequencer {
         pendingCommands[id] = command
         while let next = pendingCommands.removeValue(forKey: nextCommandID) {
             sweepExpired(now: .now)
-            nextCommandID += 1
+            nextCommandID &+= 1
             switch next {
             case .lookup(let context, let result, let send):
                 handleLookup(context, result: result, send: send)

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDHybridCheckpointStore+DuplicateValidation.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDHybridCheckpointStore+DuplicateValidation.swift
@@ -1,0 +1,64 @@
+import Foundation
+import MLXLMCommon
+
+extension SSDHybridCheckpointStore {
+    /// Concurrent prefills can reach the same prefix boundary using different
+    /// chunk sizes. Keep the first complete checkpoint, including its original
+    /// execution geometry; never compare its envelope to the donor's or combine
+    /// tensors from the two executions.
+    func validateDurableCheckpoint(_ job: WriteJob, at url: URL) throws {
+        let incoming = job.source.manifest
+        var metadata: SSDBlockMetadata?
+        var storedEnvelope: SSDHybridCheckpointEnvelope?
+        statsBox.update { $0.filesRead += 1 }
+        try SSDBlockStore.readStreaming(
+            from: url, kekKey: kekKey,
+            maximumChunkBytes: CBv2CompleteCheckpointManifest.maximumSegmentBytes,
+            maximumPlaintextBytes: config.maxReadBytes,
+            maximumMetadataBytes: 1 << 20, maximumWrappedDEKBytes: 60, requireEOF: true,
+            checkCancellation: { try self.checkWrite(job) },
+            onBytesRead: { count in
+                self.statsBox.update { $0.bytesRead += count; $0.donationReadBytes += count }
+            }, validateMetadata: { header in
+                guard header.lookupTag == job.tag.hexString,
+                    header.weightHash == self.identity.modelAggregateHash,
+                    header.layoutEpoch == SSDHybridCheckpointEnvelope.layoutEpoch(
+                        identity: self.identity, backendLayout: self.config.backendLayout),
+                    header.blockSize == PrefixCachePolicy.blockSize,
+                    let firstSize = header.chunkPlaintextSizes.first,
+                    firstSize > 0, firstSize <= CBv2CompleteCheckpointManifest.maximumEncodedBytes
+                else { throw CBv2CompleteCheckpointError.incompatibleCheckpoint }
+                metadata = header
+            }, consumeChunk: { index, bytes in
+                if index == 0 {
+                    let stored = try SSDHybridCheckpointEnvelope.decodeManifest(bytes)
+                    guard stored.identity == incoming.identity,
+                        stored.backendLayout == incoming.backendLayout,
+                        stored.position == incoming.position,
+                        stored.prefixTokens == incoming.prefixTokens,
+                        stored.cacheSalt == incoming.cacheSalt,
+                        stored.assistantCodecID == incoming.assistantCodecID,
+                        stored.tensors == incoming.tensors,
+                        stored.attentionLayers == incoming.attentionLayers,
+                        let metadata
+                    else { throw CBv2CompleteCheckpointError.incompatibleCheckpoint }
+                    let envelope = try SSDHybridCheckpointEnvelope(
+                        manifest: stored, maximumPlaintextBytes: self.config.maxReadBytes)
+                    guard bytes == envelope.manifestBytes,
+                        envelope.matches(metadata, tag: job.tag, identity: self.identity,
+                                         backendLayout: self.config.backendLayout)
+                    else { throw CBv2CompleteCheckpointError.incompatibleCheckpoint }
+                    storedEnvelope = envelope
+                } else {
+                    guard let storedEnvelope,
+                        storedEnvelope.segments.indices.contains(index - 1),
+                        bytes.count == storedEnvelope.segments[index - 1].bytes
+                    else { throw CBv2CompleteCheckpointError.invalidSegment }
+                }
+            })
+        // readStreaming authenticates every declared segment and requires EOF;
+        // an authenticated manifest alone is not durable checkpoint evidence.
+        guard storedEnvelope != nil else { throw CBv2CompleteCheckpointError.incompleteTransfer }
+        try checkWrite(job)
+    }
+}

--- a/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDHybridCheckpointStore+Write.swift
+++ b/provider-swift/Sources/ProviderCore/KVCacheSSD/SSDHybridCheckpointStore+Write.swift
@@ -187,23 +187,7 @@ extension SSDHybridCheckpointStore {
                 // A ready receipt must never rely on an advisory index entry.
                 // Reauthenticate changed timestamps too: another legitimate
                 // hit may have updated sliding recency since this stage.
-                statsBox.update { $0.filesRead += 1 }
-                try SSDBlockStore.readStreaming(
-                    from: url, kekKey: kekKey,
-                    maximumChunkBytes: CBv2CompleteCheckpointManifest.maximumSegmentBytes,
-                    maximumPlaintextBytes: config.maxReadBytes,
-                    maximumMetadataBytes: 1 << 20, maximumWrappedDEKBytes: 60, requireEOF: true,
-                    checkCancellation: { try self.checkWrite(job) },
-                    onBytesRead: { count in self.statsBox.update { $0.bytesRead += count; $0.donationReadBytes += count } },
-                    validateMetadata: {
-                        guard envelope.matches($0, tag: job.tag, identity: self.identity, backendLayout: self.config.backendLayout) else {
-                            throw CBv2CompleteCheckpointError.incompatibleCheckpoint
-                        }
-                    }, consumeChunk: { index, bytes in
-                        if index == 0, bytes != envelope.manifestBytes {
-                            throw CBv2CompleteCheckpointError.incompatibleCheckpoint
-                        }
-                    })
+                try validateDurableCheckpoint(job, at: url)
             } else {
                 guard rateLimiter.tryConsume(bytes: envelope.plaintextBytes) else {
                     result.outcome = .writeRateLimited; return

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCacheEvidenceSequencerTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCacheEvidenceSequencerTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Prefix cache terminal delivery during shutdown")
+struct PrefixCacheEvidenceSequencerTests {
+    private final class Messages: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [OutboundMessage] = []
+
+        func append(_ value: OutboundMessage) { lock.withLock { values.append(value) } }
+        var snapshot: [OutboundMessage] { lock.withLock { values } }
+    }
+
+    private final class Pause: @unchecked Sendable {
+        private let lock = NSLock()
+        private var armed = false
+        private var entered = false
+        let resume = DispatchSemaphore(value: 0)
+
+        func arm() { lock.withLock { armed = true } }
+
+        func pauseOnce() {
+            let shouldPause = lock.withLock {
+                guard armed else { return false }
+                armed = false
+                return true
+            }
+            if shouldPause {
+                lock.withLock { entered = true }
+                _ = resume.wait(timeout: .now() + 5)
+            }
+        }
+
+        func waitUntilEntered() async -> Bool {
+            for _ in 0 ..< 1000 {
+                if lock.withLock({ entered }) { return true }
+                try? await Task.sleep(for: .milliseconds(2))
+            }
+            return false
+        }
+    }
+
+    private final class WeakSequencer {
+        weak var value: PrefixCacheEvidenceSequencer?
+
+        init(_ value: PrefixCacheEvidenceSequencer?) { self.value = value }
+    }
+
+    @Test("closed cache still forwards completion and error exactly once", arguments: [false, true])
+    func terminalAfterShutdown(completed: Bool) async throws {
+        let sequencer = makeSequencer()
+        let messages = Messages()
+        let send = SendHandle(messages.append)
+        let callbacks = try #require(sequencer.callbacks(requestID: "r", nonce: "n", send: send))
+        sequencer.shutdown()
+
+        callbacks.lookup(lookup())
+        callbacks.ready(ready())
+        callbacks.terminal(terminal(completed: completed))
+        callbacks.terminal(terminal(completed: completed))
+
+        await waitForMessages(messages, count: 1)
+        #expect(messageKinds(messages.snapshot) == [completed ? "complete:r" : "error:r"])
+        #expect(sequencer.callbacks(requestID: "new", nonce: "new", send: send) == nil)
+    }
+
+    @Test("deallocated cache falls back without retaining the loaded model", arguments: [false, true])
+    func terminalAfterDeallocation(completed: Bool) throws {
+        var sequencer: PrefixCacheEvidenceSequencer? = makeSequencer()
+        let released = WeakSequencer(sequencer)
+        let messages = Messages()
+        let callbacks = try #require(sequencer?.callbacks(
+            requestID: "r", nonce: "n", send: SendHandle(messages.append)))
+        sequencer = nil
+        #expect(released.value == nil)
+
+        callbacks.lookup(lookup())
+        callbacks.ready(ready())
+        callbacks.terminal(terminal(completed: completed))
+        callbacks.terminal(terminal(completed: completed))
+
+        #expect(messageKinds(messages.snapshot) == [completed ? "complete:r" : "error:r"])
+    }
+
+    @Test("accepted lookup survives teardown and precedes a post-shutdown terminal")
+    func acceptedCommandsRetainUntilDrained() async throws {
+        let capability = capability()
+        let pause = Pause()
+        var sequencer: PrefixCacheEvidenceSequencer? = PrefixCacheEvidenceSequencer {
+            pause.pauseOnce()
+            return capability
+        }
+        let released = WeakSequencer(sequencer)
+        let messages = Messages()
+        let callbacks = try #require(sequencer?.callbacks(
+            requestID: "r", nonce: "n", send: SendHandle(messages.append)))
+        pause.arm()
+        callbacks.lookup(lookup())
+        defer { pause.resume.signal() }
+        #expect(await pause.waitUntilEntered())
+        sequencer?.shutdown()
+        sequencer = nil
+        #expect(released.value != nil)
+
+        callbacks.terminal(terminal())
+        #expect(messages.snapshot.isEmpty)
+        pause.resume.signal()
+        await waitForMessages(messages, count: 2)
+        #expect(messageKinds(messages.snapshot) == ["lookup:r", "error:r"])
+
+        for _ in 0 ..< 1000 where released.value != nil {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(released.value == nil)
+    }
+
+    @Test("outer finalizer preserves lookup-before-terminal when recovery closes the cache")
+    func finalizerDuringRecovery() async throws {
+        let sequencer = makeSequencer()
+        let messages = Messages()
+        let send = SendHandle(messages.append)
+        let callbacks = try #require(sequencer.callbacks(requestID: "r", nonce: "n", send: send))
+        let finalizer = PrefixCacheLookupReceiptFinalizer(callback: nil)
+        finalizer.configureV2(lookup: callbacks.lookup, terminal: callbacks.terminal)
+        finalizer.resolve(lookup())
+        sequencer.shutdown()
+        finalizer.sendTerminal(terminal(), fallbackFailure: .policy, send: send)
+
+        await waitForMessages(messages, count: 2)
+        #expect(messageKinds(messages.snapshot) == ["lookup:r", "error:r"])
+    }
+
+    @Test("secondary tier never duplicates the primary terminal after shutdown or deallocation")
+    func secondaryTierDoesNotForward() async throws {
+        var sequencer: PrefixCacheEvidenceSequencer? = makeSequencer()
+        let messages = Messages()
+        let callbacks = try #require(sequencer?.callbacks(
+            requestID: "r", nonce: "n", send: SendHandle(messages.append), forwardTerminal: false))
+        let afterRelease = try #require(sequencer?.callbacks(
+            requestID: "released", nonce: "released", send: SendHandle(messages.append),
+            forwardTerminal: false))
+        sequencer?.shutdown()
+        callbacks.terminal(terminal())
+        for _ in 0 ..< 1000 {
+            if await sequencer?.requestStateSnapshotForTesting(nonce: "n")?.terminalSeen == true { break }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(await sequencer?.requestStateSnapshotForTesting(nonce: "n")?.terminalSeen == true)
+        let released = WeakSequencer(sequencer)
+        sequencer = nil
+        for _ in 0 ..< 1000 where released.value != nil {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        #expect(released.value == nil)
+        afterRelease.terminal(terminal(requestID: "released"))
+        #expect(messages.snapshot.isEmpty)
+    }
+
+    @Test("racing shutdown and finalizers neither lose terminals nor reorder accepted lookups")
+    func concurrentShutdown() async throws {
+        let sequencer = makeSequencer()
+        let messages = Messages()
+        let send = SendHandle(messages.append)
+        let callbacks = try (0 ..< 64).map { index in
+            try #require(sequencer.callbacks(requestID: "r\(index)", nonce: "n\(index)", send: send))
+        }
+        let result = lookup()
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { sequencer.shutdown() }
+            for (index, callback) in callbacks.enumerated() {
+                group.addTask {
+                    callback.lookup(result)
+                    await Task.yield()
+                    callback.terminal(terminal(requestID: "r\(index)"))
+                }
+            }
+        }
+        for _ in 0 ..< 1000 {
+            if messageKinds(messages.snapshot).filter({ $0.hasPrefix("error:") }).count == 64 { break }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        let kinds = messageKinds(messages.snapshot)
+        for index in 0 ..< 64 {
+            let terminals = kinds.indices.filter { kinds[$0] == "error:r\(index)" }
+            #expect(terminals.count == 1)
+            if let lookupIndex = kinds.firstIndex(of: "lookup:r\(index)"), let terminalIndex = terminals.first {
+                #expect(lookupIndex < terminalIndex)
+            }
+        }
+    }
+
+    @Test("concurrent duplicate terminals forward once even with no cache owner", arguments: [false, true])
+    func concurrentDuplicates(releaseOwner: Bool) async throws {
+        var sequencer: PrefixCacheEvidenceSequencer? = makeSequencer()
+        let messages = Messages()
+        let callbacks = try #require(sequencer?.callbacks(
+            requestID: "r", nonce: "n", send: SendHandle(messages.append)))
+        sequencer?.shutdown()
+        if releaseOwner { sequencer = nil }
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 64 {
+                group.addTask { callbacks.terminal(terminal()) }
+            }
+        }
+        await waitForMessages(messages, count: 1)
+        #expect(messageKinds(messages.snapshot) == ["error:r"])
+        withExtendedLifetime(sequencer) {}
+    }
+
+    private func makeSequencer() -> PrefixCacheEvidenceSequencer {
+        let value = capability()
+        return PrefixCacheEvidenceSequencer { value }
+    }
+
+    private func capability() -> PrefixCacheV2Capability {
+        PrefixCacheV2Capability(
+            modelId: "model", modelAggregateHash: String(repeating: "a", count: 64),
+            promptContractId: String(repeating: "b", count: 64), blockHashVersion: "dbk3",
+            blockSize: 256, cacheEpoch: "11111111-1111-1111-1111-111111111111", enabled: true, ready: true)
+    }
+
+    private func lookup() -> PrefixCacheLookupResult {
+        PrefixCacheLookupResult(outcome: .missAbsent, tier: .ssd,
+            promptAnchor: PrefixCacheAnchor(chainHash: String(repeating: "c", count: 64), tokenCount: 256))
+    }
+
+    private func ready() -> PrefixCacheReadyResult {
+        PrefixCacheReadyResult(readyTokens: 256, requiredRecomputeTokens: 0, expectedPrefillTokensSaved: 256,
+            stageMs: 1, finalAnchor: PrefixCacheAnchor(chainHash: String(repeating: "c", count: 64), tokenCount: 256))
+    }
+
+    private func terminal(requestID: String = "r", completed: Bool = false) -> OutboundMessage {
+        if completed {
+            return .inferenceComplete(requestId: requestID, usage: UsageInfo(promptTokens: 1, completionTokens: 1),
+                stopSequence: nil, seSignature: nil, responseHash: nil)
+        }
+        return .inferenceError(requestId: requestID, failure: InferenceFailure(code: .internalFailure, statusCode: 500))
+    }
+
+    private func messageKinds(_ messages: [OutboundMessage]) -> [String] {
+        messages.map {
+            switch $0 {
+            case .prefixCacheLookupV2(let lookup): "lookup:\(lookup.requestId)"
+            case .prefixCacheReadyV2(let ready): "ready:\(ready.requestId)"
+            case .inferenceError(let requestID, _, _): "error:\(requestID)"
+            case .inferenceComplete(let requestID, _, _, _, _, _): "complete:\(requestID)"
+            default: "unexpected"
+            }
+        }
+    }
+
+    private func waitForMessages(_ messages: Messages, count: Int) async {
+        for _ in 0 ..< 1000 where messages.snapshot.count < count {
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SSDHybridCheckpointDuplicateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDHybridCheckpointDuplicateTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+@testable import MLXLMCommon
+import Testing
+@testable import ProviderCore
+
+@Suite("Complete checkpoint duplicate validation", .serialized)
+struct SSDHybridCheckpointDuplicateTests {
+    @Test("different valid prefill geometries preserve the original checkpoint and epoch",
+          arguments: [false, true], [512, 2048])
+    func differentChunkSizes(paged: Bool, storedChunkSize: Int) async throws {
+        let fixture = try SSDHybridCheckpointTestFixture(paged: paged, tokenCount: 4097)
+        defer { fixture.remove() }
+        let store = try fixture.makeStore()
+        let position = 2048
+        let incomingChunkSize = storedChunkSize == 512 ? 2048 : 512
+        #expect(try await fixture.donate(store, position: position, chunkSize: storedChunkSize) == [position])
+        let file = fixture.file(store, position: position)
+        let before = try Data(contentsOf: file)
+        let epoch = store.config.epochStore?.current
+
+        // Neither submission has staged the file: the second donation must
+        // authenticate the first execution's complete checkpoint from disk.
+        #expect(try await fixture.donate(store, receipt: 11, position: position,
+                                        chunkSize: incomingChunkSize) == [position])
+        #expect(try Data(contentsOf: file) == before)
+        #expect(store.config.epochStore?.current == epoch)
+        #expect(store.stats().entries == 1)
+        #expect(store.stats().filesWritten == 1)
+        #expect(store.stats().filesRead == 1)
+        #expect(store.stats().donationReadBytes > 0)
+        #expect(store.stats().corruptDropped == 0)
+
+        let request = fixture.request()
+        let staged = await store.stage(requestID: .init(12), request: request,
+                                       reserveReadScratch: fixture.reserveReadScratch) { manifest in
+            try fixture.codec.plan(manifest: manifest, request: request,
+                                   minimumChunkSize: 256, maximumChunkSize: 2048)
+        }
+        #expect(staged.staged)
+        let checkpoint = try #require(store.takeStaged(
+            requestID: .init(12), tokens: fixture.tokens, cacheSalt: "tenant-a",
+            maximumSequenceLength: fixture.tokens.count + request.maxTokens))
+        #expect(checkpoint.manifest.chunkSize == storedChunkSize)
+        #expect(checkpoint.manifest.position == position)
+        checkpoint.close()
+        await store.closeAndWait()
+        #expect(store.stats().stagedBytesInUse == 0)
+        #expect(await fixture.budget.outstandingReservedBytes() == 0)
+    }
+
+    enum InvalidStoredCheckpoint: String, CaseIterable, Sendable {
+        case wrongScope, wrongPrefix, wrongRuntimeIdentity, wrongAssistantCodec
+        case missingRecurrentState, wrongBoundary, missingFinalSegment
+        case lateCorruption, truncatedPayload, trailingBytes
+    }
+
+    @Test("different geometry does not excuse invalid identity, missing state, or incomplete authentication",
+          arguments: InvalidStoredCheckpoint.allCases)
+    func invalidStoredCheckpoint(_ fault: InvalidStoredCheckpoint) async throws {
+        let fixture = try SSDHybridCheckpointTestFixture(tokenCount: 4097)
+        defer { fixture.remove() }
+        let store = try fixture.makeStore()
+        let position = 2048
+        #expect(try await fixture.donate(store, position: position, chunkSize: 512) == [position])
+        let file = fixture.file(store, position: position)
+        let epoch = store.config.epochStore?.current
+        try replaceStoredCheckpoint(fault, fixture: fixture, store: store, position: position)
+
+        #expect(try await fixture.donate(store, receipt: 21, position: position, chunkSize: 2048).isEmpty)
+        #expect(store.config.epochStore?.current != epoch)
+        #expect(store.stats().filesWritten == 1)
+        #expect(store.stats().entries == 0)
+        #expect(store.stats().corruptDropped == 1)
+        #expect(!FileManager.default.fileExists(atPath: file.path))
+        await store.closeAndWait()
+        #expect(store.stats().stagedBytesInUse == 0)
+        #expect(await fixture.budget.outstandingReservedBytes() == 0)
+    }
+
+    private func replaceStoredCheckpoint(
+        _ fault: InvalidStoredCheckpoint, fixture: SSDHybridCheckpointTestFixture,
+        store: SSDHybridCheckpointStore, position: Int
+    ) throws {
+        let file = fixture.file(store, position: position)
+        switch fault {
+        case .lateCorruption, .truncatedPayload, .trailingBytes:
+            var bytes = try Data(contentsOf: file)
+            switch fault {
+            case .lateCorruption: bytes[bytes.count - 1] ^= 1
+            case .truncatedPayload: bytes.removeLast()
+            case .trailingBytes: bytes.append(0)
+            default: break
+            }
+            try bytes.write(to: file, options: .atomic)
+        default:
+            let storedPosition = fault == .wrongBoundary ? 1024 : position
+            let original = try fixture.manifest(position: storedPosition, chunkSize: 512)
+            var tokens = original.prefixTokens
+            if fault == .wrongPrefix { tokens[0] += 1 }
+            let identity = fault == .wrongRuntimeIdentity
+                ? CBv2CompleteCheckpointIdentity(
+                    modelAggregateHash: fixture.identity.modelAggregateHash,
+                    promptContractID: fixture.identity.promptContractID,
+                    buildID: fixture.identity.buildID, numericsFingerprint: "another-runtime")
+                : fixture.identity
+            let manifest = CBv2CompleteCheckpointManifest(
+                identity: identity, position: storedPosition, chunkSize: original.chunkSize,
+                prefixTokens: tokens, cacheSalt: fault == .wrongScope ? "tenant-b" : original.cacheSalt,
+                assistantCodecID: fault == .wrongAssistantCodec ? "another-assistant" : nil,
+                tensors: fault == .missingRecurrentState ? Array(original.tensors.dropLast()) : original.tensors,
+                backendLayout: original.backendLayout)
+            let envelope = try SSDHybridCheckpointEnvelope(manifest: manifest, maximumPlaintextBytes: 16 << 20)
+            let chain = store.hashes(tokens: fixture.tokens, scope: "tenant-a")
+            let tag = store.lookupKeys.checkpointTag(chainHash: chain[position / 256 - 1], cacheSalt: "tenant-a")
+            let metadata = envelope.metadata(tag: tag, identity: fixture.identity,
+                                             createdAt: store.config.nowSeconds(), backendLayout: fixture.backendLayout)
+            let header: SSDBlockMetadata
+            if fault == .missingFinalSegment {
+                // Every declared chunk is authenticated, but the manifest's
+                // final tensor segment is absent from the public envelope.
+                header = SSDBlockMetadata(
+                    lookupTag: metadata.lookupTag, weightHash: metadata.weightHash,
+                    layoutEpoch: metadata.layoutEpoch, blockSize: metadata.blockSize,
+                    layerCount: metadata.layerCount, chunks: Array(metadata.chunks.dropLast()),
+                    chunkPlaintextSizes: Array(metadata.chunkPlaintextSizes.dropLast()),
+                    createdAt: metadata.createdAt)
+            } else {
+                header = metadata
+            }
+            _ = try SSDBlockStore.writeStreaming(
+                to: file, metadata: header, kekKey: fixture.key,
+                maximumChunkBytes: CBv2CompleteCheckpointManifest.maximumSegmentBytes
+            ) { index in
+                index == 0 ? envelope.manifestBytes : Data(count: envelope.segments[index - 1].bytes)
+            }
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/SSDHybridCheckpointTestFixture.swift
+++ b/provider-swift/Tests/ProviderCoreTests/SSDHybridCheckpointTestFixture.swift
@@ -9,7 +9,7 @@ final class SSDHybridCheckpointTestFixture: @unchecked Sendable {
     let modelRoot: URL
     let key = SymmetricKey(size: .bits256)
     let identity = CBv2CompleteCheckpointIdentity(modelAggregateHash: "fixture-weights", promptContractID: "fixture-template", buildID: "fixture-build", numericsFingerprint: "fixture-numerics")
-    let tokens = (0..<513).map { $0 % 31 }
+    let tokens: [Int]
     let codec: CBv2CompleteCheckpointCodec
     let budget: GlobalKVCacheBudget
     let backend: PagedKVBackend?
@@ -18,8 +18,10 @@ final class SSDHybridCheckpointTestFixture: @unchecked Sendable {
         backend != nil ? CBv2CompleteCheckpointManifest.pagedLayout : CBv2CompleteCheckpointManifest.layout
     }
 
-    init(sharedPaged: Bool = false, paged: Bool = false, budget: GlobalKVCacheBudget? = nil) throws {
+    init(sharedPaged: Bool = false, paged: Bool = false, budget: GlobalKVCacheBudget? = nil,
+         tokenCount: Int = 513) throws {
         _ = LiveInferenceFixtures.ensureMetallibColocated()
+        tokens = (0..<tokenCount).map { $0 % 31 }
         self.sharedPaged = sharedPaged
         let usesPaged = sharedPaged || paged
         self.budget = budget ?? GlobalKVCacheBudget(capFraction: 0.9, activationReserveBytes: 0, memorySnapshot: {
@@ -79,14 +81,14 @@ final class SSDHybridCheckpointTestFixture: @unchecked Sendable {
         return store
     }
 
-    func manifest(position: Int = 256, scope: String = "tenant-a") throws -> CBv2CompleteCheckpointManifest {
-        .init(identity: identity, position: position, chunkSize: 256, prefixTokens: Array(tokens.prefix(position)),
+    func manifest(position: Int = 256, scope: String = "tenant-a", chunkSize: Int = 256) throws -> CBv2CompleteCheckpointManifest {
+        .init(identity: identity, position: position, chunkSize: chunkSize, prefixTokens: Array(tokens.prefix(position)),
               cacheSalt: scope, assistantCodecID: nil, tensors: try codec.tensorDescriptors(position: position),
               backendLayout: backendLayout)
     }
 
-    func source(position: Int = 256, scope: String = "tenant-a") throws -> CBv2CompleteCheckpointExport {
-        let manifest = try manifest(position: position, scope: scope)
+    func source(position: Int = 256, scope: String = "tenant-a", chunkSize: Int = 256) throws -> CBv2CompleteCheckpointExport {
+        let manifest = try manifest(position: position, scope: scope, chunkSize: chunkSize)
         let arrays = manifest.tensors.enumerated().map { index, tensor in
             MLXArray(Array(repeating: Float(index + 1), count: tensor.byteCount / 4)).reshaped(tensor.shape)
         }
@@ -110,8 +112,9 @@ final class SSDHybridCheckpointTestFixture: @unchecked Sendable {
         try codec.plan(manifest: manifest, request: request(), minimumChunkSize: 256, maximumChunkSize: 256)
     }
 
-    func donate(_ store: SSDHybridCheckpointStore, receipt: UInt64 = 10, position: Int = 256) async throws -> [Int] {
-        let source = try source(position: position)
+    func donate(_ store: SSDHybridCheckpointStore, receipt: UInt64 = 10, position: Int = 256,
+                chunkSize: Int = 256) async throws -> [Int] {
+        let source = try source(position: position, chunkSize: chunkSize)
         return await withCheckedContinuation { continuation in
             store.donate(source, requestID: .init(receipt), tokens: tokens, cacheSalt: "tenant-a") { continuation.resume(returning: $0) }
         }


### PR DESCRIPTION
## Summary

Fix two prefix-cache correctness bugs without changing cache architecture, defaults, or MLX dependency pins.

- **Do not lose request completion/error during cache teardown.** Recovery can close the evidence sequencer before the outer inference handler finalizes a request. Close proof admission separately from terminal delivery, retain accepted commands until they drain, and use an exactly-once direct fallback when the sequencer has already deallocated. Accepted lookup evidence still precedes its terminal; secondary cache tiers still never forward terminals.
- **Do not invalidate valid hybrid checkpoints with different prefill chunk sizes.** Concurrent requests can reach the same prefix boundary using different valid chunk sizes. Reauthenticate the existing checkpoint against its own manifest and envelope, allowing only this geometry difference, and retain its original bytes and epoch. Tenant, runtime identity, prefix, boundary, tensor descriptors, assistant codec, and historical attention layout remain strict. Every declared encrypted segment and EOF must validate; malformed or incomplete files still get removed and invalidate the epoch.

The terminal bug predates hybrid checkpoint support. The duplicate-checkpoint regression affects the recently merged complete-checkpoint path. RAM hot-cache work is deliberately excluded from this PR.

## Before

```mermaid
flowchart TD
  subgraph Terminal[Request completion during recovery]
    A[EngineV2Bridge.shutdown] --> B[PrefixCacheEvidenceSequencer closes every command]
    B --> C[Outer finalizer invokes terminal callback]
    C --> D[Closed gate or weak actor silently drops terminal]
    D --> E[Consumer stream waits for timeout]
  end
  subgraph Checkpoint[Duplicate donation at the same prefix boundary]
    F[Two requests use valid chunk sizes 512 and 2048] --> G[SSDHybridCheckpointStore write duplicate path]
    G --> H[Compare existing file with incoming envelope]
    H --> I[Valid original manifest differs]
    I --> J[Remove checkpoint and rotate cache epoch]
    J --> K[Reusable prefix becomes a cache miss]
  end
```

## After

```mermaid
flowchart TD
  subgraph Terminal[Request completion during recovery]
    A[EngineV2Bridge.shutdown] --> B[PrefixCacheEvidenceEnqueueGate closes proofs only]
    B --> C[Outer finalizer invokes terminal callback]
    C --> D[PrefixCacheTerminalDeliveryGate claims once]
    D --> E{Sequencer alive?}
    E -->|Yes| F[enqueue and drain after accepted evidence]
    E -->|No accepted work remains| G[Direct primary-tier SendHandle fallback]
    F --> H[Consumer receives completion or error exactly once]
    G --> H
  end
  subgraph Checkpoint[Duplicate donation at the same prefix boundary]
    I[Two requests use valid chunk sizes 512 and 2048] --> J[validateDurableCheckpoint]
    J --> K[Check stored identity and complete state contract]
    K --> L[Validate stored envelope and authenticate all segments plus EOF]
    L --> M{Complete and compatible?}
    M -->|Yes, chunk size may differ| N[Keep original checkpoint bytes, geometry, and epoch]
    N --> O[Later request can restore the original checkpoint]
    M -->|No| P[Existing corruption removal and epoch invalidation]
  end
```

## Regression coverage

- Shutdown and deallocation with both completion and error terminals, accepted-command ordering/lifetime, outer-finalizer recovery, secondary-tier suppression, and concurrent shutdown/duplicate callback races.
- Both chunk-size directions on contiguous and paged backends; unchanged ciphertext/epoch and restoration of the original geometry.
- Wrong scope, prefix, runtime identity, assistant codec, missing recurrent state, wrong boundary, missing final segment, late corruption, truncation, and trailing bytes remain rejected.
- Successful and rejected checkpoint paths release staging and reservation resources; accepted sequencer work releases its owner after draining.

## Validation

- `swift build --build-tests --jobs 8` — passed on Apple Silicon / Swift 6.3.3 against the repository's pinned MLX dependencies, using a source-matched Metal library.
- `swift test --skip-build --no-parallel --filter 'PrefixCache|SSDHybrid|SSDCheckpoint|SSDBlock|SSDCache|ResidentPrefix'` — passed; Swift Testing reports 238 tests in 39 suites (three opt-in live-model tests skipped). All 24 new regression cases ran.
- `../scripts/run-provider-tests.sh` from `provider-swift` — passed: 98 XCTest tests; general Swift Testing run reports 2,742 tests in 304 suites, including 44 opt-in/live-model skips; all four isolated filters passed (five additional test functions, none skipped).
- `git diff --cached --check` — passed. Independent review confirmed bugs-only scope and resource-release coverage. Live-model inference/soak benchmarks were not run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791508556&installation_model_id=21733&pr_number=875&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F875&signature=fea3ffcdc89c04b0ab74dd911d455ed9c75392fc0724a6c7dda892c0a89fa077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->