### PR TITLE
Consolidate fan control transitions and status projection

### DIFF
--- a/provider-swift/Sources/DarkbloomFanCore/FanController.swift
+++ b/provider-swift/Sources/DarkbloomFanCore/FanController.swift
@@ -274,16 +274,7 @@ public actor TransactionalFanController {
                 // can fail after the kernel accepted it, so "threw" is not proof
                 // that the fan stayed automatic.
                 possiblyControlledFans[fan.index] = fan
-                do {
-                    try writeAndVerifyManualMode(fan)
-                } catch {
-                    let directFailure = normalize(error)
-                    guard shouldAttemptFtst(after: directFailure) else {
-                        throw directFailure
-                    }
-                    try acquireFtstIfNeeded(recordOwnership: recordOwnership)
-                    try retryManualMode(fan)
-                }
+                try enterManualMode(fan, recordOwnership: recordOwnership)
                 guard let precomputedTarget = targets[fan.index] else {
                     throw FanControllerError.incompleteSession(index: fan.index)
                 }
@@ -322,15 +313,7 @@ public actor TransactionalFanController {
                 ownsFtst: mayOwnFtst
             )
         } catch {
-            let primary = normalize(error)
-            let failures = restoreTrackedState(recordOwnership: recordOwnership)
-            if !failures.isEmpty {
-                throw FanControllerError.rollbackFailed(
-                    primary: primary,
-                    failures: failures
-                )
-            }
-            throw primary
+            throw rollbackError(after: error, recordOwnership: recordOwnership)
         }
     }
 
@@ -386,16 +369,7 @@ public actor TransactionalFanController {
                 case .manual:
                     break
                 case .automatic, .system:
-                    do {
-                        try writeAndVerifyManualMode(fan)
-                    } catch {
-                        let directFailure = normalize(error)
-                        guard shouldAttemptFtst(after: directFailure) else {
-                            throw directFailure
-                        }
-                        try acquireFtstIfNeeded(recordOwnership: recordOwnership)
-                        try retryManualMode(fan)
-                    }
+                    try enterManualMode(fan, recordOwnership: recordOwnership)
                 case .unknown(let value):
                     throw FanControllerError.unknownFanMode(
                         index: fan.index,
@@ -430,21 +404,40 @@ public actor TransactionalFanController {
                 ownsFtst: mayOwnFtst
             )
         } catch {
-            let primary = normalize(error)
-            let failures = restoreTrackedState(recordOwnership: recordOwnership)
-            if !failures.isEmpty {
-                throw FanControllerError.rollbackFailed(
-                    primary: primary,
-                    failures: failures
-                )
-            }
-            throw primary
+            throw rollbackError(after: error, recordOwnership: recordOwnership)
         }
     }
 
     @discardableResult
     public func reassert() throws -> FanControlSession {
         try maintain()
+    }
+
+    /// Engage and maintenance use the same verified transition. Firmware
+    /// rejection or failed mode readback permits Ftst fallback; permission does not.
+    private func enterManualMode(
+        _ fan: FanCapability,
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void
+    ) throws {
+        do {
+            try writeAndVerifyManualMode(fan)
+        } catch {
+            let directFailure = normalize(error)
+            guard shouldAttemptFtst(after: directFailure) else {
+                throw directFailure
+            }
+            try acquireFtstIfNeeded(recordOwnership: recordOwnership)
+            try retryManualMode(fan)
+        }
+    }
+
+    private func rollbackError(
+        after error: Error,
+        recordOwnership: @Sendable (FanControlOwnership) throws -> Void
+    ) -> FanControllerError {
+        let primary = normalize(error)
+        let failures = restoreTrackedState(recordOwnership: recordOwnership)
+        return failures.isEmpty ? primary : .rollbackFailed(primary: primary, failures: failures)
     }
 
     private func writeAndVerifyManualMode(_ fan: FanCapability) throws {

--- a/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
+++ b/provider-swift/Sources/DarkbloomFanHelper/FanDaemon.swift
@@ -30,8 +30,7 @@ actor FanDaemon {
 
     private var policy: FanPolicyStateMachine
     private var pollTask: Task<Void, Never>?
-    private var leaseSessionID: UUID?
-    private var leaseExpiresAt: TimeInterval = 0
+    private var providerLease: (sessionID: UUID, expiresAt: TimeInterval)?
     private var powerSuspended = false
     private var administrativelyDisabled = false
     private var mode: FanServiceMode
@@ -110,15 +109,13 @@ actor FanDaemon {
         guard providerVersion.utf8.count <= 64 else {
             return FanIPCReply(ok: false, message: "provider version is invalid")
         }
-        leaseSessionID = sessionID
-        leaseExpiresAt = uptime() + FanIPC.leaseDurationSeconds
+        providerLease = (sessionID, uptime() + FanIPC.leaseDurationSeconds)
         return FanIPCReply(ok: true)
     }
 
     func releaseLease(sessionID: UUID) async -> FanIPCReply {
-        if leaseSessionID == sessionID {
-            leaseSessionID = nil
-            leaseExpiresAt = 0
+        if providerLease?.sessionID == sessionID {
+            providerLease = nil
             let restored = await restoreAutomatic(reason: "provider lease released")
             return FanIPCReply(
                 ok: restored,
@@ -129,16 +126,14 @@ actor FanDaemon {
     }
 
     func sessionInvalidated(_ sessionID: UUID) async {
-        guard leaseSessionID == sessionID else { return }
-        leaseSessionID = nil
-        leaseExpiresAt = 0
+        guard providerLease?.sessionID == sessionID else { return }
+        providerLease = nil
         _ = await restoreAutomatic(reason: "provider XPC session ended")
     }
 
     func emergencyRestore() async -> FanIPCReply {
         administrativelyDisabled = true
-        leaseSessionID = nil
-        leaseExpiresAt = 0
+        providerLease = nil
         let restored = await restoreAutomatic(reason: "administrator requested Auto")
         return FanIPCReply(ok: restored, message: restored ? nil : lastError)
     }
@@ -155,16 +150,7 @@ actor FanDaemon {
             triggerTemperatureC: configuration.policy.triggerCelsius,
             releaseTemperatureC: configuration.policy.releaseCelsius,
             speedPercent: configuration.policy.speedPercent,
-            fans: fanReadings.map { reading in
-                FanServiceFanStatus(
-                    index: reading.capability.index,
-                    actualRPM: reading.actualRPM,
-                    targetRPM: reading.targetRPM,
-                    minimumRPM: reading.minimumRPM,
-                    maximumRPM: reading.maximumRPM,
-                    mode: describe(reading.mode)
-                )
-            },
+            fans: fanReadings.map { FanServiceFanStatus(reading: $0) },
             lastError: lastError
         )
     }
@@ -172,15 +158,13 @@ actor FanDaemon {
     func shutdown() async {
         pollTask?.cancel()
         pollTask = nil
-        leaseSessionID = nil
-        leaseExpiresAt = 0
+        providerLease = nil
         _ = await restoreAutomatic(reason: "fan helper shutting down")
     }
 
     func prepareForSleep() async {
         powerSuspended = true
-        leaseSessionID = nil
-        leaseExpiresAt = 0
+        providerLease = nil
         _ = await restoreAutomatic(reason: "system will sleep")
     }
 
@@ -188,13 +172,13 @@ actor FanDaemon {
         // A fresh provider renewal is required after wake. This prevents a
         // stale pre-sleep lease from reasserting manual mode on resumed hardware.
         powerSuspended = false
-        leaseSessionID = nil
-        leaseExpiresAt = 0
+        providerLease = nil
         mode = effectiveEnabled ? .waitingForProvider : .disabled
     }
 
     private var providerLeaseActive: Bool {
-        !powerSuspended && leaseSessionID != nil && uptime() < leaseExpiresAt
+        guard let providerLease else { return false }
+        return !powerSuspended && uptime() < providerLease.expiresAt
     }
 
     private var effectiveEnabled: Bool {
@@ -292,21 +276,14 @@ actor FanDaemon {
     }
 
     private func persistOwnership(_ session: FanControlSession) throws {
-        try FanDurableFile.writeJSON(
-            FanSessionJournal(
-                fanIndices: session.targetRPMByFan.keys.map { $0 },
-                ownsFtst: session.ownsFtst
-            ),
-            to: paths.sessionJournal,
-            permissions: 0o600,
-            owner: journalOwner
-        )
+        try recordOwnership(FanControlOwnership(
+            fanIndices: Array(session.targetRPMByFan.keys),
+            ownsFtst: session.ownsFtst
+        ))
     }
 
     private func restoreAutomatic(reason: String) async -> Bool {
-        guard await controller.isControlling
-            || FileManager.default.fileExists(atPath: paths.sessionJournal.path)
-        else {
+        guard await hasPossibleOwnership else {
             _ = policy.reset()
             if !providerLeaseActive {
                 mode = effectiveEnabled ? .waitingForProvider : .disabled
@@ -357,12 +334,4 @@ actor FanDaemon {
         }
     }
 
-    private func describe(_ mode: FanMode) -> String {
-        switch mode {
-        case .automatic: return "auto"
-        case .manual: return "manual"
-        case .system: return "system"
-        case .unknown(let value): return "unknown(\(value))"
-        }
-    }
 }

--- a/provider-swift/Sources/DarkbloomFanService/FanServiceFanStatus+Hardware.swift
+++ b/provider-swift/Sources/DarkbloomFanService/FanServiceFanStatus+Hardware.swift
@@ -1,0 +1,23 @@
+import DarkbloomFanCore
+import DarkbloomFanProtocol
+
+extension FanServiceFanStatus {
+    /// Shared hardware projection for helper status and read-only CLI diagnosis.
+    public init(reading: FanReading) {
+        let mode: String
+        switch reading.mode {
+        case .automatic: mode = "auto"
+        case .manual: mode = "manual"
+        case .system: mode = "system"
+        case .unknown(let raw): mode = "unknown(\(raw))"
+        }
+        self.init(
+            index: reading.capability.index,
+            actualRPM: reading.actualRPM,
+            targetRPM: reading.targetRPM,
+            minimumRPM: reading.minimumRPM,
+            maximumRPM: reading.maximumRPM,
+            mode: mode
+        )
+    }
+}

--- a/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanCommand.swift
@@ -86,7 +86,7 @@ extension Fan {
                     gpuTemperatures: temperatures.map {
                         FanTemperatureStatus(key: $0.key.rawValue, celsius: $0.celsius)
                     },
-                    fans: fans.map(Self.fanStatus),
+                    fans: fans.map { FanServiceFanStatus(reading: $0) },
                     error: nil
                 )
             } catch {
@@ -97,26 +97,6 @@ extension Fan {
                     fans: [],
                     error: String(describing: error)
                 )
-            }
-        }
-
-        static func fanStatus(_ reading: FanReading) -> FanServiceFanStatus {
-            FanServiceFanStatus(
-                index: reading.capability.index,
-                actualRPM: reading.actualRPM,
-                targetRPM: reading.targetRPM,
-                minimumRPM: reading.minimumRPM,
-                maximumRPM: reading.maximumRPM,
-                mode: describe(reading.mode)
-            )
-        }
-
-        static func describe(_ mode: FanMode) -> String {
-            switch mode {
-            case .automatic: return "auto"
-            case .manual: return "manual"
-            case .system: return "system"
-            case .unknown(let raw): return "unknown(\(raw))"
             }
         }
 

--- a/provider-swift/Sources/darkbloom/Fan/FanHelperClient.swift
+++ b/provider-swift/Sources/darkbloom/Fan/FanHelperClient.swift
@@ -18,33 +18,23 @@ enum FanHelperClientError: Error, CustomStringConvertible {
 
 struct FanHelperClient {
     func status() throws -> FanServiceStatus {
-        let data = try request { proxy, reply in
+        try request { proxy, reply in
             proxy.status(withReply: reply)
-        }
-        do {
-            return try FanIPCCoding.decode(FanServiceStatus.self, from: data)
-        } catch {
-            throw FanHelperClientError.invalidReply(String(describing: error))
         }
     }
 
     func restoreAutomatic() throws -> FanIPCReply {
-        let data = try request { proxy, reply in
+        try request { proxy, reply in
             proxy.restoreAutomatic(withReply: reply)
-        }
-        do {
-            return try FanIPCCoding.decode(FanIPCReply.self, from: data)
-        } catch {
-            throw FanHelperClientError.invalidReply(String(describing: error))
         }
     }
 
-    private func request(
+    private func request<Reply: Decodable>(
         _ send: (
             DarkbloomFanHelperProtocol,
             @escaping @Sendable (Data) -> Void
         ) -> Void
-    ) throws -> Data {
+    ) throws -> Reply {
         let connection = NSXPCConnection(
             machServiceName: FanIPC.machServiceName,
             options: .privileged
@@ -64,11 +54,11 @@ struct FanHelperClient {
             reply.finish(.failure(.unavailable("connection invalidated")))
         }
         connection.resume()
+        defer { connection.invalidate() }
 
         guard let proxy = connection.remoteObjectProxyWithErrorHandler({ error in
             reply.finish(.failure(.unavailable(error.localizedDescription)))
         }) as? DarkbloomFanHelperProtocol else {
-            connection.invalidate()
             throw FanHelperClientError.unavailable("could not create XPC proxy")
         }
 
@@ -76,11 +66,14 @@ struct FanHelperClient {
             reply.finish(.success(data))
         }
         guard reply.wait(timeout: 2) else {
-            connection.invalidate()
             throw FanHelperClientError.timedOut
         }
-        connection.invalidate()
-        return try reply.result().get()
+        let data = try reply.result().get()
+        do {
+            return try FanIPCCoding.decode(Reply.self, from: data)
+        } catch {
+            throw FanHelperClientError.invalidReply(String(describing: error))
+        }
     }
 }
 

--- a/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
+++ b/provider-swift/Tests/DarkbloomFanCoreTests/FanControllerTests.swift
@@ -433,21 +433,31 @@ struct FanControllerTests {
         #expect(!backend.operations.contains(.write("Ftst", [0])))
     }
 
-    @Test("permission denial never attempts the Ftst bypass")
-    func permissionFailureDoesNotUseFtst() async throws {
+    @Test("permission denial never attempts the Ftst bypass", arguments: [false, true])
+    func permissionFailureDoesNotUseFtst(duringMaintenance: Bool) async throws {
         let backend = makeFanBackend(fanCount: 1)
+        let controller = try makeController(backend: backend)
+        if duringMaintenance {
+            _ = try await controller.engage(speedPercent: 80)
+            backend.setUI8("F0Md", 3)
+            backend.resetOperations()
+        }
         backend.queue([.failBefore(.notPrivileged(
             operation: .writeBytes,
             key: "F0Md"
         ))], for: "F0Md")
-        let controller = try makeController(backend: backend)
-
         let error = await captureControllerError {
-            _ = try await controller.engage(speedPercent: 80)
+            if duringMaintenance {
+                _ = try await controller.maintain()
+            } else {
+                _ = try await controller.engage(speedPercent: 80)
+            }
         }
         #expect(error == .smc(.notPrivileged(operation: .writeBytes, key: "F0Md")))
         #expect(!backend.operations.contains(.write("Ftst", [1])))
         #expect(try backend.uint8("Ftst") == 0)
+        #expect(try backend.uint8("F0Md") == 0)
+        #expect(await controller.currentSession() == nil)
     }
 
     @Test("a mode write that mutates then throws is still rolled back")

--- a/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
+++ b/provider-swift/Tests/DarkbloomFanHelperTests/FanDaemonTests.swift
@@ -52,6 +52,42 @@ struct FanDaemonTests {
         #expect(harness.backend.byte("F0Md") == 1)
     }
 
+    @Test("stale sessions cannot release a replacement lease", arguments: [false, true])
+    func replacementLeaseIgnoresStaleSession(explicitRelease: Bool) async throws {
+        let harness = try makeHarness()
+        defer { try? FileManager.default.removeItem(at: harness.root) }
+        let oldSession = UUID()
+        let currentSession = UUID()
+        _ = await harness.daemon.renewLease(
+            sessionID: oldSession,
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        await harness.daemon.tick()
+        harness.clock.advance(by: 10)
+        _ = await harness.daemon.renewLease(
+            sessionID: currentSession,
+            protocolVersion: FanIPC.protocolVersion,
+            providerVersion: "0.7.9"
+        )
+        if explicitRelease {
+            #expect((await harness.daemon.releaseLease(sessionID: oldSession)).ok)
+        } else {
+            await harness.daemon.sessionInvalidated(oldSession)
+        }
+        harness.clock.advance(by: FanIPC.leaseDurationSeconds - 1)
+        await harness.daemon.tick()
+        #expect((await harness.daemon.status()).providerActive)
+        #expect(harness.backend.byte("F0Md") == 1)
+
+        // Expiry belongs to the replacement session, including its exact boundary.
+        harness.clock.advance(by: 1)
+        await harness.daemon.tick()
+        #expect(!(await harness.daemon.status()).providerActive)
+        #expect(harness.backend.byte("F0Md") == 0)
+        #expect(!FileManager.default.fileExists(atPath: harness.paths.sessionJournal.path))
+    }
+
     @Test("expired lease restores Auto without a disconnect callback")
     func leaseExpiry() async throws {
         let harness = try makeHarness()

--- a/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
+++ b/provider-swift/Tests/DarkbloomFanServiceTests/FanServiceTests.swift
@@ -10,6 +10,26 @@ import Darwin
 
 @Suite("Fan service boundary")
 struct FanServiceTests {
+    @Test("hardware status preserves RPMs and wire mode names", arguments: [UInt8(0), 1, 3, 255])
+    func hardwareStatus(rawMode: UInt8) throws {
+        let reading = FanReading(
+            capability: FanCapability(
+                index: 2, actualKey: "F2Ac", minimumKey: "F2Mn",
+                maximumKey: "F2Mx", targetKey: "F2Tg", modeKey: "F2Md"
+            ),
+            actualRPM: 3_500, minimumRPM: 1_200, maximumRPM: 5_000,
+            targetRPM: 4_000, mode: FanMode(rawValue: rawMode)
+        )
+        let status = FanServiceFanStatus(reading: reading)
+        let expectedModes: [UInt8: String] = [0: "auto", 1: "manual", 3: "system", 255: "unknown(255)"]
+        let encoded = try FanIPCCoding.encode(status)
+        let decoded = try FanIPCCoding.decode(FanServiceFanStatus.self, from: encoded)
+        #expect(decoded == FanServiceFanStatus(
+            index: 2, actualRPM: 3_500, targetRPM: 4_000,
+            minimumRPM: 1_200, maximumRPM: 5_000, mode: expectedModes[rawMode]
+        ))
+    }
+
     @Test("configured provider and root are the only allowed UIDs")
     func uidAuthorization() {
         let uuid = "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
Fan control currently repeats its verified manual-mode fallback and rollback handling in both engagement and maintenance, and duplicates hardware-to-status projection in the helper and CLI. This consolidates those operations while preserving the durable journal before each possible hardware write, RPM floors, restoration retries, authentication, and status wire values. It also keeps lease identity and expiration in one optional value and gives synchronous XPC calls one typed reply/cleanup path. Production code is 46 lines smaller.

Validation: the combined final source `93c4caa5c6abb73ef9c882c1deae7eee31eef125` passed a dedicated M5 release build and **1,243 Swift Testing cases across 132 suites plus 48 XCTest cases**, with no skipped tests. The run includes the real Gemma QAT tokenizer/constraint fixture and packaged runtime smoke. All 5,093 staged source files and compiled runtime hashes were checked before and after. Provider SHA256: `45c33b44c58228f67a362c7239eda081877c846d568a73bda026e010512af060`; metallib SHA256: `20972c37e53fe6db3b3191a0434f6604c4ffc4f5ac62b370574f9922585b0fdb`.

The run combines #897, #904, #916, #917, #920 and #923 at their current source heads. Model-generation/live benchmark suites were explicitly excluded; this evidence does not claim MTP speed or live HTTP cache qualification. The QAT fixture contains verified tokenizer/config/template files only, and its temporary scanner entry was removed after validation.

Fan fixtures cover stale session release, exact replacement-lease expiry, maintenance permission denial, and wire mode/RPM projections. No privileged helper was installed and no real fan hardware was changed.

**Before**
```mermaid
flowchart LR
  P[Signed provider lease] --> D[Daemon stores session ID and expiration separately]
  D --> E[Engage duplicates manual fallback and rollback]
  D --> M[Maintain duplicates manual fallback and rollback]
  E --> J[Journal before possible SMC write]
  M --> J
  J --> O[Verified manual control or automatic restoration]
  H[Hardware readings] --> S[Daemon maps status]
  H --> C[CLI separately maps status]
  X[Status or restore XPC request] --> R[Repeated decoding and invalidation]
```

**After**
```mermaid
flowchart LR
  P[Signed provider lease] --> D[Daemon holds optional session and expiration together]
  D --> E[Engage or maintain]
  E --> T[Shared enterManualMode and rollbackError]
  T --> J[Same journal before possible SMC write]
  J --> O[Same verified manual control or automatic restoration]
  H[Hardware readings] --> S[FanServiceFanStatus reading initializer]
  S --> C[Identical helper and CLI status]
  X[Status or restore XPC request] --> R[Typed request with one decoder and deferred invalidation]
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791758519&installation_model_id=21733&pr_number=916&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F916&signature=91eb2b7ebaae8711d8f0ccc46bbfb2e27cf1f411d869f0164f724c9171627d8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->