### PR TITLE
Simplify landing calculator orchestration

### DIFF
--- a/landing/earn-calculator-dom.test.js
+++ b/landing/earn-calculator-dom.test.js
@@ -1,0 +1,93 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const Core = require("./earn-calculator-core.js");
+const source = fs.readFileSync(process.env.LANDING_CALCULATOR_SCRIPT || path.join(__dirname, "earn-calculator.js"), "utf8");
+
+// Only the DOM operations used by the calculator are needed; no browser,
+// network, dependencies, or implementation-private functions are exposed.
+function element() {
+  return {
+    children: [], style: {}, value: "", textContent: "", listeners: new Map(),
+    appendChild(child) { this.children.push(child); },
+    setAttribute() {},
+    addEventListener(name, handler) { this.listeners.set(name, handler); },
+    get options() { return this.children; },
+    set innerHTML(value) { assert.equal(value, ""); this.children = []; },
+  };
+}
+function mount(core = Core) {
+  const nodes = new Map();
+  const events = [];
+  let ready;
+  const document = {
+    getElementById(id) {
+      if (!nodes.has(id)) nodes.set(id, element());
+      return nodes.get(id);
+    },
+    createElement: element,
+    addEventListener(name, handler) { assert.equal(name, "DOMContentLoaded"); ready = handler; },
+  };
+  vm.runInNewContext(source, { window: { DarkbloomEarnings: core, va: (...args) => events.push(args) }, document, navigator: { language: "en-US" }, Intl });
+  ready();
+  return {
+    get: document.getElementById,
+    events,
+    change(id, value, name = "change") {
+      const node = document.getElementById(id);
+      node.value = value;
+      node.listeners.get(name)();
+    },
+  };
+}
+function configure(ui) {
+  ui.change("mac-type-select", "MacBook Pro");
+  ui.change("chip-select", "M5 Max (40-core GPU)");
+  ui.change("ram-select", "64");
+}
+
+test("selector cascade preserves readiness, memory options, and estimates", () => {
+  const ui = mount();
+  assert.equal(ui.get("chip-select").disabled, true);
+  assert.equal(ui.get("ram-select").disabled, true);
+  assert.equal(ui.get("calc-results").style.display, "none");
+  configure(ui);
+  assert.deepEqual(ui.get("ram-select").options.map(option => option.value), ["", "48", "64", "128"]);
+  assert.equal(ui.get("calc-results").style.display, "");
+  assert.equal(ui.get("calc-empty").style.display, "none");
+  assert.match(ui.get("calc-hero-primary").textContent, /^\$/);
+  const original = ui.get("calc-hero-primary").textContent;
+  ui.change("calc-duty-input", "50", "input");
+  assert.notEqual(ui.get("calc-hero-primary").textContent, original);
+  assert.match(ui.get("calc-hero-annualized").textContent, /50% duty cycle$/);
+  ui.change("mac-type-select", "Mac Mini");
+  assert.equal(ui.get("chip-select").value, "");
+  assert.equal(ui.get("ram-select").value, "");
+  assert.equal(ui.get("ram-select").disabled, true);
+});
+
+test("both interest buttons retain event names and selected hardware", () => {
+  const ui = mount();
+  configure(ui);
+  ui.change("calc-nofit-btn", "", "click");
+  ui.change("calc-readiness-btn", "", "click");
+  assert.equal(ui.events.length, 2);
+  const events = JSON.parse(JSON.stringify(ui.events));
+  assert.deepEqual(events.map(event => event[1].name), ["small_models_interest_click", "production_readiness_interest_click"]);
+  for (const [method, event] of events) {
+    assert.equal(method, "event");
+    assert.deepEqual(event.data, { source: "landing_earn_calc", mac_type: "MacBook Pro", chip: "M5 Max (40-core GPU)", ram_gb: 64 });
+  }
+  ui.change("mac-type-select", "Mac Mini");
+  ui.change("calc-nofit-btn", "", "click");
+  assert.equal(ui.events.length, 2);
+});
+
+test("missing core remains an empty usable selector without an estimate", () => {
+  const ui = mount(null);
+  assert.equal(ui.get("mac-type-select").options.length, 1);
+  assert.equal(ui.get("calc-empty").style.display, "");
+  assert.equal(ui.get("calc-results").style.display, "none");
+});

--- a/landing/earn-calculator.js
+++ b/landing/earn-calculator.js
@@ -56,11 +56,11 @@
     if (element) element.style.display = show ? "" : "none";
   }
 
-  function appendPlaceholder(select, label) {
+  function appendOption(select, value, label, disabled) {
     const item = document.createElement("option");
-    item.value = "";
+    item.value = value;
     item.textContent = label;
-    item.disabled = true;
+    item.disabled = Boolean(disabled);
     select.appendChild(item);
   }
 
@@ -68,12 +68,9 @@
     const macTypeSelect = document.getElementById("mac-type-select");
     if (macTypeSelect && macTypeSelect.options.length !== MAC_TYPES.length + 1) {
       macTypeSelect.innerHTML = "";
-      appendPlaceholder(macTypeSelect, "Select model");
+      appendOption(macTypeSelect, "", "Select model", true);
       MAC_TYPES.forEach(function (macType) {
-        const item = document.createElement("option");
-        item.value = macType;
-        item.textContent = macType;
-        macTypeSelect.appendChild(item);
+        appendOption(macTypeSelect, macType, macType);
       });
     }
     if (macTypeSelect) macTypeSelect.value = state.macType;
@@ -81,14 +78,11 @@
     const chipSelect = document.getElementById("chip-select");
     if (chipSelect) {
       chipSelect.innerHTML = "";
-      appendPlaceholder(chipSelect, "Select chip");
+      appendOption(chipSelect, "", "Select chip", true);
       PROVIDER_HARDWARE_OPTIONS.filter(function (option) {
         return option.macType === state.macType;
       }).forEach(function (option) {
-        const item = document.createElement("option");
-        item.value = option.chip;
-        item.textContent = option.chip;
-        chipSelect.appendChild(item);
+        appendOption(chipSelect, option.chip, option.chip);
       });
       chipSelect.disabled = !state.macType;
       chipSelect.value = state.chip;
@@ -97,12 +91,9 @@
     const ramSelect = document.getElementById("ram-select");
     if (ramSelect) {
       ramSelect.innerHTML = "";
-      appendPlaceholder(ramSelect, "Select memory");
+      appendOption(ramSelect, "", "Select memory", true);
       (config ? config.ramOptions : []).forEach(function (ram) {
-        const item = document.createElement("option");
-        item.value = String(ram);
-        item.textContent = ram + " GB";
-        ramSelect.appendChild(item);
+        appendOption(ramSelect, String(ram), ram + " GB");
       });
       ramSelect.disabled = !config;
       ramSelect.value = state.ram === null ? "" : String(state.ram);
@@ -326,80 +317,49 @@
     renderFlow(result, config);
   }
 
-  document.addEventListener("DOMContentLoaded", function () {
-    const macTypeSelect = document.getElementById("mac-type-select");
-    if (macTypeSelect) {
-      macTypeSelect.addEventListener("change", function () {
-        state.macType = macTypeSelect.value;
-        state.chip = "";
-        state.ram = null;
-        render();
-      });
-    }
-    const chipSelect = document.getElementById("chip-select");
-    if (chipSelect) {
-      chipSelect.addEventListener("change", function () {
-        state.chip = chipSelect.value;
-        state.ram = null;
-        render();
-      });
-    }
-    const ramSelect = document.getElementById("ram-select");
-    if (ramSelect) {
-      ramSelect.addEventListener("change", function () {
-        state.ram = Number(ramSelect.value);
-        render();
-      });
-    }
-    const dutyInput = document.getElementById("calc-duty-input");
-    if (dutyInput) {
-      dutyInput.addEventListener("input", function () {
-        state.dutyCyclePercent = Number(dutyInput.value);
-        render();
-      });
-    }
-
-    const notifyButton = document.getElementById("calc-nofit-btn");
-    if (notifyButton) {
-      notifyButton.addEventListener("click", function () {
-        if (window.va) {
-          const selectedHardware = hardwareOption(state.macType, state.chip);
-          if (!selectedHardware) return;
-          window.va("event", {
-            name: "small_models_interest_click",
-            data: {
-              source: "landing_earn_calc",
-              mac_type: selectedHardware.macType,
-              chip: selectedHardware.chip,
-              ram_gb: state.ram,
-            },
-          });
-        }
-      });
-    }
-    const readinessButton = document.getElementById("calc-readiness-btn");
-    if (readinessButton) {
-      readinessButton.addEventListener("click", function () {
-        if (window.va) {
-          const selectedHardware = hardwareOption(state.macType, state.chip);
-          if (!selectedHardware) return;
-          window.va("event", {
-            name: "production_readiness_interest_click",
-            data: {
-              source: "landing_earn_calc",
-              mac_type: selectedHardware.macType,
-              chip: selectedHardware.chip,
-              ram_gb: state.ram,
-            },
-          });
-        }
-      });
-    }
-
-    if (!Core || PROVIDER_HARDWARE_OPTIONS.length === 0) {
+  function bindInput(id, event, update) {
+    const input = document.getElementById(id);
+    if (!input) return;
+    input.addEventListener(event, function () {
+      update(input.value);
       render();
-      return;
-    }
+    });
+  }
+
+  function bindInterestButton(id, eventName) {
+    const button = document.getElementById(id);
+    if (!button) return;
+    button.addEventListener("click", function () {
+      if (!window.va) return;
+      const selectedHardware = hardwareOption(state.macType, state.chip);
+      if (!selectedHardware) return;
+      window.va("event", {
+        name: eventName,
+        data: {
+          source: "landing_earn_calc",
+          mac_type: selectedHardware.macType,
+          chip: selectedHardware.chip,
+          ram_gb: state.ram,
+        },
+      });
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    bindInput("mac-type-select", "change", function (value) {
+      state.macType = value;
+      state.chip = "";
+      state.ram = null;
+    });
+    bindInput("chip-select", "change", function (value) {
+      state.chip = value;
+      state.ram = null;
+    });
+    bindInput("ram-select", "change", function (value) { state.ram = Number(value); });
+    bindInput("calc-duty-input", "input", function (value) { state.dutyCyclePercent = Number(value); });
+
+    bindInterestButton("calc-nofit-btn", "small_models_interest_click");
+    bindInterestButton("calc-readiness-btn", "production_readiness_interest_click");
     render();
   });
 })();


### PR DESCRIPTION
The landing earnings calculator repeats option creation, input binding, and identical interest-event payload assembly. Centralize those operations so each handler expresses only its state change or event name; rendering, hardware estimates, selector resets, and analytics payloads remain the same. Removes 40 production lines without a dependency or deployment change.

Validation: Node 22 passes all 8 landing tests. The 3 new DOM characterization cases also pass against the original master calculator: selector cascade and duty-cycle estimates, both analytics payloads, and missing calculator core. Tests run in a local DOM fixture with no network.

```mermaid
flowchart LR
  subgraph Before
    A[Four duplicated input listeners] --> B[Mutate selection and render]
    C[Two duplicated interest listeners] --> D[Emit selected hardware analytics]
    E[Three option builders] --> B
  end
```

```mermaid
flowchart LR
  subgraph After
    A[bindInput plus specific state updates] --> B[Same selection and rendered estimate]
    C[bindInterestButton plus event name] --> D[Same selected hardware analytics]
    E[appendOption] --> B
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791757745&installation_model_id=21733&pr_number=906&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F906&signature=d41c910148c317e0bc957ad923485fb2fc8e88f15f7072c3788702be3474dc77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->