### PR TITLE
Preserve admin inputs and report partial operation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Operations helpers encode admin JSON fields, return a failure after any fleet host fails while still visiting remaining hosts, and isolate smoke-test response files.
+
 - **Admin email login** — Encode Privy OTP email/code fields as JSON strings so quoted addresses and escape characters cannot break or reshape the upstream request.
 
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)

--- a/deploy/provider-fleet/update-fleet.sh
+++ b/deploy/provider-fleet/update-fleet.sh
@@ -52,7 +52,7 @@ echo "==> Updating $ENV_NAME fleet against $COORD_URL"
 failed=0
 for HOST in $HOSTS; do
   echo "---- $HOST ----"
-  ssh "$HOST" "curl -fsSL $COORD_URL/install.sh | bash" || {
+  ssh "$HOST" "bash -o pipefail -c 'curl -fsSL $COORD_URL/install.sh | bash'" || {
     echo "!!! $HOST failed — continuing" >&2
     failed=$((failed + 1))
   }

--- a/deploy/provider-fleet/update-fleet.sh
+++ b/deploy/provider-fleet/update-fleet.sh
@@ -49,11 +49,17 @@ if [ -z "$HOSTS" ]; then
 fi
 
 echo "==> Updating $ENV_NAME fleet against $COORD_URL"
+failed=0
 for HOST in $HOSTS; do
   echo "---- $HOST ----"
   ssh "$HOST" "curl -fsSL $COORD_URL/install.sh | bash" || {
     echo "!!! $HOST failed — continuing" >&2
+    failed=$((failed + 1))
   }
 done
 
+if [ "$failed" -gt 0 ]; then
+  echo "==> Fleet update finished with $failed failed host(s)" >&2
+  exit 1
+fi
 echo "==> Fleet update complete"

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `cb8c6ebf9`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -10,6 +10,10 @@ of it; the per-component steps below explain what each target runs.
 Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
 `scripts/publish-model.sh` to registration. See the
 [model publishing procedure](../operations/model-migration.md).
+
+The admin, smoke and fleet helpers use the tools pinned here. Their local fixture
+checks are covered by [script validation](test.md#6-scripts-and-release-integrity);
+the [dev operations runbook](../operations/dev-environment.md) covers invocation.
 
 Profiler wire changes require both coordinator and provider builds; the shared
 Go/Swift fixture and focused checks are described in [test.md](test.md) and

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -922,6 +922,10 @@ node --test landing/earn-calculator-core.test.js
 ```
 
 ### 6. Scripts and release integrity
+
+`python3 scripts/test_operations_scripts.py` checks admin JSON fields, fleet
+partial-failure exit status and smoke-file ownership using stub transports. It
+makes no network request, writes no login token and updates no host.
 
 ```bash
 make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contbatch/tests -t .   (in scripts/)

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `4502b00b3`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `b19784124`
+> Last updated: 2026-09-11 · commit `cb8c6ebf9`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `4502b00b3`
+> Last updated: 2026-09-11 · commit `b19784124`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `d709d382c`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-06 · commit `f272f8641`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,
@@ -169,6 +169,11 @@ so the provider can only ever register with dev. Add the host's SSH alias to
 re-runs the installer on every listed Mac.
 
 ## Verification
+
+The fleet updater visits every configured host and exits nonzero if any update
+fails. Authenticated smoke runs use a unique temporary response file and remove
+it when the process exits. Admin login and release-deactivation commands encode
+input as JSON values, preserving quotes and backslashes.
 
 ```bash
 scripts/smoke-dev.sh                              # /health, /v1/stats, /v1/models/catalog, install.sh templating

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-11 · commit `d709d382c`
+> Last updated: 2026-09-11 · commit `b19784124`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-11 · commit `b19784124`
+> Last updated: 2026-09-11 · commit `cb8c6ebf9`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,

--- a/scripts/admin.sh
+++ b/scripts/admin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# EigenInference Admin CLI
+# Darkbloom Admin CLI
 #
 # Authenticate with Privy and manage releases, models, and pricing.
 #
@@ -18,6 +18,11 @@ COORDINATOR_URL="${EIGENINFERENCE_COORDINATOR_URL:-https://api.darkbloom.dev}"
 TOKEN_FILE="$HOME/.darkbloom/admin_token"
 
 # ─── Auth helpers ───────────────────────────────────────────
+
+# Encode user-entered values once instead of interpolating them into JSON syntax.
+json_body() {
+    python3 -c 'import json,sys; print(json.dumps(dict(zip(sys.argv[1::2], sys.argv[2::2]))))' "$@"
+}
 
 get_token() {
     # Check for admin key (dev/pre-prod).
@@ -48,25 +53,25 @@ authed_curl() {
 # ─── Commands ───────────────────────────────────────────────
 
 cmd_login() {
-    echo "EigenInference Admin Login"
+    echo "Darkbloom Admin Login"
     echo ""
-    read -p "Email: " EMAIL
+    read -r -p "Email: " EMAIL
 
     echo "Sending OTP to $EMAIL..."
     INIT_RESP=$(curl -fsSL -X POST "$COORDINATOR_URL/v1/admin/auth/init" \
         -H "Content-Type: application/json" \
-        -d "{\"email\": \"$EMAIL\"}" 2>&1) || {
+        -d "$(json_body email "$EMAIL")" 2>&1) || {
         echo "Failed to send OTP: $INIT_RESP"
         exit 1
     }
 
     echo "Check your email for the verification code."
-    read -p "OTP Code: " CODE
+    read -r -p "OTP Code: " CODE
 
     echo "Verifying..."
     VERIFY_RESP=$(curl -fsSL -X POST "$COORDINATOR_URL/v1/admin/auth/verify" \
         -H "Content-Type: application/json" \
-        -d "{\"email\": \"$EMAIL\", \"code\": \"$CODE\"}")
+        -d "$(json_body email "$EMAIL" code "$CODE")")
 
     TOKEN=$(echo "$VERIFY_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo "")
     if [ -z "$TOKEN" ]; then
@@ -95,7 +100,7 @@ cmd_releases_deactivate() {
     local platform="${2:-macos-arm64}"
     authed_curl -X DELETE "$COORDINATOR_URL/v1/admin/releases" \
         -H "Content-Type: application/json" \
-        -d "{\"version\": \"$version\", \"platform\": \"$platform\"}"
+        -d "$(json_body version "$version" platform "$platform")"
     echo ""
     echo "Release $version ($platform) deactivated."
 }

--- a/scripts/smoke-dev.sh
+++ b/scripts/smoke-dev.sh
@@ -67,7 +67,9 @@ fi
 # Authenticated tests only run if an API key is supplied.
 if [ -n "$API_KEY" ]; then
   step "chat completions (authenticated)"
-  HTTP_CODE=$(curl -sS -o /tmp/smoke-chat.json -w '%{http_code}' \
+  smoke_result=$(mktemp -t darkbloom-smoke.XXXXXX)
+  trap 'rm -f "$smoke_result"' EXIT
+  HTTP_CODE=$(curl -sS -o "$smoke_result" -w '%{http_code}' \
     -H "Authorization: Bearer $API_KEY" \
     -H "Content-Type: application/json" \
     -d '{"model":"auto","messages":[{"role":"user","content":"ping"}],"max_tokens":8,"stream":false}' \
@@ -75,7 +77,7 @@ if [ -n "$API_KEY" ]; then
   if [ "$HTTP_CODE" = "200" ]; then
     green "chat OK"
   else
-    fail "chat returned $HTTP_CODE: $(head -c 400 /tmp/smoke-chat.json)"
+    fail "chat returned $HTTP_CODE: $(head -c 400 "$smoke_result")"
   fi
 else
   echo "(skipping authenticated tests — set API_KEY to enable)"

--- a/scripts/test_operations_scripts.py
+++ b/scripts/test_operations_scripts.py
@@ -1,0 +1,101 @@
+"""Exercise operations CLIs with stub transports; no network or fleet mutations."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class OperationsScriptsTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.log = self.root / "calls.jsonl"
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env = {**os.environ, "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
+                    "OPERATIONS_TEST_LOG": str(self.log), "EIGENINFERENCE_ADMIN_KEY": "fixture-only"}
+
+    def stub(self, name, source):
+        path = self.bin / name
+        path.write_text("#!/usr/bin/env python3\n" + source)
+        path.chmod(0o755)
+
+    def calls(self):
+        return [json.loads(line) for line in self.log.read_text().splitlines()]
+
+    def test_admin_auth_and_deactivation_encode_user_values(self):
+        self.stub("curl", '''import json,os,sys
+with open(os.environ["OPERATIONS_TEST_LOG"], "a") as log:
+    log.write(json.dumps(sys.argv[1:]) + "\\n")
+print("{}")
+''')
+        email, code = 'person"\\name@example.invalid', '\\123"456'
+        result = subprocess.run(["bash", str(ROOT / "scripts/admin.sh"), "login"],
+                                input=email + "\n" + code + "\n", env=self.env,
+                                capture_output=True, text=True)
+        # The stub returns no token, so login intentionally stops before any token write.
+        self.assertEqual(result.returncode, 1)
+        init, verify = self.calls()
+        self.assertEqual(json.loads(init[init.index("-d") + 1]), {"email": email})
+        self.assertEqual(json.loads(verify[verify.index("-d") + 1]), {"email": email, "code": code})
+        version, platform = '0.9.2"', 'macos\\arm64'
+        result = subprocess.run(["bash", str(ROOT / "scripts/admin.sh"), "releases", "deactivate", version, platform],
+                                env=self.env, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = self.calls()[-1]
+        self.assertEqual(json.loads(call[call.index("-d") + 1]), {"version": version, "platform": platform})
+
+    def test_fleet_continues_after_failure_but_returns_failure(self):
+        fleet = self.root / "update-fleet.sh"
+        shutil.copy2(ROOT / "deploy/provider-fleet/update-fleet.sh", fleet)
+        (self.root / "dev-inventory.txt").write_text("first\nsecond\nthird\n")
+        self.stub("ssh", '''import json,os,sys
+with open(os.environ["OPERATIONS_TEST_LOG"], "a") as log:
+    log.write(json.dumps(sys.argv[1]) + "\\n")
+sys.exit(1 if sys.argv[1] == "second" else 0)
+''')
+        result = subprocess.run(["bash", str(fleet), "dev"], env=self.env, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(self.calls(), ["first", "second", "third"])
+        self.assertIn("1 failed host", result.stderr)
+        result = subprocess.run(["bash", str(fleet), "prod"], env=self.env, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(self.calls(), ["first", "second", "third"])
+
+    def test_smoke_uses_a_fresh_owned_response_file_and_removes_it(self):
+        self.stub("curl", '''import json,os,sys
+from pathlib import Path
+args = sys.argv[1:]
+if "-o" in args:
+    path = args[args.index("-o") + 1]
+    Path(path).write_text("fixture response")
+    with open(os.environ["OPERATIONS_TEST_LOG"], "a") as log:
+        log.write(json.dumps(path) + "\\n")
+    print("500", end="")
+elif args[-1].endswith("/v1/stats"):
+    print('{"providers_online": 1}')
+elif args[-1].endswith("/v1/models/catalog"):
+    print('{"models": [1]}')
+elif args[-1].endswith("/install.sh"):
+    print("https://api.dev.darkbloom.xyz")
+''')
+        for _ in range(2):
+            result = subprocess.run(["bash", str(ROOT / "scripts/smoke-dev.sh")],
+                                    env={**self.env, "API_KEY": "fixture-only"}, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("fixture response", result.stdout)
+        paths = self.calls()
+        self.assertEqual(len(set(paths)), 2)
+        self.assertTrue(all(not Path(path).exists() for path in paths))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_operations_scripts.py
+++ b/scripts/test_operations_scripts.py
@@ -70,6 +70,21 @@ sys.exit(1 if sys.argv[1] == "second" else 0)
         self.assertEqual(result.returncode, 2)
         self.assertEqual(self.calls(), ["first", "second", "third"])
 
+    def test_fleet_propagates_remote_download_and_installer_failures(self):
+        fleet = self.root / "update-fleet.sh"
+        shutil.copy2(ROOT / "deploy/provider-fleet/update-fleet.sh", fleet)
+        (self.root / "dev-inventory.txt").write_text("fixture-host\n")
+        self.stub("ssh", '''import subprocess,sys
+# Run only the supplied shell command locally against our curl stub.
+sys.exit(subprocess.run(["/bin/sh", "-c", sys.argv[2]]).returncode)
+''')
+        for curl_source in ("import sys; sys.exit(22)", "print('exit 7')", "print('exit 0')"):
+            with self.subTest(curl_source=curl_source):
+                self.stub("curl", curl_source)
+                result = subprocess.run(["bash", str(fleet), "dev"], env=self.env,
+                                        capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0 if "exit 0" in curl_source else 1)
+
     def test_smoke_uses_a_fresh_owned_response_file_and_removes_it(self):
         self.stub("curl", '''import json,os,sys
 from pathlib import Path


### PR DESCRIPTION
Operations helpers could corrupt quoted admin input, report a successful fleet update after SSH failures, and overwrite another smoke run's response file. Encode the admin's JSON values once, preserve literal backslashes during input, collect fleet failures while still visiting every host, and give each authenticated smoke run its own temporary response file with exit cleanup.

The fleet updater now uses remote `pipefail` so a failed download also fails the host update, and exits 1 after any failed host; its existing production opt-in check remains. Login tests deliberately receive no token and stop before writing one. The raw admin API command continues to accept caller-provided JSON.

```mermaid
flowchart LR
  subgraph Before
    A[Admin input] --> B[Interpolated JSON: quotes and backslashes alter fields]
    C[Fleet SSH attempts] --> D[Log failures, then exit success]
    E[Smoke request] --> F[Shared /tmp/smoke-chat.json]
  end
  subgraph After
    G[Same admin input] --> H[json_body: encode field values]
    I[Same fleet attempts] --> J[Visit all hosts; nonzero result if any failed]
    K[Smoke request] --> L[Unique owned response file; cleanup on exit]
  end
```

Validation: four operation-contract tests pass using stub curl/SSH executables. The admin quoting and fleet-result regressions reproduce on master. Smoke tests prove distinct paths across runs and cleanup after failed responses. Shell syntax, docs lint and whitespace checks pass. Tests perform no network request, fleet update or credential write.

Stacked on the complementary server-side OTP JSON fix #905 (`fix/privy-otp-json`). No deployment was performed. The `tooling-test` discovery added in #910 will include these tests automatically when both changes are combined.
