### PR TITLE
chore(release): prepare provider v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,56 +1,32 @@
 # Changelog
 
-## Unreleased — checkpoint write recovery
+## Release candidate v0.9.1 — cache reliability and recovery (not shipped; 2026-09-09)
 
-- Preserve unrelated valid cache checkpoints when atomic creation of a new checkpoint fails; a later donation can retry without an unnecessary cache-epoch reset. Existing files that fail reauthentication still revoke their cache evidence.
-- Distinguish complete-checkpoint host-memory, epoch, maintenance, disk-space, unsafe-path, I/O and eviction outcomes in bounded provider/coordinator telemetry.
+Source changes since `v0.9.0`. Provider changes require a new signed bundle;
+coordinator and console changes require their own deployments.
 
-## Unreleased — cache prompt parity and coverage
+### Provider
 
-- Match provider JSON response-format instructions and Qwen/Harmony system-turn folding in cache planning so structured-output requests do not generate a false prompt-anchor mismatch. Exercise the real service preparation path in shared tokenizer/hash parity tests.
-- Measure per-model saved-prefill percentages using matched prompt-token denominators, separately for provider usage, accepted evidence and cache-selected terminals. Add bounded per-model receipt rejection and prompt-length/hash mismatch diagnostics.
-- Stop queued provider slot-posture callbacks after cancellation and wait for the sampler during shutdown, preventing telemetry from being emitted after teardown returns.
+- **Request completion during recovery** — Keep completion/error delivery working after cache shutdown or deallocation, deliver each terminal once, and drain accepted cache evidence before its terminal. Preserve secondary-tier terminal suppression.
+- **Duplicate checkpoint reuse** — Keep an existing complete checkpoint when another request reaches the same prefix with a different valid prefill chunk size. Reauthenticate its original bytes, metadata and complete encrypted payload; preserve identity, tenant, state-layout and corruption checks.
+- **Checkpoint write recovery** — Preserve unrelated valid checkpoints when atomic creation of a new checkpoint fails, allowing a later donation to retry without an unnecessary cache-epoch reset. Existing files that fail reauthentication still revoke their cache evidence.
+- **SSD disk budget** — Size the shared cache at half of currently available disk space without a fixed 100 GiB ceiling. Keep a fixed 20 GiB low-disk write reserve instead of 5% of the whole disk, and check the full pending donation against space above the reserve. Preserve encryption, eviction, daily write limits and ENOSPC handling.
+- **Cache failure attribution** — Distinguish complete-checkpoint host-memory, epoch, maintenance, disk-space, unsafe-path, I/O and eviction outcomes in bounded provider/coordinator telemetry.
+- **Telemetry shutdown** — Stop queued slot-posture callbacks after cancellation and wait for the sampler during shutdown, preventing telemetry after teardown returns.
+- **Deadline diagnostics** — Report the received prediction policy, reservation ceiling and encoded deadline budget alongside the provider's prediction and decision, distinguishing refusal from acceptance followed by expiry.
 
-## Unreleased — coordinator startup
+### Companion coordinator and console changes
 
-- Fix startup recovery around live summary creation and transient store failures: pin history before the attempt marker, retry verified provider recovery with a shared deadline, and exclude pending recovery from routing until it succeeds. Exhaustion closes the new registration for retry before evicting an existing provider session.
-- Add a read-only post-stop startup observer that separates candidate health/readiness and per-model routable capacity from optional disposable-test inference. Keep successful inference and synthetic-answer correctness distinct, and omit response text, usage and credentials from reports.
-
-- Recover provider history on reconnect through indexed identity lookups instead of scanning every historical session before serving. Select the newest prior session and preserve live attestation requirements.
-- Capture missing earnings-summary history once and resume per-key additions safely alongside existing live settlement; keep base-reward money separate from inference counts/tokens. Exclude incomplete and live reconnect records from history recovery, including late async writes. Publish completed provider records and reputation atomically, preserving legacy missing-reputation behavior while refusing failed reads. Maintain summaries on record-only inserts as well as account settlement. Add startup phase timings and a database-only migration command for approved preparation before cutover.
-
-## Unreleased — partial network geography
-
-- Keep network stats loading when request-location or route analytics time out. Refresh geography independently, expose unavailable sections explicitly, and show a map notice while the rest of the overview remains usable. Preserve valid empty maps and restore geography automatically after recovery.
-
-
-## Unreleased — per-model cache reporting
-
-- Add internal model breakdowns for provider-reported cache hits/misses, cached and avoided-prefill tokens, accepted V2 proofs, cache-selected terminals and timing samples. Keep invalid/missing usage distinct from misses and retain the aggregate public status.
-
-## Unreleased — cache evidence and coordinator reconnect recovery
-
-- Preserve unchanged models' cache holders and receipts when another model loads or changes, and keep proof-mismatch fences across unrelated capability updates. Report bounded receipt rejection reasons and separate proof mismatch from ordinary holder changes.
-- Persist verified same-process APNs continuity for bounded coordinator reconnects without refreshing the original Apple proof timestamp. Preserve encrypted resume challenges, token/process/binary binding, new-process freshness checks and Apple push budgets. Stamp final continuity after the socket is marked offline while keeping periodic updates online-only.
-
-## Unreleased — provider SSD cache disk policy
-
-- Size the shared SSD cache at half of currently available disk space without a fixed 100 GiB ceiling. Keep a fixed 20 GiB low-disk write reserve instead of reserving 5% of the whole disk, so large disks with ample free space can cache. Preserve encryption, eviction, daily write limits and ENOSPC handling.
-- Check the full pending SSD donation against free space above the reserve before writing, so a donation cannot pass merely because free space starts above 20 GiB.
-
-## Unreleased: prediction decisions and backup deadlines
-
-- Record the coordinator's prediction policy, reservation ceiling and encoded deadline budget alongside each provider's returned prediction and decision. Distinguish refusals from acceptance followed by expiry without changing error codes or prediction policy.
-- Refresh remaining time after registry/provider lock waits before reserving a retained backup candidate. Skip expired reservations and shrink an enabled prediction ceiling.
-
-## Unreleased - pending-prompt admission estimates
-
-- Estimate unreflected pending prefill from each request's own prompt size, excluding requests that already produced content. Preserve the existing proxy for unknown cache work and reflected queues, so short and long arrivals no longer inherit each other's prompt lengths when the heartbeat is idle.
-
-## Unreleased: incoming request accounting
-
-- Add the unsampled request-outcome ledger and bounded admin inspection with explicit coverage and completion evidence.
-- Record recovered HTTP errors and parsed streaming mode accurately. Distinguish completed, incomplete and error response terminals after successful writes, preserving contradictory evidence and earlier content progress.
+- **Cache prompt parity** — Match provider JSON response-format instructions and Qwen/Harmony system-turn folding in cache planning so structured-output requests do not generate false prompt-anchor mismatches. Exercise the real service preparation path in shared tokenizer/hash parity tests.
+- **Per-model cache reporting** — Add internal breakdowns of provider-reported hits/misses, cached and avoided-prefill tokens, accepted V2 proofs, cache-selected terminals and timing samples. Measure saved-prefill percentages with matched prompt-token denominators for each population; retain invalid/missing usage separately from misses. Add bounded receipt rejection and prompt-length/hash mismatch diagnostics while preserving aggregate public status.
+- **Cache evidence continuity** — Preserve unchanged models' holders and receipts when another model loads or changes, retain proof-mismatch fences across unrelated capability updates, and distinguish proof mismatch from ordinary holder changes.
+- **APNs reconnect recovery** — Persist verified same-process continuity for bounded coordinator reconnects without refreshing the original Apple proof timestamp. Preserve encrypted resume challenges, token/process/binary binding, new-process freshness checks and Apple push budgets. Stamp final continuity after the socket is offline while keeping periodic updates online-only.
+- **Indexed startup recovery** — Recover history through indexed identity lookups instead of scanning every historical session before serving. Select the newest prior session, exclude live/incomplete records and late async writes, preserve live attestation requirements, and publish provider records and reputation atomically. Retry transient store failures within a shared deadline; pending recovery cannot route, and exhausted recovery closes the new registration before evicting an existing session. Preserve legacy missing-reputation behavior while refusing failed reads.
+- **Earnings-summary preparation** — Pin missing history before the durable attempt marker and resume per-key additions safely alongside live settlement. Keep base-reward money separate from inference counts/tokens and maintain summaries on record-only inserts as well as account settlement. Add a database-only migration command for approved pre-cutover preparation.
+- **Startup measurements** — Add startup phase timings and a read-only post-stop observer that separates candidate health/readiness and per-model routable capacity from optional disposable-test inference. Keep successful inference distinct from answer correctness and omit response text, usage and credentials from reports.
+- **Routing deadlines and admission** — Refresh remaining time after registry/provider lock waits before reserving a retained backup, skip expired reservations and shrink an enabled prediction ceiling. Estimate unreflected pending prefill from each request's own prompt size, excluding requests that already produced content, while preserving the proxy for unknown cache work and reflected queues.
+- **Incoming request accounting** — Add an unsampled request-outcome ledger and bounded admin inspection with explicit coverage and completion evidence. Record recovered HTTP errors and parsed streaming mode, and distinguish completed, incomplete and error response terminals after successful writes while preserving contradictory evidence and earlier content progress.
+- **Partial network geography** — Keep the stats overview available when request-location or route analytics time out. Refresh geography independently, expose unavailable sections, preserve valid empty maps and restore geography after recovery.
 
 ## Unreleased — stats request-flow refresh
 

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -158,7 +158,7 @@ func keyLimitResetFromContext(ctx context.Context) string {
 // assistant support; model-aware MTP defaults remain provider-side policy.
 // Keep this fallback in sync with ProviderCore.version so dev/in-memory
 // coordinators advertise the same floor as the Swift binary they expect.
-var LatestProviderVersion = "0.9.0"
+var LatestProviderVersion = "0.9.1"
 
 // minProviderVersionForDesiredModels is the first provider version whose Swift
 // runtime understands the desired_models message. The coordinator must NOT send

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-06 · commit `2eebb5412`
+> Last updated: 2026-09-09 · commit `87a13daf7`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -8,6 +8,12 @@ environment, and let [`.github/workflows/release-swift.yml`](../../.github/workf
 build, sign, notarize, hash, upload, and register the bundle. The coordinator
 verifies every registered artifact by re-downloading it, so a release either
 lands fully or not at all.
+
+The prepared version is **0.9.1**; its source changes since `v0.9.0` are
+collected in [`CHANGELOG.md`](../../CHANGELOG.md). The version bump prepares
+the source for the provider bundle. Publication and coordinator deployment remain
+separate operations; the bump alone does not change the registered release
+returned by `GET /v1/releases/latest`.
 
 ## Environment-free signing validation
 
@@ -103,8 +109,8 @@ Coordinator deploys are a separate runbook:
 
 The provider and coordinator versions must be identical strings:
 
-- `provider-swift/Sources/ProviderCore/ProviderCore.swift` — `public static let version = "0.9.0"`
-- `coordinator/api/server.go` — `var LatestProviderVersion = "0.9.0"`
+- `provider-swift/Sources/ProviderCore/ProviderCore.swift` — `public static let version = "0.9.1"`
+- `coordinator/api/server.go` — `var LatestProviderVersion = "0.9.1"`
 
 ```bash
 ./scripts/check-release-version.sh          # provider == coordinator, semver
@@ -112,8 +118,8 @@ The provider and coordinator versions must be identical strings:
 ```
 
 `check-release-version.sh` accepts an optional expected version
-(`check-release-version.sh v0.9.0`) and an optional reported string from a
-built binary (`darkbloom 0.9.0` or `0.9.0`); the workflow calls it in all
+(`check-release-version.sh v0.9.1`) and an optional reported string from a
+built binary (`darkbloom 0.9.1` or `0.9.1`); the workflow calls it in all
 three forms. CI job "Release Integrity" runs the two commands above on every
 push. Do not touch `minProviderVersionForDesiredModels` (`"0.5.17"`, same file)
 for a routine release; it is the floor for desired-model fan-out, not the
@@ -142,10 +148,10 @@ change that is not fixture-synced will fail the release, not just CI.
 
 ```bash
 git checkout master && git pull --ff-only
-git tag -a v0.8.17 -m "v0.8.17 — <one-line theme>
+git tag -a v0.9.1 -m "v0.9.1 — <one-line theme>
 
 <body: the changelog bullets for this release>"
-git push origin v0.8.17
+git push origin v0.9.1
 ```
 
 Accepted tag patterns (`on.push.tags`): `v*.*.*`, `v*-swift`, `v*-swift.*`.
@@ -159,7 +165,7 @@ this before writing job outputs or requesting environment approval.
 
 ```bash
 gh workflow run release-swift.yml --ref <branch> -f environment=dev
-# optional: -f version_override=0.8.17
+# optional: -f version_override=0.9.1
 ```
 
 Without a tag the version is read from `ProviderCore.swift` (or

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-09 · commit `87a13daf7`
+> Last updated: 2026-09-09 · commit `a82f89520`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -226,14 +226,14 @@ The registration payload (`coordinator/api/release_handlers.go`,
 
 ```json
 {
-  "version": "0.8.17",
+  "version": "0.9.1",
   "platform": "macos-arm64",
   "backend": "mlx-swift",
   "binary_hash": "<sha256 of bin/darkbloom>",
   "bundle_hash": "<sha256 of the tar.gz>",
   "metallib_hash": "<sha256 of mlx.metallib>",
-  "url": "<R2_PUBLIC_URL>/releases/v0.8.17/darkbloom-bundle-macos-arm64.tar.gz",
-  "changelog": "<tag subject + body, or 'Release v0.8.17'>"
+  "url": "<R2_PUBLIC_URL>/releases/v0.9.1/darkbloom-bundle-macos-arm64.tar.gz",
+  "changelog": "<tag subject + body, or 'Release v0.9.1'>"
 }
 ```
 
@@ -298,7 +298,7 @@ it** so the previous active version becomes "latest" again.
    ```bash
    curl -fsS -X DELETE "$COORD/v1/admin/releases" \
      -H "Authorization: Bearer $ADMIN_KEY" -H "Content-Type: application/json" \
-     -d '{"version":"0.8.17","platform":"macos-arm64"}'
+     -d '{"version":"0.9.1","platform":"macos-arm64"}'
    ```
 
    `handleAdminDeleteRelease` answers `409 release_in_use` while connected
@@ -321,7 +321,7 @@ it** so the previous active version becomes "latest" again.
    (`install.sh` uses the versioned URL from `/v1/releases/latest`; the
    `latest/` objects are for legacy clients.)
 4. Mark the GitHub Release as a pre-release or delete it
-   (`gh release delete v0.8.17`), and record the outcome in `CHANGELOG.md` as
+   (`gh release delete v0.9.1`), and record the outcome in `CHANGELOG.md` as
    `## Release candidate vX.Y.Z (not shipped; …)`.
 5. Do **not** re-register the same version with a different artifact. Fix
    forward with a new patch version.

--- a/provider-swift/Sources/ProviderCore/ProviderCore.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderCore.swift
@@ -250,5 +250,5 @@ public enum ProviderCore {
     // bounded forecast while preserving hard absolute expiry.
     // 0.8.13 serves Qwen image/video requests through the bounded vision path,
     // including single-decode media ingest and first-content-safe video caps.
-    public static let version = "0.9.0"
+    public static let version = "0.9.1"
 }


### PR DESCRIPTION
Prepare provider **0.9.1** from master after #875 merged. The provider still identified itself as 0.9.0 despite the cache and recovery fixes since that release. Bump `ProviderCore.version` and the coordinator's `LatestProviderVersion` fallback together, collect the post-0.9.0 changes into an explicitly unshipped candidate changelog, and update the release runbook's version and tag examples.

The release notes cover the merged provider fixes: completion/error delivery through cache teardown, valid duplicate checkpoint retention across prefill chunk sizes (#875), failed-write recovery and bounded failure attribution (#876), the 50%-of-available-disk budget with a 20 GiB reserve (#866), sampler shutdown (#874), and prediction diagnostics (#854). Coordinator cache parity, reporting, reconnect/startup recovery and console changes are documented as separately deployed companion changes.

Only the two version constants and release documentation change in this PR. Dependency pins, inference/cache policies, compatibility floors, installer bytes and signing/publication workflow remain unchanged. Existing production version discovery continues to use the registered release row; merging the bump does not publish a release.

### Before

```mermaid
flowchart LR
  CLI[darkbloom --version] --> Core[ProviderCore.version = 0.9.0]
  Empty[Coordinator has no registered release] --> Fallback[LatestProviderVersion = 0.9.0]
  Tag[Requested v0.9.1 release] --> Check[resolve-provider-release.sh and check-release-version.sh]
  Core --> Check
  Fallback --> Check
  Check --> Reject[Reject source and requested-version mismatch]
  Notes[Post-0.9.0 fixes] --> Scattered[Separate unreleased changelog sections]
```

### After

```mermaid
flowchart LR
  CLI[darkbloom --version] --> Core[ProviderCore.version = 0.9.1]
  Empty[Coordinator has no registered release] --> Fallback[LatestProviderVersion = 0.9.1]
  Tag[Future approved v0.9.1 release tag] --> Check[resolve-provider-release.sh and check-release-version.sh]
  Core --> Check
  Fallback --> Check
  Check --> Match[Source and requested version match]
  Match --> Later[Separate approved build, signing, notarization and publication]
  Notes[Merged fixes since v0.9.0] --> Candidate[0.9.1 candidate changelog and provider-release runbook]
  Registered[Existing registered release row] --> Discovery[Production version discovery remains unchanged until registration]
```

### Validation

- Source version integrity for `v0.9.1`, installer embed parity, Swift syntax parsing of the changed source file, Go formatting and diff checks pass.
- Existing release-resolution tests: 4 pass; packaging/signing helper tests: 9 pass. These use local fixtures, not signing credentials.
- The actual resolver accepts `v0.9.1` against this checkout in a local simulation; it only writes temporary outputs and dispatches no workflow.
- Documentation lint: 266 pages pass.
- `mise exec go@1.25.0 -- go test ./...` from `coordinator`: passes, including version synchronization tests (database environment unset; database-backed CI coverage remains separate).

CI must validate the final PR head, including Provider Tests and E2E Integration, before release. A full Swift provider build, signed/notarized 0.9.1 bundle, install/update and live-model validation remain release gates. This preparation does not create a tag, publish/register a bundle or deploy the coordinator.

CI status at preparation handoff: the final head is conflict-free and checks are running. Threat Model Review failed with HTTP 401 / authentication error in [run 34403365596](https://github.com/Layr-Labs/d-inference/actions/runs/34403365596); this external review check remains unresolved.
