### PR TITLE
Fix standalone admission for qualified Nemotron Lightning models

### DIFF
--- a/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
+++ b/provider-swift/Sources/ProviderCore/Server/StandaloneServer.swift
@@ -1398,7 +1398,7 @@ public actor StandaloneServer {
         // Loud insurance behind the init/setModels filter: a model without
         // a CBv2 adapter must never reach engine construction (v0.7.5
         // fail-loud — there is no legacy engine to degrade onto).
-        guard EngineV2SupportedModels.isSupported(modelType: modelInfo.modelType) else {
+        guard EngineV2SupportedModels.isSupported(model: modelInfo) else {
             standaloneLogger.error(
                 "Model '\(modelId)' (model_type \(modelInfo.modelType ?? "unknown")) has no CBv2 adapter — refusing to load")
             throw StandaloneServerError.modelNotFound(modelId)

--- a/provider-swift/Tests/ProviderCoreTests/NemotronStandaloneAdmissionTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/NemotronStandaloneAdmissionTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import ProviderCore
+
+@Suite("Nemotron standalone load admission", .serialized)
+struct NemotronStandaloneAdmissionTests {
+    private struct ReachedWeightLoad: Error {}
+
+    @Test("Qualified Lightning reaches weight loading instead of type-only rejection", arguments: [
+        "mlx-community/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-4bit",
+        "nvidia-nemotron-3.5-lightning",
+        "EigenLabs/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-MLX-4bit-mtp",
+    ])
+    func qualifiedArtifactReachesLoad(modelID: String) async throws {
+        // Only path resolution is needed: stop before reading any weights.
+        // Reuse existing snapshots without modifying them; otherwise own only
+        // a uniquely named empty snapshot, never the user's model directory.
+        var ownedSnapshot: URL?
+        if ModelScanner.resolveLocalPath(modelID: modelID) == nil {
+            let cache = try #require(ModelScanner.defaultCacheDirectory())
+            let snapshot = cache
+                .appendingPathComponent("models--" + modelID.replacingOccurrences(of: "/", with: "--"))
+                .appendingPathComponent("snapshots")
+                .appendingPathComponent("admission-test-" + UUID().uuidString)
+            try FileManager.default.createDirectory(at: snapshot, withIntermediateDirectories: true)
+            ownedSnapshot = snapshot
+            try Data("{}".utf8).write(to: snapshot.appendingPathComponent("config.json"))
+        }
+        defer {
+            if let ownedSnapshot { try? FileManager.default.removeItem(at: ownedSnapshot) }
+        }
+
+        let server = StandaloneServer(
+            config: .init(mtpMode: .off),
+            models: [.init(id: modelID, modelType: "nemotron_h", sizeBytes: 1, estimatedMemoryGb: 0.25)])
+        await server.setV2TestHooksForTesting(.init(
+            beforeWeightLoad: { _ in throw ReachedWeightLoad() },
+            makeEngine: { _, grant in InertStubEngine(kvBytesCapacity: grant) }))
+        do {
+            try await server.ensureModelLoaded(modelID)
+            Issue.record("The observation hook should stop weight loading")
+        } catch is ReachedWeightLoad {
+            // Success: actual standalone loading passed the qualified-ID guard.
+        }
+        #expect(await server.debugOutstandingKVReservationBytes() == 0)
+    }
+
+    @Test("Unqualified Nano sharing nemotron_h remains rejected")
+    func nanoRemainsRejected() async throws {
+        let modelID = "mlx-community/NVIDIA-Nemotron-Nano"
+        let server = StandaloneServer(
+            config: .init(mtpMode: .off),
+            models: [.init(id: modelID, modelType: "nemotron_h", sizeBytes: 1, estimatedMemoryGb: 0.25)])
+        do {
+            try await server.ensureModelLoaded(modelID)
+            Issue.record("Nano must remain outside the qualified serving set")
+        } catch StandaloneServerError.modelNotFound(let rejectedID) {
+            #expect(rejectedID == modelID)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Qualified Nemotron Lightning models appear in `/v1/models` but `darkbloom start --local` rejects every generation with HTTP 404: `StandaloneServer.ensureModelLoaded` checks support by model type, while `nemotron_h` deliberately requires an exact qualified model ID.

Use the existing model-aware support check at the load guard, matching `ProviderLoop`. Add regression coverage that drives standalone loading for all three qualified Lightning IDs and confirms that unqualified Nano remains rejected.

## Linked issue

Follow-up to the merged [#885](https://github.com/Layr-Labs/d-inference/pull/885). This PR targets `Layr-Labs/d-inference:master` at `71b54de3c769a6a1146737ad2e66eb43d913e8f4` and contains only the standalone admission fix and its regression tests.

## Before — behavior and code

```mermaid
flowchart LR
  A[Qualified Lightning advertised] --> B[Chat completion request]
  B --> C[StandaloneServer.ensureModelLoaded]
  C --> D[isSupported modelType: nemotron_h]
  D --> E[False: exact model ID required]
  E --> F[HTTP 404: model unavailable]
```

## After — behavior and code

```mermaid
flowchart LR
  A[Chat completion request] --> B[StandaloneServer.ensureModelLoaded]
  B --> C[isSupported model: modelInfo]
  C -->|Qualified Lightning| D[Existing memory admission]
  D -->|Enough headroom| E[Weight loading and engine construction]
  D -->|Insufficient headroom| F[HTTP 503: capacity unavailable]
  C -->|Unqualified model| G[HTTP 404: model unavailable]
```

## Test plan

- [x] `swift test -c release -j 6 --filter 'NemotronStandaloneAdmissionTests|EngineV2SupportedSetGateTests'` — nine tests across two suites passed, including all three qualified-ID cases and Nano rejection.
- [x] Reproduced HTTP 404 with the original PR through the real local CLI. With the fix, requests reach memory admission and return HTTP 503 on the 36 GiB test machine.
- [x] Verified that the patch matches the tested files and that the merged provider source tree and dependency pins match the qualification checkout. Tests ran in that checkout with #885 merged into master.
- [x] `git diff --check`.

The new admission tests stop through the existing `beforeWeightLoad` hook, so they require no downloaded weights. They reuse existing snapshots without modifying them, or remove their own uniquely named temporary snapshot after testing. This exercises the actual standalone load guard and checks pending-load reservation cleanup.

## Components touched

- [x] provider-swift (Swift CLI)

## Protocol / interface changes

- [x] No protocol/interface changes

## Notes for reviewers

This fixes a load-admission defect independently of machine RAM. Memory policy, model/dependency pins, and MTP implementation are unchanged. A successful normal serving run after the fix, with adequate memory headroom, remains separate serving qualification; the loaded-model and preloaded HTTP checks do not establish default CLI serving on the 36 GiB test machine or an MTP speedup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791679691&installation_model_id=21733&pr_number=892&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F892&signature=aa43d5799451bf1ad045276e9d763ece9aea1726b3ff8e7e79e049afd586ac73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->