### PR TITLE
Share console clipboard feedback and parse chat payloads once

### DIFF
--- a/console-ui/src/components/CodeExample.tsx
+++ b/console-ui/src/components/CodeExample.tsx
@@ -1,32 +1,23 @@
 "use client";
 
-import { useEffect, useId, useRef, useState, type KeyboardEvent } from "react";
+import { useId, useRef, useState, type KeyboardEvent } from "react";
 import { AlertCircle, Check, Copy, Loader2 } from "lucide-react";
+import { useClipboard, type CopyStatus } from "@/hooks/useClipboard";
 
 interface CodeExampleProps {
   examples: { label: string; language: string; code: string }[];
 }
 
-type CopyStatus = "idle" | "copying" | "copied" | "error";
-
 export function CodeExample({ examples }: CodeExampleProps) {
   const [activeTab, setActiveTab] = useState(0);
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
-  const copyAttempt = useRef(0);
+  const { status: copyStatus, copy, reset } = useClipboard();
   const tabRefs = useRef(new Map<number, HTMLButtonElement | null>());
   const id = useId();
   const activeExample = examples.at(activeTab);
 
-  useEffect(() => {
-    if (copyStatus !== "copied") return;
-    const timer = setTimeout(() => setCopyStatus("idle"), 2000);
-    return () => clearTimeout(timer);
-  }, [copyStatus]);
-
   const selectTab = (index: number) => {
-    copyAttempt.current += 1;
+    reset();
     setActiveTab(index);
-    setCopyStatus("idle");
   };
 
   const handleTabKey = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
@@ -41,17 +32,6 @@ export function CodeExample({ examples }: CodeExampleProps) {
     event.preventDefault();
     selectTab(nextIndex);
     tabRefs.current.get(nextIndex)?.focus();
-  };
-
-  const copyCode = async () => {
-    const attempt = ++copyAttempt.current;
-    setCopyStatus("copying");
-    try {
-      await navigator.clipboard.writeText(activeExample?.code ?? "");
-      if (copyAttempt.current === attempt) setCopyStatus("copied");
-    } catch {
-      if (copyAttempt.current === attempt) setCopyStatus("error");
-    }
   };
 
   const { Icon: CopyIcon, label: copyLabel } = copyFeedback(copyStatus);
@@ -79,7 +59,7 @@ export function CodeExample({ examples }: CodeExampleProps) {
             </button>
           ))}
         </div>
-        <button type="button" onClick={copyCode} disabled={copyStatus === "copying"} className="ml-auto flex min-h-11 shrink-0 items-center gap-1.5 px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary disabled:cursor-wait">
+        <button type="button" onClick={() => copy(activeExample.code)} disabled={copyStatus === "copying"} className="ml-auto flex min-h-11 shrink-0 items-center gap-1.5 px-3 py-2 text-xs font-medium text-text-secondary transition-colors hover:text-text-primary disabled:cursor-wait">
           <CopyIcon size={14} className={copyStatus === "copying" ? "animate-spin" : undefined} />
           <span aria-live="polite">{copyLabel}</span>
         </button>

--- a/console-ui/src/components/provider-onboarding/SetupCommand.tsx
+++ b/console-ui/src/components/provider-onboarding/SetupCommand.tsx
@@ -1,40 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useClipboard, type CopyStatus } from "@/hooks/useClipboard";
 import { Check, Copy, Loader2 } from "lucide-react";
 
-type CopyState = "idle" | "copying" | "copied" | "failed";
-
-function copyFeedback(state: CopyState) {
+function copyFeedback(state: CopyStatus) {
   if (state === "copying") return { label: "Copying…", icon: Loader2 };
   if (state === "copied") return { label: "Copied", icon: Check };
   return { label: "Copy command", icon: Copy };
 }
 
 export function SetupCommand({ command, label }: { command: string; label: string }) {
-  const [state, setState] = useState<CopyState>("idle");
-  const mounted = useRef(false);
-
-  useEffect(() => {
-    mounted.current = true;
-    return () => { mounted.current = false; };
-  }, []);
-
-  useEffect(() => {
-    if (state !== "copied") return;
-    const timer = setTimeout(() => setState("idle"), 2000);
-    return () => clearTimeout(timer);
-  }, [state]);
-
-  const copy = async () => {
-    setState("copying");
-    try {
-      await navigator.clipboard.writeText(command);
-      if (mounted.current) setState("copied");
-    } catch {
-      if (mounted.current) setState("failed");
-    }
-  };
+  const { status: state, copy } = useClipboard();
 
   const { label: feedback, icon: Icon } = copyFeedback(state);
 
@@ -44,7 +20,7 @@ export function SetupCommand({ command, label }: { command: string; label: strin
         <span className="text-xs text-text-secondary">Terminal</span>
         <button
           type="button"
-          onClick={copy}
+          onClick={() => copy(command)}
           disabled={state === "copying"}
           aria-label={`${feedback}: ${label}`}
           className="-mr-2 inline-flex min-h-11 items-center gap-2 rounded-md px-2 text-xs font-medium text-accent-brand hover:bg-accent-brand-dim disabled:cursor-wait"
@@ -54,7 +30,7 @@ export function SetupCommand({ command, label }: { command: string; label: strin
         </button>
       </div>
       <pre tabIndex={0} aria-label={`${label} command`} className="max-w-full overflow-x-auto p-4 font-mono text-[13px] leading-relaxed text-text-primary"><code>{command}</code></pre>
-      {state === "failed" && (
+      {state === "error" && (
         <p role="status" className="border-t border-border-dim px-4 py-3 text-xs leading-relaxed text-accent-red">
           Couldn’t copy. Select the command and copy it manually, or try again.
         </p>

--- a/console-ui/src/hooks/useClipboard.ts
+++ b/console-ui/src/hooks/useClipboard.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type CopyStatus = "idle" | "copying" | "copied" | "error";
+
+/** Clipboard feedback belongs to the current attempt, not a stale tab or view. */
+export function useClipboard() {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const attempt = useRef(0);
+  const reset = useCallback(() => {
+    attempt.current += 1;
+    setStatus("idle");
+  }, []);
+
+  useEffect(() => () => { attempt.current += 1; }, []);
+  useEffect(() => {
+    if (status !== "copied") return;
+    const timer = setTimeout(reset, 2000);
+    return () => clearTimeout(timer);
+  }, [status, reset]);
+
+  const copy = useCallback(async (text: string) => {
+    const current = ++attempt.current;
+    setStatus("copying");
+    try {
+      await navigator.clipboard.writeText(text);
+      if (attempt.current === current) setStatus("copied");
+    } catch {
+      if (attempt.current === current) setStatus("error");
+    }
+  }, []);
+
+  return { status, copy, reset };
+}

--- a/console-ui/src/lib/chat/stream.ts
+++ b/console-ui/src/lib/chat/stream.ts
@@ -227,20 +227,15 @@ export async function streamChat(
       return;
     }
 
-    // Attestation receipt event (sent just before [DONE]).
-    try {
-      const receipt = JSON.parse(payload);
-      if (receipt.se_signature) {
-        trustMeta.seSignature = receipt.se_signature;
-        trustMeta.responseHash = receipt.response_hash;
-        continue;
-      }
-    } catch {
-      // Not a receipt — fall through to normal chunk handling.
-    }
-
     try {
       const chunk = JSON.parse(payload);
+      // Receipts and token deltas share the SSE transport, but each payload
+      // is decoded only once before choosing its destination.
+      if (chunk.se_signature) {
+        trustMeta.seSignature = chunk.se_signature;
+        trustMeta.responseHash = chunk.response_hash;
+        continue;
+      }
       const delta = chunk.choices?.[0]?.delta;
       const content = delta?.content;
       const reasoning = delta?.reasoning_content || delta?.reasoning;


### PR DESCRIPTION
Code examples and provider setup commands each manage the same asynchronous clipboard feedback and cleanup. Share that state machine through `useClipboard`, keeping tab reset, pending-write handling, error feedback, and the two-second success reset. Chat SSE payloads now parse once before receipt/token dispatch instead of parsing every token twice.

Stacked on #902 (`refactor/repository-web`) so full TypeScript validation stays enabled. No API, encryption, trust receipt, or visible copy changes.

Validation: pinned Node 22 passes all 694 tests, complete TypeScript checking, ESLint (existing warnings), and full Next production build including types. Existing tests exercise pending/rejected clipboard writes, stale completion after tab changes, provider setup feedback, chat SSE, and encrypted responses.

```mermaid
flowchart LR
  subgraph Before
    A[CodeExample local copy lifecycle] --> B[Copying / Copied / error UI]
    C[SetupCommand local copy lifecycle] --> B
    D[SSE payload] --> E[Parse for receipt]
    E --> F[Parse again for delta]
    F --> G[Token or thinking callback]
    E --> H[Trust receipt]
  end
```

```mermaid
flowchart LR
  subgraph After
    A[CodeExample and SetupCommand] --> B[useClipboard attempt and timer lifecycle]
    B --> C[Same feedback and stale completion suppression]
    D[SSE payload] --> E[Parse once]
    E --> F[Trust receipt]
    E --> G[Same token or thinking callback]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791757806&installation_model_id=21733&pr_number=907&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F907&signature=a93a1c069d15a8d680abcd545838480828f176103c620051c663a55ac961824e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->