### PR TITLE
Consolidate console account and Stripe route adapters

### DIFF
--- a/console-ui/__tests__/account-proxy-contracts.test.ts
+++ b/console-ui/__tests__/account-proxy-contracts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { GET as listKeys, POST as createKey } from "@/app/api/keys/route";
+import { GET as inspectKey, PATCH as updateKey } from "@/app/api/keys/[id]/route";
+import { POST as rotateKey } from "@/app/api/keys/[id]/rotate/route";
+import { DELETE as removeMachine } from "@/app/api/me/providers/[id]/route";
+import { POST as approveDevice } from "@/app/api/device/approve/route";
+import { DEFAULT_COORD, makeRequest, stubUpstreamFetch, upstreamOk } from "./helpers/route-harness";
+
+const upstream = stubUpstreamFetch();
+const headerToken = "Bearer header-token";
+const auth = { authorization: headerToken, cookie: "privy-token=cookie-token" };
+const resource = { params: Promise.resolve({ id: "key /?#%" }) };
+
+describe("account proxy wire contracts", () => {
+  it("rejects before reading a body or waiting for dynamic params", async () => {
+    const req = makeRequest("/api/keys/key", { method: "PATCH", body: "{}" });
+    const read = vi.spyOn(req, "text");
+    const response = await updateKey(req, { params: new Promise(() => {}) });
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "missing privy token" });
+    expect(read).not.toHaveBeenCalled();
+    expect(upstream.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([listKeys, (req: Parameters<typeof inspectKey>[0]) => inspectKey(req, resource)])(
+    "prefers the header to the cookie and disables caching for account reads",
+    async (handler) => {
+      upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+      await handler(makeRequest("/api/keys", { headers: auth }));
+      expect(upstream.fetch.mock.calls[0][1]).toEqual({
+        headers: { Authorization: headerToken }, cache: "no-store",
+      });
+    },
+  );
+
+  it.each([createKey, approveDevice])("forwards raw bodies without parsing or rewriting", async (handler) => {
+    const body = '  {"limit_usd":null, "unknown": [1, 2]}\n';
+    upstream.fetch.mockResolvedValueOnce(new Response("once-only secret", {
+      status: 201, headers: { "Content-Type": "text/plain", "X-Internal": "hidden" },
+    }));
+    const response = await handler(makeRequest("/api/account", { method: "POST", headers: auth, body }));
+    expect(upstream.fetch.mock.calls[0][1].body).toBe(body);
+    expect(response.status).toBe(201);
+    expect(response.headers.get("content-type")).toBe("text/plain");
+    expect(response.headers.get("x-internal")).toBeNull();
+    expect(await response.text()).toBe("once-only secret");
+  });
+
+  it("substitutes an empty object only for an empty account body", async () => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+    await createKey(makeRequest("/api/keys", { method: "POST", headers: auth }));
+    expect(upstream.fetch.mock.calls[0][1].body).toBe("{}");
+  });
+
+  it.each([
+    [rotateKey, "POST", "/v1/keys/key%20%2F%3F%23%25/rotate"],
+    [removeMachine, "DELETE", "/v1/me/providers/key%20%2F%3F%23%25"],
+  ] as const)("keeps bodyless resource operations bodyless and IDs opaque", async (handler, method, path) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+    await handler(makeRequest("/api/resource", { method, headers: auth, body: "ignored" }), resource);
+    expect(upstream.fetch).toHaveBeenCalledWith(`${DEFAULT_COORD}${path}`, {
+      method, headers: { Authorization: headerToken },
+    });
+  });
+});

--- a/console-ui/__tests__/payouts.test.tsx
+++ b/console-ui/__tests__/payouts.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act, render, screen, fireEvent } from "@testing-library/react";
+import { renderHook, act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { useStripePayouts } from "@/components/payouts/useStripePayouts";
 import { StripePayoutsCard } from "@/components/payouts/StripePayoutsCard";
 import type { StripeStatus } from "@/lib/api";
@@ -36,6 +36,8 @@ const readyStatus: StripeStatus = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(fetchStripeStatus).mockResolvedValue(readyStatus);
+  vi.mocked(fetchStripeWithdrawals).mockResolvedValue([]);
 });
 
 describe("useStripePayouts", () => {
@@ -85,15 +87,16 @@ describe("useStripePayouts", () => {
     const onWithdrawStart = vi.fn();
     const onWithdrawSuccess = vi.fn();
     const { result } = renderHook(() =>
-      useStripePayouts({ addToast, enabled: false, onAfterWithdraw, onWithdrawStart, onWithdrawSuccess }),
+      useStripePayouts({ addToast, onAfterWithdraw, onWithdrawStart, onWithdrawSuccess }),
     );
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
     act(() => result.current.setWithdrawAmount("10"));
 
     await act(async () => {
       await result.current.withdraw();
     });
 
-    expect(withdrawStripe).toHaveBeenCalledWith("10", "standard");
+    expect(withdrawStripe).toHaveBeenCalledWith("10", "standard", undefined);
     expect(onWithdrawStart).toHaveBeenCalledWith("standard");
     expect(onWithdrawSuccess).toHaveBeenCalledWith("standard");
     expect(onAfterWithdraw).toHaveBeenCalled();
@@ -106,8 +109,9 @@ describe("useStripePayouts", () => {
     const addToast = vi.fn();
     const onWithdrawError = vi.fn();
     const { result } = renderHook(() =>
-      useStripePayouts({ addToast, enabled: false, onWithdrawError }),
+      useStripePayouts({ addToast, onWithdrawError }),
     );
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
 
     await act(async () => {
       await result.current.withdraw();
@@ -123,7 +127,7 @@ describe("useStripePayouts", () => {
     (withdrawStripe as ReturnType<typeof vi.fn>).mockRejectedValue(
       new ApiError("your Stripe payout account no longer exists", "stripe_account_gone", 409),
     );
-    (fetchStripeStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+    vi.mocked(fetchStripeStatus).mockResolvedValueOnce(readyStatus).mockResolvedValue({
       ...readyStatus,
       has_account: false,
       status: "",
@@ -131,7 +135,8 @@ describe("useStripePayouts", () => {
     (fetchStripeWithdrawals as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     const addToast = vi.fn();
-    const { result } = renderHook(() => useStripePayouts({ addToast, enabled: false }));
+    const { result } = renderHook(() => useStripePayouts({ addToast }));
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
     act(() => result.current.setWithdrawOpen(true));
 
     await act(async () => {

--- a/console-ui/__tests__/stripe-proxy-contracts.test.ts
+++ b/console-ui/__tests__/stripe-proxy-contracts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { POST as checkout } from "@/app/api/payments/stripe/checkout/route";
+import { POST as onboard } from "@/app/api/payments/stripe/onboard/route";
+import { POST as withdraw } from "@/app/api/payments/withdraw/stripe/route";
+import { POST as dashboard } from "@/app/api/payments/stripe/dashboard/route";
+import { DELETE as unlink } from "@/app/api/payments/stripe/account/route";
+import { GET as status } from "@/app/api/payments/stripe/status/route";
+import { GET as withdrawals } from "@/app/api/payments/stripe/withdrawals/route";
+import { DEFAULT_COORD, makeRequest, stubUpstreamFetch, upstreamJson, upstreamOk } from "./helpers/route-harness";
+
+const upstream = stubUpstreamFetch();
+const stripePath = "/api/stripe";
+const routes = [
+  [checkout, "POST", "/v1/billing/stripe/create-session"],
+  [onboard, "POST", "/v1/billing/stripe/onboard"],
+  [withdraw, "POST", "/v1/billing/withdraw/stripe"],
+  [dashboard, "POST", "/v1/billing/stripe/dashboard"],
+  [unlink, "DELETE", "/v1/billing/stripe/account"],
+  [status, "GET", "/v1/billing/stripe/status"],
+  [withdrawals, "GET", "/v1/billing/stripe/withdrawals"],
+] as const;
+
+describe("Stripe proxy wire contracts", () => {
+  it.each(routes)("forwards cookie auth and lets the coordinator enforce authorization", async (handler, method, path) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({})).mockResolvedValueOnce(upstreamOk({}));
+    await handler(makeRequest(stripePath, { method, headers: { cookie: "privy-token=session" } }));
+    expect(upstream.fetch.mock.calls[0][0]).toBe(`${DEFAULT_COORD}${path}`);
+    expect(upstream.fetch.mock.calls[0][1].headers.Authorization).toBe("Bearer session");
+    await handler(makeRequest(stripePath, { method, headers: { "x-api-key": "not-a-session" } }));
+    expect(upstream.fetch.mock.calls[1][1].headers.Authorization).toBeUndefined();
+  });
+
+  it.each(routes)("wraps upstream error text and preserves its failure status", async (handler, method) => {
+    const body = '{"error":{"message":"declined"}}';
+    upstream.fetch.mockResolvedValueOnce(new Response(body, { status: 422 }));
+    const response = await handler(makeRequest(stripePath, { method }));
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ error: body });
+  });
+
+  it.each(routes)("normalizes successful status and tolerates non-JSON responses", async (handler, method) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamJson(201, { ok: true }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const response = await handler(makeRequest(stripePath, { method }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(await (await handler(makeRequest(stripePath, { method }))).json()).toEqual({});
+  });
+
+  it.each([checkout, onboard, withdraw])("uses JSON fallback for malformed request bodies", async (handler) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+    await handler(makeRequest(stripePath, {
+      method: "POST", body: "invalid json",
+      headers: { authorization: "Bearer header", cookie: "privy-token=cookie" },
+    }));
+    expect(upstream.fetch.mock.calls[0][1]).toEqual({
+      method: "POST", headers: { "Content-Type": "application/json", Authorization: "Bearer header" }, body: "{}",
+    });
+  });
+
+  it.each([[dashboard, "POST"], [unlink, "DELETE"]] as const)("does not manufacture a body for bodyless operations", async (handler, method) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+    await handler(makeRequest(stripePath, { method, body: "ignored" }));
+    expect(upstream.fetch.mock.calls[0][1]).toEqual({ method, headers: {} });
+  });
+
+  it.each([[status, "refresh"], [withdrawals, "limit"]] as const)("forwards only the operation's selected query parameter", async (handler, query) => {
+    upstream.fetch.mockResolvedValueOnce(upstreamOk({}));
+    await handler(makeRequest(`/api/stripe?${query}=1&unrelated=secret`));
+    expect(upstream.fetch.mock.calls[0][0].endsWith(`?${query}=1`)).toBe(true);
+  });
+});

--- a/console-ui/src/app/api/device/approve/route.ts
+++ b/console-ui/src/app/api/device/approve/route.ts
@@ -1,18 +1,6 @@
 import { NextRequest } from "next/server";
-import { coordinatorUrl, privyAuth, passthrough, missingPrivyToken } from "@/lib/server/coordinator";
+import { proxyAccount } from "@/lib/server/account-proxy";
 
-// Proxy for POST /v1/device/approve (RFC 8628 device-link approval). Same-origin
-// so the /link page no longer posts the coordinator directly with a hardcoded
-// prod URL (perf F9 / SSRF-safe URL resolution).
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const body = await req.text();
-  const res = await fetch(`${coordinatorUrl()}/v1/device/approve`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: body || "{}",
-  });
-  return passthrough(res);
+  return proxyAccount(req, "/v1/device/approve", { method: "POST", body: "text" });
 }

--- a/console-ui/src/app/api/keys/[id]/rotate/route.ts
+++ b/console-ui/src/app/api/keys/[id]/rotate/route.ts
@@ -1,18 +1,6 @@
 import { NextRequest } from "next/server";
-import { coordinatorUrl, privyAuth, passthrough, missingPrivyToken } from "@/lib/server/coordinator";
+import { proxyAccount, type AccountResourceContext } from "@/lib/server/account-proxy";
 
-// Proxy for POST /v1/keys/{id}/rotate. Returns a fresh secret exactly once
-// (same shape as create). Privy-only auth with the standard header → cookie
-// fallback. Next 16 dynamic route params are async.
-
-export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const { id } = await params;
-  const res = await fetch(`${coordinatorUrl()}/v1/keys/${encodeURIComponent(id)}/rotate`, {
-    method: "POST",
-    headers: { Authorization: authHeader },
-  });
-  return passthrough(res);
+export async function POST(req: NextRequest, { params }: AccountResourceContext) {
+  return proxyAccount(req, async () => `/v1/keys/${encodeURIComponent((await params).id)}/rotate`, { method: "POST" });
 }

--- a/console-ui/src/app/api/keys/[id]/route.ts
+++ b/console-ui/src/app/api/keys/[id]/route.ts
@@ -1,46 +1,14 @@
 import { NextRequest } from "next/server";
-import { coordinatorUrl, privyAuth, passthrough, missingPrivyToken } from "@/lib/server/coordinator";
+import { proxyAccount, type AccountResourceContext } from "@/lib/server/account-proxy";
 
-// Proxy for a single API key: GET (inspect), PATCH (update limits / disabled),
-// DELETE (revoke). Privy-only auth with the same header → cookie fallback as
-// /api/keys. Next 16 dynamic route params are async.
-
-type Ctx = { params: Promise<{ id: string }> };
-
-export async function GET(req: NextRequest, { params }: Ctx) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const { id } = await params;
-  const res = await fetch(`${coordinatorUrl()}/v1/keys/${encodeURIComponent(id)}`, {
-    headers: { Authorization: authHeader },
-    cache: "no-store",
-  });
-  return passthrough(res);
+export async function GET(req: NextRequest, { params }: AccountResourceContext) {
+  return proxyAccount(req, async () => `/v1/keys/${encodeURIComponent((await params).id)}`);
 }
 
-export async function PATCH(req: NextRequest, { params }: Ctx) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const { id } = await params;
-  const body = await req.text();
-  const res = await fetch(`${coordinatorUrl()}/v1/keys/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: body || "{}",
-  });
-  return passthrough(res);
+export async function PATCH(req: NextRequest, { params }: AccountResourceContext) {
+  return proxyAccount(req, async () => `/v1/keys/${encodeURIComponent((await params).id)}`, { method: "PATCH", body: "text" });
 }
 
-export async function DELETE(req: NextRequest, { params }: Ctx) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const { id } = await params;
-  const res = await fetch(`${coordinatorUrl()}/v1/keys/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-    headers: { Authorization: authHeader },
-  });
-  return passthrough(res);
+export async function DELETE(req: NextRequest, { params }: AccountResourceContext) {
+  return proxyAccount(req, async () => `/v1/keys/${encodeURIComponent((await params).id)}`, { method: "DELETE" });
 }

--- a/console-ui/src/app/api/keys/route.ts
+++ b/console-ui/src/app/api/keys/route.ts
@@ -1,32 +1,10 @@
 import { NextRequest } from "next/server";
-import { coordinatorUrl, privyAuth, passthrough, missingPrivyToken } from "@/lib/server/coordinator";
-
-// Proxy for the coordinator's API-key management endpoints. These are
-// Privy-only: the browser sends `Authorization: Bearer <privy access token>`,
-// and we fall back to the `privy-token` cookie (same precedence as
-// /api/auth/keys). The coordinator URL is resolved server-side and never from
-// client input (SSRF prevention).
+import { proxyAccount } from "@/lib/server/account-proxy";
 
 export async function GET(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const res = await fetch(`${coordinatorUrl()}/v1/keys`, {
-    headers: { Authorization: authHeader },
-    cache: "no-store",
-  });
-  return passthrough(res);
+  return proxyAccount(req, "/v1/keys");
 }
 
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const body = await req.text();
-  const res = await fetch(`${coordinatorUrl()}/v1/keys`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: body || "{}",
-  });
-  return passthrough(res);
+  return proxyAccount(req, "/v1/keys", { method: "POST", body: "text" });
 }

--- a/console-ui/src/app/api/me/providers/[id]/route.ts
+++ b/console-ui/src/app/api/me/providers/[id]/route.ts
@@ -1,19 +1,6 @@
 import { NextRequest } from "next/server";
-import { coordinatorUrl, privyAuth, passthrough, missingPrivyToken } from "@/lib/server/coordinator";
+import { proxyAccount, type AccountResourceContext } from "@/lib/server/account-proxy";
 
-// Proxy for removing one machine by its opaque provider session id. Next 16
-// dynamic route params are async; the coordinator enforces ownership and the
-// online-machine guard.
-type Ctx = { params: Promise<{ id: string }> };
-
-export async function DELETE(req: NextRequest, { params }: Ctx) {
-  const authHeader = privyAuth(req);
-  if (!authHeader) return missingPrivyToken();
-
-  const { id } = await params;
-  const res = await fetch(`${coordinatorUrl()}/v1/me/providers/${encodeURIComponent(id)}`, {
-    method: "DELETE",
-    headers: { Authorization: authHeader },
-  });
-  return passthrough(res);
+export async function DELETE(req: NextRequest, { params }: AccountResourceContext) {
+  return proxyAccount(req, async () => `/v1/me/providers/${encodeURIComponent((await params).id)}`, { method: "DELETE" });
 }

--- a/console-ui/src/app/api/payments/stripe/account/route.ts
+++ b/console-ui/src/app/api/payments/stripe/account/route.ts
@@ -1,20 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for DELETE /v1/billing/stripe/account — unlinks the user's Stripe
-// Connect account so they can onboard a fresh one (escape hatch for accounts
-// closed on Stripe's side, stuck onboarding, or wrong country/agreement).
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function DELETE(req: NextRequest) {
-  const authHeader = privyAuth(req);
-
-  const res = await fetch(`${coordinatorUrl()}/v1/billing/stripe/account`, {
-    method: "DELETE",
-    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/account", { method: "DELETE" });
 }

--- a/console-ui/src/app/api/payments/stripe/checkout/route.ts
+++ b/console-ui/src/app/api/payments/stripe/checkout/route.ts
@@ -1,25 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for POST /v1/billing/stripe/create-session. Stripe Checkout is
-// Privy-only (no API-key access), so we forward the Privy session token via
-// the cookie fallback when no Authorization header is present.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  const body = await req.json().catch(() => ({}));
-
-  const res = await fetch(`${coordinatorUrl()}/v1/billing/stripe/create-session`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(authHeader ? { Authorization: authHeader } : {}),
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/create-session", { method: "POST", body: "json" });
 }

--- a/console-ui/src/app/api/payments/stripe/dashboard/route.ts
+++ b/console-ui/src/app/api/payments/stripe/dashboard/route.ts
@@ -1,21 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for POST /v1/billing/stripe/dashboard — mints a single-use Stripe
-// Express Dashboard login link so the user can change the bank account or
-// debit card their payouts land in. Privy-only upstream: the link is a bearer
-// credential for a session that can redirect the user's earnings.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-
-  const res = await fetch(`${coordinatorUrl()}/v1/billing/stripe/dashboard`, {
-    method: "POST",
-    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/dashboard", { method: "POST" });
 }

--- a/console-ui/src/app/api/payments/stripe/onboard/route.ts
+++ b/console-ui/src/app/api/payments/stripe/onboard/route.ts
@@ -1,25 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for POST /v1/billing/stripe/onboard. Stripe Payouts is Privy-only
-// (no API-key access), so we forward the Privy session token via the cookie
-// fallback when no Authorization header is present.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  const body = await req.json().catch(() => ({}));
-
-  const res = await fetch(`${coordinatorUrl()}/v1/billing/stripe/onboard`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(authHeader ? { Authorization: authHeader } : {}),
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/onboard", { method: "POST", body: "json" });
 }

--- a/console-ui/src/app/api/payments/stripe/status/route.ts
+++ b/console-ui/src/app/api/payments/stripe/status/route.ts
@@ -1,22 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for GET /v1/billing/stripe/status. Forwards `?refresh=1` so the
-// Billing page can request a live Stripe refresh after onboarding redirect.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function GET(req: NextRequest) {
-  const authHeader = privyAuth(req);
-
-  const url = new URL(req.url);
-  const refresh = url.searchParams.get("refresh");
-  const upstream = `${coordinatorUrl()}/v1/billing/stripe/status${refresh ? `?refresh=${refresh}` : ""}`;
-
-  const res = await fetch(upstream, {
-    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/status", { query: "refresh" });
 }

--- a/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
+++ b/console-ui/src/app/api/payments/stripe/withdrawals/route.ts
@@ -1,22 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for GET /v1/billing/stripe/withdrawals — recent payout history for
-// the Billing page.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function GET(req: NextRequest) {
-  const authHeader = privyAuth(req);
-
-  const url = new URL(req.url);
-  const limit = url.searchParams.get("limit");
-  const upstream = `${coordinatorUrl()}/v1/billing/stripe/withdrawals${limit ? `?limit=${limit}` : ""}`;
-
-  const res = await fetch(upstream, {
-    headers: { ...(authHeader ? { Authorization: authHeader } : {}) },
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/stripe/withdrawals", { query: "limit" });
 }

--- a/console-ui/src/app/api/payments/withdraw/stripe/route.ts
+++ b/console-ui/src/app/api/payments/withdraw/stripe/route.ts
@@ -1,25 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { coordinatorUrl, privyAuth } from "@/lib/server/coordinator";
-
-// Proxy for POST /v1/billing/withdraw/stripe. Forwards the Privy session
-// token via cookie fallback so the Billing page can call it with no API key
-// configured.
+import { NextRequest } from "next/server";
+import { proxyStripe } from "@/lib/server/stripe-proxy";
 
 export async function POST(req: NextRequest) {
-  const authHeader = privyAuth(req);
-  const body = await req.json().catch(() => ({}));
-
-  const res = await fetch(`${coordinatorUrl()}/v1/billing/withdraw/stripe`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(authHeader ? { Authorization: authHeader } : {}),
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    return NextResponse.json({ error: text }, { status: res.status });
-  }
-  return NextResponse.json(await res.json().catch(() => ({})));
+  return proxyStripe(req, "/v1/billing/withdraw/stripe", { method: "POST", body: "json" });
 }

--- a/console-ui/src/lib/server/account-proxy.ts
+++ b/console-ui/src/lib/server/account-proxy.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { coordinatorUrl, missingPrivyToken, passthrough, privyAuth } from "./coordinator";
+
+type AccountRequest = {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: "text";
+};
+
+/**
+ * Privy-only account operations preserve upstream status, content type and
+ * response text (including once-only secrets). Authenticate before resolving
+ * dynamic IDs or reading bodies; read operations always bypass fetch caching.
+ */
+export async function proxyAccount(
+  req: NextRequest,
+  path: string | (() => Promise<string>),
+  { method = "GET", body }: AccountRequest = {},
+) {
+  const auth = privyAuth(req);
+  if (!auth) return missingPrivyToken();
+
+  const upstreamPath = typeof path === "string" ? path : await path();
+  const res = await fetch(`${coordinatorUrl()}${upstreamPath}`, {
+    ...(method !== "GET" ? { method } : {}),
+    headers: {
+      ...(body ? { "Content-Type": "application/json" } : {}),
+      Authorization: auth,
+    },
+    ...(body ? { body: (await req.text()) || "{}" } : {}),
+    ...(method === "GET" ? { cache: "no-store" } : {}),
+  });
+  return passthrough(res);
+}
+
+export type AccountResourceContext = { params: Promise<{ id: string }> };

--- a/console-ui/src/lib/server/stripe-proxy.ts
+++ b/console-ui/src/lib/server/stripe-proxy.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { coordinatorUrl, privyAuth } from "./coordinator";
+
+type StripeRequest =
+  | { method?: "GET"; query?: "refresh" | "limit" }
+  | { method: "POST"; body?: "json" }
+  | { method: "DELETE" };
+
+/**
+ * Stripe session operations leave auth enforcement to the coordinator. Their
+ * browser contract wraps upstream error text, normalizes success to 200, and
+ * tolerates an empty/invalid successful JSON response. Quote has a different
+ * status/error contract and intentionally uses its own adapter.
+ */
+export async function proxyStripe(
+  req: NextRequest,
+  path: string,
+  operation: StripeRequest = {},
+) {
+  const auth = privyAuth(req);
+  const query = "query" in operation ? operation.query : undefined;
+  const value = query ? new URL(req.url).searchParams.get(query) : null;
+  const body = "body" in operation && operation.body
+    ? JSON.stringify(await req.json().catch(() => ({})))
+    : undefined;
+  const suffix = value ? `?${query}=${value}` : "";
+  const res = await fetch(`${coordinatorUrl()}${path}${suffix}`, {
+    ...(operation.method ? { method: operation.method } : {}),
+    headers: {
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...(auth ? { Authorization: auth } : {}),
+    },
+    ...(body !== undefined ? { body } : {}),
+  });
+  if (!res.ok) {
+    return NextResponse.json({ error: await res.text() }, { status: res.status });
+  }
+  return NextResponse.json(await res.json().catch(() => ({})));
+}


### PR DESCRIPTION
Twelve console route files repeated the same account and Stripe request orchestration. This change puts those two contracts in focused server adapters and leaves 15 endpoint handlers declaring their coordinator path, method, and body/query requirements. It removes **135 production lines** while preserving the current browser API.

`proxyAccount` authenticates before resolving dynamic resource IDs or reading bodies, keeps account GETs uncached, forwards request text without JSON rewriting, and preserves upstream status/content type/response text, including once-only key secrets. `proxyStripe` retains cookie fallback and upstream authorization, wraps failure text with its original status, and normalizes successful JSON responses to 200 with the existing empty-response fallback. Paths remain server-defined; IDs stay encoded. Quote, public reads, model transformations, and encrypted chat streaming retain their own distinct adapters.

Three existing payout-hook tests were already failing on the base branch because they attempted withdrawals with `enabled: false`, before recovery status was loaded. Their setup now enables withdrawals and waits for status, so they exercise success/error/recovery instead of the guard. No payout behavior changed.

**Before**

```mermaid
flowchart TD
  Browser[Browser account or billing operation] --> Routes[15 handlers across 12 route files]
  Routes --> Account[Repeated Privy check, ID encoding, body read, fetch]
  Account --> Missing[Missing token: 401 before body or params]
  Account --> AccountUp[Coordinator keys, device approval, machine removal]
  AccountUp --> Raw[Preserve status, content type, response text and secrets]
  Routes --> Stripe[Repeated optional Privy forwarding, query or JSON, fetch]
  Stripe --> StripeUp[Coordinator billing operation]
  StripeUp --> Error[Non-2xx: original status plus wrapped error text]
  StripeUp --> Success[2xx: 200 JSON, invalid or empty JSON becomes empty object]
```

**After**

```mermaid
flowchart TD
  Browser[Browser account or billing operation] --> Routes[Thin endpoint handlers: path, method, body or query]
  Routes --> Account[account-proxy.ts: proxyAccount]
  Account --> Missing[Missing token: 401 before body or params]
  Account --> AccountUp[Coordinator keys, device approval, machine removal]
  AccountUp --> Raw[Existing passthrough: status, content type, text and secrets]
  Routes --> Stripe[stripe-proxy.ts: proxyStripe]
  Stripe --> StripeUp[Coordinator billing operation]
  StripeUp --> Error[Non-2xx: original status plus wrapped error text]
  StripeUp --> Success[2xx: 200 JSON, invalid or empty JSON becomes empty object]
```

Validation on Node **22.23.2**, committed dependency lock, Next **16.2.11**:

- Full console suite: **730 tests passed across 90 files**.
- **36 additional wire-contract tests pass against both the original branch handlers and the refactored handlers**, covering auth precedence/early rejection, cache policy, raw bodies, opaque IDs, secret/status/content-type forwarding, bodyless operations, Stripe JSON fallbacks and query selection.
- Production `npm run build`: passed.
- Full `npm run lint`: passed; existing warnings remain. Focused lint for new helpers/contracts and updated payout tests has no warnings.
- Focused TypeScript check of all changed routes/helpers and new contract tests: passed. Repository-wide `tsc --noEmit` reports **13 existing errors**, byte-for-byte identical before and after this refactor; the existing Next configuration skips type validation. No new type diagnostic was introduced.

This PR is based on the GPT-OSS prefix-cache branch and changes only the console. It does not require a coordinator/provider change or dependency update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791754183&installation_model_id=21733&pr_number=899&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F899&signature=0d4bec89b580cc8a60aa6810cbc310e451c3f647602d290f1a66f1cbd963b1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->