### PR TITLE
Share validated dev environment setup between boot and deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python3 scripts/test-provider-release-resolution.py
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
+          python3 -m unittest discover -s scripts -p test_dev_env_refresh.py
       - name: Test startup observer against local stubs
         run: python3 -m unittest discover -s scripts/startup_measurement -t scripts -p 'test_*.py'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Dev coordinator boot now uses the same validated environment writer as deploys. Failed critical-secret or metadata downloads preserve the existing configuration instead of overwriting it with empty values.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/deploy/gcp/bootstrap.sh
+++ b/deploy/gcp/bootstrap.sh
@@ -308,7 +308,7 @@ if ! gcloud compute instances describe "$INSTANCE" --zone="$ZONE" >/dev/null 2>&
     --metadata-from-file="startup-script=$(dirname "$0")/vm-startup.sh,darkbloom-refresh-env=$(dirname "$0")/refresh-env.sh"
   echo "==> VM created. Startup script will run on first boot (~2-3 min)."
   echo "    Tail progress:"
-  echo "      gcloud compute ssh $INSTANCE --zone=$ZONE -- 'sudo tail -f /var/log/d-inference-startup.log'"
+  echo "      gcloud compute ssh $INSTANCE --project=$PROJECT --zone=$ZONE --tunnel-through-iap -- 'sudo tail -f /var/log/d-inference-startup.log'"
 else
   echo "==> VM $INSTANCE already exists (skipping create)"
   echo "    To refresh startup-script metadata after edits:"
@@ -326,7 +326,8 @@ Next steps:
                 eigeninference-micromdm-api-key; do
          echo -n "\$(openssl rand -hex 32)" | gcloud secrets versions add \$S --data-file=-
        done
-     Then add Privy values, the coordinator encryption mnemonic (generated fresh
+     Then add the database URL and Stripe secret/webhook keys required by
+     refresh-env.sh, Privy values, the coordinator encryption mnemonic (generated fresh
      for dev — not prod's; the secret keeps its legacy solana-mnemonic name),
      the dev R2 CDN URL (public URL of d-inf-app-dev), and the MDM push PKCS#12.
 
@@ -340,11 +341,16 @@ Next steps:
       Target: rotate to a dev-specific cert within 30 days once Apple issues
       the MDM Vendor CSR signing certificate.
 
+  1b. After populating the required secrets, rerun startup to install the service
+      units. First boot stops before unit creation while those secrets are empty:
+        gcloud compute ssh $INSTANCE --project=$PROJECT --zone=$ZONE --tunnel-through-iap \\
+          --command='sudo google_metadata_script_runner startup'
+
   2. Add DNS records on Vercel Domains:
        api.dev.darkbloom.xyz      A     $EXTERNAL_IP
        console.dev.darkbloom.xyz  CNAME cname.vercel-dns.com   (after step 4)
 
-  3. Push the first coordinator image (triggers startup-script to come to life):
+  3. Build and deploy the first coordinator image (requires step 1b):
        gcloud builds submit --config=deploy/gcp/cloudbuild.yaml --project=$PROJECT
 
   4. Deploy the console UI on **Vercel** (NOT on GCP):

--- a/deploy/gcp/bootstrap.sh
+++ b/deploy/gcp/bootstrap.sh
@@ -3,7 +3,7 @@
 #
 # Creates: Artifact Registry repos, Cloud SQL (Postgres), a GCE VM running the
 # coordinator container (with a persistent data disk for MicroMDM),
-# Cloud Run for console-ui, service accounts, Secret Manager entries
+# service accounts, Secret Manager entries
 # (placeholders), firewall rules. Idempotent: safe to re-run.
 #
 # Why GCE VM for the coordinator: MicroMDM uses
@@ -230,10 +230,9 @@ gcloud projects set-iam-policy "$PROJECT" "$AUDIT_TMP" --quiet >/dev/null
 rm -f "$AUDIT_TMP"
 
 echo "==> Scope Secret Manager access per-secret (tighter than project-level)"
-# Project-level secretAccessor was granted earlier as a fallback for operational
-# simplicity. Override the MDM push cert secret specifically so only the coord
-# SA can read it — no human, no other service. Revoke here if we ever had wider
-# bindings.
+# The explicit binding records this service account's access. IAM grants are
+# additive: project-level access granted earlier, including other inherited
+# principals, still applies. This binding does not restrict those grants.
 gcloud secrets add-iam-policy-binding eigeninference-mdm-push-p12-b64 \
   --member="serviceAccount:$COORD_SA_EMAIL" \
   --role="roles/secretmanager.secretAccessor" \
@@ -306,7 +305,7 @@ if ! gcloud compute instances describe "$INSTANCE" --zone="$ZONE" >/dev/null 2>&
     --image-project=ubuntu-os-cloud \
     --boot-disk-size=20GB \
     --create-disk="name=${DATA_DISK},mode=rw,boot=no,auto-delete=no,device-name=${DATA_DISK}" \
-    --metadata-from-file=startup-script="$(dirname "$0")/vm-startup.sh"
+    --metadata-from-file="startup-script=$(dirname "$0")/vm-startup.sh,darkbloom-refresh-env=$(dirname "$0")/refresh-env.sh"
   echo "==> VM created. Startup script will run on first boot (~2-3 min)."
   echo "    Tail progress:"
   echo "      gcloud compute ssh $INSTANCE --zone=$ZONE -- 'sudo tail -f /var/log/d-inference-startup.log'"
@@ -314,7 +313,7 @@ else
   echo "==> VM $INSTANCE already exists (skipping create)"
   echo "    To refresh startup-script metadata after edits:"
   echo "      gcloud compute instances add-metadata $INSTANCE --zone=$ZONE \\"
-  echo "        --metadata-from-file=startup-script=$(dirname "$0")/vm-startup.sh"
+  echo "        --metadata-from-file=startup-script=$(dirname "$0")/vm-startup.sh,darkbloom-refresh-env=$(dirname "$0")/refresh-env.sh"
 fi
 
 cat <<EOF
@@ -336,7 +335,8 @@ Next steps:
         echo -n "<prod-p12-base64url>" \\
           | gcloud secrets versions add eigeninference-mdm-push-p12-b64 --data-file=-
       This secret is CMEK-encrypted with projects/$PROJECT/.../cryptoKeys/mdm-push-cert.
-      IAM is scoped to only $COORD_SA_EMAIL — no humans, no other SAs.
+      The coordinator SA has an explicit secret binding; inherited project IAM
+      grants also apply. Review those grants separately when restricting access.
       Target: rotate to a dev-specific cert within 30 days once Apple issues
       the MDM Vendor CSR signing certificate.
 

--- a/deploy/gcp/cloudbuild.yaml
+++ b/deploy/gcp/cloudbuild.yaml
@@ -66,11 +66,11 @@ steps:
           --zone=${_ZONE} \
           --metadata=DINF_IMAGE_TAG=$SHORT_SHA
 
-        # Update the startup script metadata so the next VM reboot picks
-        # up any new env vars added to vm-startup.sh.
+        # Publish the boot script and canonical env writer together so reboot
+        # and deploy use the same configuration and validation.
         gcloud compute instances add-metadata ${_INSTANCE} \
           --zone=${_ZONE} \
-          --metadata-from-file=startup-script=deploy/gcp/vm-startup.sh
+          --metadata-from-file=startup-script=deploy/gcp/vm-startup.sh,darkbloom-refresh-env=deploy/gcp/refresh-env.sh
 
         # Re-fetch secrets from Secret Manager and regenerate the env
         # file before restarting. Pipe the script via SSH stdin to avoid

--- a/deploy/gcp/refresh-env.sh
+++ b/deploy/gcp/refresh-env.sh
@@ -8,12 +8,13 @@
 # Manager fetch will never blank the existing env file.
 set -euo pipefail
 
-ENV_DIR="/etc/d-inference"
+ENV_DIR="${ENV_DIR:-/etc/d-inference}"
 ENV_FILE="${ENV_DIR}/env"
-ENV_TMP="${ENV_FILE}.tmp.$$"
 
 mkdir -p "$ENV_DIR"
 chmod 700 "$ENV_DIR"
+ENV_TMP=$(mktemp "$ENV_DIR/.env.XXXXXX")
+trap 'rm -f "$ENV_TMP"' EXIT
 
 fetch() {
   gcloud --quiet secrets versions access latest --secret="$1" 2>/dev/null || true

--- a/deploy/gcp/vm-startup.sh
+++ b/deploy/gcp/vm-startup.sh
@@ -28,8 +28,6 @@ IMAGE_REPO="${REGISTRY_HOST}/sepolia-ai/coordinator/coordinator"
 
 DATA_DEV="/dev/disk/by-id/google-d-inference-dev-data"
 DATA_MOUNT="/mnt/disks/userdata"
-ENV_DIR="/etc/d-inference"
-ENV_FILE="${ENV_DIR}/env"
 
 # ---- 1. Packages ----
 # Install gcloud + Docker + cloud-sql-proxy FIRST. Nothing later in this script
@@ -93,53 +91,24 @@ mountpoint -q "$DATA_MOUNT" || mount -o noatime,discard "$DATA_DEV" "$DATA_MOUNT
 grep -q "$DATA_DEV" /etc/fstab || \
   echo "$DATA_DEV $DATA_MOUNT ext4 noatime,discard 0 2" >> /etc/fstab
 
-# ---- 3. Fetch secrets ----
-mkdir -p "$ENV_DIR"
-chmod 700 "$ENV_DIR"
+# ---- 3. Fetch secrets through the same validated writer used by deploys ----
+# Both metadata values are published together by bootstrap and Cloud Build.
+refresh_environment() (
+  set -euo pipefail
+  script=$(mktemp)
+  trap 'rm -f "$script"' EXIT
+  curl -fsS --connect-timeout 5 --max-time 30 \
+    -H "Metadata-Flavor: Google" \
+    http://metadata.google.internal/computeMetadata/v1/instance/attributes/darkbloom-refresh-env \
+    -o "$script"
+  bash "$script"
+)
+refresh_environment
 
+# Datadog setup below also reads optional secrets.
 fetch() {
   gcloud --quiet secrets versions access latest --secret="$1" 2>/dev/null || true
 }
-
-cat > "$ENV_FILE" <<EOF
-EIGENINFERENCE_PORT=8080
-EIGENINFERENCE_MIN_TRUST=hardware
-EIGENINFERENCE_BILLING_MOCK=false
-EIGENINFERENCE_BASE_URL=https://api.dev.darkbloom.xyz
-EIGENINFERENCE_CONSOLE_URL=https://console.dev.darkbloom.xyz
-CORS_ORIGIN=https://console.dev.darkbloom.xyz
-EIGENINFERENCE_R2_CDN_URL=$(fetch eigeninference-r2-cdn-url)
-EIGENINFERENCE_ADMIN_EMAILS=gajesh@eigenlabs.org
-EIGENINFERENCE_REFERRAL_SHARE_PCT=15
-DOMAIN=api.dev.darkbloom.xyz
-APP_PORT=8080
-EIGENINFERENCE_MDM_URL=https://localhost:9002
-EIGENINFERENCE_ADMIN_KEY=$(fetch eigeninference-admin-key)
-EIGENINFERENCE_RELEASE_KEY=$(fetch eigeninference-release-key)
-EIGENINFERENCE_PRIVY_APP_ID=$(fetch eigeninference-privy-app-id)
-EIGENINFERENCE_PRIVY_APP_SECRET=$(fetch eigeninference-privy-app-secret)
-EIGENINFERENCE_PRIVY_VERIFICATION_KEY=$(fetch eigeninference-privy-verification-key)
-EIGENINFERENCE_DATABASE_URL=$(fetch eigeninference-database-url)
-MNEMONIC=$(fetch eigeninference-solana-mnemonic)
-MICROMDM_API_KEY=$(fetch eigeninference-micromdm-api-key)
-EIGENINFERENCE_MDM_API_KEY=$(fetch eigeninference-micromdm-api-key)
-MDM_PUSH_P12_B64=$(fetch eigeninference-mdm-push-p12-b64)
-PROFILE_SIGNING_P12_B64=$(fetch eigeninference-profile-signing-p12-b64)
-PROFILE_SIGNING_P12_PASSWORD=$(fetch eigeninference-profile-signing-p12-password)
-EIGENINFERENCE_STRIPE_SECRET_KEY=$(fetch eigeninference-stripe-secret-key)
-EIGENINFERENCE_STRIPE_WEBHOOK_SECRET=$(fetch eigeninference-stripe-webhook-secret)
-EIGENINFERENCE_STRIPE_SUCCESS_URL=$(fetch eigeninference-stripe-success-url)
-EIGENINFERENCE_STRIPE_CANCEL_URL=$(fetch eigeninference-stripe-cancel-url)
-EIGENINFERENCE_STRIPE_CONNECT_WEBHOOK_SECRET=$(fetch eigeninference-stripe-connect-webhook-secret)
-EIGENINFERENCE_STRIPE_CONNECT_RETURN_URL=$(fetch eigeninference-stripe-connect-return-url)
-EIGENINFERENCE_STRIPE_CONNECT_REFRESH_URL=$(fetch eigeninference-stripe-connect-refresh-url)
-DD_API_KEY=$(fetch eigeninference-dd-api-key)
-DD_SITE=$(fetch eigeninference-dd-site)
-DD_ENV=development
-DD_SERVICE=d-inference-coordinator
-DD_AGENT_HOST=localhost
-EOF
-chmod 600 "$ENV_FILE"
 
 # ---- 4. cloud-sql-proxy systemd unit ----
 cat > /etc/systemd/system/cloud-sql-proxy.service <<EOF

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `d983690b4`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -10,6 +10,11 @@ of it; the per-component steps below explain what each target runs.
 Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
 `scripts/publish-model.sh` to registration. See the
 [model publishing procedure](../operations/model-migration.md).
+
+For the first dev coordinator deployment, follow the
+[dev bootstrap procedure](../operations/dev-environment.md): populate the required
+secrets and rerun startup before building and deploying the first image. Boot and
+deploy use the same validated environment writer.
 
 Profiler wire changes require both coordinator and provider builds; the shared
 Go/Swift fixture and focused checks are described in [test.md](test.md) and

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `a5754637d`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `a5754637d`
+> Last updated: 2026-09-11 · commit `d983690b4`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -136,6 +136,14 @@ They run in Release Integrity CI and make no external inference calls:
 
 ```bash
 python3 -m unittest discover -s scripts/startup_measurement -t scripts -p 'test_*.py'
+```
+
+Dev environment boot/deploy parity and critical-secret preservation use local
+metadata and Secret Manager stubs in Release Integrity CI. The fixtures execute
+only the environment phase, without cloud access or host service changes:
+
+```bash
+python3 -m unittest discover -s scripts -p test_dev_env_refresh.py
 ```
 
 

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `a5754637d`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-11 · commit `a5754637d`
+> Last updated: 2026-09-11 · commit `d983690b4`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -97,7 +97,7 @@ stops at that validation. After filling the required secrets, rerun startup to
 finish installing the service units before the first image deploy:
 
 ```bash
-gcloud compute ssh d-inference-dev --zone=us-central1-a --project=sepolia-ai \
+gcloud compute ssh d-inference-dev --zone=us-central1-a --project=sepolia-ai --tunnel-through-iap \
   -- 'sudo google_metadata_script_runner startup'
 ```
 

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -92,6 +92,15 @@ file on critical-secret or metadata-download failure. The writer publishes a
 mode-0600 candidate by atomic rename after validation; temporary files are
 removed on exit. A failed boot refresh stops before service reconfiguration.
 
+On a new VM, bootstrap runs before these secrets are populated and therefore
+stops at that validation. After filling the required secrets, rerun startup to
+finish installing the service units before the first image deploy:
+
+```bash
+gcloud compute ssh d-inference-dev --zone=us-central1-a --project=sepolia-ai \
+  -- 'sudo google_metadata_script_runner startup'
+```
+
 ### 3. DNS
 
 ```

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -1,6 +1,6 @@
 # Dev environment
 
-> Last updated: 2026-09-06 · commit `f272f8641`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 Runbook for the Darkbloom dev environment on Google Cloud (project
 `sepolia-ai`): a GCE VM running the same coordinator container as production,
@@ -59,7 +59,9 @@ deploy/gcp/bootstrap.sh          # PROJECT/REGION/ZONE/INSTANCE/MACHINE_TYPE/SQL
 Idempotent. Creates the Artifact Registry repo `coordinator`, the coordinator
 service account, empty Secret Manager entries, Cloud SQL `d-inference-dev-db`,
 the data disk, the static IP, and the VM with
-`deploy/gcp/vm-startup.sh` as its startup script. It prints the static IP.
+`deploy/gcp/vm-startup.sh` as its startup script and `deploy/gcp/refresh-env.sh`
+as the `darkbloom-refresh-env` metadata value. Publish both together when
+updating startup metadata. It prints the static IP.
 
 ### 2. Populate secrets
 
@@ -85,7 +87,10 @@ echo -n '<value>' | gcloud secrets versions add <secret-name> --data-file=- --pr
 `EIGENINFERENCE_ADMIN_KEY`, `EIGENINFERENCE_DATABASE_URL`,
 `EIGENINFERENCE_STRIPE_SECRET_KEY`, `EIGENINFERENCE_STRIPE_WEBHOOK_SECRET`,
 `EIGENINFERENCE_STRIPE_CONNECT_WEBHOOK_SECRET` resolves empty, so set those
-before the first deploy.
+before the first deploy. Boot uses the same writer and preserves the existing
+file on critical-secret or metadata-download failure. The writer publishes a
+mode-0600 candidate by atomic rename after validation; temporary files are
+removed on exit. A failed boot refresh stops before service reconfiguration.
 
 ### 3. DNS
 
@@ -102,7 +107,7 @@ gcloud builds submit --config=deploy/gcp/cloudbuild.yaml --project=sepolia-ai
 
 The build tags `:$SHORT_SHA` and `:latest`, pushes both, then the `deploy`
 step: writes `DINF_IMAGE_TAG=$SHORT_SHA` to VM metadata, refreshes the
-`startup-script` metadata from `deploy/gcp/vm-startup.sh`, pipes
+`startup-script` and `darkbloom-refresh-env` metadata together, pipes
 `deploy/gcp/refresh-env.sh` over IAP SSH (`sudo bash -s`) to regenerate
 `/etc/d-inference/env` from Secret Manager, runs
 `sudo systemctl restart d-inference-coordinator`, and polls
@@ -140,9 +145,9 @@ with no approval step.
   `sudo bash deploy/gcp/refresh-env.sh && sudo systemctl restart d-inference-coordinator`.
 - **Non-secret value** (`EIGENINFERENCE_MIN_TRUST`, `EIGENINFERENCE_ADMIN_EMAILS`,
   `EIGENINFERENCE_REFERRAL_SHARE_PCT`, `EIGENINFERENCE_BASE_URL`, …): these are
-  literal lines in **both** `deploy/gcp/refresh-env.sh` and
-  `deploy/gcp/vm-startup.sh` (the boot path). Edit both, merge, and let Cloud
-  Build redeploy. There is no `--set-env-vars`; the env file is the only
+  literal lines in `deploy/gcp/refresh-env.sh`, shared by deploy and boot.
+  Edit that file, merge, and let Cloud Build redeploy. There is no
+  `--set-env-vars`; the env file is the only
   source.
 - Variables are read once at process start; a restart is always required.
 

--- a/scripts/test_dev_env_refresh.py
+++ b/scripts/test_dev_env_refresh.py
@@ -1,0 +1,118 @@
+"""Exercise the boot env phase with local metadata and Secret Manager stubs."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "deploy/gcp"
+
+
+class DevEnvironmentTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env_dir = self.root / "env"
+        self.env_dir.mkdir()
+        self.env_file = self.env_dir / "env"
+        self.scratch = self.root / "scratch"
+        self.scratch.mkdir()
+        self.env = {
+            **os.environ,
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "ENV_DIR": str(self.env_dir),
+            "TMPDIR": str(self.scratch),
+            "REFRESH_SCRIPT": str(DEPLOY / "refresh-env.sh"),
+            "MISSING_SECRET": "",
+            "METADATA_FAIL": "0",
+        }
+        self.stub("gcloud", '''#!/bin/bash
+set -eu
+for arg; do
+  case "$arg" in
+    --secret=*) secret=${arg#--secret=} ;;
+  esac
+done
+[ "$secret" != "$MISSING_SECRET" ] || exit 1
+printf 'fixture-%s' "$secret"
+''')
+        self.stub("curl", '''#!/bin/bash
+set -eu
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then out=$2; break; fi
+  shift
+done
+[ "$METADATA_FAIL" = 0 ] || exit 22
+cp "$REFRESH_SCRIPT" "$out"
+''')
+
+    def stub(self, name, content):
+        path = self.bin / name
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def run_phase(self, boot):
+        if boot:
+            # Execute the actual env phase, excluding package installation,
+            # disk formatting, systemd, and all other host mutations.
+            startup = (DEPLOY / "vm-startup.sh").read_text()
+            phase = startup.split("# ---- 3.", 1)[1].split("# ---- 4.", 1)[0]
+            phase = phase.split("\n", 1)[1]
+            command = ["bash", "-euc", 'ENV_FILE="$ENV_DIR/env"\n' + phase]
+        else:
+            command = ["bash", str(DEPLOY / "refresh-env.sh")]
+        return subprocess.run(command, env=self.env, text=True, capture_output=True)
+
+    def assert_clean(self):
+        self.assertEqual(list(self.scratch.iterdir()), [])
+        self.assertEqual(list(self.env_dir.iterdir()), [self.env_file])
+
+    def test_boot_and_deploy_publish_identical_complete_environment(self):
+        deploy = self.run_phase(boot=False)
+        self.assertEqual(deploy.returncode, 0, deploy.stderr)
+        expected = self.env_file.read_bytes()
+        self.env_file.write_text("old-environment\n")
+        boot = self.run_phase(boot=True)
+        self.assertEqual(boot.returncode, 0, boot.stderr)
+        self.assertEqual(self.env_file.read_bytes(), expected)
+        self.assertIn(b"EIGENINFERENCE_IPAPI_KEY=fixture-eigeninference-ipapi-key", expected)
+        self.assertEqual(self.env_file.stat().st_mode & 0o777, 0o600)
+        self.assert_clean()
+
+    def test_missing_critical_secret_preserves_environment_on_both_paths(self):
+        for secret in ("admin-key", "database-url", "stripe-secret-key",
+                       "stripe-webhook-secret", "stripe-connect-webhook-secret"):
+            for boot in (False, True):
+                with self.subTest(secret=secret, boot=boot):
+                    self.env_file.write_text("KEEP=existing-secret\n")
+                    self.env["MISSING_SECRET"] = f"eigeninference-{secret}"
+                    result = self.run_phase(boot)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(self.env_file.read_text(), "KEEP=existing-secret\n")
+                    self.assertNotIn("existing-secret", result.stdout + result.stderr)
+                    self.assert_clean()
+
+    def test_missing_metadata_preserves_environment_and_cleans_download(self):
+        self.env_file.write_text("KEEP=existing-secret\n")
+        self.env["METADATA_FAIL"] = "1"
+        result = self.run_phase(boot=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.env_file.read_text(), "KEEP=existing-secret\n")
+        self.assert_clean()
+
+    def test_optional_secret_may_be_absent(self):
+        self.env["MISSING_SECRET"] = "eigeninference-ipapi-key"
+        result = self.run_phase(boot=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("EIGENINFERENCE_IPAPI_KEY=\n", self.env_file.read_text())
+        self.assert_clean()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Dev coordinator boot maintained a second environment template that omitted the optional geo API key and overwrote the live file even when critical Secret Manager reads failed. Boot now invokes the same validated environment writer as deploys. Both paths preserve existing configuration on failure and publish a mode-0600 candidate atomically after validation.

Bootstrap and Cloud Build publish `startup-script` and `darkbloom-refresh-env` metadata together. The boot phase fetches the latter with a bounded timeout and owns/cleans its temporary script; the canonical writer also cleans its temporary candidate. The runbook and bootstrap next-step output require rerunning startup through IAP after populating secrets, before the first image deploy. Production deployment files and current critical/optional secret policy are unchanged. Correct misleading bootstrap comments that claimed an additive IAM binding restricted inherited access; IAM grants themselves are unchanged.

Before:
```mermaid
flowchart LR
  B[VM boot] --> S[vm-startup.sh duplicate template]
  S --> E[Write live env even with empty critical secrets]
  D[Cloud Build deploy] --> R[refresh-env.sh]
  R --> V[Validate critical secrets then replace env]
```

After:
```mermaid
flowchart LR
  M[Bootstrap or Cloud Build publishes both metadata scripts] --> B[VM boot fetches canonical writer]
  B --> R[refresh-env.sh]
  D[Cloud Build deploy] --> R
  R --> V{Critical secrets present?}
  V -->|Yes| A[Atomic env publication then service setup/restart]
  V -->|No| K[Keep prior env and stop]
  B -->|Metadata unavailable| K
```

Validation: four local stub tests pass, including boot/deploy output parity, all five critical-secret failures on both paths, optional-secret absence, metadata failure, file permissions and cleanup. The old implementation fails the regressions (eight failed assertions/subcases). Shell syntax, docs lint and whitespace checks pass. An independent agent reviewed metadata wiring and error propagation. No cloud resource, secret, VM, service, or deployment was changed during validation.
