### PR TITLE
Share admin table rendering and simplify row projection

### DIFF
--- a/admin-ui/src/components/DataTable.test.ts
+++ b/admin-ui/src/components/DataTable.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { DataTable, type Column } from "./DataTable";
+
+type Row = { name: string; count: number; absent?: string };
+const columns: Column<Row>[] = [
+  { key: "name", header: "Name", render: row => createElement("strong", null, row.name) },
+  { key: "count", header: "Count", align: "right", mono: true },
+  { key: "absent", header: "Missing" },
+];
+
+describe("shared table presentation", () => {
+  it("preserves custom cells, zero counts, missing values and alignment", () => {
+    const html = renderToStaticMarkup(createElement(DataTable<Row>, {
+      columns, rows: [{ name: "<private>", count: 0 }],
+    }));
+    expect(html).toContain("<strong>&lt;private&gt;</strong>");
+    expect(html).toContain("text-right tabular-nums");
+    expect(html).toMatch(/<td[^>]*>0<\/td>/);
+    expect(html).toMatch(/<td[^>]*>—<\/td>/);
+  });
+  it("renders empty state without a table", () => {
+    const html = renderToStaticMarkup(createElement(DataTable<Row>, { columns, rows: [], empty: "No machines." }));
+    expect(html).toContain("No machines.");
+    expect(html).not.toContain("<table");
+  });
+});

--- a/admin-ui/src/components/DataTable.tsx
+++ b/admin-ui/src/components/DataTable.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from "react";
+import type { ReactNode, HTMLAttributes } from "react";
 
 export interface Column<T> {
   key: string;
-  header: string;
+  header: ReactNode;
+  headerProps?: Pick<HTMLAttributes<HTMLTableCellElement>, "onClick" | "className">;
   render?: (row: T) => ReactNode;
   mono?: boolean;
   align?: "left" | "right";
@@ -29,9 +30,10 @@ export function DataTable<T>({
             {columns.map((c) => (
               <th
                 key={c.key}
+                onClick={c.headerProps?.onClick}
                 className={`px-3 py-2 text-xs font-medium uppercase tracking-wide text-[var(--text-dim)] ${
                   c.align === "right" ? "text-right" : ""
-                }`}
+                } ${c.headerProps?.className ?? ""}`}
               >
                 {c.header}
               </th>

--- a/admin-ui/src/components/InteractiveTable.tsx
+++ b/admin-ui/src/components/InteractiveTable.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState } from "react";
+import { DataTable, type Column } from "./DataTable";
+import { tableRows } from "@/lib/table-rows";
 
-export interface ICol<T> {
-  key: string;
-  header: string;
-  render?: (row: T) => ReactNode;
-  mono?: boolean;
-  align?: "left" | "right";
-  // If set, the column header becomes click-to-sort using this value.
-  sortValue?: (row: T) => string | number;
+export interface ICol<T> extends Column<T> {
+  // Dates from TIMESTAMPTZ retain chronological ordering.
+  sortValue?: (row: T) => string | number | Date;
 }
 
 // Client-side filterable / sortable table with an optional "copy all" action.
@@ -37,32 +34,11 @@ export function InteractiveTable<T>({
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [copied, setCopied] = useState<string | null>(null);
 
-  const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    let r = needle
-      ? rows.filter((row) => searchText(row).toLowerCase().includes(needle))
-      : rows.slice();
-    if (sortKey) {
-      const col = columns.find((c) => c.key === sortKey);
-      if (col?.sortValue) {
-        const sv = col.sortValue;
-        r = [...r].sort((a, b) => {
-          // Normalize Dates to epoch millis so date columns sort chronologically
-          // (TIMESTAMPTZ values come back as JS Dates; String(date) would sort by
-          // weekday/month name, not by time).
-          const norm = (v: unknown) => (v instanceof Date ? v.getTime() : v);
-          const av = norm(sv(a));
-          const bv = norm(sv(b));
-          const cmp =
-            typeof av === "number" && typeof bv === "number"
-              ? av - bv
-              : String(av).localeCompare(String(bv));
-          return sortDir === "asc" ? cmp : -cmp;
-        });
-      }
-    }
-    return r;
-  }, [q, rows, searchText, sortKey, sortDir, columns]);
+  const filtered = useMemo(() => tableRows(
+    rows, searchText, q,
+    sortKey ? columns.find((column) => column.key === sortKey)?.sortValue : undefined,
+    sortDir,
+  ), [q, rows, searchText, sortKey, sortDir, columns]);
 
   function toggleSort(col: ICol<T>) {
     if (!col.sortValue) return;
@@ -82,11 +58,10 @@ export function InteractiveTable<T>({
     try {
       await navigator.clipboard.writeText(vals.join("\n"));
       setCopied(`Copied ${vals.length}`);
-      setTimeout(() => setCopied(null), 1500);
     } catch {
       setCopied("Copy failed");
-      setTimeout(() => setCopied(null), 1500);
     }
+    setTimeout(() => setCopied(null), 1500);
   }
 
   return (
@@ -112,54 +87,18 @@ export function InteractiveTable<T>({
         )}
       </div>
 
-      {filtered.length === 0 ? (
-        <div className="py-8 text-center text-[var(--text-faint)]">{empty}</div>
-      ) : (
-        <div className="overflow-x-auto rounded-lg border border-[var(--border)]">
-          <table className="w-full border-collapse text-left">
-            <thead>
-              <tr className="bg-[var(--bg-elevated)]">
-                {columns.map((c) => {
-                  const active = sortKey === c.key;
-                  return (
-                    <th
-                      key={c.key}
-                      onClick={() => toggleSort(c)}
-                      className={`px-3 py-2 text-xs font-medium uppercase tracking-wide text-[var(--text-dim)] ${
-                        c.align === "right" ? "text-right" : ""
-                      } ${c.sortValue ? "cursor-pointer select-none hover:text-[var(--text)]" : ""}`}
-                    >
-                      {c.header}
-                      {c.sortValue && active ? (sortDir === "asc" ? " ▲" : " ▼") : ""}
-                    </th>
-                  );
-                })}
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((row, i) => (
-                <tr
-                  key={i}
-                  className="border-t border-[var(--border)] hover:bg-[var(--bg-hover)]"
-                >
-                  {columns.map((c) => (
-                    <td
-                      key={c.key}
-                      className={`px-3 py-2 align-top ${c.mono ? "mono" : ""} ${
-                        c.align === "right" ? "text-right tabular-nums" : ""
-                      }`}
-                    >
-                      {c.render
-                        ? c.render(row)
-                        : (((row as Record<string, unknown>)[c.key] as ReactNode) ?? "—")}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <DataTable
+        rows={filtered}
+        empty={empty}
+        columns={columns.map((column) => ({
+          ...column,
+          header: <>{column.header}{column.sortValue && sortKey === column.key ? (sortDir === "asc" ? " ▲" : " ▼") : ""}</>,
+          headerProps: {
+            onClick: () => toggleSort(column),
+            className: column.sortValue ? "cursor-pointer select-none hover:text-[var(--text)]" : "",
+          },
+        }))}
+      />
     </div>
   );
 }

--- a/admin-ui/src/lib/table-rows.test.ts
+++ b/admin-ui/src/lib/table-rows.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { tableRows } from "./table-rows";
+
+const rows = [
+  { name: "Zoe", value: 10, seen: new Date("2026-09-02") },
+  { name: "Amy", value: 2, seen: new Date("2026-09-01") },
+  { name: "AMY second", value: 2, seen: new Date("2026-09-03") },
+];
+const name = (row: typeof rows[number]) => row.name;
+
+describe("table row projection", () => {
+  it("filters without case or surrounding whitespace and retains source order", () => {
+    expect(tableRows(rows, name, "  amy  ").map(name)).toEqual(["Amy", "AMY second"]);
+    expect(tableRows(rows, name, "missing")).toEqual([]);
+  });
+  it("sorts numeric values numerically and preserves tie order", () => {
+    expect(tableRows(rows, name, "", row => row.value).map(name)).toEqual(["Amy", "AMY second", "Zoe"]);
+    expect(tableRows(rows, name, "", row => row.value, "desc").map(name)).toEqual(["Zoe", "Amy", "AMY second"]);
+    expect(rows.map(name)).toEqual(["Zoe", "Amy", "AMY second"]);
+  });
+  it("sorts database Date objects chronologically", () => {
+    expect(tableRows(rows, name, "", row => row.seen).map(name)).toEqual(["Amy", "Zoe", "AMY second"]);
+  });
+  it("returns a private copy even without a filter or sort", () => {
+    const result = tableRows(rows, name, "");
+    expect(result).toEqual(rows);
+    expect(result).not.toBe(rows);
+  });
+});

--- a/admin-ui/src/lib/table-rows.ts
+++ b/admin-ui/src/lib/table-rows.ts
@@ -1,0 +1,23 @@
+/** Filter and sort a private copy; never reorder the server-provided rows. */
+export function tableRows<T>(
+  rows: T[],
+  searchText: (row: T) => string,
+  query: string,
+  sortValue?: (row: T) => string | number | Date,
+  direction: "asc" | "desc" = "asc",
+): T[] {
+  const needle = query.trim().toLowerCase();
+  const visible = needle
+    ? rows.filter((row) => searchText(row).toLowerCase().includes(needle))
+    : rows.slice();
+  if (!sortValue) return visible;
+  const normalize = (value: string | number | Date) => value instanceof Date ? value.getTime() : value;
+  return visible.sort((a, b) => {
+    const left = normalize(sortValue(a));
+    const right = normalize(sortValue(b));
+    const comparison = typeof left === "number" && typeof right === "number"
+      ? left - right
+      : String(left).localeCompare(String(right));
+    return direction === "asc" ? comparison : -comparison;
+  });
+}


### PR DESCRIPTION
Admin static and interactive tables repeat the same header/body/cell rendering. InteractiveTable now supplies sorting affordances to DataTable and keeps only filtering, sort selection, and copy-all state. A pure row projection preserves case-insensitive filtering, numeric/Date ordering, stable ties, and the caller’s row order while removing the redundant second array copy.

The shared renderer remains server-compatible; only InteractiveTable and its existing client views contain interactive state. Auth, database queries, data exposure, and table/copy behavior are unchanged. Removes 36 production lines.

Validation on pinned Node 22: all 16 tests, lint, full TypeScript check, and full Next build pass. Original master components also pass all checks and the new presentation characterization tests. The build uses an unreachable dummy ADMIN_DB_URL and does not query a database.

```mermaid
flowchart LR
  subgraph Before
    A[Server pages] --> B[DataTable duplicate markup]
    C[Client views] --> D[InteractiveTable filter sort and duplicate markup]
    B --> E[Table or empty message]
    D --> F[Table / sort arrows / filtered copy]
  end
```

```mermaid
flowchart LR
  subgraph After
    A[Server pages] --> B[DataTable shared markup]
    C[Client views] --> D[InteractiveTable controls]
    D --> E[tableRows private filter and sort]
    E --> B
    B --> F[Same table or empty message]
    D --> G[Same sort arrows and filtered copy]
  end
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791757824&installation_model_id=21733&pr_number=908&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F908&signature=6654abb4416f21115d1252ca1fa354f62cab108f6d0f23c629bf62425371cc80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->