### PR TITLE
Consolidate benchmark setup and preserve full measurement durations

### DIFF
--- a/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
@@ -101,18 +101,8 @@ public enum ArrivalInvarianceBenchmark {
         log("  path: \(modelDirectory.path)")
 
         let isVLM = ThroughputSweep.readHasVisionConfig(modelDirectory: modelDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
 
         let facts = await container.perform { context -> ModelFacts in
             let encoded = context.tokenizer.encode(

--- a/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ArrivalInvarianceBenchmark.swift
@@ -217,7 +217,7 @@ public enum ArrivalInvarianceBenchmark {
             let firstOutputs = allOutputs.first ?? []
             let stable = allOutputs.allSatisfy { $0 == firstOutputs }
             let measuredOffsets = definition.delaysMs.indices.map { index in
-                median(reports.compactMap { sample in
+                BenchmarkMeasurements.median(reports.compactMap { sample in
                     sample.rows.first { $0.row == index }?.submittedAtMs
                 })
             }
@@ -226,14 +226,14 @@ public enum ArrivalInvarianceBenchmark {
                 name: definition.name,
                 arrivalDelaysMs: definition.delaysMs,
                 samples: reports,
-                medianTTFTMs: median(reports.flatMap { $0.rows.map(\.ttftMs) }),
-                medianPerRequestDecodeTokensPerSecond: median(
+                medianTTFTMs: BenchmarkMeasurements.median(reports.flatMap { $0.rows.map(\.ttftMs) }),
+                medianPerRequestDecodeTokensPerSecond: BenchmarkMeasurements.median(
                     reports.flatMap { $0.rows.map(\.decodeTokensPerSecond) }
                 ),
-                medianAggregateDecodeTokensPerSecond: median(
+                medianAggregateDecodeTokensPerSecond: BenchmarkMeasurements.median(
                     reports.map(\.aggregateDecodeTokensPerSecond)
                 ),
-                medianMakespanMs: median(reports.map(\.makespanMs)),
+                medianMakespanMs: BenchmarkMeasurements.median(reports.map(\.makespanMs)),
                 outputsStableAcrossIterations: stable,
                 outputsMatchBurst: allOutputs.allSatisfy { $0 == burstOutputs },
                 measuredArrivalOffsetsMs: measuredOffsets,
@@ -563,16 +563,6 @@ public enum ArrivalInvarianceBenchmark {
 
     private static func milliseconds(from start: UInt64, to end: UInt64) -> Double {
         Double(end - start) / 1_000_000
-    }
-
-    private static func median(_ values: [Double]) -> Double {
-        guard !values.isEmpty else { return 0 }
-        let sorted = values.sorted()
-        let middle = sorted.count / 2
-        if sorted.count.isMultiple(of: 2) {
-            return (sorted[middle - 1] + sorted[middle]) / 2
-        }
-        return sorted[middle]
     }
 
     private static func checksum(_ tokens: [Int]) -> String {

--- a/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BackendParityHarness.swift
@@ -97,14 +97,8 @@ public enum BackendParityHarness {
         log("  path: \(modelDirectory.path)")
 
         let isVLM = ThroughputSweep.readHasVisionConfig(modelDirectory: modelDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory, using: LocalTokenizerLoader())
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory, using: LocalTokenizerLoader())
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
 
         // The SERVING model is resolved EXACTLY ONCE and reused by every
         // engine build and by the drafter.

--- a/provider-swift/Sources/ProviderBenchmark/BenchmarkMeasurements.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BenchmarkMeasurements.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Shared reporting arithmetic. Callers retain their measurement boundaries,
+/// sample validation, and choice of wall-clock versus token-stream timing.
+enum BenchmarkMeasurements {
+    static func milliseconds(_ duration: Duration) -> Double {
+        Double(duration.components.seconds) * 1000
+            + Double(duration.components.attoseconds) / 1e15
+    }
+
+    static func mean(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    /// Average both middle samples for even counts, as the Python runners do.
+    /// Empty samples retain the existing zero sentinel; no values are filtered.
+    static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let middle = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[middle - 1] + sorted[middle]) / 2
+        }
+        return sorted[middle]
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/BenchmarkModelLoader.swift
+++ b/provider-swift/Sources/ProviderBenchmark/BenchmarkModelLoader.swift
@@ -1,0 +1,18 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import ProviderCore
+
+/// Load local benchmark weights with the same factories and tokenizer as serving.
+/// Callers retain their own declaration/provenance checks and serving-model resolution.
+enum BenchmarkModelLoader {
+    static func load(directory: URL, isVLM: Bool) async throws -> ModelContainer {
+        if isVLM {
+            return try await VLMModelFactory.shared.loadContainer(
+                from: directory, using: LocalTokenizerLoader())
+        }
+        return try await LLMModelFactory.shared.loadContainer(
+            from: directory, using: LocalTokenizerLoader())
+    }
+}

--- a/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPBenchmarkRunner.swift
@@ -171,7 +171,7 @@ public enum MTPBenchmarkRunner {
                 measurementRepetitions: configuration.measurementRepetitions,
                 modeOrderSeed: configuration.modeOrderSeed,
                 coverage: coverage,
-                elapsedMs: milliseconds(ContinuousClock.now - startedAt),
+                elapsedMs: BenchmarkMeasurements.milliseconds(ContinuousClock.now - startedAt),
                 cases: results)
         }
 
@@ -953,16 +953,16 @@ public enum MTPBenchmarkRunner {
                     tokenIDs: source.tokenIDs,
                     salt: tokenEvidenceSalt),
                 timeToFirstTokenMs: performanceEligible
-                    ? median(samples.map { $0.batch.rows[row].timing.timeToFirstTokenMs })
+                    ? BenchmarkMeasurements.median(samples.map { $0.batch.rows[row].timing.timeToFirstTokenMs })
                     : nil,
                 interTokenLatencyMs: performanceEligible
-                    ? median(samples.map { $0.batch.rows[row].timing.interTokenLatencyMs })
+                    ? BenchmarkMeasurements.median(samples.map { $0.batch.rows[row].timing.interTokenLatencyMs })
                     : nil,
                 decodeTokensPerSecond: performanceEligible
-                    ? median(samples.map { $0.batch.rows[row].timing.decodeTokensPerSecond })
+                    ? BenchmarkMeasurements.median(samples.map { $0.batch.rows[row].timing.decodeTokensPerSecond })
                     : nil,
                 lastTokenLatencyMs: performanceEligible
-                    ? median(samples.map { $0.batch.rows[row].timing.lastTokenLatencyMs })
+                    ? BenchmarkMeasurements.median(samples.map { $0.batch.rows[row].timing.lastTokenLatencyMs })
                     : nil,
                 finishReason: source.finishReason)
         }
@@ -971,7 +971,7 @@ public enum MTPBenchmarkRunner {
             batchSize: key.batchSize,
             measurementRepetitions: samples.count,
             medianAggregateDecodeTokensPerSecond: performanceEligible
-                ? median(samples.map { $0.batch.aggregateDecodeTokensPerSecond })
+                ? BenchmarkMeasurements.median(samples.map { $0.batch.aggregateDecodeTokensPerSecond })
                 : nil,
             tokenParity: true,
             parityMismatchRows: [],
@@ -995,20 +995,6 @@ public enum MTPBenchmarkRunner {
     ) throws {
         guard artifact.hasVerifiableProvenance else { return }
         try MTPBenchmarkModelFacts.validateUnchanged(artifact, label: label)
-    }
-
-    private static func median(_ values: [Double]) -> Double {
-        let sorted = values.sorted()
-        let middle = sorted.count / 2
-        if sorted.count.isMultiple(of: 2) {
-            return (sorted[middle - 1] + sorted[middle]) / 2
-        }
-        return sorted[middle]
-    }
-
-    static func milliseconds(_ duration: Duration) -> Double {
-        Double(duration.components.seconds) * 1000
-            + Double(duration.components.attoseconds) / 1e15
     }
 
     private static func requireBeforeDeadline(

--- a/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
+++ b/provider-swift/Sources/ProviderBenchmark/MTPProductionSession.swift
@@ -68,14 +68,8 @@ public final class MTPProductionModelBundle: @unchecked Sendable {
         let assistantFacts = try MTPBenchmarkModelFacts.inspect(
             modelID: assistantID, directory: assistantDirectory)
         let isVLM = hasVisionConfig(directory: targetDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: targetDirectory, using: LocalTokenizerLoader())
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: targetDirectory, using: LocalTokenizerLoader())
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: targetDirectory, isVLM: isVLM)
 
         struct Snapshot: @unchecked Sendable {
             let model: any LanguageModel

--- a/provider-swift/Sources/ProviderBenchmark/ModelBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ModelBenchmark.swift
@@ -23,18 +23,15 @@ public struct BenchmarkReport: Sendable {
     public let hardwareDescription: String
 
     public var avgPrefillLatencyMs: Double {
-        guard !iterations.isEmpty else { return 0 }
-        return iterations.map(\.prefillLatencyMs).reduce(0, +) / Double(iterations.count)
+        BenchmarkMeasurements.mean(iterations.map(\.prefillLatencyMs))
     }
 
     public var avgDecodeTokensPerSecond: Double {
-        guard !iterations.isEmpty else { return 0 }
-        return iterations.map(\.decodeTokensPerSecond).reduce(0, +) / Double(iterations.count)
+        BenchmarkMeasurements.mean(iterations.map(\.decodeTokensPerSecond))
     }
 
     public var avgTotalTimeMs: Double {
-        guard !iterations.isEmpty else { return 0 }
-        return iterations.map(\.totalTimeMs).reduce(0, +) / Double(iterations.count)
+        BenchmarkMeasurements.mean(iterations.map(\.totalTimeMs))
     }
 
     public var avgPromptTokens: Int {
@@ -145,7 +142,6 @@ public struct ModelBenchmark: Sendable {
 
             let result = try await runIteration(
                 container: container,
-                modelID: modelID,
                 prompt: prompt,
                 maxTokens: maxTokens,
                 iteration: i
@@ -164,26 +160,11 @@ public struct ModelBenchmark: Sendable {
 
     private static func runIteration(
         container: ModelContainer,
-        modelID: String,
         prompt: String,
         maxTokens: Int,
         iteration: Int
     ) async throws -> BenchmarkIterationResult {
-        let messages: [ChatMessage] = [
-            ChatMessage(role: "user", content: prompt)
-        ]
-
-        let request = ChatCompletionRequest(
-            model: modelID,
-            messages: messages,
-            temperature: 0.6,
-            max_tokens: maxTokens,
-            stream: false
-        )
-
-        let rawMessages = try messages.map { msg -> MLXLMCommon.Message in
-            ["role": msg.role, "content": msg.content] as MLXLMCommon.Message
-        }
+        let rawMessages: [MLXLMCommon.Message] = [["role": "user", "content": prompt]]
 
         let iterationStart = ContinuousClock.now
 
@@ -192,10 +173,10 @@ public struct ModelBenchmark: Sendable {
             let input = try await context.processor.prepare(
                 input: UserInput(messages: rawMessages))
             let params = GenerateParameters(
-                maxTokens: request.max_tokens,
-                temperature: request.temperature ?? 0.6,
-                topP: request.top_p ?? 1.0,
-                topK: request.top_k ?? 0
+                maxTokens: maxTokens,
+                temperature: 0.6,
+                topP: 1.0,
+                topK: 0
             )
             return try MLXLMCommon.generate(
                 input: input, parameters: params, context: context)
@@ -212,7 +193,7 @@ public struct ModelBenchmark: Sendable {
                 if firstTokenTime == nil {
                     firstTokenTime = .now
                     let elapsed = firstTokenTime! - iterationStart
-                    prefillLatencyMs = Double(elapsed.components.attoseconds) / 1e15
+                    prefillLatencyMs = BenchmarkMeasurements.milliseconds(elapsed)
                 }
 
             case .info(let info):
@@ -229,7 +210,7 @@ public struct ModelBenchmark: Sendable {
         }
 
         let totalElapsed = ContinuousClock.now - iterationStart
-        let totalTimeMs = Double(totalElapsed.components.attoseconds) / 1e15
+        let totalTimeMs = BenchmarkMeasurements.milliseconds(totalElapsed)
 
         // Calculate decode TPS from the generation info's timing when available,
         // otherwise approximate from wall-clock

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillBenchmark.swift
@@ -97,18 +97,8 @@ public enum SchedulerPrefillBenchmark {
         // VLM checkpoints load via the VLM factory and measure the exact
         // text tower owned by the wrapper (the production serving path).
         let isVLM = ThroughputSweep.readHasVisionConfig(modelDirectory: modelDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
         let facts = await container.perform { ctx -> (baseTokens: [Int], weightBytes: Int) in
             eval(ctx.model.parameters().flattened().map { $0.1 })
             let encoded = ctx.tokenizer.encode(text: ThroughputSweep.seedText, addSpecialTokens: false)

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionEvaluator.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionEvaluator.swift
@@ -62,12 +62,12 @@ enum SchedulerPrefillDecisionEvaluator {
 
             let cap0Rows = medianTTFTByRow(cap0, rowCount: workload.rows.count)
             let cap1Rows = medianTTFTByRow(cap1, rowCount: workload.rows.count)
-            let cap0Throughput = median(
+            let cap0Throughput = BenchmarkMeasurements.median(
                 cap0.map(\.aggregatePromptTokensPerSecond))
-            let cap1Throughput = median(
+            let cap1Throughput = BenchmarkMeasurements.median(
                 cap1.map(\.aggregatePromptTokensPerSecond))
-            let cap0Mean = mean(cap0Rows)
-            let cap1Mean = mean(cap1Rows)
+            let cap0Mean = BenchmarkMeasurements.mean(cap0Rows)
+            let cap1Mean = BenchmarkMeasurements.mean(cap1Rows)
 
             comparisons.append(.init(
                 workload: workload.name,
@@ -281,7 +281,7 @@ enum SchedulerPrefillDecisionEvaluator {
         rowCount: Int
     ) -> [Double] {
         (0 ..< rowCount).map { row in
-            median(results.compactMap {
+            BenchmarkMeasurements.median(results.compactMap {
                 $0.rows.first { $0.row == row }?.ttftMs
             })
         }
@@ -296,21 +296,6 @@ enum SchedulerPrefillDecisionEvaluator {
                 + Double(row.promptTokens)
                     * thresholds.firstContentPerPromptTokenMs
         }
-    }
-
-    private static func mean(_ values: [Double]) -> Double {
-        guard !values.isEmpty else { return 0 }
-        return values.reduce(0, +) / Double(values.count)
-    }
-
-    private static func median(_ values: [Double]) -> Double {
-        guard !values.isEmpty else { return 0 }
-        let sorted = values.sorted()
-        let middle = sorted.count / 2
-        if sorted.count.isMultiple(of: 2) {
-            return (sorted[middle - 1] + sorted[middle]) / 2
-        }
-        return sorted[middle]
     }
 
     private static func validModelIdentity(

--- a/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionLive.swift
+++ b/provider-swift/Sources/ProviderBenchmark/SchedulerPrefillDecisionLive.swift
@@ -91,16 +91,8 @@ enum SchedulerPrefillDecisionLiveHarness {
         let iterations = max(1, iterations)
         let isVLM = ThroughputSweep.readHasVisionConfig(
             modelDirectory: modelDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader())
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader())
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
         let facts = await container.perform { context -> ModelFacts in
             let encoded = context.tokenizer.encode(
                 text: ThroughputSweep.seedText,

--- a/provider-swift/Sources/ProviderBenchmark/TeacherForcedBenchmark.swift
+++ b/provider-swift/Sources/ProviderBenchmark/TeacherForcedBenchmark.swift
@@ -103,14 +103,8 @@ public enum TeacherForcedBenchmark {
             throw Failure.runtimeIdentityUnavailable
         }
         let isVLM = declaration.visionConfig != nil
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory, using: LocalTokenizerLoader())
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory, using: LocalTokenizerLoader())
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
         guard WeightHasher.computeHash(snapshotDir: modelDirectory, modelID: modelID) == verified else {
             throw Failure.modelHashMismatch
         }

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -80,18 +80,8 @@ public enum ThroughputSweep {
         // VLM checkpoints load through the VLM factory and serve through the
         // exact text tower owned by that wrapper, matching production.
         let isVLM = readHasVisionConfig(modelDirectory: modelDirectory)
-        let container: ModelContainer
-        if isVLM {
-            container = try await VLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        } else {
-            container = try await LLMModelFactory.shared.loadContainer(
-                from: modelDirectory,
-                using: LocalTokenizerLoader()
-            )
-        }
+        let container = try await BenchmarkModelLoader.load(
+            directory: modelDirectory, isVLM: isVLM)
 
         let facts = try await container.perform { ctx -> ModelFacts in
             eval(ctx.model.parameters().flattened().map { $0.1 })

--- a/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
+++ b/provider-swift/Sources/ProviderBenchmark/ThroughputSweep.swift
@@ -612,11 +612,7 @@ public enum ThroughputSweep {
     /// Low median for even counts is avoided: use the two-sided average so the
     /// result matches Python's `statistics.median` (the runner recomputes it).
     static func median(_ values: [Double]) -> Double {
-        guard !values.isEmpty else { return 0 }
-        let sorted = values.sorted()
-        let middle = sorted.count / 2
-        if sorted.count % 2 == 1 { return sorted[middle] }
-        return (sorted[middle - 1] + sorted[middle]) / 2
+        BenchmarkMeasurements.median(values)
     }
 
     /// Whether config.json declares `vision_config` (load through VLMModelFactory

--- a/provider-swift/Tests/ProviderCoreTests/BenchmarkMeasurementsTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/BenchmarkMeasurementsTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import ProviderBenchmark
+
+@Suite("Benchmark measurement arithmetic")
+struct BenchmarkMeasurementsTests {
+    @Test("wall time includes whole seconds", arguments: [0, 1, 999, 1_000, 2_250, 120_125, -2_250])
+    func wallTime(milliseconds: Int) {
+        #expect(BenchmarkMeasurements.milliseconds(.milliseconds(milliseconds)) == Double(milliseconds))
+    }
+
+    @Test("sub-millisecond timing retains fractional precision")
+    func fractionalWallTime() {
+        #expect(abs(BenchmarkMeasurements.milliseconds(.microseconds(123)) - 0.123) < 1e-12)
+    }
+
+    @Test("median uses both middle samples without mutating or filtering observations")
+    func medianConventions() {
+        let observations = [100.0, 3, 1, 2]
+        #expect(BenchmarkMeasurements.median(observations) == 2.5)
+        #expect(observations == [100, 3, 1, 2])
+        #expect(BenchmarkMeasurements.median([100, 1, 3]) == 3)
+        #expect(BenchmarkMeasurements.median([42.5]) == 42.5)
+        #expect(BenchmarkMeasurements.median([]) == 0)
+        #expect(BenchmarkMeasurements.median([1, .infinity]).isInfinite)
+        #expect(BenchmarkMeasurements.mean([1, .nan]).isNaN)
+    }
+
+    @Test("model reports average durations and retain integer token averages")
+    func reportAverages() {
+        let report = BenchmarkReport(
+            modelID: "test/model", modelPath: "/test", prompt: "test",
+            iterations: [
+                BenchmarkIterationResult(iteration: 1, promptTokens: 3, completionTokens: 5,
+                    prefillLatencyMs: 2_250, decodeTokensPerSecond: 10, totalTimeMs: 2_750),
+                BenchmarkIterationResult(iteration: 2, promptTokens: 4, completionTokens: 6,
+                    prefillLatencyMs: 3_750, decodeTokensPerSecond: 20, totalTimeMs: 4_250),
+            ],
+            hardwareDescription: "test"
+        )
+        #expect(report.avgPrefillLatencyMs == 3_000)
+        #expect(report.avgDecodeTokensPerSecond == 15)
+        #expect(report.avgTotalTimeMs == 3_500)
+        #expect(report.avgPromptTokens == 3)
+        #expect(report.avgCompletionTokens == 5)
+
+        let empty = BenchmarkReport(modelID: "test", modelPath: "/test", prompt: "test",
+            iterations: [], hardwareDescription: "test")
+        #expect(empty.avgPrefillLatencyMs == 0)
+        #expect(empty.avgDecodeTokensPerSecond == 0)
+        #expect(empty.avgTotalTimeMs == 0)
+    }
+}


### PR DESCRIPTION
The standard `darkbloom benchmark` discarded whole seconds when converting first-token and total durations: 2.25 seconds became 250 ms, corrupting reported decode throughput too. Both timings now use the complete duration conversion already used by the MTP runner. Arrival, scheduler-policy, MTP, and throughput reports share the existing two-middle-sample median; model and scheduler means share the same ordered arithmetic. The standard runner builds its MLX message and generation settings directly instead of constructing an unused HTTP request envelope. Seven benchmark entry points also share local LLM/VLM loading with the same factory selection and tokenizer, retaining their own integrity checks and serving-model resolution. Production code is 73 lines smaller.

Measurement boundaries, token/decode denominators, model defaults, backend selection, evidence validation, report schemas, and JSON encoding remain unchanged. MTP still rejects empty repetitions before aggregation. The only intended numeric change is the standard benchmark retaining whole seconds.

Validation: the combined final source `93c4caa5c6abb73ef9c882c1deae7eee31eef125` passed a dedicated M5 release build and **1,243 Swift Testing cases across 132 suites plus 48 XCTest cases**, with no skipped tests. The run includes the real Gemma QAT tokenizer/constraint fixture and packaged runtime smoke. All 5,093 staged source files and compiled runtime hashes were checked before and after. Provider SHA256: `45c33b44c58228f67a362c7239eda081877c846d568a73bda026e010512af060`; metallib SHA256: `20972c37e53fe6db3b3191a0434f6604c4ffc4f5ac62b370574f9922585b0fdb`.

The run combines #897, #904, #916, #917, #920 and #923 at their current source heads. Model-generation/live benchmark suites were explicitly excluded; this evidence does not claim MTP speed or live HTTP cache qualification. The QAT fixture contains verified tokenizer/config/template files only, and its temporary scanner entry was removed after validation.

Pure cases cover exact/multi-second, negative and fractional durations, median behavior, invalid numbers, empty reports and token averages. Throughput/MTP/scheduler helpers are included; no model performance benchmark was run.

**Before**
```mermaid
flowchart LR
  P[Standard benchmark prompt] --> H[ChatCompletionRequest wrapper then MLX message]
  H --> T[Generation timed by ContinuousClock]
  T --> D[Only attoseconds converted to milliseconds]
  D --> R[Whole seconds lost in TTFT total and derived TPS]
  L[Seven benchmark entry points] --> F[Repeated local LLM or VLM factory choice]
  A[Arrival scheduler MTP sweep samples] --> C[Four median implementations]
  C --> J[Report]
```

**After**
```mermaid
flowchart LR
  P[Same standard benchmark prompt] --> H[Direct MLX message and same generation settings]
  H --> T[Same ContinuousClock measurement boundaries]
  T --> D[BenchmarkMeasurements includes seconds and attoseconds]
  D --> R[Full TTFT total and correctly derived TPS]
  L[Same seven benchmark entry points] --> F[BenchmarkModelLoader uses same local factories]
  A[Same arrival scheduler MTP sweep samples] --> C[Shared median with same ordered arithmetic]
  C --> J[Same report schema and values]
```
