### PR TITLE
Enable Nemotron Lightning in the coordinator-serving provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,27 @@ jobs:
         # green under.
         timeout-minutes: 10
         run: ../../scripts/run-nested-suite.sh CBv2KVSharingParityTests
+      - name: Run Nemotron production SDK gates
+        if: ${{ !cancelled() && steps.place-nested-metallib.outcome == 'success' }}
+        working-directory: libs/mlx-swift-lm
+        timeout-minutes: 20
+        run: |
+          # Each filter has its own nonzero/no-skip tripwire. Continue after a
+          # failure so one broken suite cannot hide another unexecuted gate.
+          onboarding_failed=0
+          for suite in SSMDecodeBoundsTests NemotronHTests \
+                       NemotronH35BackendParityTests NemotronH35StorageParityTests \
+                       NemotronH35MTPTests NemotronH35MTPPrimingTests \
+                       MutableInputKernelTests MutableInputExportTests \
+                       CBv2QwenMTPIntegrationTests CBv2MTPDepthControllerTests \
+                       PagedMTPBatchedColumnsTests CBv2CompleteCheckpointEngineTests \
+                       NemotronH35ProductionDefaultsTests \
+                       OpenAIServiceTests ToolCallParserIntegrationTests; do
+            if ! ../../scripts/run-nested-suite.sh "$suite"; then
+              onboarding_failed=1
+            fi
+          done
+          exit "$onboarding_failed"
       - name: Run atomic installer artifact tests
         timeout-minutes: 2
         run: ./scripts/test-install-atomic.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased — Nemotron native paging and MTP prefix checkpoints
+
+- Select native paged KV and encrypted complete-prefix caching by default for the exact Nemotron Lightning registry/Hugging Face IDs, retaining explicit rollback controls. Keep native activation/KV precision and FP32 persistent Mamba state.
+- Give the embedded MTP assistant request-owned paged KV and an exact trusted-history checkpoint codec, so prompt prefixes restore with MTP enabled without sharing speculative state. Bind persisted state to the Nemotron numerical controls. MTP uses adaptive depth up to seven and captured target verification; test and benchmark results remain scoped to the measured artifact and machine, not fleet qualification.
+
+- Route native reasoning/content/tool channels through the existing coordinator-serving engine and validate forced tool calls before publication. No new localhost testing endpoints or personal artifact aliases are included.
+
 ## Release candidate v0.9.1 — cache reliability and recovery (not shipped; 2026-09-09)
 
 Source changes since `v0.9.0`. Provider changes require a new signed bundle;

--- a/coordinator/registry/native_tool_advertisement_test.go
+++ b/coordinator/registry/native_tool_advertisement_test.go
@@ -1,0 +1,85 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// New native families use the existing explicit-model protocol. Family names
+// alone must never bypass advertisement, template, version, or runtime gates.
+func TestNativeToolAdvertisementRouting(t *testing.T) {
+	models := []protocol.ModelInfo{
+		{ID: "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit", ModelType: "nemotron_h"},
+		{ID: "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp", ModelType: "nemotron_h"},
+		{ID: "nvidia-nemotron-3.5-lightning", ModelType: "nemotron_h"},
+	}
+	for _, model := range models {
+		t.Run(model.ID, func(t *testing.T) {
+			newProvider := func(t *testing.T) (*Registry, *Provider) {
+				t.Helper()
+				reg := New(testLogger())
+				reg.SetModelCatalog([]CatalogEntry{{ID: model.ID}})
+				provider := makeSchedulerProvider(t, reg, "native-provider", model.ID, 100)
+				setProviderVersion(provider, "0.9.0")
+				return reg, provider
+			}
+			check := func(t *testing.T, reg *Registry, mode string, want int) {
+				t.Helper()
+				traits := RequestTraits{HasTools: true, ToolChoiceMode: mode,
+					RequiresToolConstraint: mode == "required" || mode == "named"}
+				if mode == "named" {
+					traits.ToolChoiceName = "add"
+				}
+				if count, _, _ := reg.QuickCapacityCheck(model.ID, 10, 32, traits); count != want {
+					t.Fatalf("%s candidates = %d, want %d", mode, count, want)
+				}
+			}
+			t.Run("models_update_enables_and_revokes", func(t *testing.T) {
+				reg, provider := newProvider(t)
+				check(t, reg, "auto", 1)
+				check(t, reg, "required", 0)
+				check(t, reg, "named", 0)
+				merged, _ := reg.MergeProviderModelsWithCapabilities(provider.ID,
+					[]protocol.ModelInfo{model}, ToolConstraintProtocolV1, []string{model.ID})
+				if len(merged) != 1 || merged[0] != model.ID {
+					t.Fatal("qualified model update was not merged")
+				}
+				check(t, reg, "required", 1)
+				check(t, reg, "named", 1)
+				reg.MergeProviderModelsWithCapabilities(provider.ID,
+					[]protocol.ModelInfo{model}, ToolConstraintProtocolV1, nil)
+				check(t, reg, "required", 0)
+				check(t, reg, "named", 0)
+				check(t, reg, "auto", 1)
+			})
+			for _, test := range []struct {
+				name   string
+				mutate func(*Provider)
+			}{
+				{"missing_advertisement", func(p *Provider) { p.ToolConstraintModels = nil }},
+				{"different_model", func(p *Provider) {
+					p.ToolConstraintModels = map[string]struct{}{"mlx-community/NVIDIA-Nemotron-Nano": {}}
+				}},
+				{"old_protocol", func(p *Provider) { p.ToolConstraintProtocol = 0 }},
+				{"unknown_protocol", func(p *Provider) { p.ToolConstraintProtocol = 2 }},
+				{"old_version", func(p *Provider) { p.Version = "0.6.2" }},
+				{"missing_version", func(p *Provider) { p.Version = "" }},
+				{"broken_template", func(p *Provider) { p.Models[0].TemplateRenderOK = boolPtr(false) }},
+				{"unverified_runtime", func(p *Provider) { p.RuntimeVerified = false }},
+			} {
+				t.Run(test.name, func(t *testing.T) {
+					reg, provider := newProvider(t)
+					reg.MergeProviderModelsWithCapabilities(provider.ID,
+						[]protocol.ModelInfo{model}, ToolConstraintProtocolV1, []string{model.ID})
+					check(t, reg, "required", 1)
+					provider.mu.Lock()
+					test.mutate(provider)
+					provider.mu.Unlock()
+					check(t, reg, "required", 0)
+					check(t, reg, "named", 0)
+				})
+			}
+		})
+	}
+}

--- a/docs/architecture/inference.md
+++ b/docs/architecture/inference.md
@@ -1,6 +1,6 @@
 # Provider inference engine
 
-> Last updated: 2026-09-06 · commit `2eebb5412`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 How a chat-completion request is served inside the `darkbloom` provider
 process in v0.8.16: one in-process engine (`mlx-swift-lm`
@@ -135,6 +135,7 @@ by `deadlineProjectionRateHaircut = 0.5`. `WedgeMonitor.suspectStallSeconds =
 | Target | Drafter | Activation |
 |---|---|---|
 | Qwen3.5 family (`qwen3_5`, `qwen3_5_moe`) | Embedded head (`Qwen35InlineMTPAssistant`, request-stateful) | `mtp_mode = "auto"` (default) when the checkpoint declares the embedded artifact |
+| Nemotron 3.5 Lightning (`nemotron_h`) | Embedded head (`NemotronH35MTPAssistant`, request-stateful) | The MTP artifact must retain the embedded module and declare it; the non-MTP artifact remains target-only |
 | Gemma 4 | Separate assistant checkpoint (`Gemma4AssistantDraftModel`, stateless) | Requires `mtp_mode = "on"`; `SpecDecArtifactFunnel` resolves the catalog-declared `spec_dec` artifact, with `mtp_drafter_path` as a directory override |
 
 `MTPAutomaticVerificationPolicy`: `initialDraftTokens = 1`;
@@ -151,6 +152,16 @@ Gemma verification controls retain their bounded automatic baseline and the
 existing target/drafter checks. Drafter-required modes retain priority
 (`provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift`,
 `providerMTPVerificationPolicy`).
+Nemotron's assistant uses one speculative request and adaptive depth up to
+seven proposed tokens. Captured target verification, batched M=1 projections
+and KV-only trusted-history priming default on, with separate rollback controls.
+Its verifier builds a layer-major window while retaining native one-token
+recurrence and every-prefix state. These controls do not establish
+a fleet-readiness claim. Target activations retain the
+checkpoint's native dtype and persistent Mamba SSM state remains FP32
+(`libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP.swift`,
+`NemotronH35MTPAssistant`; controls in the
+[configuration reference](../reference/configuration.md)).
 Engine contract: `CBv2MTPConfig` with `testedMaxDraftTokens` (≤ 7) and
 `testedMaxSpeculativeBatch = 8`
 (`libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchingV2/MTP/MTPContractsV2.swift`).
@@ -173,6 +184,16 @@ uses `CBv2MTPPrefixCheckpointDrafter` and retains its existing compact-publicati
 and conservative reservation behavior. Resident model measurements do not yet
 validate the streamed SSD path; exact gates and validation scope are in
 [`prefix-cache.md`](prefix-cache.md).
+The Nemotron embedded assistant implements the same explicit checkpoint
+contract using exact shifted post-norm target history and frontier
+(`libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP+PrefixCheckpoint.swift`,
+`capturePrefixCheckpoint`, `restorePrefixCheckpoint`). At a committed prefill
+boundary, the complete checkpoint pairs target attention KV and Mamba state
+with immutable trusted assistant history. Restoring it creates fresh
+request-owned assistant pages and primes them before drafting; speculative
+draft KV is never shared. This is prompt-prefix reuse, not persistence of an
+in-flight speculative round. The ordinary attention-only prefix index remains
+disabled for this hybrid model.
 
 ### Sampling parameters
 
@@ -195,6 +216,11 @@ validate the streamed SSD path; exact gates and validation scope are in
 | `n`, `best_of` | **Not represented**: one alternative | — |
 
 ### Streaming reasoning state
+
+`NativeChannelSplitter` treats tool payloads as opaque while routing reasoning
+markers. It emits unclosed-frame payload incrementally and retains only a
+possible closing-marker suffix; it does not buffer an entire unfinished tool
+call (`provider-swift/Sources/ProviderCore/Inference/NativeChannelSplitter.swift`).
 
 `ReasoningPromptProbe.streamingPrefix` in
 `provider-swift/Sources/ProviderCore/Inference/ReasoningPromptProbe.swift`
@@ -226,7 +252,8 @@ Resolution happens before submit so a bad parser name never orphans a request.
 | `gpt_oss` | `.harmony` | `HarmonyToolCallParser` |
 | prefix `gemma` (`gemma4`, `gemma4_text`) | `.gemma` | `GemmaFunctionParser` |
 | prefix `qwen3_5` | `.qwen35` | `Qwen35ToolCallParser` (XML first, framed-JSON fallback) |
-| prefix `qwen3_next`, prefix `nemotron` | `.xmlFunction` | `XMLFunctionParser` |
+| prefix `qwen3_next` | `.xmlFunction` | `XMLFunctionParser` |
+| prefix `nemotron` | `.nemotron` | Native Nemotron tool-frame parser |
 | `llama` with `vocab_size ≥ 128000` or `rope_scaling.rope_type == "llama3"` | `.llama3` | `Llama3ToolCallParser` |
 | prefix `lfm2` / `glm4` / `mistral3` | `.lfm2` / `.glm4` / `.mistral` | `PythonicToolCallParser` / `GLM4ToolCallParser` / `MistralToolCallParser` |
 | anything else, including `qwen3_vl_moe` | `nil` → `.json` | `JSONToolCallParser` (`<tool_call>…</tool_call>`) |
@@ -297,6 +324,7 @@ records tiny-model correctness and remaining release gates.
 | `qwen3_5` | Dense Qwen 3.5/3.8, recurrent state | Embedded MTP head; complete streamed SSD checkpoints on native contiguous or segmented paged KV; explicit paging requires observed native types; resident bank is opt-in |
 | `qwen3_5_moe` | Qwen 3.5/3.6 MoE, recurrent state | Same complete-checkpoint and segmented-native paging gates as dense Qwen |
 | `qwen3_vl_moe` | Qwen3-VL MoE wrapper | Served via CBv2 adapter + vision prefill; `cbv2Capabilities` all `false` (no prefix reuse, paged, compiled decode, packed prefill or MTP) |
+| `nemotron_h` | Nemotron 3.5 Lightning | Advertisement is limited to `EngineV2SupportedModels.isNemotron35ListingModelID`, not every checkpoint sharing this type. Native Mamba/MoE/attention target; `nemotron35LightningModelID` is target-only and `nemotron35LightningMTPModelID` retains the embedded head. Listing eligibility is not registry publication or performance qualification |
 
 Quantization is detected by name, in order: `4bit`|`q4`|`int4` → `4bit`;
 `8bit`|`q8`|`int8` → `8bit`; `3bit`|`q3` → `3bit`; `bf16`; `fp16`|`f16`; else
@@ -305,6 +333,17 @@ Quantization is detected by name, in order: `4bit`|`q4`|`int4` → `4bit`;
 `detectQuantization`). KV quantization was retired in v0.8.0. Memory sizing
 (the `1.2` padded estimate and the load gate) is in
 [`hardware-support.md`](hardware-support.md).
+
+### Coordinator-serving native channels
+
+Coordinator requests construct `MultiModelBatchSchedulerEngine` inside
+`provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift`
+(`handleInferenceRequest`). Native Nemotron output passes through
+`NativeToolStreamRouter` and the SDK's typed `.parsed` event, so tool arguments
+are not reparsed as reasoning markers. `MLXOpenAIService.streamChatCompletionFrames`
+serializes SSE frames; the provider encrypts and sends them back over the
+coordinator connection. This integration does not start a local HTTP endpoint
+or change consumer/OpenRouter routing.
 
 ## Invariants
 

--- a/docs/architecture/prefix-cache.md
+++ b/docs/architecture/prefix-cache.md
@@ -1,6 +1,6 @@
 # KV cache layouts and prefix caching
 
-> Last updated: 2026-09-07 · commit `2827184f5`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 How the provider lays out a request's KV cache, how it decides whether a
 previously computed prefix can be reused, and where reusable state lives:
@@ -48,6 +48,9 @@ for these exact fleet model IDs, not family names, aliases or substrings:
 - `EigenLabs/Qwen3.8-27B-4bit-mtp`
 - `gpt-oss-20b`
 - `gemma-4-26b-qat-4bit`
+- `nvidia-nemotron-3.5-lightning`
+- `EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp`
+- `mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit` (target-only artifact)
 
 Every other ID, including unlisted Qwen artifacts, Gemma 8-bit and unknown
 models, resolves contiguous under `auto`. Per-model configuration still overrides
@@ -92,7 +95,7 @@ record completed validation. Final sustained, connected-serving, quality and
 production-key restart checks remain subject to the
 [acceptance criteria](../design/release-090-acceptance.md).
 This selection change is not a release or deployment claim. SSD prefix reuse
-defaults on only for the three exact Qwen IDs above. An explicit affirmative
+defaults on for the exact Qwen and Nemotron Lightning IDs above. An explicit affirmative
 `DARKBLOOM_PREFIX_CACHE` opts other models into their existing cache eligibility
 checks; a non-affirmative nonempty value disables all tiers. Both SSD codecs,
 local/connected load hashing and benchmark expectations use the model-scoped

--- a/docs/consumer/models.md
+++ b/docs/consumer/models.md
@@ -1,6 +1,6 @@
 # Models reference
 
-> Last updated: 2026-09-05 · commit `169b342e6`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 Reference for `GET /v1/models` and `GET /v1/models/{id}`: every field of a `ModelEntry`, how the `model` you send is resolved, and the capability flags the API exposes and enforces. For SDK users and integrators. The catalog itself is database-driven — builds, capabilities and prices live in the coordinator's registry and price tables, and public names are aliases maintained by operators (`coordinator/api/model_alias_handlers.go`, [`../architecture/model-registry.md`](../architecture/model-registry.md)) — so there is no static list to reproduce here; `GET /v1/models` is the list.
 
@@ -99,7 +99,8 @@ A key created with `allowed_models` can only use those ids. Any other `model` fa
 Prefix reuse is a runtime provider capability scoped to the exact model artifact,
 prompt contract and request isolation scope. A family name or model-list entry
 alone does not guarantee a cache hit. Complete SSD checkpoints support eligible
-loaded Qwen recurrent targets and paged GPT-OSS/Gemma historical attention;
+loaded Qwen and selected Nemotron Lightning recurrent targets (including typed
+embedded MTP history), and paged GPT-OSS/Gemma historical attention;
 the [cache capability reference](../reference/ssd-kv-cache.md#per-family-reuse-capability)
 records backend and identity gates. This does not change API feature flags.
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-09 · commit `1c74d7a17`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -10,8 +10,23 @@ map: the console UI job lints and builds but does not run vitest, and the
 benchmark-wrapper tests run only locally). The e2e suite needs an Apple Silicon
 Mac with the test checkpoints cached.
 
+The Nemotron coordinator-serving path uses typed SDK events. `OpenAIServiceTests`
+and `ToolCallParserIntegrationTests` in `libs/mlx-swift-lm/Tests/MLXLMServerTests`
+check SSE/collected reasoning, content, tool calls, usage and terminals without
+starting a localhost server. `MutableInputKernelTests` and
+`MutableInputExportTests` in the SDK's `Tests/OnboardingQualificationTests`
+exercise declared Metal writes, alias ownership and export/import. CI runs each
+selected suite through the nonzero/no-skip wrapper
+(`.github/workflows/ci.yml`, `scripts/run-nested-suite.sh`).
+
 For HF artifact downloads, `HuggingFaceDownloadTests` covers source preference,
-checksum rejection, fallback, and cancellation. `scripts/test-publish-model.sh`
+checksum rejection, fallback, and cancellation. Native Nemotron CI also runs
+`NemotronHTests`, `NemotronH35BackendParityTests`, `NemotronH35StorageParityTests`,
+`NemotronH35MTPTests`, and `NemotronH35MTPPrimingTests` with nonzero/no-skip guards.
+The MTP tests cover native paged storage, typed durable prefix history, rollback,
+and teardown; `CBv2QwenMTPIntegrationTests` independently covers allocation-refusal
+ownership in the shared engine. Loaded-artifact tests remain an additional gate,
+not evidence supplied by tiny fixtures. `scripts/test-publish-model.sh`
 checks the artifact workflow payload. `TestHuggingFaceArtifactPostgresAndCache`
 in `coordinator/store/hugging_face_artifact_test.go` uses a disposable
 `DATABASE_URL` to check storage and cache invalidation.

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -1,6 +1,6 @@
 # Provider CLI reference
 
-> Last updated: 2026-09-06 · commit `2eebb5412`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 Reference for the `darkbloom` command-line tool: every subcommand and flag, the
 files and identifiers it creates, the `provider.toml` keys it reads with their
@@ -169,7 +169,7 @@ Exit 1 (and `{}` in JSON mode) when no live local server is recorded
 | Backend parity | `--parity`, `--assistant-model <id>` (`String?`), `--parity-max-tokens` (`48`), `--parity-prefix-tokens` (`28672`) (`BenchmarkCommand+Parity.swift`) |
 
 `--kv-backend auto` uses the candidate's
-[exact five-artifact allowlist](../architecture/prefix-cache.md#kv-layouts): eligible
+[exact qualified-artifact allowlist](../architecture/prefix-cache.md#kv-layouts): eligible
 cohort models try paged, all other IDs use contiguous, and automatic paged
 failures or the version-bound crash-loop guard fall back to contiguous.
 Explicit `--kv-backend paged` refuses construction failures rather than measuring
@@ -416,7 +416,7 @@ Two of the detailed checks cover the KV-backend rollout:
 
 `auto` never fails this check — it promises nothing, so whichever backend it
 lands on is honoured by definition. Candidate `auto` can report paged for the
-[exact five-artifact cohort](../architecture/prefix-cache.md#kv-layouts), or contiguous
+[exact qualified-artifact cohort](../architecture/prefix-cache.md#kv-layouts), or contiguous
 after fallback; non-cohort `auto` remains contiguous. None is a posture fault
 or validation of the candidate rollout. Explicit `paged` construction failures
 refuse the load; a policy veto that serves contiguous instead still fails the
@@ -756,7 +756,7 @@ override `provider.toml` for one process, are in
 | `[backend] idle_timeout_mins` | `60` | Unload a model idle this long; `0` disables |
 | `[backend] max_model_slots` | `3` | Resident models |
 | `[backend] engine_v2_max_concurrent` | `4` (clamped to `[1, 8]`) | Concurrent requests per engine |
-| `[backend] engine_v2_kv_backend` | `"auto"` | `auto` / `paged` / `contiguous`; per-model table `engine_v2_kv_backend_by_model` takes precedence. Candidate `auto` tries paged only for the [exact five-artifact allowlist](../architecture/prefix-cache.md#kv-layouts), with contiguous fallback; all other IDs remain contiguous (`EngineV2KVBackendPolicy.parseSelection`, `preferredBackend`) |
+| `[backend] engine_v2_kv_backend` | `"auto"` | `auto` / `paged` / `contiguous`; per-model table `engine_v2_kv_backend_by_model` takes precedence. Candidate `auto` tries paged only for the [exact qualified-artifact allowlist](../architecture/prefix-cache.md#kv-layouts), with contiguous fallback; all other IDs remain contiguous (`EngineV2KVBackendPolicy.parseSelection`, `preferredBackend`) |
 | `[backend] mtp_mode` | `auto` | Written by `darkbloom beta enable|disable mtp` |
 | `[backend] startup_preload` | `true` | Load advertised models at start |
 | `[coordinator] url` | `"wss://api.darkbloom.dev/ws/provider"` | |
@@ -775,8 +775,8 @@ provider plist's `EnvironmentVariables`
 `passthroughEnvironment`). Every other variable — including `PATH` and all the
 media, SSD-prefix and memory-cap tunables — reaches the engine only under
 `darkbloom start --foreground` or `--local`. The `DARKBLOOM_PREFIX_CACHE` switch
-defaults to enabled for the three exact Qwen artifacts in the
-[release cohort](../design/release-090-paged-qwen-cache.md). Other models need an
+defaults to enabled for the exact Qwen and Nemotron Lightning artifacts in the
+[cache cohort](../architecture/prefix-cache.md#kv-layouts). Other models need an
 explicit affirmative value for SSD caching. Resident payload retention requires
 `DARKBLOOM_PREFIX_CACHE_MEMORY=1`; both switches are forwarded to the daemon,
 and the global disable wins (`PrefixCachePolicy.isEnabled`, `isMemoryEnabled`). Coordinator cache preference separately requires

--- a/docs/provider/hardware-requirements.md
+++ b/docs/provider/hardware-requirements.md
@@ -1,6 +1,6 @@
 # Provider hardware requirements
 
-> Last updated: 2026-09-07 · commit `0b46b1618`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 Reference for what a Mac needs to run the `darkbloom` provider: the minimum
 requirements, the chip families the provider distinguishes, which catalog
@@ -83,6 +83,18 @@ with less than `minimumLoadKVBytes` of KV headroom is unloaded again
 (`provider-swift/Sources/ProviderCore/Inference/KVHeadroomProbe.swift`;
 [after the load](../architecture/hardware-support.md#after-the-load)).
 
+## Nemotron embedded assistant memory
+
+Nemotron 3.5 Lightning retains native convolution/KV dtypes and FP32 persistent
+Mamba SSM state. Embedded MTP adds request-local assistant KV/history plus
+speculative target-state reservations; file size alone is not an admission
+estimate. `NemotronH35MTPAssistant.requestStateBytesPerToken` conservatively
+charges assistant pages/history, and ordinary runtime memory gates remain in force
+(`libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP.swift`). Complete prefix
+checkpoints preserve immutable trusted history and restore independent assistant
+state. Captured verification and adaptive depth do not imply a qualified device tier.
+See [engine MTP constraints](../architecture/inference.md#multi-token-prediction).
+
 ## Disk for the SSD prefix cache
 
 | Rule | Where it is specified | Code |
@@ -90,7 +102,7 @@ with less than `minimumLoadKVBytes` of KV headroom is unloaded again
 | Location | [`../reference/ssd-kv-cache.md#paths`](../reference/ssd-kv-cache.md#paths) | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCacheFactory.swift` |
 | Box-wide budget (`ssdDiskBudgetBytes`, based on currently available space), the `DARKBLOOM_PREFIX_CACHE_DISK_GB` override, LRU eviction | [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules) | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) |
 | Low-disk write stop (`lowDiskFloorBytes`; reads continue) and the daily write cap (`defaultMaxWriteBytesPerDay`) | [`../reference/ssd-kv-cache.md#size-and-eviction-rules`](../reference/ssd-kv-cache.md#size-and-eviction-rules) | `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDPrefixCachePolicy.swift` |
-| When it is used at all | Eligible Qwen uses complete SSD on native contiguous or segmented paged storage; historical GPT-OSS/Gemma complete checkpoints require paged storage. Loaded capability, identity and key gates apply; resident RAM is opt-in | [`../architecture/prefix-cache.md`](../architecture/prefix-cache.md) |
+| When it is used at all | Eligible Qwen and selected Nemotron Lightning use complete SSD on native contiguous or segmented paged target storage; historical GPT-OSS/Gemma complete checkpoints require paged storage. Loaded capability, identity and key gates apply; resident RAM is opt-in | [`../architecture/prefix-cache.md`](../architecture/prefix-cache.md) |
 
 ## Thermal and power
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-07 · commit `0b46b1618`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -367,6 +367,10 @@ Parsing convention: affirmative values are `1`/`true`/`yes`/`on`, negative value
 | `DARKBLOOM_CBV2_LEGACY_REQUEST_TIMEOUT` | affirmative | off | `provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+Configuration.swift` | Restores the legacy per-request timeout. |
 | `DARKBLOOM_CBV2_MTP` | negative disables | unset (beta flag decides) | `provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift`; `provider-swift/Sources/ProviderCore/Config/BetaFeatures.swift` | Kill switch for MTP speculation; beats the `provider.toml` beta flag. See [`../provider/beta-features.md`](../provider/beta-features.md). |
 | `DARKBLOOM_MTP_MAX_RECTANGULAR_TOKENS` | integer | policy default | `provider-swift/Sources/ProviderCore/Inference/MTPAutomaticVerificationPolicy.swift` | Tighten-only cap on rectangular MTP verification tokens. |
+| `DARKBLOOM_NEMOTRON35_MTP_CAPTURE_VERIFY` | exact `0` disables | on | `libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP.swift` (`requiredVerificationMode`) | Captured rectangular verification with every-prefix recurrent state; `0` uses serial target verification. Not forwarded to LaunchAgents. |
+| `DARKBLOOM_NEMOTRON35_MTP_BATCHED_M1` | exact `0` disables | on | `libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTPExactRows.swift` (`NemotronMTPExecution`) | Batch-axis projection dispatch that retains matrix M=1. No change to target precision; not forwarded to LaunchAgents. |
+| `DARKBLOOM_NEMOTRON35_MTP_KV_ONLY_HISTORY` | exact `0` disables | on | `libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP.swift` (`NemotronH35MTPAssistant`) | Trusted-history replay may compute only the embedded assistant's K/V. Prefix save/restore uses the separate typed history codec. Not forwarded to LaunchAgents. |
+| `DARKBLOOM_NEMOTRON35_MTP_MAX_DRAFT_TOKENS` | integer `1`…`7` | `7` | `libs/mlx-swift-lm/Libraries/MLXLLM/Models/NemotronH35MTP.swift` (`NemotronH35MTPAssistant`) | Upper proposal limit for adaptive depth; invalid selected limits fall back to seven. This is not a fixed proposal count. Not forwarded to LaunchAgents. |
 | `DARKBLOOM_MTP_VERIFICATION_MODE` | `rectangular`, `serial`, `serial_target`, `automatic` | `automatic` | `provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift` | MTP verification strategy (benchmark session). |
 | `DARKBLOOM_PREFILL_DEADLINE_MODE` | `off`, `enforce` | `off` | `provider-swift/Sources/ProviderCore/Inference/PrefillDeadlineMode.swift` | Prefill-deadline admission on the provider. |
 | `DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL` | integer layers | projected from `provider.toml` (`18`) | `provider-swift/Sources/ProviderCore/Config/GemmaOptimizationEnvironment.swift` | Gemma-4 prefill chunk-eval layers; the provider sets it for the engine, `scripts/install.sh` sets `18` for the smoke test. |
@@ -393,7 +397,7 @@ Internals and file format: [`ssd-kv-cache.md`](ssd-kv-cache.md).
 
 | Variable | Values / type | Default | Read in | Effect |
 |---|---|---|---|---|
-| `DARKBLOOM_PREFIX_CACHE` | affirmative opts in; non-affirmative nonempty disables | on for exact Qwen cohort, off otherwise | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift` (`isEnabled`) | Unset/empty uses the [model default](../design/release-090-paged-qwen-cache.md). Explicit affirmative values permit other models subject to capability/identity gates; resident payloads require the separate memory opt-in. |
+| `DARKBLOOM_PREFIX_CACHE` | affirmative opts in; non-affirmative nonempty disables | on for exact Qwen and Nemotron Lightning cohorts, off otherwise | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift` (`isEnabled`) | Unset/empty uses the [model default](../architecture/prefix-cache.md#kv-layouts). Explicit affirmative values permit other models subject to capability/identity gates; resident payloads require the separate memory opt-in. |
 | `DARKBLOOM_PREFIX_CACHE_MEMORY` | affirmative (`1`, `true`, `yes`, `on`) | off | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift` (`isMemoryEnabled`) | Explicit opt-in for both paged resident blocks and the recurrent RAM bank; global disable wins. Forwarded by LaunchAgent. |
 | `DARKBLOOM_PREFIX_CACHE_STATS_INTERVAL_SECS` | seconds (`0` off) | `120` | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` | Cadence of the local SSD stats line and typed per-store heartbeat observation; `0` omits the observation. Sample age still advances between ticks; see [telemetry](../architecture/telemetry.md#durable-prefix-cache-observations). |
 | `DARKBLOOM_PREFIX_CACHE_DISK_GB` | GiB | Half the currently available space; `20` if space cannot be measured | `provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift` (`ssdDiskBudgetBytes`) | Box-wide on-disk budget across all models, with no fixed default ceiling. A valid positive override is used verbatim. The separate 20 GiB free-space write reserve still applies. |

--- a/docs/reference/ssd-kv-cache.md
+++ b/docs/reference/ssd-kv-cache.md
@@ -1,6 +1,6 @@
 # SSD KV cache reference
 
-> Last updated: 2026-09-09 · commit `56ceac15a`
+> Last updated: 2026-09-10 · commit `dcc3d0809`
 
 Exact on-disk format, paths, identity binding, environment knobs, size and
 eviction rules, and per-family reuse capability of the provider's encrypted SSD
@@ -213,13 +213,15 @@ exact-artifact release validation claim.
 | Gemma 4 (`gemma4`, `gemma4_text`) | Historical full/window attention | Segmented paged | Effective text target has historical capability; normal stateless assistant is compatible; vision requests still stage cold |
 | Qwen 3.5/3.8 dense (`qwen3_5`) | Full KV, recurrent state and optional typed MTP | Native contiguous or segmented paged | Supported floating/affine embedding typing, full owners and verified complete codec/storage identity |
 | Qwen 3.5/3.6 MoE (`qwen3_5_moe`) | Same recurrent complete codec | Native contiguous or segmented paged | Same gate as dense Qwen |
+| Selected Nemotron 3.5 Lightning (`nemotron_h`) | Native attention KV, Mamba convolution/FP32 SSM state, and optional shifted trusted MTP history | Native contiguous or segmented paged target | Exact Lightning model ID, loaded native types, complete checkpoint identity and typed Nemotron assistant codec when MTP is active |
 | Qwen3-VL MoE (`qwen3_vl_moe`) | Unsupported | No paged capability | No complete store (`unsupported_layout`) |
 
-The global cache switch defaults on and the resident-memory switch defaults off.
-Backend `auto` still resolves contiguous: eligible Qwen can build its complete
-store there; GPT-OSS and Gemma require explicit paged selection for their
-historical complete store. Runtime identity, disk/key and loaded capability
-checks apply independently of family names.
+SSD activation and backend selection have separate exact-model defaults; see
+the [backend and cache cohorts](../architecture/prefix-cache.md#kv-layouts).
+Resident-memory retention defaults off. Runtime identity, disk/key and loaded
+capability checks apply independently of family names. A paging fallback may
+still use eligible complete recurrent checkpoints on native contiguous storage;
+GPT-OSS/Gemma historical complete checkpoints require segmented paging.
 
 All families also require a valid artifact prompt contract. The directory-based
 check requires `chat_template.jinja` and a passing render self-check. The versioned
@@ -244,10 +246,11 @@ Capability constants: `libs/mlx-swift-lm/Libraries/MLXLMCommon/ContinuousBatchin
 `provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+ModelAdapter.swift` (`ProductionModelAdapter`). An explicit `paged` selection is refused when the
 model lacks the required capability (reason `model_capability`); the kill switch
 can separately degrade it to contiguous.
-Eligible dense and MoE Qwen now support explicit paging only with segmented
-storage and a per-layer native type table measured from the loaded target.
-Complete Qwen restoration supports both native storage layouts; `auto` remains
-contiguous until the release validation gates are complete.
+Eligible recurrent targets use segmented paging with a per-layer native type
+table measured from the loaded target. Complete restoration supports both
+native target storage layouts. Model-scoped automatic selection is defined by
+`EngineV2KVBackendPolicy.preferredBackend`; it does not replace the loaded
+capability or checkpoint-identity gates.
 
 ## Status and outcome vocabularies
 

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -90,10 +90,12 @@ public enum MTPMode: String, Sendable, Equatable, Codable {
     case off
 
     /// `model_type` values whose embedded heads self-activate under `auto`.
-    /// Kept in sync with `SpecDecArtifactFunnel.isQwen35Target` — the funnel
-    /// stays the single authority on which models it will *resolve*; this set
-    /// only decides which ones `auto` is willing to *ask about*.
-    static let automaticQwen35ModelTypes: Set<String> = ["qwen3_5", "qwen3_5_moe"]
+    /// Kept in sync with `SpecDecArtifactFunnel.isInlineTarget` — the
+    /// funnel stays the single authority on which models it will *resolve*;
+    /// this set only decides which ones `auto` is willing to *ask about*.
+    static let automaticEmbeddedModelTypes: Set<String> = [
+        "qwen3_5", "qwen3_5_moe", "nemotron_h",
+    ]
 
     func enablesMTP(forModelType modelType: String?, embeddedArtifactDeclared: Bool) -> Bool {
         switch self {
@@ -107,7 +109,7 @@ public enum MTPMode: String, Sendable, Equatable, Codable {
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                     .lowercased(), !raw.isEmpty
             else { return false }
-            return Self.automaticQwen35ModelTypes.contains(raw)
+            return Self.automaticEmbeddedModelTypes.contains(raw)
         }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+ModelAdapter.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+ModelAdapter.swift
@@ -53,6 +53,10 @@ extension EngineV2Factory {
                 layerKinds = qwen.cbv2LayerKinds
                 modelCapabilities = qwen.cbv2Capabilities
                 newCaches = { make in qwen.newCacheV2(makeLayerCache: make) }
+            case let nemotron as NemotronH35Model:
+                layerKinds = nemotron.cbv2LayerKinds
+                modelCapabilities = nemotron.cbv2Capabilities
+                newCaches = { make in nemotron.newCacheV2(makeLayerCache: make) }
             default:
                 return nil
             }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2KVBackendPolicy.swift
@@ -1,7 +1,7 @@
 // Copyright © 2026 Eigen Labs.
 // Backend policy: per-model config wins, slot/model capabilities may veto it,
 // and the fleet kill switch overrides every caller. Auto selects paged only
-// for the five exact release artifact IDs. Explicit paged failures refuse the load; automatic
+// for exact qualified release artifact IDs. Explicit paged failures refuse the load; automatic
 // failures may degrade. The crash-loop guard applies only to automatic selection.
 
 import Foundation
@@ -28,6 +28,7 @@ public enum EngineV2KVBackendPolicy {
         case .contiguous: return .contiguous
         case .paged: return .paged
         case .auto:
+            if EngineV2SupportedModels.isNemotron35ListingModelID(modelID) { return .paged }
             switch modelID {
             case "qwen3.5-35b-a3b", "qwen3.6-35b-a3b-vl-mtp-mxfp8",
                 "EigenLabs/Qwen3.8-27B-4bit-mtp", "gpt-oss-20b", "gemma-4-26b-qat-4bit":

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2MTPAssistant.swift
@@ -53,6 +53,15 @@ struct ProductionProviderMTPAssistantLoader: ProviderMTPAssistantLoading {
             }
         }
 
+        if let nemotron = target as? NemotronH35Model {
+            do {
+                let assistant = try NemotronH35MTPAssistant.load(from: artifact.directory, target: nemotron)
+                return ProviderMTPAssistantHandle(owner: assistant, drafter: assistant)
+            } catch {
+                throw ProviderMTPAssistantLoadError.loadFailed(String(describing: error))
+            }
+        }
+
         guard let gemmaTarget = target as? Gemma4TextModel else {
             throw ProviderMTPAssistantLoadError.targetIncompatible(
                 String(describing: type(of: target)))

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SupportedModels.swift
@@ -29,6 +29,30 @@
 import Foundation
 
 public enum EngineV2SupportedModels {
+    public static let nemotron35LightningModelID =
+        "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit"
+    public static let nemotron35LightningMTPModelID =
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp"
+    public static let nemotron35LightningRegistryModelID = "nvidia-nemotron-3.5-lightning"
+
+    public static func isNemotron35ListingModelID(_ modelID: String?) -> Bool {
+        switch modelID {
+        case nemotron35LightningModelID, nemotron35LightningMTPModelID,
+            nemotron35LightningRegistryModelID:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Nano and Lightning share a model_type but have different checkpoint
+    /// contracts. Only the selected Lightning artifact is onboarded here.
+    public static func isSupported(model: ModelInfo) -> Bool {
+        if normalized(model.modelType) == "nemotron_h" {
+            return isNemotron35ListingModelID(model.id)
+        }
+        return isSupported(modelType: model.modelType)
+    }
     /// Exact config namespaces registered by the official Gemma 4 target
     /// factories. Keep this closed: assistant checkpoints intentionally share
     /// the `gemma4` prefix and must never become advertised chat targets.
@@ -57,7 +81,7 @@ public enum EngineV2SupportedModels {
         var supported: [ModelInfo] = []
         var unsupported: [ModelInfo] = []
         for model in models {
-            if isSupported(modelType: model.modelType) {
+            if isSupported(model: model) {
                 supported.append(model)
             } else {
                 unsupported.append(model)

--- a/provider-swift/Sources/ProviderCore/Inference/KVEstimation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/KVEstimation.swift
@@ -42,6 +42,9 @@ public enum KVEstimation {
     private static let recurrentLayerTypes: Set<String> = [
         "linear_attention",   // Qwen3.5 GatedDeltaNet
         "recurrent",
+        "mamba",  // fixed recurrent state, not growing attention KV
+        "mlp",    // stand-alone feed-forward blocks in hybrid trunks
+        "moe",
     ]
 
     // MARK: - config.json read
@@ -100,6 +103,7 @@ public enum KVEstimation {
         // `sliding_window_pattern=5` → repeating [S, S, S, S, F].
         var slidingWindowPattern: Int? = cfg["sliding_window_pattern"] as? Int
         var layerTypes: [String]? = cfg["layer_types"] as? [String]
+            ?? cfg["layers_block_type"] as? [String]
 
         // MoE + dimension fields for the adaptive-prefill roofline seed.
         // E (`num_local_experts`) and k (`num_experts_per_tok`) decide how many

--- a/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/MultiModelBatchSchedulerEngine.swift
@@ -741,7 +741,12 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             toolHandler: toolHandler,
             prepared: prepared,
             releaseBox: releaseBox,
-            reasoningPrefix: reasoningPrefix
+            reasoningPrefix: reasoningPrefix,
+            nativeReasoningPrefix: ToolChoiceEnforcementPolicy.nativeStructuredTarget(
+                ChatTemplateFixContext(modelId: modelId, modelType: modelType))
+                ? (ReasoningPromptProbe.streamingPrefix(forPromptTail:
+                    tokenizer.inner.decode(tokenIds: Array(promptTokens.suffix(ReasoningPromptProbe.tailTokenCount)),
+                                           skipSpecialTokens: false)) ?? "<think></think>") : nil
         )
     }
 
@@ -771,7 +776,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         toolHandler: BatchedToolStreamHandler?,
         prepared: ToolChoicePromptPolicy.Prepared,
         releaseBox: OneShotRelease,
-        reasoningPrefix: String? = nil
+        reasoningPrefix: String? = nil,
+        nativeReasoningPrefix: String? = nil
     ) async throws -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         do {
             try checkFirstContentDeadline()
@@ -786,7 +792,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
             toolHandler: toolHandler,
             prepared: prepared,
             releaseBox: releaseBox,
-            reasoningPrefix: reasoningPrefix)
+            reasoningPrefix: reasoningPrefix,
+            nativeReasoningPrefix: nativeReasoningPrefix)
         do {
             try checkFirstContentDeadline()
             return stream
@@ -809,7 +816,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
         toolHandler: BatchedToolStreamHandler?,
         prepared: ToolChoicePromptPolicy.Prepared,
         releaseBox: OneShotRelease,
-        reasoningPrefix: String? = nil
+        reasoningPrefix: String? = nil,
+        nativeReasoningPrefix: String? = nil
     ) -> AsyncThrowingStream<MLXServerGenerationEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task {
@@ -824,6 +832,8 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 // carrying the cause + reconciled usage so they survive the
                 // throw instead of being flattened into a string by `failed`.
                 var failedTerminal: MultiModelBatchSchedulerEngineError?
+                var router = NativeToolStreamRouter(handler: toolHandler,
+                    requiresToolCall: prepared.requiresToolCall, nativePrefix: nativeReasoningPrefix)
                 startedAt = Date()
 
                 // Restore the prompt-side reasoning state in the downstream
@@ -831,7 +841,7 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 // and bypasses the tool handler because it is not generated
                 // output. Real content and usage continue through the normal
                 // event handling below.
-                if let reasoningPrefix {
+                if let reasoningPrefix, !router.usesNativeChannels {
                     continuation.yield(.content(reasoningPrefix))
                 }
 
@@ -847,36 +857,13 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                         if firstTokenAt == nil { firstTokenAt = Date() }
                         lastTokenAt = Date()
                         if !text.isEmpty {
-                            if let handler = toolHandler {
-                                if let visible = handler.processChunk(text),
-                                    !visible.isEmpty
-                                {
-                                    if prepared.requiresToolCall {
-                                        let policy =
-                                            switch prepared.mode {
-                                            case .named: "named"
-                                            case .required: "required"
-                                            case .auto, .none: "constrained"
-                                            }
-                                        await cancelUpstream()
-                                        await releaseBox.fire()
-                                        continuation.finish(
-                                            throwing: MultiModelBatchSchedulerEngineError
-                                                .toolChoiceViolation(
-                                                    "\(policy) tool_choice produced visible text before a tool call"
-                                                ))
-                                        return
-                                    }
-                                    // Auto prose remains genuinely streaming. Tool-call bytes
-                                    // stay withheld and parsed calls are emitted only after the
-                                    // validation boundary below; a later invalid call therefore
-                                    // becomes a normal in-band stream error without exposing the
-                                    // invalid call. Buffering this prose would turn every
-                                    // tool-enabled auto stream into a non-streaming response.
-                                    continuation.yield(.content(visible))
-                                }
-                            } else {
-                                continuation.yield(.content(text))
+                            do {
+                                for routed in try router.process(text) { continuation.yield(routed) }
+                            } catch {
+                                await cancelUpstream()
+                                await releaseBox.fire()
+                                continuation.finish(throwing: error)
+                                return
                             }
                         }
                     case .info(let p, let c, _, let reason):
@@ -939,12 +926,19 @@ public struct MultiModelBatchSchedulerEngine: MLXServerEngine, Sendable {
                 // sampler-constrained; Qwen required/named are prompt-forced
                 // and fail closed here before a call is exposed. This remains
                 // defense in depth for every mode.
+                do {
+                    for routed in try router.finishText() { continuation.yield(routed) }
+                } catch {
+                    await releaseBox.fire()
+                    continuation.finish(throwing: error)
+                    return
+                }
                 let toolCalls = toolHandler?.finish() ?? []
                 if prepared.mode == .auto,
                     let residual = toolHandler?.takeResidualText(),
                     !residual.isEmpty
                 {
-                    continuation.yield(.content(residual))
+                    continuation.yield(router.visibleEvent(residual))
                 }
                 if prepared.mode == .auto, (toolHandler?.parseFailureCount ?? 0) > 0 {
                     emitToolConstraintTelemetry(

--- a/provider-swift/Sources/ProviderCore/Inference/NativeChannelSplitter.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/NativeChannelSplitter.swift
@@ -1,0 +1,86 @@
+import Foundation
+import MLXLMServer
+
+/// Bounded native think-channel lexer. Tool frames are opaque argument data:
+/// reasoning markers within them are never interpreted as channel controls.
+/// Conversely, tool frames inside reasoning remain reasoning, not invocations.
+struct NativeChannelSplitter {
+    private enum State { case content, reasoning, tool(end: String) }
+    private var state: State
+    private var buffer = ""
+    private let protectToolFrames: Bool
+    var bufferedCharacterCount: Int { buffer.count }
+
+    init(prefix: String, protectToolFrames: Bool) {
+        state = prefix == "<think>" ? .reasoning : .content
+        self.protectToolFrames = protectToolFrames
+    }
+
+    mutating func parse(_ text: String) -> [ParsedReasoning] {
+        buffer += text
+        return drain(final: false)
+    }
+
+    mutating func finish() -> [ParsedReasoning] { drain(final: true) }
+
+    private mutating func drain(final: Bool) -> [ParsedReasoning] {
+        var result: [ParsedReasoning] = []
+        while !buffer.isEmpty {
+            let markers: [String]
+            let reasoning: Bool
+            switch state {
+            case .content:
+                markers = protectToolFrames ? ["<think>", "<tool_call>", "<function="] : ["<think>"]
+                reasoning = false
+            case .reasoning:
+                markers = ["</think>"]
+                reasoning = true
+            case .tool(let end):
+                markers = [end]
+                reasoning = false
+            }
+            let found = markers.compactMap { marker -> (String, Range<String.Index>)? in
+                buffer.range(of: marker).map { (marker, $0) }
+            }.min { $0.1.lowerBound < $1.1.lowerBound }
+            if let (marker, range) = found {
+                switch state {
+                case .content:
+                    append(String(buffer[..<range.lowerBound]), reasoning: false, to: &result)
+                    if marker == "<think>" { state = .reasoning }
+                    else {
+                        append(marker, reasoning: false, to: &result)
+                        state = .tool(end: marker == "<tool_call>" ? "</tool_call>" : "</function>")
+                    }
+                case .reasoning:
+                    append(String(buffer[..<range.lowerBound]), reasoning: true, to: &result)
+                    state = .content
+                case .tool:
+                    append(String(buffer[..<range.upperBound]), reasoning: false, to: &result)
+                    state = .content
+                }
+                buffer.removeSubrange(buffer.startIndex..<range.upperBound)
+            } else {
+                var keep = 0
+                if !final {
+                    let maximum = min(buffer.count, (markers.map(\.count).max() ?? 1) - 1)
+                    if maximum > 0 {
+                        for count in (1...maximum).reversed() {
+                            let suffix = String(buffer.suffix(count))
+                            if markers.contains(where: { $0.hasPrefix(suffix) }) { keep = count; break }
+                        }
+                    }
+                }
+                let split = buffer.index(buffer.endIndex, offsetBy: -keep)
+                append(String(buffer[..<split]), reasoning: reasoning, to: &result)
+                buffer = String(buffer[split...])
+                break
+            }
+        }
+        return result
+    }
+
+    private func append(_ text: String, reasoning: Bool, to result: inout [ParsedReasoning]) {
+        guard !text.isEmpty else { return }
+        result.append(.init(content: reasoning ? "" : text, reasoningContent: reasoning ? text : nil))
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/NativeToolStreamRouter.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/NativeToolStreamRouter.swift
@@ -1,0 +1,55 @@
+import MLXLMCommon
+import MLXLMServer
+
+/// Classify native reasoning BEFORE tool parsing. Tool-like text inside a
+/// reasoning block is never an invocation. Original token accounting is owned
+/// by the engine; this layer only routes already generated text.
+struct NativeToolStreamRouter {
+    private let handler: BatchedToolStreamHandler?
+    private let requiresToolCall: Bool
+    private var parser: NativeChannelSplitter?
+
+    init(handler: BatchedToolStreamHandler?, requiresToolCall: Bool, nativePrefix: String?) {
+        self.handler = handler
+        self.requiresToolCall = requiresToolCall
+        if let nativePrefix {
+            self.parser = NativeChannelSplitter(prefix: nativePrefix, protectToolFrames: handler != nil)
+        }
+    }
+
+    var usesNativeChannels: Bool { parser != nil }
+
+    mutating func process(_ text: String) throws -> [MLXServerGenerationEvent] {
+        let pieces = parser != nil ? parser!.parse(text) : [.init(content: text, reasoningContent: nil)]
+        return try route(pieces)
+    }
+
+    mutating func finishText() throws -> [MLXServerGenerationEvent] {
+        try route(parser?.finish() ?? [])
+    }
+
+    func visibleEvent(_ text: String) -> MLXServerGenerationEvent {
+        usesNativeChannels ? .parsed(.init(content: text, reasoningContent: nil)) : .content(text)
+    }
+
+    private func route(_ pieces: [ParsedReasoning]) throws -> [MLXServerGenerationEvent] {
+        var events: [MLXServerGenerationEvent] = []
+        for piece in pieces {
+            if let reasoning = piece.reasoningContent, !reasoning.isEmpty {
+                events.append(.parsed(.init(content: "", reasoningContent: reasoning)))
+            }
+            guard !piece.content.isEmpty else { continue }
+            let visible: String?
+            if let handler { visible = handler.processChunk(piece.content) }
+            else { visible = piece.content }
+            guard let visible, !visible.isEmpty else { continue }
+            if requiresToolCall {
+                if usesNativeChannels && ToolChoiceEnforcementPolicy.isFramingWhitespace(visible) { continue }
+                throw MultiModelBatchSchedulerEngineError.toolChoiceViolation(
+                    "forced tool_choice produced visible text before a validated call")
+            }
+            events.append(visibleEvent(visible))
+        }
+        return events
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+Activation.swift
@@ -20,7 +20,7 @@ extension PrefixCachePolicy {
     }
 
     /// Default SSD activation is separate from backend selection. Only these
-    /// exact Qwen artifacts default on; an explicit affirmative global flag
+    /// exact Qwen and Nemotron Lightning artifacts default on; an affirmative global flag
     /// opts other models into their existing capability/identity gates. This
     /// keeps offline cache comparisons available without enabling GPT/Gemma
     /// caching merely because their attention backend now defaults to paged.
@@ -28,13 +28,13 @@ extension PrefixCachePolicy {
         modelId: String,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        let defaultEnabled: Bool
+        var defaultEnabled = EngineV2SupportedModels.isNemotron35ListingModelID(modelId)
         switch modelId {
         case "qwen3.5-35b-a3b", "qwen3.6-35b-a3b-vl-mtp-mxfp8",
             "EigenLabs/Qwen3.8-27B-4bit-mtp":
             defaultEnabled = true
         default:
-            defaultEnabled = false
+            break
         }
         return environmentEnabled(environment[environmentFlag], defaultValue: defaultEnabled)
     }

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+CheckpointIdentity.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy+CheckpointIdentity.swift
@@ -42,6 +42,7 @@ extension PrefixCachePolicy {
             for (key, value) in values where
                 key.hasPrefix("MLX_") || key.hasPrefix("DARKBLOOM_CBV2_")
                     || key.hasPrefix("DARKBLOOM_QWEN_") || key.hasPrefix("DARKBLOOM_MTP_")
+                    || key.hasPrefix("DARKBLOOM_NEMOTRON35_")
                     || key.hasPrefix("DARKBLOOM_GPTOSS_") || key.hasPrefix("DARKBLOOM_GEMMA4_") {
                 numerics[scope + "." + key] = value
             }

--- a/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/PrefixCachePolicy.swift
@@ -1,6 +1,6 @@
 // Copyright © 2026 Eigen Labs.
 //
-// Production prefix-cache policy. Encrypted SSD defaults on for exact Qwen artifacts;
+// Production prefix-cache policy. Encrypted SSD defaults on for exact qualified artifacts;
 // retaining resident KV between requests requires an explicit local opt-in.
 
 import Foundation

--- a/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/SlotSizingSnapshot.swift
@@ -146,6 +146,8 @@ public struct SlotSizingSnapshot: Sendable, Equatable {
                     bytes: bytes,
                     moduleKVRate: nil,
                     isQwenVLMWrapper: true)
+            case let nemotron as NemotronH35Model:
+                rate = fp16KVBytesPerToken(layerKinds: nemotron.cbv2LayerKinds)
             case is MLXVLM.Qwen35:
                 return ModuleFacts(
                     bytes: bytes,

--- a/provider-swift/Sources/ProviderCore/Inference/ToolChoiceEnforcementPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolChoiceEnforcementPolicy.swift
@@ -1,20 +1,27 @@
 // Copyright © 2026 Eigen Labs.
 
+import Foundation
 import MLXLMCommon
 import MLXLMServer
 
 /// Selects the enforcement boundary for forced tool choices. Gemma keeps its
-/// token-level grammar; Qwen's published XML tool format is prompt-forced and
+/// token-level grammar; supported native structured formats are prompt-forced and
 /// then rejected fail-closed unless parsing, function selection, and schema
 /// validation all succeed before any call is exposed to the client.
 enum ToolChoiceEnforcementPolicy {
     enum Strategy: Equatable {
         case none
         case gemmaGrammar
-        case qwenPostValidation
+        case structuredPostValidation
     }
 
     static let qwen38ConstrainedModelID = "EigenLabs/Qwen3.8-27B-4bit"
+
+    static func isFramingWhitespace(_ text: String) -> Bool {
+        // XML framing whitespace only. Foundation's broader character set
+        // also includes invisible Unicode characters that are not framing.
+        text.utf8.allSatisfy { $0 == 0x20 || $0 == 0x09 || $0 == 0x0A || $0 == 0x0D }
+    }
 
     static func forcedStrategy(
         mode: ToolConstraintMode,
@@ -28,14 +35,16 @@ enum ToolChoiceEnforcementPolicy {
         }
 
         if Gemma4TemplateFix.applies(to: modelContext) { return .gemmaGrammar }
-        if Qwen35TemplateFix.applies(to: modelContext) { return .qwenPostValidation }
+        if Qwen35TemplateFix.applies(to: modelContext) || nativeStructuredTarget(modelContext) {
+            return .structuredPostValidation
+        }
         throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
             "inference-enforced tool_choice is unsupported for this model family")
     }
 
     /// Whether this concrete advertised model can honor required/named tool
     /// choice. Gemma's sampler grammar remains bound to its pinned template;
-    /// Qwen is enforced by prompt forcing plus withheld post-validation.
+    /// native Qwen/Nemotron use prompt forcing plus withheld post-validation.
     static func advertisesCapability(for model: ModelInfo) -> Bool {
         let context = ChatTemplateFixContext(
             modelId: model.id, modelType: model.modelType)
@@ -43,8 +52,18 @@ enum ToolChoiceEnforcementPolicy {
             return model.toolConstraintTemplateHash
                 == Gemma4ToolConstraintContract.pinnedTemplateSHA256
         }
+        if nativeStructuredTarget(context) {
+            return true
+        }
         return model.id == qwen38ConstrainedModelID
             && Qwen35TemplateFix.applies(to: context)
+    }
+
+    /// Explicit family admission is supplied by each model onboarding change.
+    /// Shared tool-frame validation alone must not advertise a new model.
+    static func nativeStructuredTarget(_ context: ChatTemplateFixContext) -> Bool {
+        context.modelType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nemotron_h"
+            && EngineV2SupportedModels.isNemotron35ListingModelID(context.modelId)
     }
 
     static func validateParser(
@@ -59,10 +78,10 @@ enum ToolChoiceEnforcementPolicy {
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
                     "inference-enforced Gemma tool_choice requires the gemma tool parser")
             }
-        case .qwenPostValidation:
-            guard format == .xmlFunction else {
+        case .structuredPostValidation:
+            guard format == .xmlFunction || format == .nemotron else {
                 throw MultiModelBatchSchedulerEngineError.invalidToolPayload(
-                    "inference-enforced Qwen tool_choice requires the qwen3_coder tool parser")
+                    "inference-enforced structured tool_choice requires an XML or Nemotron tool parser")
             }
         }
     }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintFactory.swift
@@ -31,8 +31,8 @@ enum ToolConstraintFactory {
         } else {
             let strategy = try ToolChoiceEnforcementPolicy.forcedStrategy(
                 mode: prepared.mode, modelContext: modelContext)
-            if strategy == .qwenPostValidation {
-                // Qwen's XML parser withholds call bytes until finish; the
+            if strategy == .structuredPostValidation {
+                // The structured parser withholds call bytes until finish; the
                 // shared validator below the stream rejects missing, wrong,
                 // undeclared, or schema-invalid calls before exposing them.
                 return nil

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTP.swift
@@ -20,7 +20,7 @@ extension ProviderLoop {
             let modelId = advertisedModels.values
                 .filter({
                     SpecDecArtifactFunnel.isGemma4Target(modelType: $0.modelType)
-                        || SpecDecArtifactFunnel.isQwen35Target(modelType: $0.modelType)
+                        || SpecDecArtifactFunnel.isInlineTarget(modelType: $0.modelType)
                 })
                 .map(\.id)
                 .sorted()

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
@@ -364,7 +364,7 @@ extension ProviderLoop {
         // whose family has no CBv2 adapter can never serve — advertising it
         // would invite requests that always refuse. Keep the previous build
         // serving; the catalog entry is the thing that needs fixing.
-        guard EngineV2SupportedModels.isSupported(modelType: info.modelType) else {
+        guard EngineV2SupportedModels.isSupported(model: info) else {
             desiredSwapDrop.removeValue(forKey: modelId)
             logger.error(
                 "Prefetch verified \(modelId) but model_type '\(info.modelType ?? "unknown")' "

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -621,7 +621,7 @@ public actor ProviderLoop {
                 ineligibleModelIds.append(model.id)
                 continue
             }
-            if EngineV2SupportedModels.isSupported(modelType: model.modelType) {
+            if EngineV2SupportedModels.isSupported(model: model) {
                 advertised[model.id] = model
             } else {
                 unsupportedModelIds.append(model.id)

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecArtifactFunnel.swift
@@ -162,7 +162,7 @@ actor SpecDecArtifactFunnel {
         guard request.enabled else {
             return .init(artifact: nil, status: .disabled(.configDisabled, configured: false))
         }
-        if Self.isQwen35Target(modelType: request.modelType),
+        if Self.isInlineTarget(modelType: request.modelType),
             let directory = request.modelDirectory,
             request.inlineDeclaration.mayDeclareEmbeddedArtifact
         {
@@ -177,7 +177,7 @@ actor SpecDecArtifactFunnel {
             }
         }
         guard Self.isGemma4Target(modelType: request.modelType)
-            || Self.isQwen35Target(modelType: request.modelType)
+            || Self.isInlineTarget(modelType: request.modelType)
         else {
             return .init(artifact: nil, status: .disabled(.targetUnsupported, configured: true))
         }
@@ -375,6 +375,14 @@ actor SpecDecArtifactFunnel {
         return modelType == "qwen3_5" || modelType == "qwen3_5_moe"
     }
 
+    static func isInlineQwenTarget(modelType: String?) -> Bool {
+        isQwen35Target(modelType: modelType)
+    }
+
+    static func isInlineTarget(modelType: String?) -> Bool {
+        isInlineQwenTarget(modelType: modelType)
+            || modelType?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "nemotron_h"
+    }
     static func killSwitchEnabled(environment: [String: String]) -> Bool {
         guard let raw = environment["DARKBLOOM_CBV2_MTP"]?
             .trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !raw.isEmpty

--- a/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
+++ b/provider-swift/Sources/ProviderCore/SpecDec/SpecDecStore.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import CoreFoundation
 import Foundation
 import Logging
 import ProviderCoreFoundation
@@ -324,23 +325,27 @@ enum SpecDecStore {
         else {
             return rejectInline("config.json is not a JSON object: \(configURL.path)")
         }
-        guard let inline = root["mtplx_mtp"] as? [String: Any],
-            inline["included"] as? Bool == true
-        else {
-            return rejectInline(
-                "config.json does not declare mtplx_mtp.included=true — not an inline-MTP checkpoint: \(configURL.path)")
-        }
-        guard root["mtplx_mtp_quantization"] as? [String: Any] != nil else {
-            return rejectInline(
-                "config.json is missing the mtplx_mtp_quantization object: \(configURL.path)")
-        }
         guard let index = try? JSONDecoder().decode(InlineWeightIndex.self, from: indexData)
         else {
             return rejectInline(
                 "model.safetensors.index.json does not decode (weight_map): \(indexURL.path)")
         }
 
-        let prefix = (inline["prefix"] as? String) ?? "mtp."
+        let prefix: String
+        if let inline = root["mtplx_mtp"] as? [String: Any],
+            inline["included"] as? Bool == true
+        {
+            guard root["mtplx_mtp_quantization"] as? [String: Any] != nil else {
+                return rejectInline(
+                    "config.json is missing the mtplx_mtp_quantization object: \(configURL.path)")
+            }
+            prefix = (inline["prefix"] as? String) ?? "mtp."
+        } else if declaresNemotronLightningMTP(root) {
+            prefix = "mtp."
+        } else {
+            return rejectInline(
+                "config.json does not declare mtplx_mtp.included=true or retained Nemotron Lightning MTP — not an inline-MTP checkpoint: \(configURL.path)")
+        }
         guard !prefix.isEmpty, prefix.utf8.count <= 128,
             prefix.utf8.allSatisfy({
                 (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0)
@@ -442,12 +447,30 @@ enum SpecDecStore {
             data.count <= Self.inlineProbeMaximumConfigBytes,
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return .undeterminable }
-        guard let inline = root["mtplx_mtp"] as? [String: Any],
+        if let inline = root["mtplx_mtp"] as? [String: Any],
             inline["included"] as? Bool == true
-        else { return .absent }
-        return .declared
+        {
+            return .declared
+        }
+        if declaresNemotronLightningMTP(root) {
+            return .declared
+        }
+        return .absent
     }
 
+    /// Lightning must explicitly declare the retained attention/MoE MTP head.
+    static func declaresNemotronLightningMTP(_ root: [String: Any]) -> Bool {
+        guard root["model_type"] as? String == "nemotron_h",
+            let declaration = root["darkbloom_embedded_mtp"] as? [String: Any],
+            declaration["architecture"] as? String == "nemotron_h_attention_moe",
+            let version = declaration["version"] as? NSNumber,
+            CFGetTypeID(version) != CFBooleanGetTypeID(), version.doubleValue == 1,
+            let layers = root["num_nextn_predict_layers"] as? NSNumber,
+            CFGetTypeID(layers) != CFBooleanGetTypeID(), layers.doubleValue == 1,
+            root["mtp_layers_block_type"] as? [String] == ["attention", "moe"]
+        else { return false }
+        return true
+    }
     private static func rejectInline(
         _ reason: String
     ) -> Result<SpecDecArtifact, InlineArtifactRejection> {

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -141,7 +141,7 @@ enum DoctorRunner {
                 servingSetIsLive = false
                 let runtimeCapabilities = ProviderRuntimeCapabilityDetector.detectLive(hardware: hw)
                 let daemonBasis = ModelScanner.scanModels(hardwareInfo: hw)
-                    .filter { EngineV2SupportedModels.isSupported(modelType: $0.modelType) }
+                    .filter { EngineV2SupportedModels.isSupported(model: $0) }
                     .filter {
                         ModelRuntimeRequirements.isEligible(modelID: $0.id, available: runtimeCapabilities)
                     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2KVBackendPolicyTests.swift
@@ -20,6 +20,9 @@ struct EngineV2KVBackendPolicyTests {
     @Test(arguments: [
         "qwen3.5-35b-a3b", "qwen3.6-35b-a3b-vl-mtp-mxfp8",
         "EigenLabs/Qwen3.8-27B-4bit-mtp", "gpt-oss-20b", "gemma-4-26b-qat-4bit",
+        "nvidia-nemotron-3.5-lightning",
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp",
+        "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit",
     ])
     func exactReleaseArtifactAutoPolicy(modelID: String) {
         let parsed = EngineV2KVBackendPolicy.parseSelection(
@@ -54,6 +57,8 @@ struct EngineV2KVBackendPolicyTests {
         " qwen3.5-35b-a3b", "qwen3.5-35b-a3b ", "org/qwen3.5-35b-a3b",
         "qwen3.5-35b-a3b-other", "qwen3.6-35b-a3b-vl-mtp-mxfp8-other",
         "EigenLabs/Qwen3.8-27B-4bit-mtp-other",
+        "nvidia-nemotron-3.5-lightning-other", "NVIDIA-NEMOTRON-3.5-LIGHTNING",
+        "nvidia-nemotron-3.5-lightning ", "arbitrary/Nemotron-MTP",
     ] as [String?])
     func otherIDsRemainContiguous(modelID: String?) {
         #expect(EngineV2KVBackendPolicy.preferredBackend(

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2ProductionWiringTests.swift
@@ -287,6 +287,7 @@ private func makeOpenAIRequest(model: String = "gemma-4-26b-qat-4bit") -> OpenAI
 /// Collect a server-engine event stream into a comparable shape.
 private enum RecordedServerEvent: Equatable {
     case content(String)
+    case reasoning(String)
     case info(prompt: Int, completion: Int)
 }
 
@@ -298,6 +299,9 @@ private func recordServerStream(
         switch event {
         case .content(let text):
             events.append(.content(text))
+        case .parsed(let parsed):
+            if !parsed.content.isEmpty { events.append(.content(parsed.content)) }
+            if let reasoning = parsed.reasoningContent { events.append(.reasoning(reasoning)) }
         case .info(let info):
             events.append(.info(prompt: info.promptTokens, completion: info.completionTokens))
         case .toolCall:
@@ -1342,7 +1346,7 @@ struct EngineV2RequestRoutingTests {
         } catch let error as MultiModelBatchSchedulerEngineError {
             #expect(
                 error == .toolChoiceViolation(
-                    "required tool_choice produced visible text before a tool call"))
+                    "forced tool_choice produced visible text before a validated call"))
         }
         #expect(emitted.isEmpty)
         #expect(engine.submitted.count == 1)
@@ -1419,7 +1423,7 @@ struct EngineV2RequestRoutingTests {
         #expect(engine.submitted[0].tokenConstraint == nil)
     }
 
-    @Test("required Qwen tool choice rejects a non-XML parser before submit")
+    @Test("required Qwen tool choice rejects an unframed JSON parser before submit")
     func requiredQwenToolChoiceRejectsParserOverride() async throws {
         let engine = WiringScriptedEngine(script: .stream([]))
         let bridge = makeBridge(engine: engine)
@@ -1444,7 +1448,7 @@ struct EngineV2RequestRoutingTests {
             Issue.record("expected Qwen parser mismatch rejection")
         } catch let error as MultiModelBatchSchedulerEngineError {
             #expect(error == .invalidToolPayload(
-                "inference-enforced Qwen tool_choice requires the qwen3_coder tool parser"))
+                "inference-enforced structured tool_choice requires an XML or Nemotron tool parser"))
         }
         #expect(engine.submitted.isEmpty)
     }
@@ -1519,7 +1523,7 @@ struct EngineV2RequestRoutingTests {
         } catch let error as MultiModelBatchSchedulerEngineError {
             #expect(
                 error == .toolChoiceViolation(
-                    "named tool_choice produced visible text before a tool call"))
+                    "forced tool_choice produced visible text before a validated call"))
         }
         #expect(emitted.isEmpty)
     }

--- a/provider-swift/Tests/ProviderCoreTests/EngineV2SupportedSetGateTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/EngineV2SupportedSetGateTests.swift
@@ -40,6 +40,21 @@ private func modelInfo(id: String, modelType: String?) -> ModelInfo {
 
 @Suite("EngineV2 supported-set advertise gate")
 struct EngineV2SupportedSetGateTests {
+    @Test("Lightning exact variants are supported without admitting shared-type Nano", arguments: [
+        "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit",
+        "nvidia-nemotron-3.5-lightning",
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp",
+    ])
+    func lightningVariantGate(modelID: String) async throws {
+        let lightning = modelInfo(id: modelID, modelType: "nemotron_h")
+        let nano = modelInfo(id: "mlx-community/NVIDIA-Nemotron-Nano", modelType: "nemotron_h")
+        #expect(EngineV2SupportedModels.isSupported(model: lightning))
+        #expect(!EngineV2SupportedModels.isSupported(model: nano))
+        #expect(!EngineV2SupportedModels.isSupported(modelType: "nemotron_h"))
+        let loop = try makeGateLoop(models: [lightning, nano])
+        #expect(await loop.isModelAdvertised(lightning.id))
+        #expect(!(await loop.isModelAdvertised(nano.id)))
+    }
 
     @Test("init drops unsupported families from the advertised set; supported ones stay")
     func initGateFiltersAdvertisedSet() async throws {

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolCallLiveTests.swift
@@ -263,6 +263,7 @@ struct GemmaToolCallLiveTests {
             switch event {
             case .toolCall(let call): calls.append(call)
             case .content(let text): visible += text
+            case .parsed(let parsed): visible += parsed.content
             case .info: break
             }
         }

--- a/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/MultiModelBatchSchedulerEngineTests.swift
@@ -307,7 +307,7 @@ func templateContextUsesReviewedNestedPrecedence() {
     #expect(context?["preserve_thinking"] as? Bool == true)
 }
 
-@Test("forced Qwen tool choices render a tool-only prompt")
+@Test("legacy forced Qwen tool choices retain their tool-only prompt")
 func templateContextDisablesThinkingForForcedQwenTools() {
     let request = OpenAIChatCompletionRequest(
         model: "EigenLabs/Qwen3.8-27B-4bit",
@@ -327,6 +327,7 @@ func templateContextDisablesThinkingForForcedQwenTools() {
     #expect(context?["reasoning_effort"] as? String == "high")
     #expect(context?["preserve_thinking"] as? Bool == true)
 }
+
 
 @Test("none off and zero disable; minimal remains an explicit effort")
 func templateContextNormalizesOnlyReviewedDisableSpellings() {

--- a/provider-swift/Tests/ProviderCoreTests/NativeChannelSplitterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NativeChannelSplitterTests.swift
@@ -1,0 +1,51 @@
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Native channel boundary fidelity")
+struct NativeChannelSplitterTests {
+    @Test func ordinaryThinkSemanticsMatchExistingParserAcrossChunkWidths() {
+        for prefix in ["<think>", "<think></think>"] {
+            for text in ["Plain answer.", "Reason Ω</think>Answer", "A<think>B</think>C<think>unfinished</thi"] {
+                for width in [1, 2, 9, 128] {
+                    var reference = StreamingReasoningParser(format: .qwen3)
+                    _ = reference.parse(prefix)
+                    var native = NativeChannelSplitter(prefix: prefix, protectToolFrames: false)
+                    var expected: [ParsedReasoning] = [], actual: [ParsedReasoning] = []
+                    let characters = Array(text)
+                    for start in stride(from: 0, to: characters.count, by: width) {
+                        let chunk = String(characters[start..<min(characters.count, start + width)])
+                        expected += reference.parse(chunk)
+                        actual += native.parse(chunk)
+                        #expect(native.bufferedCharacterCount < 14)
+                    }
+                    expected += reference.finish(); actual += native.finish()
+                    #expect(expected.map(\.content).joined() == actual.map(\.content).joined())
+                    #expect(expected.compactMap(\.reasoningContent).joined() == actual.compactMap(\.reasoningContent).joined())
+                }
+            }
+        }
+    }
+
+    @Test func bareToolArgumentsAreOpaqueAndBufferIsBounded() {
+        var splitter = NativeChannelSplitter(prefix: "<think></think>", protectToolFrames: true)
+        let text = "<function=write><parameter=text>" + String(repeating: "x", count: 65536)
+            + "<think>literal</think></parameter></function>"
+        let pieces = splitter.parse(text) + splitter.finish()
+        #expect(pieces.map(\.content).joined() == text)
+        #expect(pieces.compactMap(\.reasoningContent).isEmpty)
+        #expect(splitter.bufferedCharacterCount == 0)
+    }
+
+    @Test func unclosedToolFrameDrainsPayloadIncrementally() {
+        var splitter = NativeChannelSplitter(prefix: "<think></think>", protectToolFrames: true)
+        let payload = "<tool_call>" + String(repeating: "credential-sentinel ", count: 8192)
+        let pieces = splitter.parse(payload)
+        #expect(pieces.map(\.content).joined() == payload)
+        #expect(pieces.compactMap(\.reasoningContent).isEmpty)
+        #expect(splitter.bufferedCharacterCount <= "</tool_call>".count - 1)
+        #expect(splitter.finish().map(\.content).joined().isEmpty)
+        #expect(splitter.bufferedCharacterCount == 0)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/NativeModelToolChoiceTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NativeModelToolChoiceTests.swift
@@ -1,0 +1,43 @@
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Native model forced-tool enforcement")
+struct NativeModelToolChoiceTests {
+    @Test func onlyFramingWhitespaceIsIgnorableInForcedMode() {
+        #expect(ToolChoiceEnforcementPolicy.isFramingWhitespace("\n\n \t\r"))
+        #expect(!ToolChoiceEnforcementPolicy.isFramingWhitespace("Let me think"))
+        #expect(!ToolChoiceEnforcementPolicy.isFramingWhitespace("<think>"))
+        #expect(!ToolChoiceEnforcementPolicy.isFramingWhitespace("\u{200B}"))
+    }
+
+    @Test func nativeFamiliesUseWithheldSchemaValidatedCalls() throws {
+        let contexts = [
+            ChatTemplateFixContext(modelId: EngineV2SupportedModels.nemotron35LightningModelID, modelType: "nemotron_h"),
+        ]
+        for context in contexts {
+            for mode: ToolConstraintMode in [.required, .named("add")] {
+                let strategy = try ToolChoiceEnforcementPolicy.forcedStrategy(mode: mode, modelContext: context)
+                #expect(strategy == .structuredPostValidation)
+                try ToolChoiceEnforcementPolicy.validateParser(.xmlFunction, strategy: strategy)
+                #expect(throws: (any Error).self) {
+                    try ToolChoiceEnforcementPolicy.validateParser(.qwen35, strategy: strategy)
+                }
+                try ToolChoiceEnforcementPolicy.validateParser(.nemotron, strategy: strategy)
+                #expect(throws: (any Error).self) {
+                    try ToolChoiceEnforcementPolicy.validateParser(.json, strategy: strategy)
+                }
+            }
+        }
+    }
+
+    @Test func unqualifiedVariantsRemainRefusedAndAutoIsUnchanged() throws {
+        let context = ChatTemplateFixContext(modelId: "unqualified-nemotron", modelType: "nemotron_h")
+        #expect(throws: (any Error).self) {
+            try ToolChoiceEnforcementPolicy.forcedStrategy(mode: .required, modelContext: context)
+        }
+        #expect(try ToolChoiceEnforcementPolicy.forcedStrategy(mode: .auto, modelContext: context) == .none)
+        #expect(try ToolChoiceEnforcementPolicy.forcedStrategy(mode: .none, modelContext: context) == .none)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/NativeToolCapabilityAdvertisementTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NativeToolCapabilityAdvertisementTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+/// Exercise the serialized provider messages consumed by coordinator routing,
+/// rather than inferring network eligibility from local tool enforcement.
+@Suite("Native tool capability advertisement")
+struct NativeToolCapabilityAdvertisementTests {
+    private func model(_ id: String, _ type: String?, template: String? = nil) -> ModelInfo {
+        ModelInfo(id: id, modelType: type, sizeBytes: 1, estimatedMemoryGb: 1,
+                  toolConstraintTemplateHash: template)
+    }
+
+    private var nativeModels: [ModelInfo] {
+        [model(EngineV2SupportedModels.nemotron35LightningModelID, "nemotron_h"),
+         model(EngineV2SupportedModels.nemotron35LightningMTPModelID, "nemotron_h"),
+         model(EngineV2SupportedModels.nemotron35LightningRegistryModelID, "nemotron_h")]
+    }
+
+    private var legacyModels: [ModelInfo] {
+        [model("gemma-4-qualified", "gemma4_text",
+               template: Gemma4ToolConstraintContract.pinnedTemplateSHA256),
+         model("EigenLabs/Qwen3.8-27B-4bit", "qwen3_5")]
+    }
+
+    private var unsupportedModels: [ModelInfo] {
+        [model("mlx-community/NVIDIA-Nemotron-Nano", "nemotron_h"),
+         model("unknown-lightning", "nemotron_h"),
+         model("unqualified-qwen27", "qwen3_5"),
+         model("misleading-nemotron", "nemotron_h_unknown"),
+         model("unknown", nil),
+         model("gemma-4-drifted", "gemma4_text", template: "wrong-template")]
+    }
+
+    private func config(_ models: [ModelInfo], runtime: Set<ProviderRuntimeCapability> = []) -> CoordinatorClientConfig {
+        CoordinatorClientConfig(url: "wss://coordinator.invalid/ws",
+            hardware: HardwareInfo(machineModel: "test", chipName: "Apple M5 Max",
+                chipFamily: .m5, chipTier: .max, memoryGb: 128, memoryAvailableGb: 124,
+                cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40, memoryBandwidthGbs: 546),
+            models: models, backendName: "mlx_swift_lm", runtimeCapabilities: runtime)
+    }
+
+    private func registration(_ config: CoordinatorClientConfig,
+                              models: [ModelInfo]? = nil) throws -> ProviderMessage.Register {
+        let bytes = try CoordinatorClientCodec.encodeRegistration(from: config, models: models)
+        let message = try ProviderProtocolCodec.decodeProviderMessage(from: bytes)
+        guard case .register(let result) = message else {
+            throw AdvertisementError.unexpectedMessage
+        }
+        return result
+    }
+
+    private func update(_ models: [ModelInfo]) throws -> ProviderMessage.ModelsUpdate {
+        let bytes = try CoordinatorClientCodec.encodeOutboundMessage(.modelsUpdate(models: models))
+        let message = try ProviderProtocolCodec.decodeProviderMessage(from: bytes)
+        guard case .modelsUpdate(let result) = message else {
+            throw AdvertisementError.unexpectedMessage
+        }
+        return result
+    }
+
+    @Test func registrationAdvertisesNativeAndPreservesLegacyContracts() throws {
+        let models = nativeModels + legacyModels + unsupportedModels
+        let result = try registration(config(models, runtime: [.appleM5, .mlxNAX]))
+        let expected = (nativeModels + legacyModels).map(\.id).sorted()
+        #expect(result.toolConstraintProtocol == 1)
+        #expect(result.toolConstraintModels == expected)
+        #expect(result.models.map(\.id) == models.map(\.id))
+        for model in nativeModels {
+            let context = ChatTemplateFixContext(modelId: model.id, modelType: model.modelType)
+            for mode: ToolConstraintMode in [.required, .named("add")] {
+                #expect(try ToolChoiceEnforcementPolicy.forcedStrategy(mode: mode, modelContext: context)
+                        == .structuredPostValidation)
+            }
+        }
+    }
+
+    @Test func modelsUpdateAddsAndRevokesOnlyExplicitSupportedModels() throws {
+        let native = try update(nativeModels + unsupportedModels)
+        #expect(native.toolConstraintProtocol == 1)
+        #expect(native.toolConstraintModels == nativeModels.map(\.id).sorted())
+
+        // Replacing a native build by an unqualified family cannot leave a
+        // stale positive claim in the next authoritative models_update.
+        var changed = nativeModels[0]
+        changed.modelType = "unknown"
+        let revoked = try update([changed] + unsupportedModels)
+        #expect(revoked.toolConstraintProtocol == 1)
+        #expect(revoked.toolConstraintModels == [])
+    }
+
+    @Test func reconnectUsesCurrentModelsAndRetainsRuntimeAndTemplateGates() throws {
+        let initial = config(nativeModels + legacyModels)
+        let constrained = try registration(initial)
+        // The protected Qwen27 artifact still requires M5/NAX capabilities;
+        // adding native families does not bypass that preexisting filter.
+        #expect(!constrained.models.contains { $0.id == "EigenLabs/Qwen3.8-27B-4bit" })
+        #expect(constrained.toolConstraintModels == (nativeModels + [legacyModels[0]]).map(\.id).sorted())
+
+        var broken = nativeModels[0]
+        broken.templateRenderOK = false
+        let fresh = try registration(initial, models: [broken])
+        #expect(fresh.toolConstraintModels == [broken.id])
+        #expect(fresh.models.count == 1)
+        #expect(fresh.models.first?.templateRenderOK == false)
+        // Template health is a separate coordinator gate; preserve its exact
+        // negative report rather than changing or erasing it during encoding.
+
+        let empty = try registration(initial, models: unsupportedModels)
+        #expect(empty.toolConstraintProtocol == nil)
+        #expect(empty.toolConstraintModels == nil)
+    }
+
+    @Test func nativeExactIDRequiresArchitectureAndLegacyExactIDIsUnchanged() {
+        #expect(!ToolChoiceEnforcementPolicy.advertisesCapability(for:
+            model(EngineV2SupportedModels.nemotron35LightningModelID, "llama")))
+        // Existing Qwen35TemplateFix recognizes this trusted exact ID even
+        // when older discovery metadata does not name its architecture.
+        #expect(ToolChoiceEnforcementPolicy.advertisesCapability(for:
+            model("EigenLabs/Qwen3.8-27B-4bit", "llama")))
+    }
+
+    private enum AdvertisementError: Error { case unexpectedMessage }
+}

--- a/provider-swift/Tests/ProviderCoreTests/NativeToolStreamRouterTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NativeToolStreamRouterTests.swift
@@ -1,0 +1,83 @@
+import MLXLMCommon
+import MLXLMServer
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Native reasoning before tool parsing")
+struct NativeToolStreamRouterTests {
+    @Test func reasoningMarkersInsideArgumentsRemainArgumentData() throws {
+        for format: ToolCallFormat in [.nemotron, .qwen35] {
+            let handler = BatchedToolStreamHandler(format: format, tools: nil)
+            var router = NativeToolStreamRouter(handler: handler, requiresToolCall: true, nativePrefix: "<think></think>")
+            let frame = "<tool_call><function=write><parameter=text>literal <think>code</think> end</parameter></function></tool_call>"
+            for character in frame { _ = try router.process(String(character)) }
+            _ = try router.finishText()
+            let calls = handler.finish()
+            #expect(calls.count == 1)
+            #expect(calls.first?.function.arguments["text"] == .string("literal <think>code</think> end"))
+        }
+    }
+
+    @Test func nativeBareFunctionInsideReasoningIsNeverInvoked() throws {
+        let handler = BatchedToolStreamHandler(format: .nemotron, tools: nil)
+        var router = NativeToolStreamRouter(handler: handler, requiresToolCall: true, nativePrefix: "<think>")
+        _ = try router.process("An example: <function=fake></function></think>\n")
+        _ = try router.process("<function=add><parameter=a>19</parameter><parameter=b>23</parameter></function>")
+        _ = try router.finishText()
+        #expect(handler.finish().map(\.function.name) == ["add"])
+    }
+
+    @Test func reasoningToolExampleIsNeverInvokedEvenWithSplitMarkers() throws {
+        let handler = BatchedToolStreamHandler(format: .qwen35, tools: nil)
+        var router = NativeToolStreamRouter(handler: handler, requiresToolCall: true, nativePrefix: "<think>")
+        let thought = #"Consider 🌊 <tool_call>{"name":"fake","arguments":{}}</tool_call> privately."#
+        let output = thought + #"</think> <tool_call>{"name":"add","arguments":{"a":19,"b":23}}</tool_call>"#
+        var events: [MLXServerGenerationEvent] = []
+        for character in output { events += try router.process(String(character)) }
+        events += try router.finishText()
+        var reasoning = ""
+        for event in events {
+            guard case .parsed(let piece) = event else {
+                Issue.record("native thought must not become raw content")
+                continue
+            }
+            #expect(piece.content.isEmpty)
+            reasoning += piece.reasoningContent ?? ""
+        }
+        #expect(reasoning == thought)
+        let calls = handler.finish()
+        #expect(calls.count == 1)
+        #expect(calls.first?.function.name == "add")
+    }
+
+    @Test func truncatedThoughtNeverPromotesToAnswerOrTool() throws {
+        let handler = BatchedToolStreamHandler(format: .qwen35, tools: nil)
+        var router = NativeToolStreamRouter(handler: handler, requiresToolCall: true, nativePrefix: "<think>")
+        let thought = "Unfinished analysis with <tool_call>"
+        let events = try router.process(thought) + router.finishText()
+        var restored = ""
+        for event in events {
+            guard case .parsed(let piece) = event else { Issue.record("unexpected raw content"); continue }
+            #expect(piece.content.isEmpty)
+            restored += piece.reasoningContent ?? ""
+        }
+        #expect(restored == thought)
+        #expect(handler.finish().isEmpty)
+    }
+
+    @Test func ordinaryNativeAnswerStreamsWithoutWaitingForEOF() throws {
+        var router = NativeToolStreamRouter(handler: nil, requiresToolCall: false, nativePrefix: "<think></think>")
+        #expect(try router.process("Thanks.") == [.parsed(.init(content: "Thanks.", reasoningContent: nil))])
+        #expect(try router.finishText().isEmpty)
+    }
+
+    @Test func forcedProseStillFailsAndLegacyRoutingIsUnchanged() throws {
+        var forced = NativeToolStreamRouter(handler: nil, requiresToolCall: true, nativePrefix: "<think></think>")
+        #expect(throws: (any Error).self) { try forced.process("No, I won't call it.") }
+        var legacy = NativeToolStreamRouter(handler: nil, requiresToolCall: false, nativePrefix: nil)
+        #expect(try legacy.process("legacy text") == [.content("legacy text")])
+        var legacyForced = NativeToolStreamRouter(handler: nil, requiresToolCall: true, nativePrefix: nil)
+        #expect(throws: (any Error).self) { try legacyForced.process(" \n") }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Nemotron35ArchitectureTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Nemotron35ArchitectureTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Nemotron Lightning pre-load architecture")
+struct Nemotron35ArchitectureTests {
+    @Test("standalone Mamba and MoE blocks do not inflate growing KV")
+    func blockSequenceDefinesAttentionLayers() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nemotron-architecture-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let config = root.appendingPathComponent("config.json")
+        try Data("""
+            {"model_type":"nemotron_h", "num_hidden_layers":4,
+             "num_key_value_heads":2, "num_attention_heads":32, "head_dim":128,
+             "layers_block_type":["mamba","moe","attention","mlp"]}
+            """.utf8).write(to: config)
+        let architecture = KVEstimation.parseModelArchitecture(at: config)
+        #expect(architecture.layerTypes == ["mamba", "moe", "attention", "mlp"])
+        let bytes = KVEstimation.computeKVBytesPerToken(
+            numLayers: 4, kvHeads: 2, headDim: 128, numKvSharedLayers: 0,
+            globalHeadDim: nil, numGlobalKvHeads: nil,
+            slidingWindowPattern: nil, layerTypes: architecture.layerTypes)
+        // Pre-load estimate uses fp16; loaded native types are probed separately.
+        #expect(bytes == 2 * 2 * 128 * 2)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/NemotronMTPDeclarationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NemotronMTPDeclarationTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("Nemotron embedded MTP declaration")
+struct NemotronMTPDeclarationTests {
+    private var declaration: [String: Any] {
+        ["model_type": "nemotron_h", "num_nextn_predict_layers": 1,
+         "mtp_layers_block_type": ["attention", "moe"],
+         "darkbloom_embedded_mtp": ["version": 1, "architecture": "nemotron_h_attention_moe"]]
+    }
+    @Test func explicitEmbeddedContractAndMode() {
+        #expect(SpecDecStore.declaresNemotronLightningMTP(declaration))
+        #expect(MTPMode.auto.enablesMTP(forModelType: "nemotron_h", embeddedArtifactDeclared: true))
+        #expect(!MTPMode.auto.enablesMTP(forModelType: "nemotron_h", embeddedArtifactDeclared: false))
+        #expect(!MTPMode.off.enablesMTP(forModelType: "nemotron_h", embeddedArtifactDeclared: true))
+        var copiedMetadata = declaration
+        copiedMetadata.removeValue(forKey: "darkbloom_embedded_mtp")
+        #expect(!SpecDecStore.declaresNemotronLightningMTP(copiedMetadata))
+        for invalid: Any in [true, 0, 2, 1.5, "1"] {
+            var wrong = declaration
+            wrong["num_nextn_predict_layers"] = invalid
+            #expect(!SpecDecStore.declaresNemotronLightningMTP(wrong))
+        }
+    }
+    @Test func newArtifactHasExplicitListingBoundary() {
+        #expect(EngineV2SupportedModels.isNemotron35ListingModelID(EngineV2SupportedModels.nemotron35LightningMTPModelID))
+        #expect(EngineV2SupportedModels.isNemotron35ListingModelID("nvidia-nemotron-3.5-lightning"))
+        #expect(EngineV2SupportedModels.isNemotron35ListingModelID("EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp"))
+        #expect(!EngineV2SupportedModels.isNemotron35ListingModelID("arbitrary/Nemotron-MTP"))
+        #expect(SpecDecArtifactFunnel.isInlineTarget(modelType: "nemotron_h"))
+        #expect(!SpecDecArtifactFunnel.isInlineQwenTarget(modelType: "nemotron_h"))
+    }
+    @Test func requestStatefulAssistantRetainsAdaptiveDepth() {
+        #expect(MTPAutomaticVerificationPolicy.fixedDraftTokens(usesRequestStatefulDrafter: true) == nil)
+        #expect(MTPAutomaticVerificationPolicy.fixedDraftTokens(usesRequestStatefulDrafter: false) == 1)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/NemotronPagingPrefixIntegrationTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NemotronPagingPrefixIntegrationTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Nemotron native paging and complete prefix eligibility", .serialized)
+struct NemotronPagingPrefixIntegrationTests {
+    private var environment: [String: String] {
+        [KVBackendGuardStore.pathEnvKey: "/dev/null"]
+    }
+
+    private func tinyTarget() throws -> NemotronH35Model {
+        let data = Data("""
+            {"model_type":"nemotron_h", "vocab_size":100, "hidden_size":64,
+             "num_hidden_layers":4, "num_attention_heads":4, "num_key_value_heads":2,
+             "head_dim":64, "mamba_num_heads":4, "mamba_head_dim":16,
+             "ssm_state_size":16, "conv_kernel":4, "n_groups":2,
+             "intermediate_size":128, "moe_intermediate_size":64,
+             "moe_shared_expert_intermediate_size":64, "n_routed_experts":4,
+             "num_experts_per_tok":2, "layers_block_type":["mamba","moe","mamba","attention"],
+             "norm_eps":0.00001, "mamba_ssm_cache_dtype":"float32"}
+            """.utf8)
+        return NemotronH35Model(try JSONDecoder().decode(NemotronH35Configuration.self, from: data))
+    }
+
+    private func preparation(_ model: NemotronH35Model, paged: Bool = true) throws
+        -> EngineV2Factory.ProductionBackendPreparation
+    {
+        _ = LiveInferenceFixtures.ensureMetallibColocated()
+        return try EngineV2Factory.prepareProductionBackend(
+            model: model, modelID: EngineV2SupportedModels.nemotron35LightningRegistryModelID,
+            kvBytesCapacity: 128 << 20, maxConcurrentRequests: 1, kvBackend: .auto,
+            maxContextLength: 1024,
+            environment: paged ? environment : environment.merging(
+                [EngineV2KVBackendPolicy.killSwitchEnvKey: "0"]) { _, value in value })
+    }
+
+    private func storage(_ model: NemotronH35Model,
+                         _ prepared: EngineV2Factory.ProductionBackendPreparation,
+                         assistant: (any CBv2MTPDrafter)? = nil) -> CompleteCheckpointStorageIdentity?
+    {
+        EngineV2SlotFactory.completeCheckpointStorage(
+            kind: prepared.kind, layerKinds: prepared.layerKinds,
+            supportsRecurrent: prepared.modelCapabilities.supportsRecurrentCheckpointReuse,
+            supportsHistoricalAttention: false,
+            modelDTypes: model.cbv2CompleteCheckpointKVDTypes,
+            nativeDTypes: prepared.pagedLayerDTypes, pagedConfig: prepared.pagedPoolConfig,
+            assistant: .init(drafter: assistant))
+    }
+
+    @Test("Automatic Lightning backend uses native pages and complete recurrent checkpoints")
+    func automaticNativeTarget() throws {
+        let model = try tinyTarget()
+        let prepared = try preparation(model)
+        #expect(prepared.kind == .paged)
+        #expect(prepared.fallbackReason == nil)
+        #expect(prepared.pagedPoolConfig?.segmentSizeBytes != nil)
+        #expect(prepared.pagedLayerDTypes == model.cbv2CompleteCheckpointKVDTypes)
+        #expect(prepared.layerKinds.count == 1)
+        #expect(model.cbv2RecurrentStateSpec.layers.count == 2)
+        #expect(!prepared.modelCapabilities.supportsPrefixReuse)
+        #expect(!prepared.residentPrefixCacheEnabled)
+        #expect(storage(model, prepared)?.backendLayout == CBv2CompleteCheckpointManifest.pagedLayout)
+    }
+
+    @Test("Paging kill switch preserves native contiguous complete checkpoints")
+    func operatorOverrideRemainsSafe() throws {
+        let model = try tinyTarget()
+        let prepared = try preparation(model, paged: false)
+        #expect(prepared.kind == .contiguous)
+        #expect(prepared.fallbackReason == "kill_switch")
+        #expect(storage(model, prepared)?.backendLayout == CBv2CompleteCheckpointManifest.layout)
+    }
+
+    @Test("Loaded embedded assistant passes the actual provider prefix gate",
+          .enabled(if: ProcessInfo.processInfo.environment["DARKBLOOM_NEMOTRON35_MTP_MODEL"] != nil))
+    func loadedAssistantCheckpointEligibility() throws {
+        let path = try #require(ProcessInfo.processInfo.environment["DARKBLOOM_NEMOTRON35_MTP_MODEL"])
+        let directory = URL(fileURLWithPath: path)
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        let model = NemotronH35Model(try JSONDecoder().decode(NemotronH35Configuration.self, from: data))
+        let base = try JSONDecoder().decode(BaseConfiguration.self, from: data)
+        try loadWeights(modelDirectory: directory, model: model, perLayerQuantization: base.perLayerQuantization)
+        eval(model)
+        let assistant = try NemotronH35MTPAssistant.load(from: directory, target: model)
+        #expect(EngineV2SlotFactory.CompleteCheckpointAssistant(drafter: assistant) == .persistentCodec)
+        let prepared = try preparation(model)
+        #expect(prepared.kind == .paged)
+        #expect(prepared.layerKinds.count == 6)
+        #expect(storage(model, prepared, assistant: assistant)?.backendLayout == CBv2CompleteCheckpointManifest.pagedLayout)
+        #expect(PrefixCachePolicy.hybridConfig(
+            modelId: EngineV2SupportedModels.nemotron35LightningRegistryModelID,
+            promptContractID: "test-contract", kvBytesCapacity: 128 << 20,
+            hasMTPDrafter: true,
+            supportsMTPPrefixCheckpoint: assistant is any CBv2MTPPrefixCheckpointDrafter,
+            environment: [PrefixCachePolicy.memoryEnvironmentFlag: "1"]) != nil)
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCacheCheckpointIdentityTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCacheCheckpointIdentityTests.swift
@@ -68,6 +68,13 @@ struct PrefixCacheCheckpointIdentityTests {
         "DARKBLOOM_GEMMA4_PREFILL_LAST_QUERY",
         "DARKBLOOM_GEMMA4_PREFILL_TAIL_MIN_CHUNK",
         "DARKBLOOM_GEMMA4_PREFILL_TAIL_ROWS",
+        "DARKBLOOM_QWEN_MTP_MAX_DRAFT",
+        "DARKBLOOM_NEMOTRON35_MTP_CAPTURE_VERIFY",
+        "DARKBLOOM_NEMOTRON35_MTP_KV_ONLY_HISTORY",
+        "DARKBLOOM_NEMOTRON35_MTP_BATCHED_M1",
+        "DARKBLOOM_NEMOTRON35_MTP_WINDOW_SSM",
+        "DARKBLOOM_NEMOTRON35_MTP_COMPILED_MOE",
+        "DARKBLOOM_NEMOTRON35_MTP_MAX_DRAFT_TOKENS",
     ])
     func modelOptimizationChanges(key: String) throws {
         let base = try #require(identity())
@@ -80,6 +87,9 @@ struct PrefixCacheCheckpointIdentityTests {
         case "DARKBLOOM_GEMMA4_PREFILL_TAIL_MIN_CHUNK":
             optimized = "128"
             rollback = "256"
+        case "DARKBLOOM_QWEN_MTP_MAX_DRAFT", "DARKBLOOM_NEMOTRON35_MTP_MAX_DRAFT_TOKENS":
+            optimized = "5"
+            rollback = "4"
         default:
             optimized = "1"
             rollback = "0"

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCacheLoadHashTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCacheLoadHashTests.swift
@@ -6,6 +6,20 @@ import Testing
 
 @Suite("SSD load hashing follows model capability")
 struct PrefixCacheLoadHashTests {
+    @Test("Lightning default SSD activation always brackets model loading with fresh hashes", arguments: [
+        "nvidia-nemotron-3.5-lightning",
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp",
+    ])
+    func lightningLoadHashBracket(modelID: String) throws {
+        let directory = try snapshot(#"{"model_type":"nemotron_h"}"#)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(PrefixCachePolicy.requiresLoadHashBracket(
+            modelId: modelID, modelDirectory: directory, environment: [:]))
+        #expect(!PrefixCachePolicy.requiresLoadHashBracket(
+            modelId: modelID, modelDirectory: directory,
+            environment: [PrefixCachePolicy.environmentFlag: "0"]))
+    }
+
     private func snapshot(_ config: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ssd-load-hash-\(UUID().uuidString)")

--- a/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/PrefixCachePolicyTests.swift
@@ -32,8 +32,11 @@ struct PrefixCachePolicyTests {
     @Test(arguments: [
         "qwen3.5-35b-a3b", "qwen3.6-35b-a3b-vl-mtp-mxfp8",
         "EigenLabs/Qwen3.8-27B-4bit-mtp",
+        "nvidia-nemotron-3.5-lightning",
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp",
+        "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit",
     ])
-    func qwenDefaultSSD(modelID: String) {
+    func qualifiedArtifactDefaultSSD(modelID: String) {
         for value in [nil, "", "   "] as [String?] {
             let environment = value.map { [PrefixCachePolicy.environmentFlag: $0] } ?? [:]
             #expect(PrefixCachePolicy.isEnabled(modelId: modelID, environment: environment))
@@ -49,6 +52,8 @@ struct PrefixCachePolicyTests {
         "gpt-oss-20b", "gemma-4-26b-qat-4bit", "gemma-4-26b", "gemma-4-26b-8bit", "unknown", "",
         "qwen3.5-35b-a3b-other", "QWEN3.5-35B-A3B", " qwen3.5-35b-a3b",
         "qwen3.6-35b-a3b", "EigenLabs/Qwen3.8-27B-4bit",
+        "nvidia-nemotron-3.5-lightning-other", "NVIDIA-NEMOTRON-3.5-LIGHTNING",
+        "nvidia-nemotron-3.5-lightning ", "arbitrary/Nemotron-MTP",
     ])
     func otherArtifactsRequireExplicitSSDOptIn(modelID: String) {
         for value in [nil, "", "   ", "0", "false", "junk"] as [String?] {

--- a/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen36ProductionCanaryTests.swift
@@ -378,6 +378,11 @@ private enum Qwen36ProductionCanary {
                     result.firstContentLatency = startedAt.duration(to: .now)
                 }
                 result.text += text
+            case .parsed(let parsed):
+                if result.firstContentLatency == nil, !parsed.content.isEmpty {
+                    result.firstContentLatency = startedAt.duration(to: .now)
+                }
+                result.text += parsed.content
             case .toolCall(let call):
                 result.toolCalls.append(call)
             case .info(let info):


### PR DESCRIPTION
Target repository: [Layr-Labs/d-inference](https://github.com/Layr-Labs/d-inference).

## Summary

Enable explicitly qualified Nemotron Lightning artifacts on the existing coordinator-serving provider path, including retained MTP, native paging, complete prefix reuse, and validated native tool channels.

## Scope

Add exact model admission, declared embedded-head discovery/loading, memory and cache eligibility, and native reasoning/content/tool routing. Keep production authentication, encryption, billing, routing, and API endpoints unchanged. The coordinator addition is a routing regression test.

No model weights, credentials, machine-specific configuration, new localhost endpoints, personal artifact aliases, unrelated model onboarding, fixed-depth experiments, or profiling controls are included.

## Dependencies and merge gate

Requires the runtime and Nemotron model changes in [Layr-Labs/mlx-swift-lm](https://github.com/Layr-Labs/mlx-swift-lm), with the approved [Swift](https://github.com/Layr-Labs/mlx-swift), [C](https://github.com/Layr-Labs/mlx-c), and [core](https://github.com/Layr-Labs/mlx) chain. The root core/Swift/SDK gitlinks are pinned to the exact dependency commits listed below. Validate a fresh recursive checkout before merging.

Core #18, C #10, Swift #23, SDK runtime #145, and Nemotron model #146 are merged. This provider PR now pins the exact merged core/Swift/SDK main commits below. The update changes only the three dependency gitlinks; provider implementation and repository URLs are unchanged. Provider review and release qualification remain required; this PR remains open.

## Before — behavior and code

```mermaid
flowchart LR
  A["OpenRouter or client"] --> B["Coordinator"] --> C["ProviderLoop.handleInferenceRequest"] --> D["Lightning outside qualified serving set"]
```

## After — behavior and code

```mermaid
flowchart LR
  A["OpenRouter or client"] --> B["Coordinator"] --> C["ProviderLoop.handleInferenceRequest"] --> D["MultiModelBatchSchedulerEngine and CBv2 Nemotron"] --> E["NativeToolStreamRouter and typed SSE"] --> F["Encrypted chunks to coordinator"] --> G["Client SSE"]
```

## Validation

### Merged dependency chain — September 10, 2026

A fresh public recursive checkout of provider head `1cea71c3e7e9ef10b94fb97acf5be1ed2ef1f98c` resolved all three root pins, both nested core/C pins, and the SDK's Swift revision consistently, with no local dependency edits. The resolved implementation matches the approved source trees; the changes are dependency identity/pin updates. The fresh provider release build passed, and all 15 selected component tests across five suites passed with zero failures and zero skips. Coverage: Nemotron architecture, embedded-MTP declarations, native paging/prefix policy, native tool routing, and channel splitting. The loaded-model prefix test was explicitly excluded from this component run; full-model and release qualification are not inferred.

The SDK runtime's CodeQL checks passed after its Swift repin, but its separate Build and Test workflow reported a startup failure. Do not describe that workflow, all CI, or full release qualification as passed.

Command: `swift test -c release --filter 'Nemotron35ArchitectureTests|NemotronMTPDeclarationTests|NemotronPagingPrefixIntegrationTests|NativeToolStreamRouterTests|NativeChannelSplitterTests' --skip loadedAssistantCheckpointEligibility`. A source-matched metallib was supplied, and the checkout remained clean.

### Earlier composed-source qualification

The aligned composed source passed:

- 239 focused SDK tests, without skips, covering target/parity, MTP ownership, paging, mutable-input kernels/export, checkpoint behavior, and native parsing/SSE.
- One loaded retained-model test comparing paged/contiguous assistant behavior and cold/restored prefix continuation.
- A release provider build and 125 provider tests across 20 suites, including loaded-model prefix eligibility, without skips.
- Full coordinator registry and protocol package tests, including required/named-tool capability activation and revocation across the three qualified Lightning IDs.
- Documentation lint across 266 pages and workflow YAML syntax validation.

Tests used aligned local dependency source and a source-matched metallib. The added dependency pins now specify that source chain; a fresh published-dependency build and live OpenRouter/fleet qualification are separate checks. The changed C/Swift files were checked byte-for-byte against the tested source. The final test reruns supplied the required colocated metallib and retained artifact; no skipped gate is counted as completed.

## Compatibility and rollout

Existing upstream direct/local functionality remains unchanged. The production path remains coordinator → provider engine → encrypted coordinator response; no additional inference service is introduced. Ordinary read-only kernels retain their existing API behavior. Normal model/backend/MTP rollback controls remain available.

Do not treat these component tests as a deployment approval. Complete connected-serving, restart, and release qualification on the published dependency chain. Historical throughput is not attributed to this newly scoped change. A prior four-requested-tools case returned only one call in both serial and MTP; its cause and resolution are not claimed here. No universal first-token latency or device-tier guarantee is made.

## Prerequisite PRs

- [Layr-Labs/mlx: Track declared mutable inputs in Metal custom kernels](https://github.com/Layr-Labs/mlx/pull/18)
- [Layr-Labs/mlx-c: Add explicit mutable-input declarations to the C Metal kernel API](https://github.com/Layr-Labs/mlx-c/pull/10)
- [Layr-Labs/mlx-swift: Expose mutableInputs in Swift custom Metal kernels](https://github.com/Layr-Labs/mlx-swift/pull/23)
- [Layr-Labs/mlx-swift-lm: Support request-owned paged MTP and typed native generation channels](https://github.com/Layr-Labs/mlx-swift-lm/pull/145)
- [Layr-Labs/mlx-swift-lm: Add native Nemotron 3.5 Lightning with retained MTP and complete prefix reuse](https://github.com/Layr-Labs/mlx-swift-lm/pull/146)

All five prerequisite PRs are merged into their respective main branches. The provider gitlinks now identify the final merged dependency chain; no provider merge, release, model activation, or deployment is implied.

## Pinned dependency revisions

| Location | Repository | Commit |
|---|---|---|
| `libs/mlx` | Layr-Labs/mlx | `3fa8f25e6451174d7b06be372c3a24272b77d88e` |
| `libs/mlx-swift` | Layr-Labs/mlx-swift | `6d6796d7a81b656d2749d39067e0a6bea2bc2986` |
| `libs/mlx-swift-lm` | Layr-Labs/mlx-swift-lm | `93a27fcdba1142de9001e305ab183d13c99520d8` |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791609323&installation_model_id=21733&pr_number=885&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F885&signature=6a8787709d733e6dbbd894771099da870434a8ff26577aa28302f8fa3fdda364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

