### PR TITLE
Restore complete console TypeScript validation

### DIFF
--- a/console-ui/__tests__/payouts.test.tsx
+++ b/console-ui/__tests__/payouts.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act, render, screen, fireEvent } from "@testing-library/react";
+import { renderHook, act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { useStripePayouts } from "@/components/payouts/useStripePayouts";
 import { StripePayoutsCard } from "@/components/payouts/StripePayoutsCard";
 import type { StripeStatus } from "@/lib/api";
@@ -36,6 +36,8 @@ const readyStatus: StripeStatus = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(fetchStripeStatus).mockResolvedValue(readyStatus);
+  vi.mocked(fetchStripeWithdrawals).mockResolvedValue([]);
 });
 
 describe("useStripePayouts", () => {
@@ -85,15 +87,16 @@ describe("useStripePayouts", () => {
     const onWithdrawStart = vi.fn();
     const onWithdrawSuccess = vi.fn();
     const { result } = renderHook(() =>
-      useStripePayouts({ addToast, enabled: false, onAfterWithdraw, onWithdrawStart, onWithdrawSuccess }),
+      useStripePayouts({ addToast, onAfterWithdraw, onWithdrawStart, onWithdrawSuccess }),
     );
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
     act(() => result.current.setWithdrawAmount("10"));
 
     await act(async () => {
       await result.current.withdraw();
     });
 
-    expect(withdrawStripe).toHaveBeenCalledWith("10", "standard");
+    expect(withdrawStripe).toHaveBeenCalledWith("10", "standard", undefined);
     expect(onWithdrawStart).toHaveBeenCalledWith("standard");
     expect(onWithdrawSuccess).toHaveBeenCalledWith("standard");
     expect(onAfterWithdraw).toHaveBeenCalled();
@@ -106,8 +109,9 @@ describe("useStripePayouts", () => {
     const addToast = vi.fn();
     const onWithdrawError = vi.fn();
     const { result } = renderHook(() =>
-      useStripePayouts({ addToast, enabled: false, onWithdrawError }),
+      useStripePayouts({ addToast, onWithdrawError }),
     );
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
 
     await act(async () => {
       await result.current.withdraw();
@@ -123,7 +127,7 @@ describe("useStripePayouts", () => {
     (withdrawStripe as ReturnType<typeof vi.fn>).mockRejectedValue(
       new ApiError("your Stripe payout account no longer exists", "stripe_account_gone", 409),
     );
-    (fetchStripeStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+    vi.mocked(fetchStripeStatus).mockResolvedValueOnce(readyStatus).mockResolvedValue({
       ...readyStatus,
       has_account: false,
       status: "",
@@ -131,7 +135,8 @@ describe("useStripePayouts", () => {
     (fetchStripeWithdrawals as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
     const addToast = vi.fn();
-    const { result } = renderHook(() => useStripePayouts({ addToast, enabled: false }));
+    const { result } = renderHook(() => useStripePayouts({ addToast }));
+    await waitFor(() => expect(result.current.status).toEqual(readyStatus));
     act(() => result.current.setWithdrawOpen(true));
 
     await act(async () => {

--- a/console-ui/__tests__/provider-dashboard-fixtures.ts
+++ b/console-ui/__tests__/provider-dashboard-fixtures.ts
@@ -41,8 +41,6 @@ export function baseProvider(overrides: Partial<MyProvider> = {}): MyProvider {
     },
     lifetime_requests_served: 480,
     lifetime_tokens_generated: 1_200_000,
-    earnings_total_micro_usd: 5_000_000,
-    earnings_count: 480,
     last_challenge_verified: new Date().toISOString(),
     version: "0.5.16",
     ...overrides,

--- a/console-ui/__tests__/provider-dashboard-warnings.test.ts
+++ b/console-ui/__tests__/provider-dashboard-warnings.test.ts
@@ -48,8 +48,6 @@ function baseProvider(overrides: Partial<MyProvider> = {}): MyProvider {
     },
     lifetime_requests_served: 0,
     lifetime_tokens_generated: 0,
-    earnings_total_micro_usd: 0,
-    earnings_count: 0,
     last_challenge_verified: new Date().toISOString(),
     version: "0.3.10",
     ...overrides,

--- a/console-ui/next.config.ts
+++ b/console-ui/next.config.ts
@@ -41,12 +41,6 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react"],
   },
-  typescript: {
-    // @noble/curves >=1.9 ships raw .ts files with .ts import extensions,
-    // which fails Next.js type-checking even with skipLibCheck: true.
-    // This is a known upstream issue in viem's dependency tree.
-    ignoreBuildErrors: true,
-  },
   async headers() {
     return [
       {

--- a/console-ui/package.json
+++ b/console-ui/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bundle:check": "node scripts/analyze-bundle.mjs --budget",
-    "bundle:budget": "next build && node scripts/analyze-bundle.mjs --budget"
+    "bundle:budget": "next build && node scripts/analyze-bundle.mjs --budget",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@datadog/browser-rum": "^6.32.0",

--- a/console-ui/src/app/providers/dashboard/RemoveMachineButton.test.tsx
+++ b/console-ui/src/app/providers/dashboard/RemoveMachineButton.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { RemoveMachineButton } from "./RemoveMachineButton";
 import { makeProvider } from "./testFixtures";
 
-const getAccessToken = vi.fn(async () => "tok");
+const getAccessToken = vi.fn<() => Promise<string | null>>().mockResolvedValue("tok");
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({ getAccessToken }),
 }));
@@ -15,9 +15,9 @@ vi.mock("@/hooks/useToast", () => ({
     selector({ addToast }),
 }));
 
-const deleteProvider = vi.fn(async () => {});
+const deleteProvider = vi.fn<typeof import("@/lib/api").deleteProvider>().mockResolvedValue(undefined);
 vi.mock("@/lib/api", () => ({
-  deleteProvider: (...args: unknown[]) => deleteProvider(...args),
+  deleteProvider: (...args: Parameters<typeof deleteProvider>) => deleteProvider(...args),
 }));
 
 const REMOVE_BTN = { name: "Remove machine" } as const;
@@ -77,7 +77,7 @@ describe("RemoveMachineButton", () => {
   });
 
   it("warns and aborts when no auth token is available", async () => {
-    getAccessToken.mockResolvedValue(null as unknown as string);
+    getAccessToken.mockResolvedValue(null);
     render(<RemoveMachineButton provider={makeProvider()} />);
     fireEvent.click(screen.getByRole("button", REMOVE_BTN));
 

--- a/console-ui/src/app/providers/dashboard/testFixtures.ts
+++ b/console-ui/src/app/providers/dashboard/testFixtures.ts
@@ -1,7 +1,7 @@
 // Shared test fixtures for the provider dashboard. Builds a fully-populated
 // MyProvider so individual tests only override the few fields they exercise.
 
-import type { MyProvider, MyReputation } from "../types";
+import type { MyProvider, MyReputation, MyHardware } from "../types";
 
 export function makeReputation(overrides: Partial<MyReputation> = {}): MyReputation {
   return {
@@ -17,7 +17,12 @@ export function makeReputation(overrides: Partial<MyReputation> = {}): MyReputat
   };
 }
 
-export function makeProvider(overrides: Partial<MyProvider> = {}): MyProvider {
+type ProviderOverrides = Omit<Partial<MyProvider>, "reputation" | "hardware"> & {
+  reputation?: Partial<MyReputation>;
+  hardware?: Partial<MyHardware>;
+};
+
+export function makeProvider(overrides: ProviderOverrides = {}): MyProvider {
   const { reputation, hardware, ...rest } = overrides;
   return {
     id: "p1",

--- a/console-ui/src/app/providers/earnings/EarningsContent.tsx
+++ b/console-ui/src/app/providers/earnings/EarningsContent.tsx
@@ -55,7 +55,7 @@ export default function EarningsContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const getAuthHeaders = useCallback(async () => {
+  const getAuthHeaders = useCallback(async (): Promise<Record<string, string>> => {
     const accessToken = await getAccessToken().catch(() => null);
     if (accessToken) {
       return { Authorization: `Bearer ${accessToken}` };

--- a/console-ui/src/components/providers/PrivyClientProvider.tsx
+++ b/console-ui/src/components/providers/PrivyClientProvider.tsx
@@ -6,10 +6,17 @@ import dynamic from "next/dynamic";
 const PRIVY_APP_ID = process.env.NEXT_PUBLIC_PRIVY_APP_ID || "";
 const IS_PRIVY_CONFIGURED = PRIVY_APP_ID && PRIVY_APP_ID !== "placeholder";
 
+/** The identity fields consumed by the console; the lazy SDK may provide more. */
+export interface ConsoleUser {
+  id: string;
+  userId?: string;
+  email?: { address: string };
+}
+
 export interface AuthState {
   ready: boolean;
   authenticated: boolean;
-  user: unknown;
+  user: ConsoleUser | null;
   login: () => void;
   logout: () => Promise<void>;
   getAccessToken: () => Promise<string | null>;

--- a/console-ui/src/components/providers/PrivyRealProvider.tsx
+++ b/console-ui/src/components/providers/PrivyRealProvider.tsx
@@ -31,7 +31,7 @@ function PrivyAuthBridge({ onAuthChange }: { onAuthChange: (s: AuthState) => voi
   // (readiness, authentication, or which user). A token refresh that leaves
   // those untouched must not churn the context. The action callbacks above are
   // stable refs, so they are intentionally excluded from the deps.
-  const userId = (user as { id?: string } | null)?.id ?? null;
+  const userId = user?.id ?? null;
   useEffect(() => {
     onAuthChange({ ready, authenticated, user, login, logout, getAccessToken });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -58,7 +58,10 @@ export default function PrivyRealProvider({
         },
         // Don't auto-create embedded web3 wallets — nothing in the console uses
         // them, and it avoids pulling the @solana/viem code paths (perf F1b).
-        embeddedWallets: { createOnLogin: "off" },
+        embeddedWallets: {
+          ethereum: { createOnLogin: "off" },
+          solana: { createOnLogin: "off" },
+        },
       }}
     >
       <PrivyAuthBridge onAuthChange={onAuthChange} />

--- a/console-ui/src/hooks/useAuth.ts
+++ b/console-ui/src/hooks/useAuth.ts
@@ -87,7 +87,7 @@ export function useAuth() {
   const [apiKeyReady, setApiKeyReady] = useState(false);
 
   // Derive useful fields from the Privy user
-  const email = (user as { email?: { address?: string } } | null)?.email?.address || null;
+  const email = user?.email?.address || null;
 
   const displayName = email || null;
 

--- a/console-ui/vitest.config.ts
+++ b/console-ui/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 export default defineConfig({
   oxc: {
-    jsx: "automatic",
+    jsx: { runtime: "automatic" },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
The console could previously ship while TypeScript reported thirteen errors. This refactor restores full build-time validation, expresses the minimal identity supplied by the lazy Privy bridge, updates the installed SDK/config contracts, and makes provider test fixtures reflect the actual wire model. Payout tests now wait for the existing withdrawal initialization guard.

The minimal identity contract removes consumer assertions while preserving the lazy SDK boundary. Wallet creation remains off using the installed SDK's per-chain options. Provider fixtures expose partial nested overrides only where their builder supplies the defaults; removed per-machine earnings fields are not added back to the wire schema. Existing account/Stripe route refactors in #899 are separate.

**Before**
```mermaid
flowchart LR
  Auth[Lazy Privy bridge] --> Unknown[Untyped console identity]
  Unknown --> Views[Consumers assert or fail type checking]
  Source[Console source and tests] --> Ignore[Next build skips TypeScript failures]
  Ignore --> Bundle[Production bundle]
```

**After**
```mermaid
flowchart LR
  Auth[Lazy Privy bridge] --> Identity[Explicit console identity contract]
  Identity --> Views[Typed identity consumers]
  Source[Console source and tests] --> Check[Whole-project TypeScript validation]
  Check -->|valid| Bundle[Production bundle]
  Check -->|invalid| Stop[Build fails before publication]
```

Validation on Node 22.23.2 and committed dependencies: full `npm run typecheck`, Next 16.2.11 production build **including type validation**, lint (existing warnings only), and **694 tests across 88 files** pass. The original master had 13 TypeScript errors; none remain. No dependency upgrades or provider/coordinator schema changes.

Three payout-test setup corrections are identical to #899; they enable the existing recovery-gated flow before checking results. The 36 additional adapter tests in #899 are not part of this master-based PR, explaining its different test count.
