### PR TITLE
Fix duplicate-provider scan race with attestation renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ compatibility checks and outstanding runtime qualification.
 
 ### Companion coordinator and console changes
 
+- **Concurrent duplicate-provider detection** — Read each provider's immutable attestation snapshot under its mutex before comparing device serials, so duplicate scans do not race attestation renewal. Matching duplicates still disconnect through the existing cleanup path.
 - **Warm-pool headroom** — Grow warm replicas from measured headroom before a failed request, using measured occupancy growth, per-model headroom limits and bounded load bursts. Requires a coordinator deployment; the provider release does not activate this policy.
 - **Earnings navigation** — Keep earnings accessible after removing all linked Macs and display the supported payout-coverage notice. Requires a console deployment.
 

--- a/coordinator/registry/duplicate_attestation_race_test.go
+++ b/coordinator/registry/duplicate_attestation_race_test.go
@@ -1,0 +1,36 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+)
+
+func TestDisconnectDuplicatesWithConcurrentAttestation(t *testing.T) {
+	reg := New(testLogger())
+	p := reg.Register("other", nil, testRegisterMessage())
+	p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "OTHER"})
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			p.SetAttestationResult(&attestation.VerificationResult{Valid: true, SerialNumber: "OTHER"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			reg.DisconnectDuplicatesBySerial("keep", "KEPT-SERIAL")
+		}
+	}()
+	close(start)
+	wg.Wait()
+	if reg.GetProvider("other") != p {
+		t.Fatal("a different device must remain connected during duplicate scans")
+	}
+}

--- a/coordinator/registry/provider_lifecycle.go
+++ b/coordinator/registry/provider_lifecycle.go
@@ -202,7 +202,7 @@ func (r *Registry) DisconnectDuplicatesBySerial(keepID string, serial string) {
 		if id == keepID {
 			continue
 		}
-		if p.AttestationResult != nil && p.AttestationResult.SerialNumber == serial {
+		if result := p.GetAttestationResult(); result != nil && result.SerialNumber == serial {
 			toEvict = append(toEvict, id)
 		}
 	}

--- a/docs/architecture/security/attestation.md
+++ b/docs/architecture/security/attestation.md
@@ -1,6 +1,6 @@
 # Provider attestation
 
-> Last updated: 2026-09-08 · commit `eba352122`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 How the coordinator decides how far to trust a provider connection: three
 trust levels (`none`, `self_signed`, `hardware`), two flags carried alongside
@@ -296,6 +296,13 @@ failure reason with status `untrusted`. The provider CLI renders the last one
 received (`darkbloom status`, `Trust: <level> / <status>`).
 
 ## Invariants
+
+Attestation results are immutable snapshots published by `SetAttestationResult`.
+`DisconnectDuplicatesBySerial` reads each snapshot through `GetAttestationResult`
+under the provider mutex before comparing serials; the registry read lock alone
+does not protect attestation renewal. Matching sessions are disconnected after
+the scan releases the registry lock (`coordinator/registry/provider_evidence.go`,
+`coordinator/registry/provider_lifecycle.go`).
 
 1. `hardware` is granted only by a received MDM `SecurityInfo` whose SIP and `SecureBootLevel == "full"` agree with the SE blob, or by trust reuse of such evidence after a fresh signed challenge; MDA and code identity never change the level — `coordinator/api/provider.go` (`verifyProviderViaMDM`), `coordinator/api/trust_reuse.go` (`tryTrustReuseFastSkip`), `coordinator/registry/provider_evidence.go` (`SetMDAProofIfHardwareBound`, `GrantProcessCodeAttested`).
 2. A stored `hardware` level and a stored `MDAVerified` flag are never restored on reconnect; the connection re-earns them — `coordinator/registry/persistence.go` (`RestoreProviderState`).

--- a/docs/architecture/security/attestation.md
+++ b/docs/architecture/security/attestation.md
@@ -1,6 +1,6 @@
 # Provider attestation
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `41609402e`
 
 How the coordinator decides how far to trust a provider connection: three
 trust levels (`none`, `self_signed`, `hardware`), two flags carried alongside
@@ -297,25 +297,19 @@ received (`darkbloom status`, `Trust: <level> / <status>`).
 
 ## Invariants
 
-Attestation results are immutable snapshots published by `SetAttestationResult`.
-`DisconnectDuplicatesBySerial` reads each snapshot through `GetAttestationResult`
-under the provider mutex before comparing serials; the registry read lock alone
-does not protect attestation renewal. Matching sessions are disconnected after
-the scan releases the registry lock (`coordinator/registry/provider_evidence.go`,
-`coordinator/registry/provider_lifecycle.go`).
-
-1. `hardware` is granted only by a received MDM `SecurityInfo` whose SIP and `SecureBootLevel == "full"` agree with the SE blob, or by trust reuse of such evidence after a fresh signed challenge; MDA and code identity never change the level — `coordinator/api/provider.go` (`verifyProviderViaMDM`), `coordinator/api/trust_reuse.go` (`tryTrustReuseFastSkip`), `coordinator/registry/provider_evidence.go` (`SetMDAProofIfHardwareBound`, `GrantProcessCodeAttested`).
-2. A stored `hardware` level and a stored `MDAVerified` flag are never restored on reconnect; the connection re-earns them — `coordinator/registry/persistence.go` (`RestoreProviderState`).
-3. Only a posture mismatch proven by a received SecurityInfo demotes; lookup failures, timeouts, and not-enrolled outcomes leave trust unchanged and retry — `coordinator/api/provider.go` (`verifyProviderViaMDM`).
-4. The coordinator sends only `SecurityInfo` and `DeviceInformation` MDM commands and honours only webhook responses for an outstanding `CommandUUID` — `coordinator/mdm/mdm.go` (`assertReadOnlyCommand`, `HandleWebhook`).
-5. Every challenge and code-identity signature is verified against the SE key from the registration blob, never a key carried in the reply — `coordinator/api/provider.go` (`verifyChallengeResponse`), `coordinator/api/provider_codeattest.go` (`handleCodeAttestationResponse`).
-6. `sip_enabled == false` or `secure_boot_enabled == false` in any challenge reply, a binary/model-hash drift, or an encrypted-chunk violation untrusts the provider immediately, without the three-strike count — `coordinator/api/provider.go` (`verifyChallengeResponse`, `decryptTextResponseChunk`).
-7. A code-identity proof is accepted only for the exact (SE key, APNs token, `K`) it was issued to and only within `challengeValidity`; cached proofs authorise a resume challenge, never a grant — `coordinator/api/provider_codeattest.go` (`codeAttestLoopForGeneration`, `handleCodeAttestationResponse`), `coordinator/api/code_attest_throttle.go`.
-8. Code identity becomes mandatory only when an attestor is configured and `APNS_ENFORCE_AFTER` has passed — `coordinator/registry/attestation_policy.go` (`codeAttestationEnforcedLocked`).
-9. Routing evaluates `providerLivenessGateReasonLocked` in a fixed order and skips any provider whose last verified challenge is older than [`challengeFreshnessMaxAge`](../routing.md#challenge-freshness) — `coordinator/registry/routing_eligibility.go`, `coordinator/registry/scheduler.go`.
-10. Hard untrust writes a durable tombstone that wins any race with a pending hardware grant — `coordinator/api/trust_reuse.go` (`invalidateTrustReuse`), `coordinator/registry/provider_evidence.go` (`GrantHardwareEvidenceAtEpochIfNotUntrusted`).
-11. Effective `RuntimeCapabilities` require hardware trust and code proof; `SetAttested` below hardware and `SetCodeAttested(false)` clear them — `coordinator/registry/provider_evidence.go`.
-12. The [runtime manifest](#runtime-manifest) accepts every active release's values (one set per template name, `mlx_metallib` included); registering a release can only widen it and deactivating one narrows it, so a registration never deroutes providers on the previous release — `coordinator/api/server.go` (`SyncRuntimeManifest`, `RuntimeManifest`).
+1. Attestation results are immutable snapshots published by `SetAttestationResult`. `DisconnectDuplicatesBySerial` reads each snapshot through `GetAttestationResult` under the provider mutex before comparing serials; the registry read lock alone does not protect attestation renewal. Matching sessions are disconnected after the scan releases the registry lock (`coordinator/registry/provider_evidence.go`, `coordinator/registry/provider_lifecycle.go`).
+2. `hardware` is granted only by a received MDM `SecurityInfo` whose SIP and `SecureBootLevel == "full"` agree with the SE blob, or by trust reuse of such evidence after a fresh signed challenge; MDA and code identity never change the level — `coordinator/api/provider.go` (`verifyProviderViaMDM`), `coordinator/api/trust_reuse.go` (`tryTrustReuseFastSkip`), `coordinator/registry/provider_evidence.go` (`SetMDAProofIfHardwareBound`, `GrantProcessCodeAttested`).
+3. A stored `hardware` level and a stored `MDAVerified` flag are never restored on reconnect; the connection re-earns them — `coordinator/registry/persistence.go` (`RestoreProviderState`).
+4. Only a posture mismatch proven by a received SecurityInfo demotes; lookup failures, timeouts, and not-enrolled outcomes leave trust unchanged and retry — `coordinator/api/provider.go` (`verifyProviderViaMDM`).
+5. The coordinator sends only `SecurityInfo` and `DeviceInformation` MDM commands and honours only webhook responses for an outstanding `CommandUUID` — `coordinator/mdm/mdm.go` (`assertReadOnlyCommand`, `HandleWebhook`).
+6. Every challenge and code-identity signature is verified against the SE key from the registration blob, never a key carried in the reply — `coordinator/api/provider.go` (`verifyChallengeResponse`), `coordinator/api/provider_codeattest.go` (`handleCodeAttestationResponse`).
+7. `sip_enabled == false` or `secure_boot_enabled == false` in any challenge reply, a binary/model-hash drift, or an encrypted-chunk violation untrusts the provider immediately, without the three-strike count — `coordinator/api/provider.go` (`verifyChallengeResponse`, `decryptTextResponseChunk`).
+8. A code-identity proof is accepted only for the exact (SE key, APNs token, `K`) it was issued to and only within `challengeValidity`; cached proofs authorise a resume challenge, never a grant — `coordinator/api/provider_codeattest.go` (`codeAttestLoopForGeneration`, `handleCodeAttestationResponse`), `coordinator/api/code_attest_throttle.go`.
+9. Code identity becomes mandatory only when an attestor is configured and `APNS_ENFORCE_AFTER` has passed — `coordinator/registry/attestation_policy.go` (`codeAttestationEnforcedLocked`).
+10. Routing evaluates `providerLivenessGateReasonLocked` in a fixed order and skips any provider whose last verified challenge is older than [`challengeFreshnessMaxAge`](../routing.md#challenge-freshness) — `coordinator/registry/routing_eligibility.go`, `coordinator/registry/scheduler.go`.
+11. Hard untrust writes a durable tombstone that wins any race with a pending hardware grant — `coordinator/api/trust_reuse.go` (`invalidateTrustReuse`), `coordinator/registry/provider_evidence.go` (`GrantHardwareEvidenceAtEpochIfNotUntrusted`).
+12. Effective `RuntimeCapabilities` require hardware trust and code proof; `SetAttested` below hardware and `SetCodeAttested(false)` clear them — `coordinator/registry/provider_evidence.go`.
+13. The [runtime manifest](#runtime-manifest) accepts every active release's values (one set per template name, `mlx_metallib` included); registering a release can only widen it and deactivating one narrows it, so a registration never deroutes providers on the previous release — `coordinator/api/server.go` (`SyncRuntimeManifest`, `RuntimeManifest`).
 
 ## Failure modes
 


### PR DESCRIPTION
Duplicate-device scans read a provider’s attestation pointer without the mutex used by attestation renewal. Concurrent renewal and a new connection’s duplicate scan race; repeated pointer reads also do not represent one snapshot. Use the existing `GetAttestationResult` accessor before comparing serials, preserving which sessions are disconnected and the existing teardown path.

Before:
```mermaid
flowchart LR
  A[Attestation renewal] --> B[SetAttestationResult under provider mutex]
  C[New connection duplicate scan] --> D[Read mutable attestation pointer under registry lock only]
  B -. races .-> D
  D --> E[Match serial and disconnect duplicate sessions]
```

After:
```mermaid
flowchart LR
  A[Attestation renewal] --> B[SetAttestationResult under provider mutex]
  C[New connection duplicate scan] --> D[GetAttestationResult under same provider mutex]
  B --> F[Immutable attestation snapshot]
  D --> F
  F --> E[Same serial match and disconnect after registry scan]
```

Validation:
- New concurrent attestation/duplicate-scan regression fails on master under `-race`, with races in `DisconnectDuplicatesBySerial` and `SetAttestationResult`.
- `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry/...` passes after the fix (registry 24.654s; routing simulations 4.066s). Existing duplicate tests verify that matching sessions are removed while the kept session and other devices remain connected.
- `scripts/docs-check.sh --all` passes (278 documents); canonical attestation ownership documentation and changelog updated.

No wire format, model defaults, trust policy or deployment changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791761925&installation_model_id=21733&pr_number=919&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F919&signature=7add7b72fdca954ac81fe42667488eaaec0d235f76978e1f7ce6502d7296a362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->