### PR TITLE
Share provider CLI login, diagnostics and model selection

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+BenchmarkSession.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2Factory+BenchmarkSession.swift
@@ -297,71 +297,61 @@ extension EngineV2Factory {
             prepared.assistant?.release()
             throw error
         }
-        guard let engine = await bundle.bridge.ownedEngine as? EngineV2 else {
-            await bundle.bridge.shutdown()
-            bundle.releaseAssistant()
-            throw EngineV2BenchmarkSession.Failure.unexpectedEngine
-        }
-        guard !mtpEnabled || (bundle.mtpStatus.active && engine.mtpMetricsSnapshot() != nil) else {
-            await bundle.bridge.shutdown()
-            bundle.releaseAssistant()
-            throw EngineV2BenchmarkSession.Failure.mtpUnavailable
-        }
+        // Bundle ownership transfers only after every benchmark gate passes.
+        // All post-build refusals drain the engine before releasing the assistant.
         do {
+            guard let engine = await bundle.bridge.ownedEngine as? EngineV2 else {
+                throw EngineV2BenchmarkSession.Failure.unexpectedEngine
+            }
+            guard !mtpEnabled || (bundle.mtpStatus.active && engine.mtpMetricsSnapshot() != nil) else {
+                throw EngineV2BenchmarkSession.Failure.mtpUnavailable
+            }
             try gemmaMTPVerification?.validateObservedMetrics(engine.mtpMetricsSnapshot())
+            guard !PrefixCachePolicy.isMemoryEnabled(environment: effectiveEnvironment),
+                engine.hybridPrefixCache == nil else {
+                throw EngineV2BenchmarkSession.Failure.unexpectedResidentCache
+            }
+            if PrefixCachePolicy.isEnabled(modelId: modelId, environment: effectiveEnvironment) {
+                let cacheStatus = bundle.bridge.prefixCacheModelStatus()
+                let hasEvidenceSource = bundle.bridge.durablePrefixCacheEvidenceSource != nil
+                guard hasEvidenceSource, cacheStatus.state == .ready else {
+                    throw EngineV2BenchmarkSession.Failure.ssdUnavailable(
+                        status: cacheStatus, hasEvidenceSource: hasEvidenceSource)
+                }
+            }
+            if requirePersistentKey, bundle.bridge.ssdHybridCheckpointStore?.usesEphemeralKey == true {
+                throw EngineV2BenchmarkSession.Failure.persistentKeyUnavailable
+            }
+            var postBuildHeadroom: UInt64?
+            if useProductionKVGrant {
+                // The ordinary post-load guard clears reclaimable load buffers and
+                // requires minimum live OS/activation headroom. It is a refusal gate,
+                // not a second, smaller logical grant derived from Memory.active.
+                Memory.clearCache()
+                let sample = budget.memoryHeadroomSnapshot()
+                postBuildHeadroom = sample.runtimeRemainingBytes
+                let kind = await bundle.bridge.kvBackendKind
+                let ceiling = await bundle.bridge.kvBackendPoolBytes()
+                guard KVHeadroomProbe.postBuildServeable(kvBackendKind: kind, pagedPoolBytes: ceiling,
+                    activationReserveBytes: reserve, measuredHeadroomBytes: sample.runtimeRemainingBytes) else {
+                    throw EngineV2BenchmarkSession.Failure.unservablePostLoad(
+                        headroomBytes: sample.runtimeRemainingBytes,
+                        requiredBytes: UnifiedMemoryCap.minimumLoadKVBytes)
+                }
+            }
+            let backend = await bundle.bridge.kvBackendKind.rawValue
+            let fallback = await bundle.bridge.kvBackendFallbackReason
+            return EngineV2BenchmarkSession(
+                bundle: bundle, engine: engine,
+                backend: backend, fallback: fallback,
+                memoryEnabled: PrefixCachePolicy.isMemoryEnabled(environment: effectiveEnvironment),
+                activationReserveBytes: reserve, postLoadMaximumKVBytes: maximumKVBytes,
+                budget: budget, assistantIdentity: benchmarkAssistantIdentity(preparation.artifact),
+                productionGrant: productionGrant, postBuildHeadroomBytes: postBuildHeadroom)
         } catch {
             await bundle.bridge.shutdown()
             bundle.releaseAssistant()
             throw error
         }
-        guard !PrefixCachePolicy.isMemoryEnabled(environment: effectiveEnvironment),
-            engine.hybridPrefixCache == nil else {
-            await bundle.bridge.shutdown()
-            bundle.releaseAssistant()
-            throw EngineV2BenchmarkSession.Failure.unexpectedResidentCache
-        }
-        if PrefixCachePolicy.isEnabled(modelId: modelId, environment: effectiveEnvironment) {
-            let cacheStatus = bundle.bridge.prefixCacheModelStatus()
-            let hasEvidenceSource = bundle.bridge.durablePrefixCacheEvidenceSource != nil
-            guard hasEvidenceSource, cacheStatus.state == .ready else {
-                await bundle.bridge.shutdown()
-                bundle.releaseAssistant()
-                throw EngineV2BenchmarkSession.Failure.ssdUnavailable(
-                    status: cacheStatus, hasEvidenceSource: hasEvidenceSource)
-            }
-        }
-        if requirePersistentKey, bundle.bridge.ssdHybridCheckpointStore?.usesEphemeralKey == true {
-            await bundle.bridge.shutdown()
-            bundle.releaseAssistant()
-            throw EngineV2BenchmarkSession.Failure.persistentKeyUnavailable
-        }
-        var postBuildHeadroom: UInt64?
-        if useProductionKVGrant {
-            // The ordinary post-load guard clears reclaimable load buffers and
-            // requires minimum live OS/activation headroom. It is a refusal gate,
-            // not a second, smaller logical grant derived from Memory.active.
-            Memory.clearCache()
-            let sample = budget.memoryHeadroomSnapshot()
-            postBuildHeadroom = sample.runtimeRemainingBytes
-            let kind = await bundle.bridge.kvBackendKind
-            let ceiling = await bundle.bridge.kvBackendPoolBytes()
-            guard KVHeadroomProbe.postBuildServeable(kvBackendKind: kind, pagedPoolBytes: ceiling,
-                activationReserveBytes: reserve, measuredHeadroomBytes: sample.runtimeRemainingBytes) else {
-                await bundle.bridge.shutdown()
-                bundle.releaseAssistant()
-                throw EngineV2BenchmarkSession.Failure.unservablePostLoad(
-                    headroomBytes: sample.runtimeRemainingBytes,
-                    requiredBytes: UnifiedMemoryCap.minimumLoadKVBytes)
-            }
-        }
-        let backend = await bundle.bridge.kvBackendKind.rawValue
-        let fallback = await bundle.bridge.kvBackendFallbackReason
-        return EngineV2BenchmarkSession(
-            bundle: bundle, engine: engine,
-            backend: backend, fallback: fallback,
-            memoryEnabled: PrefixCachePolicy.isMemoryEnabled(environment: effectiveEnvironment),
-            activationReserveBytes: reserve, postLoadMaximumKVBytes: maximumKVBytes,
-            budget: budget, assistantIdentity: benchmarkAssistantIdentity(preparation.artifact),
-            productionGrant: productionGrant, postBuildHeadroomBytes: postBuildHeadroom)
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/EngineV2SlotFactory+MTP.swift
@@ -193,6 +193,8 @@ extension EngineV2SlotFactory {
     ) async throws -> EngineV2PreparedModel {
         let snapshot = await modelSnapshot(container: container)
 
+        var fallbackStatus = previousStatus.active
+            ? previousStatus.fallingBack(.engineInactive) : previousStatus
         if previousStatus.active,
             let previousArtifact,
             let assistant,
@@ -218,22 +220,9 @@ extension EngineV2SlotFactory {
             logWarning(
                 "mtp: model=\(modelId) recovery fallback reason=\(reason.rawValue) detail="
                     + (revalidation.detail ?? "installed assistant binding is not reusable"))
-            let target = try servingModel(
-                modelId: modelId,
-                isVLM: isVLM,
-                modelDirectory: modelDirectory,
-                snapshot: snapshot,
-                emitTelemetry: emitTelemetry,
-                logInfo: logInfo)
-            return EngineV2PreparedModel(
-                snapshot: snapshot,
-                servingModel: target,
-                assistant: nil,
-                mtpStatus: previousStatus.fallingBack(reason),
-                mtpArtifact: nil)
+            fallbackStatus = previousStatus.fallingBack(reason)
         }
 
-        let reason: MTPFallbackReason? = previousStatus.active ? .engineInactive : nil
         let target = try servingModel(
             modelId: modelId,
             isVLM: isVLM,
@@ -245,7 +234,7 @@ extension EngineV2SlotFactory {
             snapshot: snapshot,
             servingModel: target,
             assistant: nil,
-            mtpStatus: reason.map(previousStatus.fallingBack) ?? previousStatus,
+            mtpStatus: fallbackStatus,
             mtpArtifact: nil)
     }
 }

--- a/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/CompetingInferenceDiagnostics.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ProviderCore
 
 /// Snapshot of non-Darkbloom inference that can steal unified memory / ports.
 /// Injectable for pure unit tests (see `DoctorChecksTests`).
@@ -11,12 +12,12 @@ struct LocalContentionSnapshot: Equatable, Sendable {
     static let empty = LocalContentionSnapshot(ollamaPortListening: false, competingProcessHints: [])
 
     /// Best-effort live probe. Failures degrade to empty (no false WARNs).
-    static func live() -> LocalContentionSnapshot {
+    static func live(runner: SecurityCommandRunner = .live) -> LocalContentionSnapshot {
         var ollama = false
         var hints: [String] = []
 
         // Port 11434 — Ollama default
-        if let out = runCapture("/usr/sbin/lsof", args: ["-nP", "-iTCP:11434", "-sTCP:LISTEN"]) {
+        if let out = try? runner.run("/usr/sbin/lsof", ["-nP", "-iTCP:11434", "-sTCP:LISTEN"]).stdout {
             if out.contains("LISTEN") {
                 ollama = true
                 if out.lowercased().contains("ollama") {
@@ -26,7 +27,7 @@ struct LocalContentionSnapshot: Equatable, Sendable {
         }
 
         // Process table hints (names only — no args, avoid leaking paths/keys)
-        if let ps = runCapture("/bin/ps", args: ["-axo", "comm="]) {
+        if let ps = try? runner.run("/bin/ps", ["-axo", "comm="]).stdout {
             let lower = ps.lowercased()
             let watch = ["ollama", "llama-server", "mlx_lm.server", "vllm", "text-generation-launcher"]
             for name in watch where lower.contains(name) {
@@ -40,22 +41,6 @@ struct LocalContentionSnapshot: Equatable, Sendable {
         )
     }
 
-    private static func runCapture(_ path: String, args: [String]) -> String? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: path)
-        p.arguments = args
-        let pipe = Pipe()
-        p.standardOutput = pipe
-        p.standardError = FileHandle.nullDevice
-        do {
-            try p.run()
-            p.waitUntilExit()
-        } catch {
-            return nil
-        }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8)
-    }
 }
 
 func competingInferenceCheck(_ snap: LocalContentionSnapshot) -> DoctorCheck {

--- a/provider-swift/Sources/darkbloom/Diagnostics/DiagnosticReportRenderer.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DiagnosticReportRenderer.swift
@@ -24,8 +24,6 @@ enum DiagnosticReportRenderer {
 
     /// Overall verdict: any fail → fail; with `strict`, any warn also → fail.
     static func hasFailure(_ diagnostics: [Diagnostic], strict: Bool) -> Bool {
-        if diagnostics.contains(where: { $0.level == .fail }) { return true }
-        if strict && diagnostics.contains(where: { $0.level == .warn }) { return true }
-        return false
+        diagnostics.contains { $0.level.isFailure(strict: strict) }
     }
 }

--- a/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
+++ b/provider-swift/Sources/darkbloom/Diagnostics/DoctorRunner.swift
@@ -244,18 +244,10 @@ enum DoctorRunner {
     /// Best-effort read of whether the system is currently being kept awake,
     /// via `pmset -g assertions`. Informational only (the provider
     /// self-caffeinates while serving), so nil/UNKNOWN on any failure is fine.
-    private static func systemSleepPrevented() -> Bool? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
-        p.arguments = ["-g", "assertions"]
-        let out = Pipe()
-        p.standardOutput = out
-        p.standardError = Pipe()
-        guard (try? p.run()) != nil else { return nil }
-        p.waitUntilExit()
-        guard p.terminationStatus == 0 else { return nil }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8) else { return nil }
+    static func systemSleepPrevented(runner: SecurityCommandRunner = .live) -> Bool? {
+        guard let result = try? runner.run("/usr/bin/pmset", ["-g", "assertions"]),
+              result.terminationStatus == 0 else { return nil }
+        let text = result.stdout
         // `PreventUserIdleSystemSleep` / `PreventSystemSleep` report 1 when an
         // assertion (e.g. caffeinate, an active inference) is holding the system
         // awake. Any "1" on those lines ⇒ sleep currently prevented.

--- a/provider-swift/Sources/darkbloom/DoctorCommand.swift
+++ b/provider-swift/Sources/darkbloom/DoctorCommand.swift
@@ -101,12 +101,9 @@ struct Doctor: AsyncParsableCommand {
             print("  pid file: \(ProcessLifecycle.defaultPIDFile().path)")
         }
 
-        let hasFailure = checks.contains { $0.status == .fail }
-            || diagnosis.contains { $0.level == .fail }
-        let hasWarning = checks.contains { $0.status == .warn }
-            || diagnosis.contains { $0.level == .warn }
-
-        if hasFailure || (strict && hasWarning) {
+        if checks.contains(where: { $0.status.isFailure(strict: strict) })
+            || DiagnosticReportRenderer.hasFailure(diagnosis, strict: strict)
+        {
             throw ExitCode.failure
         }
     }
@@ -182,17 +179,11 @@ struct Doctor: AsyncParsableCommand {
 
 // MARK: - Doctor
 
-enum CheckStatus: Equatable {
-    case pass
-    case warn
-    case fail
+typealias CheckStatus = DiagnosticLevel
 
-    var marker: String {
-        switch self {
-        case .pass: return "[PASS]"
-        case .warn: return "[WARN]"
-        case .fail: return "[FAIL]"
-        }
+extension DiagnosticLevel {
+    func isFailure(strict: Bool) -> Bool {
+        self == .fail || (strict && self == .warn)
     }
 
     init(_ verdict: BootSecurityVerdict) {
@@ -346,10 +337,11 @@ func buildCoordinatorDoctorChecks(
     let base = coordinatorHTTPBase(coordinatorOverride ?? snapshot.config.coordinator.url)
     var checks: [DoctorCheck] = []
 
+    let linked = AuthTokenStore.load() != nil
     checks.append(.init(
         name: "account link",
-        status: AuthTokenStore.load() == nil ? .warn : .pass,
-        detail: AuthTokenStore.load() == nil ? "not logged in; run darkbloom login" : "auth token present"
+        status: linked ? .pass : .warn,
+        detail: !linked ? "not logged in; run darkbloom login" : "auth token present"
     ))
 
     switch checkMDMEnrollment(coordinatorURL: coordinatorOverride ?? snapshot.config.coordinator.url) {

--- a/provider-swift/Sources/darkbloom/LoginCommand.swift
+++ b/provider-swift/Sources/darkbloom/LoginCommand.swift
@@ -20,25 +20,9 @@ struct Login: AsyncParsableCommand {
         let coordinatorURL = snapshot.config.coordinator.url
 
         do {
-            try await performDeviceCodeLogin(
+            try await performTerminalDeviceLogin(
                 coordinatorURL: coordinatorURL,
-                onDisplayCode: { userCode, verificationURI, expiresIn in
-                    print()
-                    print("  To link this machine, open this URL in your browser:")
-                    print()
-                    print("    \(verificationURI)")
-                    print()
-                    print("  Then enter this code:")
-                    print()
-                    print("    \(userCode)")
-                    print()
-                    print("  Waiting for approval (expires in \(expiresIn / 60) minutes)...")
-                },
-                onPollTick: {
-                    print(".", terminator: "")
-                    fflush(stdout)
-                }
-            )
+                introduction: "  To link this machine, open this URL in your browser:")
 
             print()
             print()
@@ -52,4 +36,29 @@ struct Login: AsyncParsableCommand {
             throw ExitCode.failure
         }
     }
+}
+
+/// Both entry points share the device-code display and polling feedback; each
+/// caller keeps its own introduction, completion message and failure policy.
+@discardableResult
+func performTerminalDeviceLogin(coordinatorURL: String, introduction: String) async throws -> String {
+    try await performDeviceCodeLogin(
+        coordinatorURL: coordinatorURL,
+        onDisplayCode: { userCode, verificationURI, expiresIn in
+            print()
+            print(introduction)
+            print()
+            print("    \(verificationURI)")
+            print()
+            print("  Then enter this code:")
+            print()
+            print("    \(userCode)")
+            print()
+            print("  Waiting for approval (expires in \(expiresIn / 60) minutes)...")
+        },
+        onPollTick: {
+            print(".", terminator: "")
+            fflush(stdout)
+        }
+    )
 }

--- a/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Modes.swift
@@ -156,24 +156,12 @@ extension Start {
     ) async throws {
         warnBootSecurity(snapshot: bootSecuritySnapshot, coordinatorEnforced: true)
 
-        let selectedModels: [ModelInfo]
-        if !model.isEmpty {
-            selectedModels = advertisedModels(
-                from: snapshot.models,
-                config: config,
-                modelOverrides: model,
-                runtimeCapabilities: runtimeCapabilities)
-        } else if all {
-            selectedModels = snapshot.models.filter {
-                ModelRuntimeRequirements.isEligible(
-                    modelID: $0.id, available: runtimeCapabilities)
-            }
-        } else {
-            selectedModels = advertisedModels(
-                from: snapshot.models,
-                config: config,
-                runtimeCapabilities: runtimeCapabilities)
-        }
+        let selectedModels = advertisedModels(
+            from: snapshot.models,
+            config: config,
+            modelOverrides: model,
+            includeDisabled: all,
+            runtimeCapabilities: runtimeCapabilities)
 
         guard !selectedModels.isEmpty else {
             printError("No models selected.")

--- a/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
+++ b/provider-swift/Sources/darkbloom/StartCommand+Preflight.swift
@@ -53,25 +53,9 @@ extension Start {
         }
 
         do {
-            try await performDeviceCodeLogin(
+            try await performTerminalDeviceLogin(
                 coordinatorURL: coordinatorURL,
-                onDisplayCode: { userCode, verificationURI, expiresIn in
-                    print()
-                    print("  Open this URL in your browser:")
-                    print()
-                    print("    \(verificationURI)")
-                    print()
-                    print("  Then enter this code:")
-                    print()
-                    print("    \(userCode)")
-                    print()
-                    print("  Waiting for approval (expires in \(expiresIn / 60) minutes)...")
-                },
-                onPollTick: {
-                    print(".", terminator: "")
-                    fflush(stdout)
-                }
-            )
+                introduction: "  Open this URL in your browser:")
             print()
             print("  Account linked successfully!")
             print()

--- a/provider-swift/Tests/DarkbloomCLITests/AdvertisedModelSelectionTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/AdvertisedModelSelectionTests.swift
@@ -1,0 +1,27 @@
+import ProviderCore
+import Testing
+@testable import darkbloom
+
+@Suite("Shared serving model selection")
+struct AdvertisedModelSelectionTests {
+    @Test("explicit order and duplicates take precedence over all/config, then eligibility applies")
+    func selectionPrecedence() {
+        let gated = ModelRuntimeRequirements.qwen38ConcreteModelID
+        let models = ["a", gated, "b"].map {
+            ModelInfo(id: $0, sizeBytes: 1, estimatedMemoryGb: 1)
+        }
+        var config = ProviderConfig(provider: ProviderSettings(name: "selection-fixture"))
+        config.backend.enabledModels = ["a"]
+        func ids(overrides: [String] = [], all: Bool = false,
+                 capabilities: Set<ProviderRuntimeCapability> = []) -> [String] {
+            advertisedModels(from: models, config: config, modelOverrides: overrides,
+                             includeDisabled: all, runtimeCapabilities: capabilities).map(\.id)
+        }
+        #expect(ids() == ["a"])
+        #expect(ids(all: true) == ["a", "b"])
+        #expect(ids(overrides: ["b", "missing", gated, "a", "b"], all: true) == ["b", "a", "b"])
+        #expect(ids(all: true, capabilities: [.appleM5, .mlxNAX]) == ["a", gated, "b"])
+        config.backend.enabledModels = []
+        #expect(ids() == ["a", "b"])
+    }
+}

--- a/provider-swift/Tests/DarkbloomCLITests/DiagnosticProbeTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/DiagnosticProbeTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import ProviderCore
+import Testing
+@testable import darkbloom
+
+@Suite("Diagnostic subprocess projections")
+struct DiagnosticProbeTests {
+    @Test("contention probes preserve scoped arguments, nonzero output and sorted unique hints")
+    func contentionProbeContract() {
+        var calls: [(String, [String])] = []
+        let runner = SecurityCommandRunner { path, arguments in
+            calls.append((path, arguments))
+            return SecurityCommandResult(
+                terminationStatus: 1,
+                stdout: path == "/usr/sbin/lsof"
+                    ? "ollama LISTEN" : "ollama\nllama-server\nvllm\nollama")
+        }
+        let snapshot = LocalContentionSnapshot.live(runner: runner)
+        #expect(snapshot.ollamaPortListening)
+        #expect(snapshot.competingProcessHints == ["llama-server", "ollama", "vllm"])
+        #expect(calls.count == 2)
+        #expect(calls[0].0 == "/usr/sbin/lsof")
+        #expect(calls[0].1 == ["-nP", "-iTCP:11434", "-sTCP:LISTEN"])
+        #expect(calls[1].0 == "/bin/ps")
+        #expect(calls[1].1 == ["-axo", "comm="])
+    }
+
+    @Test("unavailable contention probes remain informational")
+    func unavailableContentionProbes() {
+        let runner = SecurityCommandRunner { _, _ in throw URLError(.unknown) }
+        #expect(LocalContentionSnapshot.live(runner: runner) == .empty)
+        #expect(DoctorRunner.systemSleepPrevented(runner: runner) == nil)
+    }
+
+    @Test("sleep assertions require a successful command and either prevention flag")
+    func sleepAssertionContract() {
+        for (status, stdout, expected) in [
+            (Int32(0), "PreventUserIdleSystemSleep 1", Optional(true)),
+            (Int32(0), "PreventSystemSleep 1", Optional(true)),
+            (Int32(0), "PreventUserIdleSystemSleep 0\nPreventSystemSleep 0", Optional(false)),
+            (Int32(1), "PreventSystemSleep 1", nil),
+        ] {
+            let runner = SecurityCommandRunner { path, arguments in
+                #expect(path == "/usr/bin/pmset")
+                #expect(arguments == ["-g", "assertions"])
+                return SecurityCommandResult(terminationStatus: status, stdout: stdout)
+            }
+            #expect(DoctorRunner.systemSleepPrevented(runner: runner) == expected)
+        }
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ProviderMTPFactoryTests.swift
@@ -322,6 +322,37 @@ struct ProviderMTPFactoryTests {
         #expect(recovered.mtpStatus.active)
     }
 
+    @Test("recovery fallback preserves the new target and the precise inactive reason")
+    func recoveryFallbackReasons() async throws {
+        let artifact = try mtpFactoryArtifact()
+        defer { try? FileManager.default.removeItem(at: artifact.directory) }
+        let prepared = try await EngineV2SlotFactory.prepareProductionModel(
+            modelId: "gemma-4-test", isVLM: false,
+            container: mtpFactoryContainer(),
+            specDecPreparation: .init(artifact: artifact, status: .candidate(artifact)),
+            assistantLoader: MTPFactoryRecordingLoader(
+                recorder: MTPFactoryIdentityRecorder(), failure: nil))
+        defer { prepared.assistant?.release() }
+        let replacement = MTPFactoryTarget()
+        let container = mtpFactoryContainer(replacement)
+        let disabled = MTPActivationStatus.disabled(.configDisabled, configured: false)
+        for (status, assistant, expected) in [
+            (disabled, nil, MTPFallbackReason.configDisabled),
+            (prepared.mtpStatus, nil, .engineInactive),
+            (prepared.mtpStatus, prepared.assistant, .assistantTargetIncompatible),
+        ] {
+            let recovered = try await EngineV2SlotFactory.prepareRecoveryModel(
+                modelId: "gemma-4-test", isVLM: false, container: container,
+                previousArtifact: artifact, previousStatus: status, assistant: assistant)
+            #expect(ObjectIdentifier(recovered.servingModel) == ObjectIdentifier(replacement))
+            #expect(recovered.assistant == nil)
+            #expect(recovered.mtpArtifact == nil)
+            #expect(recovered.assistantBytes == 0)
+            #expect(recovered.mtpStatus.reason == expected)
+            #expect(recovered.mtpStatus.configured == status.configured)
+        }
+    }
+
     @Test("VLM resolution fails loud for an unsupported wrapper")
     func unsupportedVLMWrapperRefuses() {
         #expect(throws: EngineV2ProductionError.self) {


### PR DESCRIPTION
Doctor's local process probes each manage subprocess pipes, while login/start duplicate device-code presentation and foreground serving repeats the model selection policy. Route those operations through the existing shared implementations: the concurrent capture runner from #904, one terminal login adapter, and `advertisedModels`. Doctor's detailed and sectioned results now share one severity enum and strict-warning rule; the account-link check reads its token state once.

This removes 52 production lines. Each entry point retains its own login introduction/success/failure messages. Model overrides keep their order and duplicates, outrank `--all` and configured filters, and remain subject to runtime eligibility. The lsof/ps probes still accept available stdout on nonzero exit; pmset still requires success. Diagnostic probes collect process names, not command-line arguments.

Stacked on #904 because its shared runner drains stdout/stderr concurrently, fixing the existing wait-before-drain deadlock for these CLI callers. The runner intentionally retains its existing lack of a timeout. No auth storage, enrollment, model admission, backend policy or inference math changes.

Validation: the combined final source `93c4caa5c6abb73ef9c882c1deae7eee31eef125` passed a dedicated M5 release build and **1,243 Swift Testing cases across 132 suites plus 48 XCTest cases**, with no skipped tests. The run includes the real Gemma QAT tokenizer/constraint fixture and packaged runtime smoke. All 5,093 staged source files and compiled runtime hashes were checked before and after. Provider SHA256: `45c33b44c58228f67a362c7239eda081877c846d568a73bda026e010512af060`; metallib SHA256: `20972c37e53fe6db3b3191a0434f6604c4ffc4f5ac62b370574f9922585b0fdb`.

The run combines #897, #904, #916, #917, #920 and #923 at their current source heads. Model-generation/live benchmark suites were explicitly excluded; this evidence does not claim MTP speed or live HTTP cache qualification. The QAT fixture contains verified tokenizer/config/template files only, and its temporary scanner entry was removed after validation.

The old/delegated model-selection branches also agree across 144 CPU combinations. CLI tests cover selection order, capability gates, probe arguments/failure/status, doctor verdicts and attestation presentation. No live login or report upload occurred.

```mermaid
flowchart LR
  A[Login and start] --> B[Duplicated terminal callbacks]
  C[Doctor probes] --> D[Independent process and pipe handling]
  E[Foreground start] --> F[Repeated model selection branches]
  G[Doctor checks and report] --> H[Separate severity and exit logic]
```

```mermaid
flowchart LR
  A[Login and start] --> B[Shared terminal login adapter]
  C[Doctor probes] --> D[Shared concurrent process capture]
  E[Foreground and local start] --> F[advertisedModels]
  G[Detailed checks and sectioned report] --> H[DiagnosticLevel and strict verdict]
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791761926&installation_model_id=21733&pr_number=920&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F920&signature=443a253095b5fd9c16156bf9607fd054a536b101eb39c5dbe9ca34d5ae155db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->