### PR TITLE
fix(mediafetch): release shared byte budget after reader panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Remote media recovery** — Release shared byte-budget reservations when a media reader panics, allowing sibling workers to finish and the request to fail instead of hanging.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/mediafetch/budget.go
+++ b/coordinator/mediafetch/budget.go
@@ -75,7 +75,7 @@ type budgetReader struct {
 	budget *byteBudget
 }
 
-func (r *budgetReader) Read(p []byte) (int, error) {
+func (r *budgetReader) Read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
@@ -83,7 +83,8 @@ func (r *budgetReader) Read(p []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	n, readErr := r.source.Read(p[:reserved])
-	r.budget.finish(reserved, n)
-	return n, readErr
+	// A worker may recover a source-reader panic. Release its reservation even
+	// then, or siblings can remain in reserve's Cond.Wait after cancellation.
+	defer func() { r.budget.finish(reserved, n) }()
+	return r.source.Read(p[:reserved])
 }

--- a/coordinator/mediafetch/budget_test.go
+++ b/coordinator/mediafetch/budget_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestByteBudgetExactLimitAcrossConcurrentReaders(t *testing.T) {
@@ -72,3 +73,38 @@ func TestByteBudgetBoundsConcurrentOverflow(t *testing.T) {
 		t.Fatalf("inFlight = %d after readers complete, want 0", budget.inFlight)
 	}
 }
+
+// Fetch workers recover reader panics. Their shared byte budget must release
+// the abandoned read so a sibling can finish and fetchAll can join its workers.
+func TestByteBudgetReaderPanicDoesNotStrandSibling(t *testing.T) {
+	budget := newByteBudget(100)
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected controlled reader panic")
+			}
+		}()
+		_, _ = budget.reader(panickingBudgetSource{}).Read(make([]byte, 101))
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		got, err := io.ReadAll(budget.reader(bytes.NewBufferString("sibling")))
+		if err == nil && string(got) != "sibling" {
+			err = errors.New("sibling read was incomplete")
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("recovered reader panic stranded another read in the shared budget")
+	}
+}
+
+type panickingBudgetSource struct{}
+
+func (panickingBudgetSource) Read([]byte) (int, error) { panic("controlled media reader panic") }

--- a/docs/architecture/components/consumer.md
+++ b/docs/architecture/components/consumer.md
@@ -1,6 +1,6 @@
 # Consumer surface
 
-> Last updated: 2026-09-04 · commit `7ae06021f`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 The consumer surface is the coordinator's OpenAI- and Anthropic-compatible request pipeline: it speaks OpenAI Chat Completions, OpenAI Responses, Anthropic Messages and legacy Completions to clients and turns each request into one provider job through a single pipeline in `handleChatCompletions` (`coordinator/api/consumer.go`), with an endpoint-specific lowering step before it and a re-shaping step after it. This page is for engineers changing or debugging that pipeline: it explains what "compatible" means concretely, walks the stages, and lists the invariants and failure modes that follow. The exact routes, headers, and JSON shapes are in [`../../reference/api-contracts.md`](../../reference/api-contracts.md).
 
@@ -55,6 +55,8 @@ Provider-side execution between stages 13 and 14 — the WebSocket `inference_re
 6. **Providers never see the caller.** They receive an encrypted job carrying the build id and the prompt, not the API key or account.
 7. **A departed client cancels the job.** Client disconnect before commit is recorded as 499 and sends `cancel` to the provider (`emitClientGone`, `sendProviderCancel`).
 
+8. **Media worker failure releases shared read capacity.** `budgetReader.Read` releases its byte reservation on normal return and panic; `fetchAll` can then recover a failed worker, cancel siblings and join them without leaving readers blocked in the shared budget (`coordinator/mediafetch/budget.go`, `coordinator/mediafetch/resolver.go`).
+
 ## Failure modes
 
 | Symptom | Cause | Where |
@@ -86,6 +88,7 @@ Provider-side execution between stages 13 and 14 — the WebSocket `inference_re
 | Endpoint lowering | `coordinator/promptcontract/endpoint_lower.go`, `coordinator/promptcontract/endpoint_lower_responses.go`, `coordinator/promptcontract/endpoint_lower_messages.go` |
 | Endpoint-specific response and stream builders | `coordinator/api/generic_endpoint_response.go`, `coordinator/api/generic_endpoint_stream.go`, `coordinator/api/generic_endpoint_stop.go`, `coordinator/api/responses_stream.go`, `coordinator/api/chat_metadata_stream.go`, `coordinator/api/sse_response.go` |
 | Provider metadata, timing header | `coordinator/api/response_metadata.go`, `coordinator/api/profiler_dispatch.go` |
+| Remote media reads and worker cleanup | `coordinator/mediafetch/budget.go` (`budgetReader.Read`, `byteBudget.finish`), `coordinator/mediafetch/resolver.go` (`fetchAll`) |
 | Tools and media | `coordinator/api/toolschema.go`, `coordinator/api/tool_constraints.go`, `coordinator/api/media_resolve.go` |
 | Self-route policy | `coordinator/api/self_route.go` |
 | Sealed client transport | `coordinator/api/sender_encryption.go` |


### PR DESCRIPTION
A panic while reading a remote media response could leave its shared byte-budget reservation occupied. `fetchAll` recovers the panic and cancels sibling workers, but a sibling blocked in the budget's condition wait cannot observe that cancellation, so the request can hang while joining workers.

Release the reservation with a defer in `budgetReader.Read`, accounting for returned bytes on ordinary reads and releasing the abandoned reservation when the source panics. The existing fetch-worker recovery remains responsible for reporting failure.

Before:
```mermaid
flowchart TD
  A[Concurrent media request] --> B[budgetReader.Read reserves shared bytes]
  B --> C[Source reader panics before finish]
  C --> D[fetchAll recovers and cancels siblings]
  D --> E[Sibling stays in byteBudget.reserve Cond.Wait]
  E --> F[Request waits indefinitely for workers]
```

After:
```mermaid
flowchart TD
  A[Concurrent media request] --> B[budgetReader.Read reserves shared bytes]
  B --> C[Source read returns or panics]
  C --> D[Deferred byteBudget.finish releases reservation and wakes readers]
  D --> E[fetchAll preserves normal result or recovers worker failure]
  E --> F[Workers join and request completes or returns existing error]
```

Validation: the new controlled reader test fails on master after its one-second deadline because a sibling cannot read. With the fix, `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/mediafetch -count=1` passes, including existing concurrent exact-limit, aggregate-overflow and fetch-worker panic containment tests. `scripts/docs-check.sh --all` passes (277 documents), and `git diff --check` passes. All tests use local controlled readers/servers; no external media or deployment calls.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758215&installation_model_id=21733&pr_number=914&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F914&signature=d4cf88f9828b66f61cc17f4230705befbffc64632015ee416a65f316fa66b4dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->