### PR TITLE
feat: lifetime earnings per machine on the provider earnings page

### DIFF
--- a/console-ui/__tests__/by-machine-list.test.tsx
+++ b/console-ui/__tests__/by-machine-list.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  ByMachineList,
+  machineLabel,
+  displayLabels,
+  type MachineEarnings,
+} from "@/app/providers/earnings/ByMachineList";
+
+const machine = (overrides: Partial<MachineEarnings>): MachineEarnings => ({
+  provider_key: "k".repeat(44),
+  total_micro_usd: 1_500_000,
+  total_usd: "1.500000",
+  job_count: 42,
+  prompt_tokens: 1000,
+  completion_tokens: 500,
+  last_earned_at: "2026-09-10T12:00:00Z",
+  ...overrides,
+});
+
+describe("machineLabel", () => {
+  it("uses chip and memory when known", () => {
+    expect(machineLabel(machine({ chip_name: "Apple M4 Max", memory_gb: 64 }))).toBe(
+      "Apple M4 Max · 64 GB",
+    );
+  });
+
+  it("falls back to a key suffix without hardware info", () => {
+    expect(machineLabel(machine({ provider_key: "abcdef123456" }))).toBe("Machine …123456");
+  });
+
+  it("labels the empty key as Other", () => {
+    expect(machineLabel(machine({ provider_key: "" }))).toBe("Other");
+  });
+});
+
+describe("displayLabels", () => {
+  it("disambiguates identical hardware with key suffixes", () => {
+    const labels = displayLabels([
+      machine({ provider_key: "key-one-aaaaaa", chip_name: "Apple M4 Max", memory_gb: 64 }),
+      machine({ provider_key: "key-two-bbbbbb", chip_name: "Apple M4 Max", memory_gb: 64 }),
+      machine({ provider_key: "key-three-cccccc", chip_name: "Apple M3 Pro", memory_gb: 36 }),
+    ]);
+    expect(labels).toEqual([
+      "Apple M4 Max · 64 GB (…aaaaaa)",
+      "Apple M4 Max · 64 GB (…bbbbbb)",
+      "Apple M3 Pro · 36 GB",
+    ]);
+  });
+});
+
+describe("ByMachineList", () => {
+  it("renders one row per machine with earnings and jobs", () => {
+    render(
+      <ByMachineList
+        machines={[
+          machine({ chip_name: "Apple M4 Max", memory_gb: 64 }),
+          machine({ provider_key: "zzzz11223344", total_usd: "0.250000" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Apple M4 Max · 64 GB")).toBeTruthy();
+    expect(screen.getByText("Machine …223344")).toBeTruthy();
+    expect(screen.getByText("$1.500000")).toBeTruthy();
+    expect(screen.getByText("$0.250000")).toBeTruthy();
+    // "Last earned" was cut deliberately — it read as "last active" but only
+    // reflected earnings rows, going stale for online-but-idle machines.
+    expect(screen.queryByText("Last active")).toBeNull();
+  });
+
+  it("shows the unattributed bucket as Other with an explainer", () => {
+    render(<ByMachineList machines={[machine({ provider_key: "" })]} />);
+    expect(screen.getByText("Other")).toBeTruthy();
+    expect(screen.getByText(/not attributed to a machine/)).toBeTruthy();
+  });
+
+  it("renders nothing when there are no machines", () => {
+    const { container } = render(<ByMachineList machines={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/console-ui/__tests__/by-machine-list.test.tsx
+++ b/console-ui/__tests__/by-machine-list.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import {
   ByMachineList,
   machineLabel,
-  displayLabels,
+  machineId,
   type MachineEarnings,
 } from "@/app/providers/earnings/ByMachineList";
 
@@ -18,49 +18,46 @@ const machine = (overrides: Partial<MachineEarnings>): MachineEarnings => ({
   ...overrides,
 });
 
-describe("machineLabel", () => {
+describe("machineLabel / machineId", () => {
   it("uses chip and memory when known", () => {
     expect(machineLabel(machine({ chip_name: "Apple M4 Max", memory_gb: 64 }))).toBe(
       "Apple M4 Max · 64 GB",
     );
   });
 
-  it("falls back to a key suffix without hardware info", () => {
-    expect(machineLabel(machine({ provider_key: "abcdef123456" }))).toBe("Machine …123456");
+  it("falls back to a generic label without hardware info", () => {
+    expect(machineLabel(machine({}))).toBe("Machine");
   });
 
-  it("labels the empty key as Other", () => {
+  it("labels the empty key as Other with no ID", () => {
     expect(machineLabel(machine({ provider_key: "" }))).toBe("Other");
+    expect(machineId(machine({ provider_key: "" }))).toBe("");
   });
-});
 
-describe("displayLabels", () => {
-  it("disambiguates identical hardware with key suffixes", () => {
-    const labels = displayLabels([
-      machine({ provider_key: "key-one-aaaaaa", chip_name: "Apple M4 Max", memory_gb: 64 }),
-      machine({ provider_key: "key-two-bbbbbb", chip_name: "Apple M4 Max", memory_gb: 64 }),
-      machine({ provider_key: "key-three-cccccc", chip_name: "Apple M3 Pro", memory_gb: 36 }),
-    ]);
-    expect(labels).toEqual([
-      "Apple M4 Max · 64 GB (…aaaaaa)",
-      "Apple M4 Max · 64 GB (…bbbbbb)",
-      "Apple M3 Pro · 36 GB",
-    ]);
+  it("derives the ID from the stable key tail", () => {
+    expect(machineId(machine({ provider_key: "abcdef123456" }))).toBe("ID …123456");
   });
 });
 
 describe("ByMachineList", () => {
-  it("renders one row per machine with earnings and jobs", () => {
+  it("shows every machine with an always-visible ID", () => {
     render(
       <ByMachineList
         machines={[
-          machine({ chip_name: "Apple M4 Max", memory_gb: 64 }),
-          machine({ provider_key: "zzzz11223344", total_usd: "0.250000" }),
+          machine({ provider_key: "key-one-aaaaaa", chip_name: "Apple M4 Max", memory_gb: 64 }),
+          machine({
+            provider_key: "key-two-dddddd",
+            chip_name: "Apple M4 Max",
+            memory_gb: 64,
+            total_usd: "0.250000",
+          }),
         ]}
       />,
     );
-    expect(screen.getByText("Apple M4 Max · 64 GB")).toBeTruthy();
-    expect(screen.getByText("Machine …223344")).toBeTruthy();
+    // Identical hardware stays distinguishable because the ID is always shown.
+    expect(screen.getAllByText("Apple M4 Max · 64 GB")).toHaveLength(2);
+    expect(screen.getByText("ID …aaaaaa")).toBeTruthy();
+    expect(screen.getByText("ID …dddddd")).toBeTruthy();
     expect(screen.getByText("$1.500000")).toBeTruthy();
     expect(screen.getByText("$0.250000")).toBeTruthy();
     // "Last earned" was cut deliberately — it read as "last active" but only

--- a/console-ui/src/app/providers/earnings/ByMachineList.tsx
+++ b/console-ui/src/app/providers/earnings/ByMachineList.tsx
@@ -1,0 +1,81 @@
+// Lifetime earnings broken down per machine. Machines are identified by
+// provider_key (stable X25519 hardware identity) and labeled with the
+// hardware description from their provider record. Earnings rows with no
+// provider_key (recorded before the crediting path populated it) aggregate
+// into one "Other" bucket — they cannot be attributed retroactively, but the
+// dollars must still appear somewhere.
+
+export interface MachineEarnings {
+  provider_key: string;
+  chip_name?: string;
+  memory_gb?: number;
+  total_micro_usd: number;
+  total_usd: string;
+  job_count: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  last_earned_at: string;
+}
+
+export function machineLabel(m: MachineEarnings): string {
+  if (!m.provider_key) return "Other";
+  if (m.chip_name) {
+    return m.memory_gb ? `${m.chip_name} · ${m.memory_gb} GB` : m.chip_name;
+  }
+  return `Machine …${m.provider_key.slice(-6)}`;
+}
+
+// Identical hardware (two M4 Max · 64 GB boxes) would otherwise render
+// indistinguishable rows; duplicates get their stable key suffix appended.
+export function displayLabels(machines: MachineEarnings[]): string[] {
+  const base = machines.map(machineLabel);
+  const counts = new Map<string, number>();
+  for (const label of base) counts.set(label, (counts.get(label) ?? 0) + 1);
+  return machines.map((m, i) =>
+    (counts.get(base[i]) ?? 0) > 1 && m.provider_key
+      ? `${base[i]} (…${m.provider_key.slice(-6)})`
+      : base[i],
+  );
+}
+
+export function ByMachineList({ machines }: { machines: MachineEarnings[] }) {
+  if (!machines || machines.length === 0) return null;
+  const labels = displayLabels(machines);
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-text-primary mb-3">Earnings by Machine</h3>
+      <div className="rounded-xl bg-bg-secondary shadow-sm overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border-dim">
+              <th className="text-left text-xs text-text-tertiary font-medium px-4 py-3">Machine</th>
+              <th className="text-left text-xs text-text-tertiary font-medium px-4 py-3">Earned</th>
+              <th className="text-left text-xs text-text-tertiary font-medium px-4 py-3">Jobs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {machines.map((m, i) => (
+              <tr key={m.provider_key || "other"} className="border-b border-border-dim/50 last:border-0">
+                <td className="px-4 py-3 text-sm text-text-primary">
+                  {labels[i]}
+                  {!m.provider_key && (
+                    <span className="block text-xs text-text-tertiary">
+                      earnings not attributed to a machine
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-sm font-mono text-accent-green">
+                  ${m.total_usd}
+                </td>
+                <td className="px-4 py-3 text-sm text-text-tertiary">
+                  {m.job_count.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/console-ui/src/app/providers/earnings/ByMachineList.tsx
+++ b/console-ui/src/app/providers/earnings/ByMachineList.tsx
@@ -1,9 +1,10 @@
 // Lifetime earnings broken down per machine. Machines are identified by
 // provider_key (stable X25519 hardware identity) and labeled with the
-// hardware description from their provider record. Earnings rows with no
-// provider_key (recorded before the crediting path populated it) aggregate
-// into one "Other" bucket — they cannot be attributed retroactively, but the
-// dollars must still appear somewhere.
+// hardware description from their provider record; every row also shows the
+// tail of that key as a machine ID, so identical hardware stays
+// distinguishable. Earnings rows with no provider_key (recorded before the
+// crediting path populated it) aggregate into one "Other" bucket — they
+// cannot be attributed retroactively, but the dollars must still appear.
 
 export interface MachineEarnings {
   provider_key: string;
@@ -22,25 +23,15 @@ export function machineLabel(m: MachineEarnings): string {
   if (m.chip_name) {
     return m.memory_gb ? `${m.chip_name} · ${m.memory_gb} GB` : m.chip_name;
   }
-  return `Machine …${m.provider_key.slice(-6)}`;
+  return "Machine";
 }
 
-// Identical hardware (two M4 Max · 64 GB boxes) would otherwise render
-// indistinguishable rows; duplicates get their stable key suffix appended.
-export function displayLabels(machines: MachineEarnings[]): string[] {
-  const base = machines.map(machineLabel);
-  const counts = new Map<string, number>();
-  for (const label of base) counts.set(label, (counts.get(label) ?? 0) + 1);
-  return machines.map((m, i) =>
-    (counts.get(base[i]) ?? 0) > 1 && m.provider_key
-      ? `${base[i]} (…${m.provider_key.slice(-6)})`
-      : base[i],
-  );
+export function machineId(m: MachineEarnings): string {
+  return m.provider_key ? `ID …${m.provider_key.slice(-6)}` : "";
 }
 
 export function ByMachineList({ machines }: { machines: MachineEarnings[] }) {
   if (!machines || machines.length === 0) return null;
-  const labels = displayLabels(machines);
 
   return (
     <div>
@@ -55,15 +46,13 @@ export function ByMachineList({ machines }: { machines: MachineEarnings[] }) {
             </tr>
           </thead>
           <tbody>
-            {machines.map((m, i) => (
+            {machines.map((m) => (
               <tr key={m.provider_key || "other"} className="border-b border-border-dim/50 last:border-0">
                 <td className="px-4 py-3 text-sm text-text-primary">
-                  {labels[i]}
-                  {!m.provider_key && (
-                    <span className="block text-xs text-text-tertiary">
-                      earnings not attributed to a machine
-                    </span>
-                  )}
+                  {machineLabel(m)}
+                  <span className="block text-xs font-mono text-text-tertiary">
+                    {m.provider_key ? machineId(m) : "earnings not attributed to a machine"}
+                  </span>
                 </td>
                 <td className="px-4 py-3 text-sm font-mono text-accent-green">
                   ${m.total_usd}

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -20,6 +20,7 @@ import {
   StripeWithdrawModal,
   useStripePayouts,
 } from "@/components/payouts";
+import { ByMachineList, type MachineEarnings } from "./ByMachineList";
 
 interface Earning {
   id: number;
@@ -36,6 +37,7 @@ interface Earning {
 interface EarningsResponse {
   account_id: string;
   earnings: Earning[];
+  by_provider?: MachineEarnings[];
   total_micro_usd: number;
   total_usd: string;
   count: number;
@@ -223,6 +225,9 @@ export default function EarningsContent() {
           )}
         </div>
       </StripePayoutsCard>
+
+      {/* Lifetime earnings per machine */}
+      <ByMachineList machines={data?.by_provider ?? []} />
 
       {/* Earnings history */}
       <div>

--- a/coordinator/api/billing_earnings_test.go
+++ b/coordinator/api/billing_earnings_test.go
@@ -103,3 +103,101 @@ func TestAccountEarningsUsesLifetimeTotalsAndCurrentBalance(t *testing.T) {
 		t.Fatalf("latest earning job_id = %q, want job-2", resp.Earnings[0].JobID)
 	}
 }
+
+func TestAccountEarningsGroupsByMachine(t *testing.T) {
+	srv, st := testWithdrawServer(t)
+
+	accountID := "acct-by-machine"
+	now := time.Now()
+
+	// Machine 1 has a provider record (hardware label available); machine 2
+	// has none (e.g. unlinked); the empty key simulates rows recorded before
+	// provider_key existed.
+	if err := st.UpsertProvider(context.Background(), store.ProviderRecord{
+		ID:        "session-uuid-1",
+		AccountID: accountID,
+		PublicKey: "machine-key-1",
+		Hardware:  json.RawMessage(`{"chip_name":"Apple M4 Max","memory_gb":64}`),
+	}); err != nil {
+		t.Fatalf("upsert provider: %v", err)
+	}
+
+	entries := []store.ProviderEarning{
+		{AccountID: accountID, ProviderID: "conn-1", ProviderKey: "machine-key-1", JobID: "job-1",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 300_000, PromptTokens: 100, CompletionTokens: 50,
+			CreatedAt: now.Add(-3 * time.Minute)},
+		{AccountID: accountID, ProviderID: "conn-2", ProviderKey: "machine-key-1", JobID: "job-2",
+			Model: "base_reward", AmountMicroUSD: 40_000, CreatedAt: now.Add(-2 * time.Minute)},
+		{AccountID: accountID, ProviderID: "conn-3", ProviderKey: "machine-key-2", JobID: "job-3",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 200_000, PromptTokens: 80, CompletionTokens: 40,
+			CreatedAt: now.Add(-1 * time.Minute)},
+		{AccountID: accountID, ProviderID: "conn-4", ProviderKey: "", JobID: "job-4",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 10_000, CreatedAt: now.Add(-4 * time.Minute)},
+	}
+	for _, entry := range entries {
+		if err := st.CreditProviderAccount(&entry); err != nil {
+			t.Fatalf("credit provider account: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/provider/account-earnings?limit=10", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyConsumer, accountID))
+	w := httptest.NewRecorder()
+	srv.handleAccountEarnings(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		ByProvider []struct {
+			ProviderKey      string `json:"provider_key"`
+			ChipName         string `json:"chip_name"`
+			MemoryGB         int    `json:"memory_gb"`
+			TotalMicroUSD    int64  `json:"total_micro_usd"`
+			TotalUSD         string `json:"total_usd"`
+			JobCount         int64  `json:"job_count"`
+			PromptTokens     int64  `json:"prompt_tokens"`
+			CompletionTokens int64  `json:"completion_tokens"`
+		} `json:"by_provider"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if len(resp.ByProvider) != 3 {
+		t.Fatalf("by_provider length = %d, want 3: %s", len(resp.ByProvider), w.Body.String())
+	}
+
+	// Highest total first: machine-1 (300k inference + 40k base reward).
+	m1 := resp.ByProvider[0]
+	if m1.ProviderKey != "machine-key-1" {
+		t.Fatalf("first machine = %q, want machine-key-1", m1.ProviderKey)
+	}
+	if m1.TotalMicroUSD != 340_000 || m1.TotalUSD != "0.340000" {
+		t.Fatalf("machine-1 total = %d/%q, want 340000/0.340000", m1.TotalMicroUSD, m1.TotalUSD)
+	}
+	if m1.JobCount != 1 {
+		t.Fatalf("machine-1 job_count = %d, want 1 (base_reward rows are not jobs)", m1.JobCount)
+	}
+	if m1.PromptTokens != 100 || m1.CompletionTokens != 50 {
+		t.Fatalf("machine-1 tokens = %d/%d, want 100/50", m1.PromptTokens, m1.CompletionTokens)
+	}
+	if m1.ChipName != "Apple M4 Max" || m1.MemoryGB != 64 {
+		t.Fatalf("machine-1 hardware = %q/%d, want Apple M4 Max/64", m1.ChipName, m1.MemoryGB)
+	}
+
+	// Machine 2 has no provider record: aggregates present, hardware empty.
+	m2 := resp.ByProvider[1]
+	if m2.ProviderKey != "machine-key-2" || m2.TotalMicroUSD != 200_000 {
+		t.Fatalf("second machine = %q/%d, want machine-key-2/200000", m2.ProviderKey, m2.TotalMicroUSD)
+	}
+	if m2.ChipName != "" || m2.MemoryGB != 0 {
+		t.Fatalf("machine-2 hardware should be empty, got %q/%d", m2.ChipName, m2.MemoryGB)
+	}
+
+	// Legacy rows (no provider_key) aggregate under the empty key.
+	m3 := resp.ByProvider[2]
+	if m3.ProviderKey != "" || m3.TotalMicroUSD != 10_000 {
+		t.Fatalf("third bucket = %q/%d, want empty-key/10000", m3.ProviderKey, m3.TotalMicroUSD)
+	}
+}

--- a/coordinator/api/billing_handlers.go
+++ b/coordinator/api/billing_handlers.go
@@ -14,6 +14,7 @@ package api
 // read-only endpoints and inference.
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"github.com/eigeninference/d-inference/coordinator/auth"
 	"github.com/eigeninference/d-inference/coordinator/billing"
 	"github.com/eigeninference/d-inference/coordinator/payments"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
 	"github.com/eigeninference/d-inference/coordinator/store"
 	"github.com/google/uuid"
 )
@@ -835,9 +837,17 @@ func (s *Server) handleAccountEarnings(w http.ResponseWriter, r *http.Request) {
 
 	availableBalance, withdrawableBalance := s.store.GetBalanceWithWithdrawable(accountID)
 
+	byProvider, err := s.accountEarningsByMachine(r.Context(), accountID)
+	if err != nil {
+		s.logger.Error("get account earnings by provider failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to fetch earnings"))
+		return
+	}
+
 	body, err := json.Marshal(map[string]any{
 		"account_id":                     accountID,
 		"earnings":                       earnings,
+		"by_provider":                    byProvider,
 		"total_micro_usd":                summary.TotalMicroUSD,
 		"total_usd":                      fmt.Sprintf("%.6f", float64(summary.TotalMicroUSD)/1_000_000),
 		"count":                          summary.Count,
@@ -854,4 +864,68 @@ func (s *Server) handleAccountEarnings(w http.ResponseWriter, r *http.Request) {
 	}
 	s.readCache.Set(cacheKey, body, 20*time.Second)
 	writeCachedJSON(w, body)
+}
+
+// machineEarnings is one entry of the account-earnings "by_provider" array:
+// a machine's lifetime aggregates enriched with the hardware description from
+// its provider record (matched on the persisted X25519 public key), so the
+// dashboard can label machines even when they are offline.
+type machineEarnings struct {
+	ProviderKey      string    `json:"provider_key"`
+	ChipName         string    `json:"chip_name,omitempty"`
+	MemoryGB         int       `json:"memory_gb,omitempty"`
+	TotalMicroUSD    int64     `json:"total_micro_usd"`
+	TotalUSD         string    `json:"total_usd"`
+	JobCount         int64     `json:"job_count"`
+	PromptTokens     int64     `json:"prompt_tokens"`
+	CompletionTokens int64     `json:"completion_tokens"`
+	LastEarnedAt     time.Time `json:"last_earned_at"`
+}
+
+// accountEarningsByMachine returns lifetime earnings grouped by machine
+// (stable provider_key), enriched with hardware labels from the account's
+// provider records. Rows recorded before provider_key existed surface as one
+// entry with an empty key; the frontend labels it as earlier activity.
+func (s *Server) accountEarningsByMachine(ctx context.Context, accountID string) ([]machineEarnings, error) {
+	grouped, err := s.store.GetAccountEarningsByProvider(accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hardware lookup keyed on the persisted X25519 public key.
+	type hwInfo struct {
+		chip     string
+		memoryGB int
+	}
+	hwByKey := map[string]hwInfo{}
+	if records, err := s.store.ListProvidersByAccount(ctx, accountID); err == nil {
+		for _, rec := range records {
+			if rec.PublicKey == "" || len(rec.Hardware) == 0 {
+				continue
+			}
+			var hw protocol.Hardware
+			if json.Unmarshal(rec.Hardware, &hw) == nil {
+				hwByKey[rec.PublicKey] = hwInfo{chip: hw.ChipName, memoryGB: hw.MemoryGB}
+			}
+		}
+	}
+
+	results := make([]machineEarnings, 0, len(grouped))
+	for _, m := range grouped {
+		entry := machineEarnings{
+			ProviderKey:      m.ProviderKey,
+			TotalMicroUSD:    m.TotalMicroUSD,
+			TotalUSD:         fmt.Sprintf("%.6f", float64(m.TotalMicroUSD)/1_000_000),
+			JobCount:         m.JobCount,
+			PromptTokens:     m.PromptTokens,
+			CompletionTokens: m.CompletionTokens,
+			LastEarnedAt:     m.LastEarnedAt,
+		}
+		if hw, ok := hwByKey[m.ProviderKey]; ok {
+			entry.ChipName = hw.chip
+			entry.MemoryGB = hw.memoryGB
+		}
+		results = append(results, entry)
+	}
+	return results, nil
 }

--- a/coordinator/store/account_earnings_by_provider_test.go
+++ b/coordinator/store/account_earnings_by_provider_test.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestGetAccountEarningsByProvider verifies grouping is keyed on the stable
+// provider_key (not the rotating provider_id), sorted by total descending,
+// with base_reward rows counted in money but not in jobs/tokens.
+func TestGetAccountEarningsByProvider(t *testing.T) {
+	s := NewMemory(Config{})
+	now := time.Now()
+
+	entries := []ProviderEarning{
+		// machine A earns across two connections (rotating provider_id).
+		{AccountID: "acct", ProviderID: "conn-1", ProviderKey: "key-a", JobID: "j1",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 100_000, PromptTokens: 10, CompletionTokens: 5,
+			CreatedAt: now.Add(-3 * time.Hour)},
+		{AccountID: "acct", ProviderID: "conn-2", ProviderKey: "key-a", JobID: "j2",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 100_000, PromptTokens: 10, CompletionTokens: 5,
+			CreatedAt: now.Add(-1 * time.Hour)},
+		{AccountID: "acct", ProviderID: "conn-3", ProviderKey: "key-a", JobID: "j3",
+			Model: "base_reward", AmountMicroUSD: 50_000, CreatedAt: now.Add(-2 * time.Hour)},
+		// machine B.
+		{AccountID: "acct", ProviderID: "conn-4", ProviderKey: "key-b", JobID: "j4",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 400_000, PromptTokens: 40, CompletionTokens: 20,
+			CreatedAt: now.Add(-30 * time.Minute)},
+		// Another account must not leak in.
+		{AccountID: "other", ProviderID: "conn-5", ProviderKey: "key-a", JobID: "j5",
+			Model: "qwen3.5-35b-a3b", AmountMicroUSD: 999_000, CreatedAt: now},
+	}
+	for _, e := range entries {
+		if err := s.CreditProviderAccount(&e); err != nil {
+			t.Fatalf("credit: %v", err)
+		}
+	}
+
+	got, err := s.GetAccountEarningsByProvider("acct")
+	if err != nil {
+		t.Fatalf("GetAccountEarningsByProvider: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("groups = %d, want 2", len(got))
+	}
+
+	// Sorted by total descending: key-b (400k) before key-a (250k).
+	if got[0].ProviderKey != "key-b" || got[0].TotalMicroUSD != 400_000 {
+		t.Fatalf("first = %q/%d, want key-b/400000", got[0].ProviderKey, got[0].TotalMicroUSD)
+	}
+	a := got[1]
+	if a.ProviderKey != "key-a" {
+		t.Fatalf("second = %q, want key-a", a.ProviderKey)
+	}
+	if a.TotalMicroUSD != 250_000 {
+		t.Fatalf("key-a total = %d, want 250000 (includes base reward)", a.TotalMicroUSD)
+	}
+	if a.JobCount != 2 {
+		t.Fatalf("key-a job_count = %d, want 2 (base_reward excluded)", a.JobCount)
+	}
+	if a.PromptTokens != 20 || a.CompletionTokens != 10 {
+		t.Fatalf("key-a tokens = %d/%d, want 20/10", a.PromptTokens, a.CompletionTokens)
+	}
+	if !a.LastEarnedAt.Equal(now.Add(-1 * time.Hour)) {
+		t.Fatalf("key-a last_earned_at = %v, want %v", a.LastEarnedAt, now.Add(-1*time.Hour))
+	}
+
+	// Empty account → empty slice, not nil error.
+	empty, err := s.GetAccountEarningsByProvider("nobody")
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty account: got %v, %v", empty, err)
+	}
+}

--- a/coordinator/store/interface.go
+++ b/coordinator/store/interface.go
@@ -848,6 +848,22 @@ type ProviderEarningsSummary struct {
 	CompletionTokens int64 `json:"completion_tokens"`
 }
 
+// ProviderMachineEarnings is one machine's lifetime earnings within an
+// account, aggregated by provider_key (the stable X25519 hardware identity —
+// provider_id rotates per connection and must not be used for grouping).
+// Rows recorded before provider_key existed aggregate under an empty key.
+type ProviderMachineEarnings struct {
+	ProviderKey string `json:"provider_key"`
+	// TotalMicroUSD includes base_reward rows; JobCount and token totals
+	// exclude them (base rewards add money but are not inference jobs),
+	// matching ProviderEarningsSummary semantics.
+	TotalMicroUSD    int64     `json:"total_micro_usd"`
+	JobCount         int64     `json:"job_count"`
+	PromptTokens     int64     `json:"prompt_tokens"`
+	CompletionTokens int64     `json:"completion_tokens"`
+	LastEarnedAt     time.Time `json:"last_earned_at"`
+}
+
 // AccountEarningsWindows holds an account's rolling-window earnings (row count
 // and micro-USD sum over the last 24 h and the last 7 d) as computed by the
 // store, so the dashboard header never sums a truncated row page.

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -578,6 +578,10 @@ type ProviderEarningsStore interface {
 	// GetAccountEarningsSummary returns lifetime aggregates for an account across all linked nodes.
 	GetAccountEarningsSummary(accountID string) (ProviderEarningsSummary, error)
 
+	// GetAccountEarningsByProvider returns an account's lifetime earnings
+	// grouped by provider_key (stable machine identity), highest total first.
+	GetAccountEarningsByProvider(accountID string) ([]ProviderMachineEarnings, error)
+
 	// AccountEarningsWindows returns the account's last-24h and last-7d row
 	// count and micro-USD sum as of now, aggregated by the store over the
 	// 7 d window only. Every provider_earnings row counts (base_reward rows

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2844,6 +2844,47 @@ func (s *MemoryStore) GetAccountEarningsSummary(accountID string) (ProviderEarni
 	return summary, nil
 }
 
+// GetAccountEarningsByProvider returns an account's lifetime earnings grouped
+// by provider_key (stable machine identity), highest total first.
+func (s *MemoryStore) GetAccountEarningsByProvider(accountID string) ([]ProviderMachineEarnings, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	byKey := make(map[string]*ProviderMachineEarnings)
+	for _, earning := range s.providerEarnings {
+		if earning.AccountID != accountID {
+			continue
+		}
+		m, ok := byKey[earning.ProviderKey]
+		if !ok {
+			m = &ProviderMachineEarnings{ProviderKey: earning.ProviderKey}
+			byKey[earning.ProviderKey] = m
+		}
+		m.TotalMicroUSD += earning.AmountMicroUSD
+		// base_reward rows add money but are not inference jobs.
+		if earning.Model != "base_reward" {
+			m.JobCount++
+			m.PromptTokens += int64(earning.PromptTokens)
+			m.CompletionTokens += int64(earning.CompletionTokens)
+		}
+		if earning.CreatedAt.After(m.LastEarnedAt) {
+			m.LastEarnedAt = earning.CreatedAt
+		}
+	}
+
+	results := make([]ProviderMachineEarnings, 0, len(byKey))
+	for _, m := range byKey {
+		results = append(results, *m)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].TotalMicroUSD != results[j].TotalMicroUSD {
+			return results[i].TotalMicroUSD > results[j].TotalMicroUSD
+		}
+		return results[i].ProviderKey < results[j].ProviderKey
+	})
+	return results, nil
+}
+
 // RecordProviderPayout stores a payout record for a provider wallet.
 func (s *MemoryStore) RecordProviderPayout(payout *ProviderPayout) error {
 	s.mu.Lock()

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -4084,6 +4084,44 @@ func (s *PostgresStore) GetAccountEarningsSummary(accountID string) (ProviderEar
 	return summary, nil
 }
 
+// GetAccountEarningsByProvider returns an account's lifetime earnings grouped
+// by provider_key (stable machine identity), highest total first. Totals
+// include base_reward rows; job/token counts exclude them, matching the
+// earnings_summary semantics.
+func (s *PostgresStore) GetAccountEarningsByProvider(accountID string) ([]ProviderMachineEarnings, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := s.pool.Query(ctx,
+		`SELECT provider_key,
+		        COALESCE(SUM(amount_micro_usd), 0),
+		        COUNT(*) FILTER (WHERE model <> 'base_reward'),
+		        COALESCE(SUM(prompt_tokens) FILTER (WHERE model <> 'base_reward'), 0),
+		        COALESCE(SUM(completion_tokens) FILTER (WHERE model <> 'base_reward'), 0),
+		        MAX(created_at)
+		 FROM provider_earnings
+		 WHERE account_id = $1
+		 GROUP BY provider_key
+		 ORDER BY 2 DESC, provider_key ASC`,
+		accountID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("store: query account earnings by provider: %w", err)
+	}
+	defer rows.Close()
+
+	results := []ProviderMachineEarnings{}
+	for rows.Next() {
+		var m ProviderMachineEarnings
+		if err := rows.Scan(&m.ProviderKey, &m.TotalMicroUSD, &m.JobCount,
+			&m.PromptTokens, &m.CompletionTokens, &m.LastEarnedAt); err != nil {
+			continue
+		}
+		results = append(results, m)
+	}
+	return results, nil
+}
+
 // RecordProviderPayout stores a payout record for a provider wallet.
 func (s *PostgresStore) RecordProviderPayout(payout *ProviderPayout) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## What

Adds a lifetime **Earnings by Machine** breakdown to the provider earnings page (`/providers/earnings`). Providers running multiple Macs had no way to see which machine earned what: the earnings page aggregates "across all linked provider nodes," and the fleet dashboard's machine cards deliberately show no dollars. Asked for by a provider (Mark M) in #support, 2026-09-11.

## Behavior — before / after

```mermaid
flowchart LR
  subgraph Before
    A1[Provider asks: which Mac earned what?] --> B1[Earnings page: account totals only]
    A1 --> C1[Fleet dashboard: tokens/reputation, no dollars]
    B1 --> D1[No answer in-product — community menu-bar app or nothing]
  end
  subgraph After
    A2[Provider opens /providers/earnings] --> B2[Earnings by Machine table:<br/>lifetime earned + jobs per machine,<br/>sorted highest first]
  end
```

## Code — before / after

```mermaid
flowchart LR
  subgraph Before
    E1[EarningsContent] --> P1["/api/me/earnings proxy"] --> H1[handleAccountEarnings] --> S1[GetAccountEarnings + Summary]
  end
  subgraph After
    E2[EarningsContent] --> X2[ByMachineList — new]
    E2 --> P2["/api/me/earnings proxy (unchanged)"] --> H2[handleAccountEarnings<br/>+ by_provider array] --> S2[GetAccountEarningsByProvider — new<br/>postgres GROUP BY + memory impl]
    H2 --> R2[ListProvidersByAccount<br/>hardware labels via persisted PublicKey]
  end
```

## Design notes (what we learned building this)

- **Group by `provider_key`, never `provider_id`.** The earnings rows carry both; `provider_id` is the per-connection UUID that rotates on restart and would scatter one machine across dozens of buckets. `provider_key` is the persisted X25519 hardware identity — the store documents it as the sessions↔earnings unifier.
- **Aggregation must be server-side.** The account-earnings endpoint returns lifetime totals but caps history rows (default 100, max 1000). Grouping rows client-side would silently undercount per-machine totals on any active fleet. The new store method is a single `GROUP BY` over `provider_earnings`, reusing the endpoint's existing 20s per-account cache.
- **`base_reward` rows count in money, not in jobs/tokens** — matching the existing `earnings_summary` semantics.
- **Machine labels resolve server-side** from the account's provider records (`PublicKey` is persisted, so offline machines still get chip/memory names).
- **Every row shows an always-visible machine ID** ("ID …aaaaaa") — the tail of the machine's stable hardware key. Without it, two identical Macs ("Apple M4 Max · 64 GB" twice) would be indistinguishable; showing it always, rather than only on clashes, keeps the meaning obvious. The nicer long-term fix is user-nameable machines — follow-up below.
- **The "Other" bucket**: rows whose `provider_key` is empty (the column has existed since table creation with `DEFAULT ''`, so this covers any period before the crediting path populated it). Those rows cannot be attributed retroactively — nothing durable maps them to hardware — but the dollars must still appear somewhere. The bucket renders only if such rows exist. **Open question for someone with replica access:** `SELECT COUNT(*), MIN(created_at), MAX(created_at) FROM provider_earnings WHERE provider_key = '';` — if 0, per-machine history is complete back to day one and "Other" never renders.
- **No "Last active" column, deliberately.** The obvious source (`MAX(created_at)` of earnings rows) means "last *earned*", which reads wrongly stale for an online-but-idle machine. Cut rather than mislead; the fleet dashboard is the place for liveness.

## Follow-ups (not in this PR)

- **Per-window breakdowns (24h / 7d)** — this PR ships lifetime only; windows multiply the query and UI and deserve their own pass.
- **User-nameable machines** — would let the ID line become a friendly name.
- **Echo an "earned" stat onto fleet dashboard machine cards** — currently deliberately dollar-free; product call.
- **Product/IA note (from support):** Fleet ("Your fleet") and Earnings ("Your earnings") pages now both carry per-machine information with different slices (operational vs financial). The split is starting to feel inefficient — worth rethinking whether these merge into one per-machine view. Flagging for discussion rather than acting unilaterally.

## Tests

- `coordinator/store/account_earnings_by_provider_test.go` — grouping across rotating connection IDs, base-reward money-not-jobs, account isolation, sort order, empty account.
- `coordinator/api/billing_earnings_test.go` — new `TestAccountEarningsGroupsByMachine`: full handler path, hardware enrichment, no-record machine, legacy empty-key bucket.
- `console-ui/__tests__/by-machine-list.test.tsx` — labels, identical-hardware disambiguation, Other bucket, empty state (7 tests).

`go build` + `go vet` + `gofmt` clean; `npm run build` + eslint clean (0 errors). Full `./store/` suite passes. Local `./api/` run has 6 pre-existing failures that reproduce identically on master — environmental only (sparse checkout missing `scripts/`+`provider-swift/` for two file-reading tests; local Go 1.27 vs pinned 1.25 for four `encoding/json` byte-exactness tests). CI on pinned Go is authoritative.

## Screenshots

> Simulated preview: the real page components rendered by the local dev server with fixture data (the live page needs an authenticated session and a coordinator that already serves `by_provider`). Fixtures deliberately include two identical machines (distinguishable by their IDs) and the "Other" bucket.

### Before
![before](https://raw.githubusercontent.com/EigenMustafa/d-inference/assets/payout-notice-887/earnings-by-machine/before-v2.png)

### After
![after](https://raw.githubusercontent.com/EigenMustafa/d-inference/assets/payout-notice-887/earnings-by-machine/after-v3.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
