### PR TITLE
fix(console): retain earnings access after removing all Macs

### DIFF
--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -152,7 +152,7 @@ export default function EarningsContent() {
       <div>
         <h2 className="text-lg font-semibold text-text-primary">Provider Earnings</h2>
         <p className="text-sm text-text-tertiary mt-0.5">
-          Across all linked provider nodes
+          Earnings stay available after you remove your Macs.
         </p>
       </div>
 

--- a/console-ui/src/components/console-entry/workspaces.test.ts
+++ b/console-ui/src/components/console-entry/workspaces.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { providerDestination, workspaceForPath } from "./workspaces";
+import { providerDestination, summarizeProviders, workspaceForPath, type ProviderAccount } from "./workspaces";
 import { accountItems, isNavigationActive, navigationGroups } from "../navigation/items";
 
+const EARNINGS_PATH = "/providers/earnings";
+
 describe("Workspace routing", () => {
+  it("keeps earnings reachable after the last Mac is removed and the account is reloaded", () => {
+    const linked = summarizeProviders({ providers: [{ id: "mac-1", online: true }] });
+    const removed = summarizeProviders({ providers: [] });
+    expect(removed.status).toBe("new");
+    for (const account of [linked, removed]) {
+      const items = navigationGroups("provider", account).flatMap((group) => group.items);
+      expect(items.find((item) => item.label === "Your earnings")?.href).toBe(EARNINGS_PATH);
+    }
+  });
+  it.each<ProviderAccount["status"]>(["guest", "loading", "error", "new", "linked"])(
+    "keeps the earnings entry available when provider discovery is %s",
+    (status) => {
+      const items = navigationGroups("provider", { status, total: 0, online: 0 }).flatMap((group) => group.items);
+      expect(items.some((item) => item.href === EARNINGS_PATH)).toBe(true);
+    },
+  );
   it("treats roles as navigation preferences while retaining shared pages and deep links", () => {
     expect(workspaceForPath("/chat")).toBe("consumer");
-    expect(workspaceForPath("/providers/earnings")).toBe("provider");
+    expect(workspaceForPath(EARNINGS_PATH)).toBe("provider");
     expect(workspaceForPath("/link")).toBeNull();
     expect(workspaceForPath("/settings")).toBeNull();
     expect(workspaceForPath("/stats")).toBeNull();
@@ -14,7 +32,7 @@ describe("Workspace routing", () => {
   });
   it("separates provider earnings from consumer billing and the calculator", () => {
     const items = navigationGroups("provider", { status: "linked", total: 1, online: 1 }).flatMap((group) => group.items);
-    expect(items.find((item) => item.label === "Your earnings")?.href).toBe("/providers/earnings");
+    expect(items.find((item) => item.label === "Your earnings")?.href).toBe(EARNINGS_PATH);
     expect(items.find((item) => item.label === "Earnings calculator")?.href).toBe("/earn");
     expect(items.some((item) => item.href === "/chat")).toBe(false);
     expect(accountItems("provider").some((item) => item.href === "/billing")).toBe(false);

--- a/console-ui/src/components/navigation/items.ts
+++ b/console-ui/src/components/navigation/items.ts
@@ -19,12 +19,12 @@ const ACCOUNT_ITEMS: NavigationItem[] = [
 ];
 export function navigationGroups(mode: Workspace, account: ProviderAccount) {
   if (mode === "consumer") return CONSUMER_GROUPS;
-  const existing = account.status !== "new" && account.status !== "guest";
   return [
     { label: "Provider workspace", items: [
       { href: "/providers", icon: Server, label: "Your fleet" },
       { href: "/providers/setup", icon: Cpu, label: account.status === "linked" ? "Add a Mac" : "Set up a Mac" },
-      ...(existing ? [{ href: "/providers/earnings", icon: Coins, label: "Your earnings" }] : []),
+      // Earnings belong to the account, even after its last Mac is removed.
+      { href: "/providers/earnings", icon: Coins, label: "Your earnings" },
       { href: "/earn", icon: Coins, label: "Earnings calculator" },
     ] },
     { label: "Network", items: [


### PR DESCRIPTION
Removing the last Mac makes `summarizeProviders` classify the account as `new`. `navigationGroups` then hides **Your earnings**, so a former provider loses the console entry to their balance and withdrawal controls even though their money remains on the account.

Keep **Your earnings** in the provider workspace for every discovery state, and explain on the earnings page that earnings remain available after Macs are removed. Guests reach the existing sign-in prompt. This also keeps access independent of discovery failures and avoids requiring another balance/history request merely to render navigation.

The existing backend already supports this: provider deletion intentionally preserves `provider_earnings`, earnings queries use `account_id`, and Stripe withdrawal authenticates the user and checks account payout eligibility without requiring a provider. No payout rules or ledger behavior change.

### Before

```mermaid
flowchart TD
  A[User removes last Mac and reloads console] --> B[useProviderAccount fetches an empty provider list]
  B --> C[summarizeProviders returns new]
  C --> D[navigationGroups omits Your earnings]
  D --> E[Sidebar has no entry to earnings or withdrawals]
  F[Account balance and earnings history remain stored]
```

### After

```mermaid
flowchart TD
  A[User removes last Mac and reloads console] --> B[useProviderAccount and summarizeProviders still return new]
  B --> C[navigationGroups always includes Your earnings]
  C --> D[Sidebar links to providers/earnings]
  D --> E[EarningsContent checks sign-in]
  E -->|Signed in| F[Account earnings and StripePayoutsCard]
  E -->|Guest| G[Existing sign-in prompt]
  F --> H[Existing withdrawal flow checks balance and payout eligibility]
```

### Verification

- 38 tests passed across `workspaces.test.ts`, `useProviderAccount.test.tsx`, and `stripe-payouts.test.ts`. Regression coverage includes a linked account becoming empty and every discovery status.
- Changed-file ESLint passed without warnings; the pre-commit full source lint passed with 81 warnings and no errors. `git diff --check` passed.
- Broader `__tests__/payouts.test.tsx`: 13 passed, 3 failed. Reproduced the same failures with production files restored to unchanged master `73093957b`. The submit, error, and closed-account tests hit the existing previous-withdrawals readiness guard. These failures are outside this navigation change.
- No production withdrawal, browser session validation, or full build performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791654402&installation_model_id=21733&pr_number=888&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F888&signature=5c2b951a8160729f3cffeecc2668256c8a0ee4c70e5cf8db070a1df1c8754892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->