### PR TITLE
Count complete response bodies in E2E load results

### DIFF
--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `965589a91`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -119,6 +119,13 @@ integer index; the event profiler keeps its separate nearest-rank convention.
 `e2e/testbed/profile/profile.go` indexes one event snapshot while preserving
 request-start order, repeated starts and individual error counts. Reports should
 be built after event producers have finished.
+
+`LoadGenerator.Run` measures each request through completion of the response body.
+An incomplete body counts as a failed request even when its HTTP status is 200;
+failed reads do not enter successful latency percentiles. The local HTTP fixtures
+in `e2e/testbed/load_response_test.go` cover delayed and truncated bodies without
+a provider or model. Earlier load reports measured response headers only; their
+latencies are not comparable to this corrected end-to-end measurement.
 
 ```bash
 go test -race -short ./e2e/testbed/...

--- a/e2e/benchmark_test.go
+++ b/e2e/benchmark_test.go
@@ -312,7 +312,7 @@ func runBenchmark(t *testing.T, name string, suiteCfg testbed.SuiteConfig, reqCf
 			modelStats[rr.ModelID] = st
 		}
 		st.count++
-		if rr.StatusCode == 200 {
+		if rr.StatusCode == http.StatusOK && rr.Error == nil {
 			st.success++
 			st.totalDuration += rr.Duration
 			if st.minDuration == 0 || rr.Duration < st.minDuration {
@@ -346,7 +346,7 @@ func runBenchmark(t *testing.T, name string, suiteCfg testbed.SuiteConfig, reqCf
 			userStats[rr.UserIndex] = st
 		}
 		st.count++
-		if rr.StatusCode == 200 {
+		if rr.StatusCode == http.StatusOK && rr.Error == nil {
 			st.success++
 		} else {
 			st.errors++

--- a/e2e/testbed/load.go
+++ b/e2e/testbed/load.go
@@ -205,8 +205,9 @@ func (lg *LoadGenerator) Run() *LoadResult {
 				return
 			}
 
-			respBody, _ := io.ReadAll(resp.Body)
+			respBody, readErr := io.ReadAll(resp.Body)
 			resp.Body.Close()
+			e2eDuration = time.Since(reqStart)
 
 			rr := RequestResult{
 				Index:      idx,
@@ -252,7 +253,10 @@ func (lg *LoadGenerator) Run() *LoadResult {
 				}
 			}
 
-			if resp.StatusCode == http.StatusOK {
+			if readErr != nil {
+				errorCount.Add(1)
+				rr.Error = fmt.Errorf("read response body: %w", readErr)
+			} else if resp.StatusCode == http.StatusOK {
 				successCount.Add(1)
 
 				timingsMu.Lock()

--- a/e2e/testbed/load_response_test.go
+++ b/e2e/testbed/load_response_test.go
@@ -1,0 +1,50 @@
+package testbed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func fixtureLoad(server *httptest.Server) *LoadGenerator {
+	return &LoadGenerator{
+		Suite:  &Suite{Ctx: context.Background(), Coordinator: &Coordinator{baseURL: server.URL}},
+		Config: RequestConfig{Concurrency: 1, TotalRequests: 1, ModelID: "fixture"},
+	}
+}
+
+func TestLoadCountsTruncatedSuccessBodyAsFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		fmt.Fprint(w, "truncated")
+	}))
+	defer server.Close()
+	result := fixtureLoad(server).Run()
+	require.Equal(t, 0, result.SuccessCount)
+	require.Equal(t, 1, result.ErrorCount)
+	require.Equal(t, http.StatusOK, result.RequestResults[0].StatusCode)
+	require.ErrorContains(t, result.RequestResults[0].Error, "unexpected EOF")
+	require.Empty(t, result.ProfileRun.SegmentTimings)
+}
+
+func TestLoadDurationIncludesResponseBody(t *testing.T) {
+	bodyHold := make(chan time.Duration, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		start := time.Now()
+		time.Sleep(30 * time.Millisecond)
+		bodyHold <- time.Since(start)
+		fmt.Fprint(w, "complete")
+	}))
+	defer server.Close()
+	result := fixtureLoad(server).Run()
+	require.Equal(t, 1, result.SuccessCount)
+	require.GreaterOrEqual(t, result.RequestResults[0].Duration, <-bodyHold)
+	require.Equal(t, result.RequestResults[0].Duration, result.ProfileRun.SegmentTimings[SegmentTotalE2E][0])
+}


### PR DESCRIPTION
Load requests previously stopped their end-to-end timer when HTTP headers arrived and counted HTTP 200 responses as successful even when reading the body failed. Measure through body completion and record truncated or interrupted reads as failures, excluding them from successful latency statistics.

Stacked on #903, which consolidates load reporting. This change does not measure TTFT or alter provider inference. Historical reports using header-only timing are not directly comparable; their evidence remains unchanged.

Before:
```mermaid
flowchart LR
  A[LoadGenerator.Run sends request] --> B[Client.Do returns headers]
  B --> C[Stop E2E timer]
  C --> D[ReadAll ignores error]
  D --> E[HTTP 200 enters success counts and latency statistics]
```

After:
```mermaid
flowchart LR
  A[LoadGenerator.Run sends request] --> B[Client.Do returns headers]
  B --> C[ReadAll consumes body]
  C --> D[Stop E2E timer]
  D --> E{Body read succeeded?}
  E -->|No| F[Record read error and exclude successful latency statistics]
  E -->|Yes| G[Classify HTTP status using existing policy]
```

Validation: both delayed-body and truncated-body HTTP fixtures fail against the previous implementation and pass with the fix. `go test -race -short ./e2e/testbed/...` passes, as do docs lint and whitespace checks. Fixtures use localhost only, with no provider, model, or GPU workload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758500&installation_model_id=21733&pr_number=915&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F915&signature=5ef61d8d4406f9db541e1f355e19392c258879cff6c8ed83fc1257510d707a11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->