### PR TITLE
fix(auth): preserve OTP email and code as JSON string values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Admin email login** — Encode Privy OTP email/code fields as JSON strings so quoted addresses and escape characters cannot break or reshape the upstream request.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/auth/privy.go
+++ b/coordinator/auth/privy.go
@@ -7,6 +7,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
@@ -202,9 +203,11 @@ func (p *PrivyAuth) InitEmailOTP(email string) error {
 		return errors.New("privy: app_secret required for OTP init")
 	}
 
-	body := fmt.Sprintf(`{"email":"%s"}`, email)
+	body, _ := json.Marshal(struct {
+		Email string `json:"email"`
+	}{Email: email})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://auth.privy.io/api/v1/auth/email/init", strings.NewReader(body))
+		"https://auth.privy.io/api/v1/auth/email/init", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -232,9 +235,12 @@ func (p *PrivyAuth) VerifyEmailOTP(email, code string) (string, error) {
 		return "", errors.New("privy: app_secret required for OTP verify")
 	}
 
-	body := fmt.Sprintf(`{"email":"%s","code":"%s"}`, email, code)
+	body, _ := json.Marshal(struct {
+		Email string `json:"email"`
+		Code  string `json:"code"`
+	}{Email: email, Code: code})
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"https://auth.privy.io/api/v1/auth/email/authenticate", strings.NewReader(body))
+		"https://auth.privy.io/api/v1/auth/email/authenticate", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}

--- a/coordinator/auth/privy_otp_test.go
+++ b/coordinator/auth/privy_otp_test.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type otpRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f otpRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestEmailOTPJSONPreservesUntrustedStrings(t *testing.T) {
+	for _, input := range []struct{ name, email, code string }{
+		{"ordinary", "user@example.com", "123456"},
+		{"empty fields", "", ""},
+		{"quoted address", `"quoted.local"@example.com`, "123456"},
+		{"escape sequences", "name\\part\n@example.com", "12\t34\\56"},
+		{"attempted extra field", `user@example.com","admin":true,"extra":"`, `123","email":"other@example.com`},
+	} {
+		for _, verify := range []bool{false, true} {
+			t.Run(input.name+map[bool]string{false: "/init", true: "/verify"}[verify], func(t *testing.T) {
+				_, pem := genES256Key(t)
+				a := newAuth(t, pem, "test-secret", testMemStore())
+				called := false
+				a.httpClient.Transport = otpRoundTripper(func(r *http.Request) (*http.Response, error) {
+					called = true
+					if r.Method != http.MethodPost || r.URL.Host != "auth.privy.io" || r.Header.Get("Content-Type") != "application/json" {
+						t.Fatalf("unexpected OTP request: %s %s %v", r.Method, r.URL, r.Header)
+					}
+					id, secret, ok := r.BasicAuth()
+					if !ok || id != testAppID || secret != "test-secret" || r.Header.Get("Privy-App-Id") != testAppID {
+						t.Fatal("OTP authentication headers changed")
+					}
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if input.name == "ordinary" {
+						want := `{"email":"user@example.com"}`
+						if verify {
+							want = `{"email":"user@example.com","code":"123456"}`
+						}
+						if string(body) != want {
+							t.Fatalf("ordinary OTP wire bytes changed: %q", body)
+						}
+					}
+					var got map[string]string
+					if err := json.Unmarshal(body, &got); err != nil {
+						t.Fatalf("OTP payload is not a string-valued JSON object: %q: %v", body, err)
+					}
+					wantFields, path := 1, "/api/v1/auth/email/init"
+					if verify {
+						wantFields, path = 2, "/api/v1/auth/email/authenticate"
+						if got["code"] != input.code {
+							t.Fatalf("code was rewritten: %q", got["code"])
+						}
+					}
+					if len(got) != wantFields || got["email"] != input.email || r.URL.Path != path {
+						t.Fatalf("OTP request changed fields or operation: %s %q", r.URL.Path, body)
+					}
+					return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"token":"access-token"}`)), Header: make(http.Header)}, nil
+				})
+				if verify {
+					token, err := a.VerifyEmailOTP(input.email, input.code)
+					if err != nil || token != "access-token" {
+						t.Fatalf("verify: token=%q error=%v", token, err)
+					}
+				} else if err := a.InitEmailOTP(input.email); err != nil {
+					t.Fatal(err)
+				}
+				if !called {
+					t.Fatal("OTP transport was not called")
+				}
+			})
+		}
+	}
+}

--- a/docs/architecture/security/identity-binding.md
+++ b/docs/architecture/security/identity-binding.md
@@ -1,6 +1,6 @@
 # Identity binding
 
-> Last updated: 2026-09-07 · commit `efcde6334`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 A provider connection carries five identities — a Secure Enclave P-256 key, an
 X25519 process key `K`, an APNs device token, an Apple device identity
@@ -99,6 +99,7 @@ RFC 8628-style flow implemented in `coordinator/api/device_auth.go` and
 | Key | A single **static** PEM `SubjectPublicKeyInfo` parsed with `x509.ParsePKIXPublicKey`; must be ECDSA. There is no JWKS fetch and no key rotation without a restart | `coordinator/auth/privy.go` (`NewPrivyAuth`) |
 | Token checks | Algorithm exactly `ES256`; issuer `privy.io`; audience = app ID; standard `exp`/`nbf` via `jwt.RegisteredClaims`; non-empty `sub` | `coordinator/auth/privy.go` (`VerifyToken`) |
 | Result | `sub` is the Privy DID (`did:privy:…`); `GetOrCreateUser` looks it up or creates `User{AccountID: uuid, PrivyUserID, Email}` after fetching details from `https://auth.privy.io/api/v1/users/<did>` with Basic auth `app_id:app_secret` and `Privy-App-Id` | `coordinator/auth/privy.go` (`GetOrCreateUser`, `fetchUserDetails`) |
+| Admin email OTP | `InitEmailOTP` and `VerifyEmailOTP` encode email/code with typed JSON serialization before calling Privy; quotes, backslashes and control characters remain inside their string fields | `coordinator/auth/privy.go` |
 | Failure | Missing header → `401 authentication_error "missing credentials"`; bad token → `401 authentication_error "invalid Privy token"` | `coordinator/api/server.go` (`requirePrivyAuth`) |
 
 ## Invariants


### PR DESCRIPTION
Privy OTP requests interpolated the email and code directly into JSON. Quotes and backslashes could make the request invalid or add fields. Serialize typed string fields for both OTP operations, preserving the ordinary request bytes, authentication headers, endpoints, and response/error handling.

Before:
```mermaid
flowchart LR
  A[Admin email login] --> B[InitEmailOTP or VerifyEmailOTP]
  B --> C[Interpolate email and code into JSON]
  C --> D[Quoted or escaped input breaks JSON or adds fields]
  C --> E[Plain input sent to Privy]
```

After:
```mermaid
flowchart LR
  A[Admin email login] --> B[InitEmailOTP or VerifyEmailOTP]
  B --> C[Marshal typed email and code string fields]
  C --> D[Valid JSON with original string values]
  D --> E[Same Privy endpoint and response handling]
```

Validation: the new transport-level regression test fails on the previous implementation for quoted addresses, escape/control characters, and attempted field injection in both operations. `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/auth -count=1` passes after the fix. Ordinary request bytes are explicitly checked. `scripts/docs-check.sh --all` passes (277 documents); `git diff --check` passes. The new-branch pre-push hook did not select a diff range; validation above was run explicitly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791757718&installation_model_id=21733&pr_number=905&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F905&signature=8b4224cb92342ffbb9ba12f3fa93fe06373a5b04b2da74d340c981f74cdad81f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->