### PR TITLE
feat(console-ui): payout-coverage notice on provider earnings page

### DIFF
--- a/console-ui/__tests__/payout-coverage-notice.test.tsx
+++ b/console-ui/__tests__/payout-coverage-notice.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StripePayoutsCard } from "@/components/payouts/StripePayoutsCard";
+import { PayoutCoverageNotice } from "@/components/payouts/PayoutCoverageNotice";
+import type { StripeStatus } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual };
+});
+
+const NOTICE_SNIPPET = /does not, by itself, establish payout availability/;
+
+const baseProps = {
+  withdrawals: [],
+  balanceMicroUsd: 5_000_000,
+  onboardLoading: false,
+  selectedCountry: "",
+  onCountryChange: () => {},
+  onOnboard: () => {},
+  onOpenWithdraw: () => {},
+  title: "Withdraw Earnings",
+  icon: <span />,
+  noun: "earnings",
+  className: "",
+};
+
+const noAccountStatus: StripeStatus = {
+  configured: true,
+  has_account: false,
+  status: "",
+  min_withdraw_micro_usd: 1_000_000,
+};
+
+const restrictedStatus: StripeStatus = {
+  ...noAccountStatus,
+  has_account: true,
+  status: "restricted",
+};
+
+const readyStatus: StripeStatus = {
+  ...noAccountStatus,
+  has_account: true,
+  status: "ready",
+};
+
+describe("PayoutCoverageNotice", () => {
+  it("renders the coverage caveat", () => {
+    render(<PayoutCoverageNotice />);
+    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
+  });
+});
+
+describe("StripePayoutsCard countryNotice slot", () => {
+  it("shows the notice under the country picker before onboarding", () => {
+    render(
+      <StripePayoutsCard
+        {...baseProps}
+        status={noAccountStatus}
+        countryNotice={<PayoutCoverageNotice />}
+      />,
+    );
+    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
+  });
+
+  it("shows the notice for accounts stuck in a restricted state", () => {
+    render(
+      <StripePayoutsCard
+        {...baseProps}
+        status={restrictedStatus}
+        countryNotice={<PayoutCoverageNotice />}
+      />,
+    );
+    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
+  });
+
+  it("does not show the notice once payouts are ready (no country picker)", () => {
+    render(
+      <StripePayoutsCard
+        {...baseProps}
+        status={readyStatus}
+        countryNotice={<PayoutCoverageNotice />}
+      />,
+    );
+    expect(screen.queryByText(NOTICE_SNIPPET)).toBeNull();
+  });
+
+  it("renders nothing extra when the slot is not passed (billing unchanged)", () => {
+    render(<StripePayoutsCard {...baseProps} status={noAccountStatus} />);
+    expect(screen.queryByText(NOTICE_SNIPPET)).toBeNull();
+  });
+});

--- a/console-ui/__tests__/payout-coverage-notice.test.tsx
+++ b/console-ui/__tests__/payout-coverage-notice.test.tsx
@@ -1,92 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { StripePayoutsCard } from "@/components/payouts/StripePayoutsCard";
 import { PayoutCoverageNotice } from "@/components/payouts/PayoutCoverageNotice";
-import type { StripeStatus } from "@/lib/api";
-
-vi.mock("@/lib/api", async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return { ...actual };
-});
-
-const NOTICE_SNIPPET = /does not, by itself, establish payout availability/;
-
-const baseProps = {
-  withdrawals: [],
-  balanceMicroUsd: 5_000_000,
-  onboardLoading: false,
-  selectedCountry: "",
-  onCountryChange: () => {},
-  onOnboard: () => {},
-  onOpenWithdraw: () => {},
-  title: "Withdraw Earnings",
-  icon: <span />,
-  noun: "earnings",
-  className: "",
-};
-
-const noAccountStatus: StripeStatus = {
-  configured: true,
-  has_account: false,
-  status: "",
-  min_withdraw_micro_usd: 1_000_000,
-};
-
-const restrictedStatus: StripeStatus = {
-  ...noAccountStatus,
-  has_account: true,
-  status: "restricted",
-};
-
-const readyStatus: StripeStatus = {
-  ...noAccountStatus,
-  has_account: true,
-  status: "ready",
-};
 
 describe("PayoutCoverageNotice", () => {
   it("renders the coverage caveat", () => {
     render(<PayoutCoverageNotice />);
-    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
-  });
-});
-
-describe("StripePayoutsCard countryNotice slot", () => {
-  it("shows the notice under the country picker before onboarding", () => {
-    render(
-      <StripePayoutsCard
-        {...baseProps}
-        status={noAccountStatus}
-        countryNotice={<PayoutCoverageNotice />}
-      />,
-    );
-    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
-  });
-
-  it("shows the notice for accounts stuck in a restricted state", () => {
-    render(
-      <StripePayoutsCard
-        {...baseProps}
-        status={restrictedStatus}
-        countryNotice={<PayoutCoverageNotice />}
-      />,
-    );
-    expect(screen.getByText(NOTICE_SNIPPET)).toBeTruthy();
-  });
-
-  it("does not show the notice once payouts are ready (no country picker)", () => {
-    render(
-      <StripePayoutsCard
-        {...baseProps}
-        status={readyStatus}
-        countryNotice={<PayoutCoverageNotice />}
-      />,
-    );
-    expect(screen.queryByText(NOTICE_SNIPPET)).toBeNull();
-  });
-
-  it("renders nothing extra when the slot is not passed (billing unchanged)", () => {
-    render(<StripePayoutsCard {...baseProps} status={noAccountStatus} />);
-    expect(screen.queryByText(NOTICE_SNIPPET)).toBeNull();
+    expect(
+      screen.getByText(/payouts aren't available in every country yet/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/check whether your country's withdrawal path/),
+    ).toBeTruthy();
   });
 });

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -15,6 +15,7 @@ import {
   ArrowDownToLine,
 } from "lucide-react";
 import {
+  PayoutCoverageNotice,
   PayoutModal,
   StripePayoutsCard,
   StripeWithdrawModal,
@@ -208,6 +209,7 @@ export default function EarningsContent() {
         icon={<ArrowDownToLine size={16} className="text-teal" />}
         noun="earnings"
         className="rounded-xl bg-bg-secondary shadow-sm p-5"
+        countryNotice={<PayoutCoverageNotice />}
       >
         {/* Withdrawable earnings display */}
         <div className="flex items-baseline gap-1 mb-1 mt-1">

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -188,6 +188,9 @@ export default function EarningsContent() {
         </div>
       </div>
 
+      {/* Payout coverage caveat — set expectations before bank linking */}
+      <PayoutCoverageNotice />
+
       {/* Withdraw Earnings (Stripe Connect) */}
       <StripePayoutsCard
               confirmationPending={payouts.withdrawConfirmationPending}
@@ -209,7 +212,6 @@ export default function EarningsContent() {
         icon={<ArrowDownToLine size={16} className="text-teal" />}
         noun="earnings"
         className="rounded-xl bg-bg-secondary shadow-sm p-5"
-        countryNotice={<PayoutCoverageNotice />}
       >
         {/* Withdrawable earnings display */}
         <div className="flex items-baseline gap-1 mb-1 mt-1">

--- a/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
+++ b/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
@@ -5,9 +5,9 @@ import { Globe } from "lucide-react";
 // (Stripe Connect coverage varies by country).
 export function PayoutCoverageNotice() {
   return (
-    <div className="flex items-center gap-3.5 rounded-xl bg-bg-secondary shadow-sm px-5 py-4">
+    <div className="flex items-center gap-3.5 rounded-xl bg-accent-amber-dim/50 border border-accent-amber/10 shadow-sm px-5 py-4">
       <div
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-amber-dim text-accent-amber"
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-amber/20 text-accent-amber"
         aria-hidden
       >
         <Globe size={16} />

--- a/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
+++ b/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
@@ -1,8 +1,8 @@
 import { Globe } from "lucide-react";
 
-// Payout-coverage caveat shown next to the Stripe country picker. Wording
-// agreed with legal — running a provider does not by itself guarantee a
-// payout path in every region (Stripe Connect coverage varies by country).
+// Payout-coverage caveat shown next to the Stripe country picker — running
+// a provider does not by itself guarantee a payout path in every region
+// (Stripe Connect coverage varies by country).
 export function PayoutCoverageNotice() {
   return (
     <div className="flex items-start gap-2.5 rounded-lg border border-accent-amber/20 bg-accent-amber-dim px-4 py-3 mb-4">
@@ -12,7 +12,7 @@ export function PayoutCoverageNotice() {
         itself, establish payout availability in certain regions. We are
         actively evaluating additional jurisdictions for payment integration;
         however, we cannot confirm whether or when coverage will extend to
-        your country.
+        every country.
       </p>
     </div>
   );

--- a/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
+++ b/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
@@ -1,18 +1,23 @@
 import { Globe } from "lucide-react";
 
-// Payout-coverage caveat shown next to the Stripe country picker — running
+// Payout-coverage caveat shown above the Withdraw Earnings card — running
 // a provider does not by itself guarantee a payout path in every region
 // (Stripe Connect coverage varies by country).
 export function PayoutCoverageNotice() {
   return (
-    <div className="flex items-start gap-2.5 rounded-lg border border-accent-amber/20 bg-accent-amber-dim px-4 py-3 mb-4">
-      <Globe size={16} className="mt-0.5 shrink-0 text-accent-amber" aria-hidden />
+    <div className="flex items-center gap-3.5 rounded-xl bg-bg-secondary shadow-sm px-5 py-4">
+      <div
+        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-amber-dim text-accent-amber"
+        aria-hidden
+      >
+        <Globe size={16} />
+      </div>
       <p className="text-sm leading-relaxed text-text-secondary">
-        Please note that operating as a provider on the platform does not, by
-        itself, establish payout availability in certain regions. We are
-        actively evaluating additional jurisdictions for payment integration;
-        however, we cannot confirm whether or when coverage will extend to
-        every country.
+        <span className="font-semibold text-text-primary">Heads up:</span>{" "}
+        payouts aren&apos;t available in every country yet. Before you start
+        serving requests, please check whether your country&apos;s withdrawal
+        path is supported via Stripe. We&apos;re actively working on covering
+        more regions.
       </p>
     </div>
   );

--- a/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
+++ b/console-ui/src/components/payouts/PayoutCoverageNotice.tsx
@@ -1,0 +1,19 @@
+import { Globe } from "lucide-react";
+
+// Payout-coverage caveat shown next to the Stripe country picker. Wording
+// agreed with legal — running a provider does not by itself guarantee a
+// payout path in every region (Stripe Connect coverage varies by country).
+export function PayoutCoverageNotice() {
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-accent-amber/20 bg-accent-amber-dim px-4 py-3 mb-4">
+      <Globe size={16} className="mt-0.5 shrink-0 text-accent-amber" aria-hidden />
+      <p className="text-sm leading-relaxed text-text-secondary">
+        Please note that operating as a provider on the platform does not, by
+        itself, establish payout availability in certain regions. We are
+        actively evaluating additional jurisdictions for payment integration;
+        however, we cannot confirm whether or when coverage will extend to
+        your country.
+      </p>
+    </div>
+  );
+}

--- a/console-ui/src/components/payouts/StripePayoutsCard.tsx
+++ b/console-ui/src/components/payouts/StripePayoutsCard.tsx
@@ -31,6 +31,7 @@ export function StripePayoutsCard({
   icon,
   noun,
   className,
+  countryNotice,
   children,
 }: {
   status: StripeStatus | null;
@@ -52,6 +53,8 @@ export function StripePayoutsCard({
   icon: React.ReactNode;
   noun: string;
   className: string;
+  /** Optional notice rendered under the CountryPicker (e.g. payout-coverage caveat). */
+  countryNotice?: React.ReactNode;
   children?: React.ReactNode;
 }) {
   // Stripe payouts not configured on this coordinator — hide the card entirely.
@@ -100,6 +103,7 @@ export function StripePayoutsCard({
             Your country
           </label>
           <CountryPicker options={status?.countries} value={selectedCountry} onChange={onCountryChange} />
+          {countryNotice}
           <button
             onClick={onOnboard}
             disabled={onboardLoading || !selectedCountry || status?.payouts_available === false}
@@ -148,6 +152,7 @@ export function StripePayoutsCard({
             Country
           </label>
           <CountryPicker options={status?.countries} value={selectedCountry} onChange={onCountryChange} />
+          {countryNotice}
           <button
             onClick={onOnboard}
             disabled={onboardLoading || !selectedCountry || status?.payouts_available === false}

--- a/console-ui/src/components/payouts/StripePayoutsCard.tsx
+++ b/console-ui/src/components/payouts/StripePayoutsCard.tsx
@@ -31,7 +31,6 @@ export function StripePayoutsCard({
   icon,
   noun,
   className,
-  countryNotice,
   children,
 }: {
   status: StripeStatus | null;
@@ -53,8 +52,6 @@ export function StripePayoutsCard({
   icon: React.ReactNode;
   noun: string;
   className: string;
-  /** Optional notice rendered under the CountryPicker (e.g. payout-coverage caveat). */
-  countryNotice?: React.ReactNode;
   children?: React.ReactNode;
 }) {
   // Stripe payouts not configured on this coordinator — hide the card entirely.
@@ -103,7 +100,6 @@ export function StripePayoutsCard({
             Your country
           </label>
           <CountryPicker options={status?.countries} value={selectedCountry} onChange={onCountryChange} />
-          {countryNotice}
           <button
             onClick={onOnboard}
             disabled={onboardLoading || !selectedCountry || status?.payouts_available === false}
@@ -152,7 +148,6 @@ export function StripePayoutsCard({
             Country
           </label>
           <CountryPicker options={status?.countries} value={selectedCountry} onChange={onCountryChange} />
-          {countryNotice}
           <button
             onClick={onOnboard}
             disabled={onboardLoading || !selectedCountry || status?.payouts_available === false}

--- a/console-ui/src/components/payouts/index.ts
+++ b/console-ui/src/components/payouts/index.ts
@@ -5,6 +5,7 @@ export { PayoutModal } from "./PayoutModal";
 export { MethodOption } from "./MethodOption";
 export { StripeWithdrawModal } from "./StripeWithdrawModal";
 export { CountryPicker } from "./CountryPicker";
+export { PayoutCoverageNotice } from "./PayoutCoverageNotice";
 export { WithdrawalsList } from "./WithdrawalsList";
 export { PayoutDestinationRow } from "./PayoutDestinationRow";
 export { StripePayoutsCard } from "./StripePayoutsCard";


### PR DESCRIPTION
## What

Adds a payout-coverage notice to the provider earnings page (`/providers/earnings`), shown between the stats row and the **Withdraw Earnings** card. Providers in several regions currently hit Stripe Connect onboarding failures (e.g. BR recipient-ToS 400s, AE `transfers` capability 400 — #782) or have no Stripe payout path at all, and today they only find out *after* they've started serving. This sets expectations up front, before linking a bank.

## Behavior — before / after

```mermaid
flowchart LR
  subgraph Before
    A1[Provider opens /providers/earnings] --> B1[Withdraw Earnings card]
    B1 --> C1[Pick country → Link bank via Stripe]
    C1 --> D1[Stripe 400 / no payout path<br/>discovered only after serving]
  end
  subgraph After
    A2[Provider opens /providers/earnings] --> N2[Coverage notice above Withdraw card:<br/>check your country's withdrawal path first]
    N2 --> B2[Withdraw Earnings card]
    B2 --> C2[Pick country → Link bank via Stripe]
    C2 --> D2[Same flow — expectations set upfront]
  end
```

## Code — before / after

```mermaid
flowchart LR
  subgraph Before
    E1[EarningsContent] --> S1[StripePayoutsCard]
    G1[billing page] --> S1
  end
  subgraph After
    E2[EarningsContent] --> X2[PayoutCoverageNotice — new component]
    E2 --> S2[StripePayoutsCard — untouched]
    G2[billing page] --> S2
  end
```

## Changes

- **New** `console-ui/src/components/payouts/PayoutCoverageNotice.tsx` — static notice matching the page's card geometry (rounded-xl, shadow) with a faint amber background tint (`bg-accent-amber-dim/50` + `border-accent-amber/10`) and an amber globe icon chip; works in light/dark via theme tokens. Always visible on the earnings page.
- `EarningsContent` — renders the notice between the stats grid and the Withdraw Earnings card.
- No changes to shared components — `StripePayoutsCard` and the billing page are untouched.

Copy:

> **Heads up:** payouts aren't available in every country yet. Before you start serving requests, please check whether your country's withdrawal path is supported via Stripe. We're actively working on covering more regions.

## Tests

`console-ui/__tests__/payout-coverage-notice.test.tsx` (vitest): notice renders its copy.

`npx vitest run` on the new + payout suites passes (3 pre-existing failures in `payouts.test.tsx` reproduce identically on clean master — unrelated). `npx eslint src/` — 0 errors, no new warnings. `npm run build` passes.

## Screenshots

> **Note:** these are a **simulated preview** — a static mockup of the earnings page built with the console's actual design tokens (`globals.css`) and markup structure, since the live page requires an authenticated session with real Stripe state. Layout and styling match the implementation; fonts/spacing may differ by a few pixels from the deployed app.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/EigenMustafa/d-inference/assets/payout-notice-887/before.png) | ![after](https://raw.githubusercontent.com/EigenMustafa/d-inference/assets/payout-notice-887/after.png) |

<details>
<summary>After — dark mode</summary>

![after dark](https://raw.githubusercontent.com/EigenMustafa/d-inference/assets/payout-notice-887/after-dark.png)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
