### PR TITLE
feat(provider): trial GitHub upgrade downloads with R2 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — GitHub upgrade download trial
+
+- Try the matching GitHub release bundle for a random 10% of production stable-version upgrade downloads, falling back to R2 on network, HTTP, or checksum failure. Keep coordinator release discovery, R2 URLs and hashes, and signature verification authoritative. GitHub attempts have a 30-second idle timeout and a 120-second total transfer limit.
+
 ## Release candidate v0.9.1 — cache reliability and recovery (not shipped; 2026-09-09)
 
 Source changes since `v0.9.0`. Provider changes require a new signed bundle;

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-09 · commit `a82f89520`
+> Last updated: 2026-09-09 · commit `73093957b`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -14,6 +14,38 @@ collected in [`CHANGELOG.md`](../../CHANGELOG.md). The version bump prepares
 the source for the provider bundle. Publication and coordinator deployment remain
 separate operations; the bump alone does not change the registered release
 returned by `GET /v1/releases/latest`.
+
+## GitHub upgrade download trial
+
+For providers containing this change, `SelfUpdater.downloadAndVerify` chooses
+GitHub for a fresh random 10% of eligible upgrade downloads. This covers manual
+`darkbloom update`, in-process auto-update, and watchdog recovery updates. The
+trial applies to the production coordinator (`https://api.darkbloom.dev`) and
+stable `macos-arm64` releases with the versioned R2 bundle path; dev coordinators,
+prereleases, and custom bundle paths continue using the registered URL directly.
+This is a transport trial, not a separate beta release channel.
+
+[`ReleaseBundleDownloader.swift`](../../provider-swift/Sources/ProviderCore/Update/ReleaseBundleDownloader.swift)
+(`githubURL`, `download`) derives the GitHub asset from the coordinator-selected
+version: `Layr-Labs/d-inference`, tag `vX.Y.Z`, asset
+`darkbloom-bundle-macos-arm64.tar.gz`. It never uses GitHub release discovery.
+The coordinator's registered R2 URL and bundle hash remain authoritative; both
+transports must pass that hash before the existing binary, metallib, and pinned
+code-signature checks can run.
+
+A GitHub network, HTTP, checksum, or file-read failure removes the failed
+transfer and retries the exact registered R2 URL once. Cancellation stops the
+update without starting a fallback. GitHub has a 30-second handshake/idle timeout
+and a 120-second whole-transfer limit; the existing R2 session limits remain in
+place. Provider logs identify source selection and fallback.
+
+The release workflow already uploads the identical signed tarball to both
+locations. It registers R2 before publishing the GitHub asset, so upgrades during
+that interval may receive GitHub 404 and fall back normally. Verify publication
+using the existing release checks below. Existing installed provider versions
+keep their old download behavior until upgraded to a bundle containing this
+change; the trial takes effect on their subsequent upgrades. The installer
+continues using R2.
 
 ## Environment-free signing validation
 

--- a/provider-swift/Sources/ProviderCore/Update/ReleaseBundleDownloader.swift
+++ b/provider-swift/Sources/ProviderCore/Update/ReleaseBundleDownloader.swift
@@ -1,0 +1,118 @@
+import CryptoKit
+import Foundation
+import Logging
+
+/// GitHub is an optional transport mirror. Release discovery and every hash
+/// still come from the coordinator's R2-backed release record.
+struct ReleaseBundleDownloader: Sendable {
+    typealias Download = @Sendable (URL) async throws -> (URL, URLResponse)
+
+    static let githubPercentage = 10
+    static let githubRequestTimeout: TimeInterval = 30
+    static let githubResourceTimeout: TimeInterval = 120
+    private static let logger = Logger(label: "ai.darkbloom.ReleaseBundleDownloader")
+    private static let githubSession = makeGitHubSession()
+
+    let r2Download: Download
+    let githubDownload: Download
+    let randomPercent: @Sendable () -> Int
+
+    init(
+        r2Session: URLSession,
+        githubDownload: @escaping Download = { try await githubSession.download(from: $0) },
+        randomPercent: @escaping @Sendable () -> Int = { Int.random(in: 0..<100) }
+    ) {
+        self.init(
+            r2Download: { try await r2Session.download(from: $0) },
+            githubDownload: githubDownload,
+            randomPercent: randomPercent
+        )
+    }
+
+    init(
+        r2Download: @escaping Download,
+        githubDownload: @escaping Download,
+        randomPercent: @escaping @Sendable () -> Int
+    ) {
+        self.r2Download = r2Download
+        self.githubDownload = githubDownload
+        self.randomPercent = randomPercent
+    }
+
+    static func makeGitHubSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = githubRequestTimeout
+        configuration.timeoutIntervalForResource = githubResourceTimeout
+        configuration.waitsForConnectivity = false
+        return URLSession(configuration: configuration)
+    }
+
+    /// Mirror only the versioned production bundle layout emitted by CI.
+    /// Never discover a version through GitHub's mutable "latest" endpoint.
+    static func githubURL(release: ReleaseInfo) -> URL? {
+        guard release.platform == "macos-arm64",
+              let version = SemanticVersion(release.version),
+              release.version == "\(version.major).\(version.minor).\(version.patch)",
+              let source = URL(string: release.url),
+              source.scheme == "https",
+              source.path == "/releases/v\(release.version)/darkbloom-bundle-macos-arm64.tar.gz"
+        else { return nil }
+        return URL(string: "https://github.com/Layr-Labs/d-inference/releases/download/v\(release.version)/darkbloom-bundle-macos-arm64.tar.gz")
+    }
+
+    func download(release: ReleaseInfo, allowGitHub: Bool) async -> Result<URL, UpdateError> {
+        guard let r2URL = URL(string: release.url) else {
+            return .failure(.invalidURL(release.url))
+        }
+        do {
+            try Task.checkCancellation()
+            if allowGitHub, let mirror = Self.githubURL(release: release),
+               randomPercent() < Self.githubPercentage {
+                Self.logger.info("Release download selected GitHub", metadata: ["version": "\(release.version)"])
+                do {
+                    return .success(try await downloadAndVerify(
+                        from: mirror, hash: release.bundleHash, using: githubDownload
+                    ))
+                } catch {
+                    try Task.checkCancellation()
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        throw error
+                    }
+                    Self.logger.warning("GitHub release download failed; falling back to R2",
+                        metadata: ["version": "\(release.version)", "error": "\(error)"])
+                }
+            }
+            try Task.checkCancellation()
+            Self.logger.info("Release download selected R2", metadata: ["version": "\(release.version)"])
+            return .success(try await downloadAndVerify(
+                from: r2URL, hash: release.bundleHash, using: r2Download
+            ))
+        } catch let error as UpdateError {
+            return .failure(error)
+        } catch {
+            return .failure(.downloadFailed(error.localizedDescription))
+        }
+    }
+
+    private func downloadAndVerify(
+        from url: URL, hash: String, using download: Download
+    ) async throws -> URL {
+        let (file, response) = try await download(url)
+        var verified = false
+        defer {
+            if !verified { try? FileManager.default.removeItem(at: file) }
+        }
+        try Task.checkCancellation()
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw UpdateError.downloadFailed("HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)")
+        }
+        let data = try Data(contentsOf: file)
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        guard digest == hash.lowercased() else {
+            throw UpdateError.hashMismatch(expected: hash, got: digest)
+        }
+        try Task.checkCancellation()
+        verified = true
+        return file
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
+++ b/provider-swift/Sources/ProviderCore/Update/SelfUpdater.swift
@@ -66,6 +66,7 @@ public struct SelfUpdater: Sendable {
     /// `checkForUpdate` uses, from the same injected seam.
     internal let currentVersion: String
     private let urlSession: URLSession
+    private let bundleDownloader: ReleaseBundleDownloader
     private let now: @Sendable () -> Double
     /// Test seam threaded into every `UpdateRecoveryStore` this updater
     /// constructs; production always uses the no-op default.
@@ -127,7 +128,8 @@ public struct SelfUpdater: Sendable {
             Date().timeIntervalSince1970
         },
         recoveryFaultInjector:
-            @escaping @Sendable (UpdateRecoveryStore.FaultPoint) throws -> Void = { _ in }
+            @escaping @Sendable (UpdateRecoveryStore.FaultPoint) throws -> Void = { _ in },
+        bundleDownloader: ReleaseBundleDownloader? = nil
     ) {
         // Convert WebSocket URL to HTTP if needed
         var base = WebSocketURLScheme.toHTTP(coordinatorBaseURL)
@@ -141,6 +143,7 @@ public struct SelfUpdater: Sendable {
         self.verifyCodeSignatures = verifyCodeSignatures
         self.currentVersion = currentVersion
         self.urlSession = urlSession
+        self.bundleDownloader = bundleDownloader ?? ReleaseBundleDownloader(r2Session: urlSession)
         self.now = now
         self.recoveryFaultInjector = recoveryFaultInjector
     }
@@ -325,35 +328,13 @@ public struct SelfUpdater: Sendable {
 
     // MARK: - Download and Verify
 
-    /// Download the release bundle and verify its SHA-256 hash.
+    /// Download using the 10% GitHub transport trial, with R2 fallback. The
+    /// coordinator's bundle hash and all subsequent signature checks still apply.
     public func downloadAndVerify(release: ReleaseInfo) async -> Result<URL, UpdateError> {
-        guard let downloadURL = URL(string: release.url) else {
-            return .failure(.invalidURL(release.url))
-        }
-
-        do {
-            let (tempFileURL, response) = try await urlSession.download(from: downloadURL)
-
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200
-            else {
-                return .failure(.downloadFailed("HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)"))
-            }
-
-            // Verify SHA-256
-            let fileData = try Data(contentsOf: tempFileURL)
-            let digest = SHA256.hash(data: fileData)
-            let computedHash = digest.map { String(format: "%02x", $0) }.joined()
-
-            guard computedHash == release.bundleHash.lowercased() else {
-                try? FileManager.default.removeItem(at: tempFileURL)
-                return .failure(.hashMismatch(expected: release.bundleHash, got: computedHash))
-            }
-
-            return .success(tempFileURL)
-        } catch {
-            return .failure(.downloadFailed(error.localizedDescription))
-        }
+        await bundleDownloader.download(
+            release: release,
+            allowGitHub: coordinatorBaseURL == "https://api.darkbloom.dev"
+        )
     }
 
     // MARK: - Stage / Commit

--- a/provider-swift/Tests/ProviderCoreTests/ReleaseBundleDownloaderTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ReleaseBundleDownloaderTests.swift
@@ -1,0 +1,204 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("ReleaseBundleDownloader")
+struct ReleaseBundleDownloaderTests {
+    private static let bytes = Data("authoritative signed bundle fixture".utf8)
+    private static let hash = SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+
+    private func release(
+        version: String = "0.9.2",
+        platform: String = "macos-arm64",
+        url: String? = nil,
+        hash: String = Self.hash
+    ) -> ReleaseInfo {
+        ReleaseInfo(
+            version: version, platform: platform,
+            url: url ?? "https://r2.example/releases/v\(version)/darkbloom-bundle-macos-arm64.tar.gz",
+            bundleHash: hash
+        )
+    }
+
+    private func downloader(_ fixture: Downloads, roll: Int = 0) -> ReleaseBundleDownloader {
+        ReleaseBundleDownloader(
+            r2Download: { try await fixture.download($0) },
+            githubDownload: { try await fixture.download($0) },
+            randomPercent: { roll }
+        )
+    }
+
+    @Test("Exactly ten of 100 draws select GitHub; all downloads use the authoritative hash")
+    func probability() async throws {
+        let fixture = try Downloads()
+        defer { fixture.cleanup() }
+        for roll in 0..<100 {
+            let result = await downloader(fixture, roll: roll).download(
+                release: release(hash: Self.hash.uppercased()), allowGitHub: true
+            )
+            let file = try result.get()
+            #expect(try Data(contentsOf: file) == Self.bytes)
+            try FileManager.default.removeItem(at: file)
+        }
+        let requests = await fixture.requests
+        #expect(requests.count == 100)
+        #expect(requests.filter { $0.host == "github.com" }.count == 10)
+        #expect(requests.prefix(10).allSatisfy {
+            $0.absoluteString == "https://github.com/Layr-Labs/d-inference/releases/download/v0.9.2/darkbloom-bundle-macos-arm64.tar.gz"
+        })
+        #expect(requests.suffix(90).allSatisfy { $0.absoluteString == release().url })
+    }
+
+    @Test("GitHub errors and corrupt bytes fall back to R2 and clean failed downloads", arguments: [
+        Reply.http(404), .http(429), .http(500), .failure(.timedOut),
+        .failure(.cannotFindHost), .corrupt, .unreadable,
+    ])
+    func fallback(reply: Reply) async throws {
+        let fixture = try Downloads(github: reply)
+        defer { fixture.cleanup() }
+        let result = await downloader(fixture).download(release: release(), allowGitHub: true)
+        let file = try result.get()
+        #expect(try Data(contentsOf: file) == Self.bytes)
+        #expect(await fixture.requests.map(\.host) == ["github.com", "r2.example"])
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.root.path) == [file.lastPathComponent])
+    }
+
+    @Test("R2 remains authoritative after mirror failure", arguments: [Reply.http(503), .corrupt])
+    func bothFail(r2: Reply) async throws {
+        let fixture = try Downloads(github: .corrupt, r2: r2)
+        defer { fixture.cleanup() }
+        let result = await downloader(fixture).download(release: release(), allowGitHub: true)
+        switch (r2, result) {
+        case (.http, .failure(.downloadFailed(let reason))): #expect(reason == "HTTP 503")
+        case (.corrupt, .failure(.hashMismatch(let expected, _))): #expect(expected == Self.hash)
+        default: Issue.record("expected the R2 failure, got \(result)")
+        }
+        #expect(await fixture.requests.count == 2)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.root.path).isEmpty)
+    }
+
+    @Test("Unselected failures do not try GitHub")
+    func r2OnlyFailure() async throws {
+        let fixture = try Downloads(r2: .http(503))
+        defer { fixture.cleanup() }
+        let result = await downloader(fixture, roll: 10).download(release: release(), allowGitHub: true)
+        guard case .failure(.downloadFailed) = result else {
+            Issue.record("expected R2 failure"); return
+        }
+        #expect(await fixture.requests.map(\.host) == ["r2.example"])
+    }
+
+    @Test("Cancellation never starts a fallback", arguments: [Reply.cancel, .failure(.cancelled)])
+    func cancellation(reply: Reply) async throws {
+        let fixture = try Downloads(github: reply)
+        defer { fixture.cleanup() }
+        let result = await downloader(fixture).download(release: release(), allowGitHub: true)
+        guard case .failure = result else { Issue.record("expected cancellation failure"); return }
+        #expect(await fixture.requests.map(\.host) == ["github.com"])
+    }
+
+    @Test("An already cancelled task does not start any download")
+    func alreadyCancelled() async throws {
+        let fixture = try Downloads()
+        defer { fixture.cleanup() }
+        let result = await Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await downloader(fixture).download(release: release(), allowGitHub: true)
+        }.value
+        guard case .failure = result else { Issue.record("expected cancellation failure"); return }
+        #expect(await fixture.requests.isEmpty)
+    }
+
+    @Test("Only versioned stable macOS bundles have a mirror")
+    func mirrorEligibility() {
+        #expect(ReleaseBundleDownloader.githubURL(release: release()) != nil)
+        for version in ["0.9.2-beta.1", "0.9.2-dev.1", "v0.9.2", "0.9.2+build", "0.9.2+../../latest", "latest"] {
+            #expect(ReleaseBundleDownloader.githubURL(release: release(version: version)) == nil)
+        }
+        #expect(ReleaseBundleDownloader.githubURL(release: release(platform: "linux-amd64")) == nil)
+        for url in [
+            "https://r2.example/releases/latest/darkbloom-bundle-macos-arm64.tar.gz",
+            "https://r2.example/releases/v0.9.1/darkbloom-bundle-macos-arm64.tar.gz",
+            "https://r2.example/releases/v0.9.2/custom.tar.gz",
+            "http://r2.example/releases/v0.9.2/darkbloom-bundle-macos-arm64.tar.gz",
+        ] {
+            #expect(ReleaseBundleDownloader.githubURL(release: release(url: url)) == nil)
+        }
+    }
+
+    @Test("Ineligible release layouts use the exact registered URL")
+    func customReleaseUsesRegisteredURL() async throws {
+        let fixture = try Downloads()
+        defer { fixture.cleanup() }
+        let custom = release(url: "https://r2.example/custom.tar.gz?version=0.9.2")
+        _ = try await downloader(fixture).download(release: custom, allowGitHub: true).get()
+        #expect(await fixture.requests.map(\.absoluteString) == [custom.url])
+    }
+
+    @Test("SelfUpdater enables the mirror only for production, preserving WebSocket URL normalization",
+          arguments: ["https://api.darkbloom.dev", "wss://api.darkbloom.dev/ws/provider", "https://dev.example"])
+    func selfUpdaterWiring(coordinator: String) async throws {
+        let fixture = try Downloads()
+        defer { fixture.cleanup() }
+        let updater = SelfUpdater(
+            coordinatorBaseURL: coordinator, installRoot: nil,
+            verifyCodeSignatures: true, currentVersion: "0.9.1",
+            bundleDownloader: downloader(fixture)
+        )
+        _ = try await updater.downloadAndVerify(release: release()).get()
+        #expect(updater.verifiesCodeSignatures)
+        let expectedHost = coordinator == "https://dev.example" ? "r2.example" : "github.com"
+        #expect(await fixture.requests.map(\.host) == [expectedHost])
+    }
+
+    @Test("GitHub has bounded idle and total transfer timeouts")
+    func timeoutConfiguration() {
+        let session = ReleaseBundleDownloader.makeGitHubSession()
+        defer { session.invalidateAndCancel() }
+        #expect(session.configuration.timeoutIntervalForRequest == 30)
+        #expect(session.configuration.timeoutIntervalForResource == 120)
+        #expect(!session.configuration.waitsForConnectivity)
+    }
+
+    enum Reply: Sendable {
+        case http(Int)
+        case failure(URLError.Code)
+        case corrupt
+        case unreadable
+        case cancel
+    }
+
+    private actor Downloads {
+        nonisolated let root: URL
+        var requests: [URL] = []
+        let github: Reply
+        let r2: Reply
+
+        init(github: Reply = .http(200), r2: Reply = .http(200)) throws {
+            self.github = github
+            self.r2 = r2
+            root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+
+        nonisolated func cleanup() { try? FileManager.default.removeItem(at: root) }
+
+        func download(_ url: URL) throws -> (URL, URLResponse) {
+            requests.append(url)
+            let reply = url.host == "github.com" ? github : r2
+            let file = root.appendingPathComponent(UUID().uuidString)
+            var status = 200
+            switch reply {
+            case .failure(let code): throw URLError(code)
+            case .cancel: throw CancellationError()
+            case .http(let code):
+                status = code
+                try ReleaseBundleDownloaderTests.bytes.write(to: file)
+            case .corrupt: try Data("corrupt mirror".utf8).write(to: file)
+            case .unreadable: try FileManager.default.createDirectory(at: file, withIntermediateDirectories: true)
+            }
+            return (file, HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

R2 release downloads can be slow. Trial GitHub as the first download source for a fresh random 10% of eligible production upgrades, with the other 90% continuing directly to R2. Manual, automatic, and watchdog updates share this behavior through `SelfUpdater.downloadAndVerify`.

`ReleaseBundleDownloader` derives the exact GitHub tag and asset from the coordinator-selected stable macOS release. Network, HTTP, checksum, and file-read failures clean up the failed transfer and fall back to the registered R2 URL. GitHub attempts have a 30-second idle timeout and a 120-second total transfer limit; cancellation stops without fallback. The coordinator's R2-backed release metadata and hashes remain authoritative, and existing binary, metallib, and code-signature checks remain enforced.

The trial applies to the production coordinator and versioned stable bundle paths. Dev coordinators, prereleases, custom paths, and the shell installer retain their existing source. CI already uploads the identical signed tarball to both hosts, so no publishing changes are needed. Existing providers first need to install a version containing this change; sampling starts on subsequent upgrades. This PR does not publish a release.

## Before

```mermaid
flowchart TD
    A[Manual, automatic, or watchdog upgrade] --> B[SelfUpdater.checkForUpdate]
    B --> C[Coordinator selects release and R2 URL plus hashes]
    C --> D[SelfUpdater.downloadAndVerify downloads R2]
    D --> E{Download and bundle hash valid?}
    E -->|No| F[Upgrade fails; installed version retained]
    E -->|Yes| G[stageBundle verifies binary, metallib, and code signature]
    G --> H[Existing commit and recovery flow]
```

## After

```mermaid
flowchart TD
    A[Manual, automatic, or watchdog upgrade] --> B[SelfUpdater.checkForUpdate]
    B --> C[Coordinator selects release and R2 URL plus hashes]
    C --> D[SelfUpdater.downloadAndVerify delegates to ReleaseBundleDownloader]
    D --> E{Eligible and random draw below 10?}
    E -->|Yes: 10% of eligible downloads| F[Try exact GitHub release asset within timeout]
    E -->|No| G[Download registered R2 URL]
    F --> H{Download and authoritative bundle hash valid?}
    H -->|Failure| I[Remove failed transfer and log fallback]
    I --> G
    H -->|Valid| J[Existing stageBundle signature and artifact checks]
    G --> K{Download and authoritative bundle hash valid?}
    K -->|Valid| J
    K -->|Failure| L[Upgrade fails; installed version retained]
    F -->|Cancelled| L
    J --> M[Existing commit and recovery flow]
```

## Validation

- Swift provider and test build passed.
- `swift test --skip-build --no-parallel --filter 'ReleaseBundleDownloaderTests|SelfUpdater'`: 31 tests passed after staging the source-matched metallib with `scripts/fetch-metallib.sh`. The initial run lacked that fixture and failed three existing runtime tests; the rerun passed all tests.
- Coverage includes the exact 10-of-100 selection boundary, HTTP/network/integrity fallback, failed-file cleanup, cancellation, R2 failure propagation, eligibility, production wiring, timeout configuration, and existing signature/staging behavior.
- `make docs-check`, `scripts/check-release-version.sh`, `scripts/sync-install-embed.sh check`, and `git diff --check` passed.
- Read-only live checks: the v0.9.0 GitHub asset returned HTTP 200 without authentication; GitHub's reported v0.9.1 asset SHA-256 matched the live coordinator's authoritative bundle hash. No live upgrade or release publication was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791582690&installation_model_id=21733&pr_number=881&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F881&signature=fe4bd68f5d180cfe5f684011139743923633471b514b0c250a2c35a33fefceed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->