### PR TITLE
Preserve installer recovery backups and own temporary downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python3 scripts/test-provider-release-resolution.py
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
+          python3 -m unittest discover -s scripts -p test_installer_rollback.py
       - name: Test startup observer against local stubs
         run: python3 -m unittest discover -s scripts/startup_measurement -t scripts -p 'test_*.py'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Provider installation retains the previous app or legacy bundle if restoring it after a failed swap also fails. The installer reports the recovery path instead of deleting the only backup or claiming successful restoration.
+- Installer downloads use private temporary files and remove incomplete downloads on failure.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -185,12 +185,21 @@ verify_staged_app_payload() {
         && verify_file_hash "$app_bin/mlx.metallib" "$metallib_hash" "App metallib"
 }
 
+restore_install_path() {
+    local previous=$1
+    local destination=$2
+    [ -d "$previous" ] || return 0
+    mv "$previous" "$destination" || {
+        fail_install "Could not restore $destination; previous installation retained at $previous."
+        return 1
+    }
+}
+
 commit_staged_app() {
     local staged_app=$1
     local install_dir=$2
     local backup="$install_dir/.install-backup-$$-$RANDOM"
     local destination="$install_dir/Darkbloom.app"
-    local had_previous=0
     mkdir -p "$backup" "$install_dir/bin"
 
     if [ -d "$destination" ]; then
@@ -198,11 +207,9 @@ commit_staged_app() {
             rm -rf "$backup"
             return 1
         }
-        had_previous=1
     fi
     if ! mv "$staged_app" "$destination"; then
-        [ "$had_previous" -eq 1 ] \
-            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -214,8 +221,7 @@ commit_staged_app() {
         || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
     then
         rm -rf "$destination"
-        [ "$had_previous" -eq 1 ] \
-            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -236,7 +242,7 @@ commit_staged_flat_bundle() {
         }
     fi
     if ! mv "$staged_bin" "$destination"; then
-        [ -d "$backup/bin" ] && mv "$backup/bin" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/bin" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -288,7 +294,7 @@ install_bundle_atomically() {
         }
         commit_staged_app "$stage/Darkbloom.app" "$install_dir" || {
             rm -rf "$stage"
-            fail_install "Atomic app swap failed; previous install was restored."
+            fail_install "App swap failed."
             return 1
         }
     else
@@ -308,7 +314,7 @@ install_bundle_atomically() {
         fi
         commit_staged_flat_bundle "$flat_bin" "$install_dir" || {
             rm -rf "$stage"
-            fail_install "Atomic flat-bundle swap failed; previous install was restored."
+            fail_install "Flat-bundle swap failed."
             return 1
         }
     fi
@@ -397,7 +403,8 @@ echo ""
 echo "→ [2/5] Downloading Darkbloom v${VERSION}..."
 mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 
-TARBALL="/tmp/darkbloom-bundle.tar.gz"
+TARBALL=$(mktemp "${TMPDIR:-/tmp}/darkbloom-bundle.XXXXXX")
+trap 'rm -f "$TARBALL"' EXIT
 curl -f#L "$BUNDLE_URL" -o "$TARBALL"
 
 ACTUAL_HASH=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
@@ -406,18 +413,17 @@ if [ "$ACTUAL_HASH" != "$BUNDLE_HASH" ]; then
     echo "  ✗ Bundle hash mismatch — refusing to install possibly-tampered binary."
     echo "    Expected: $BUNDLE_HASH"
     echo "    Got:      $ACTUAL_HASH"
-    rm -f "$TARBALL"
     exit 1
 fi
 echo "  Bundle hash verified ✓"
 
 echo "  Staging and verifying the complete app before touching the live install ..."
 if ! install_bundle_atomically "$TARBALL" "$INSTALL_DIR" "$BINARY_HASH" "$METALLIB_HASH"; then
-    rm -f "$TARBALL"
-    echo "  Existing installation was left unchanged."
+    echo "  Installation failed; check the messages above for any retained recovery backup."
     exit 1
 fi
 rm -f "$TARBALL"
+trap - EXIT
 echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -237,8 +237,11 @@ commit_install_paths() {
         installed[i]=1
     done
     if [ "$i" -eq "${#names[@]}" ]; then
-        rm -rf "$backup"
-        return $?
+        # Both live paths are committed. Cleanup cannot undo that success.
+        if ! rm -rf "$backup"; then
+            echo "  Warning: Installation succeeded, but obsolete backup cleanup failed at $backup. Resolve the filesystem error before removing that directory." >&2
+        fi
+        return 0
     fi
     for ((j=i; j>=0; j--)); do
         if [ "${installed[j]}" -eq 1 ]; then

--- a/coordinator/api/install.sh
+++ b/coordinator/api/install.sh
@@ -188,67 +188,102 @@ verify_staged_app_payload() {
 restore_install_path() {
     local previous=$1
     local destination=$2
-    [ -d "$previous" ] || return 0
+    [ -e "$previous" ] || [ -L "$previous" ] || return 0
     mv "$previous" "$destination" || {
         fail_install "Could not restore $destination; previous installation retained at $previous."
         return 1
     }
 }
 
+# Preserve entries outside the release's payload (including dangling symlinks).
+# Work only in staging: copying or preparing a link must not change the live bin.
+preserve_extra_bin_entries() (
+    local previous=$1
+    local staged=$2
+    local entry name
+    [ -d "$previous" ] || return 0
+    shopt -s dotglob nullglob
+    for entry in "$previous"/*; do
+        name=${entry##*/}
+        if [ ! -e "$staged/$name" ] && [ ! -L "$staged/$name" ]; then
+            cp -a "$entry" "$staged/$name" || return 1
+        fi
+    done
+)
+
+# Replace the app and bin as one recoverable operation. Preparation has already
+# completed; every successful move is tracked so rollback touches only our paths.
+commit_install_paths() {
+    local install_dir=$1
+    local staged_bin=$2
+    local staged_app=${3:-}
+    local backup i j rollback_failed=0
+    local -a sources=() names=() saved=() installed=()
+    backup=$(mktemp -d "$install_dir/.install-backup-XXXXXX") || return 1
+    if [ -n "$staged_app" ]; then
+        sources+=("$staged_app")
+        names+=("Darkbloom.app")
+    fi
+    sources+=("$staged_bin")
+    names+=("bin")
+    for ((i=0; i<${#names[@]}; i++)); do
+        saved[i]=0
+        installed[i]=0
+        if [ -e "$install_dir/${names[i]}" ] || [ -L "$install_dir/${names[i]}" ]; then
+            mv "$install_dir/${names[i]}" "$backup/${names[i]}" || break
+            saved[i]=1
+        fi
+        mv "${sources[i]}" "$install_dir/${names[i]}" || break
+        installed[i]=1
+    done
+    if [ "$i" -eq "${#names[@]}" ]; then
+        rm -rf "$backup"
+        return $?
+    fi
+    for ((j=i; j>=0; j--)); do
+        if [ "${installed[j]}" -eq 1 ]; then
+            if ! rm -rf "$install_dir/${names[j]}"; then
+                fail_install "Could not remove failed installation at $install_dir/${names[j]}; recovery backup retained at $backup."
+                rollback_failed=1
+                continue
+            fi
+        fi
+        if [ "${saved[j]}" -eq 1 ]; then
+            restore_install_path "$backup/${names[j]}" "$install_dir/${names[j]}" || rollback_failed=1
+        fi
+    done
+    [ "$rollback_failed" -eq 0 ] && rm -rf "$backup"
+    return 1
+}
+
 commit_staged_app() {
     local staged_app=$1
     local install_dir=$2
-    local backup="$install_dir/.install-backup-$$-$RANDOM"
-    local destination="$install_dir/Darkbloom.app"
-    mkdir -p "$backup" "$install_dir/bin"
-
-    if [ -d "$destination" ]; then
-        mv "$destination" "$backup/Darkbloom.app" || {
-            rm -rf "$backup"
-            return 1
-        }
-    fi
-    if ! mv "$staged_app" "$destination"; then
-        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
-    fi
-
-    local app_bin="$destination/Contents/MacOS"
-    if ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom" "$install_dir/bin/darkbloom" \
-        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$install_dir/bin/darkbloom-enclave" \
-        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$install_dir/bin/mlx.metallib" \
-        || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
+    local staged_bin
+    # chmod and symlink failures are checked explicitly: callers use `if`/`||`,
+    # which disables Bash errexit inside the entire function call.
+    chmod +x "$staged_app/Contents/MacOS/darkbloom" "$staged_app/Contents/MacOS/darkbloom-enclave" || return 1
+    staged_bin=$(mktemp -d "$install_dir/.install-bin-XXXXXX") || return 1
+    if ln -s "../Darkbloom.app/Contents/MacOS/darkbloom" "$staged_bin/darkbloom" \
+        && ln -s "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$staged_bin/darkbloom-enclave" \
+        && ln -s "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$staged_bin/mlx.metallib" \
+        && ln -s "darkbloom-enclave" "$staged_bin/eigeninference-enclave" \
+        && preserve_extra_bin_entries "$install_dir/bin" "$staged_bin" \
+        && commit_install_paths "$install_dir" "$staged_bin" "$staged_app"
     then
-        rm -rf "$destination"
-        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
+        return 0
     fi
-    chmod +x "$app_bin/darkbloom" "$app_bin/darkbloom-enclave"
-    rm -rf "$backup"
+    rm -rf "$staged_bin"
+    return 1
 }
 
 commit_staged_flat_bundle() {
     local staged_bin=$1
     local install_dir=$2
-    local backup="$install_dir/.install-backup-$$-$RANDOM"
-    local destination="$install_dir/bin"
-    mkdir -p "$backup"
-    if [ -d "$destination" ]; then
-        mv "$destination" "$backup/bin" || {
-            rm -rf "$backup"
-            return 1
-        }
-    fi
-    if ! mv "$staged_bin" "$destination"; then
-        restore_install_path "$backup/bin" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
-    fi
-    chmod +x "$destination/darkbloom" "$destination/darkbloom-enclave"
-    ln -sfn "darkbloom-enclave" "$destination/eigeninference-enclave"
-    rm -rf "$backup"
+    chmod +x "$staged_bin/darkbloom" "$staged_bin/darkbloom-enclave" \
+        && ln -sfn "darkbloom-enclave" "$staged_bin/eigeninference-enclave" \
+        && preserve_extra_bin_entries "$install_dir/bin" "$staged_bin" \
+        && commit_install_paths "$install_dir" "$staged_bin"
 }
 
 install_bundle_atomically() {

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-11 · commit `101a97ad5`
+> Last updated: 2026-09-11 · commit `75a7185dc`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `101a97ad5`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -14,6 +14,13 @@ Model publishing can pass `HUGGING_FACE_ARTIFACT_JSON` through
 Profiler wire changes require both coordinator and provider builds; the shared
 Go/Swift fixture and focused checks are described in [test.md](test.md) and
 [prediction telemetry](../reference/prediction-decision-telemetry.md).
+
+Installer changes start in `scripts/install.sh`. Regenerate the coordinator's
+embedded copy with `scripts/sync-install-embed.sh`, then run
+`scripts/sync-install-embed.sh check` and the offline installer fixtures in
+[test.md](test.md). The commit helpers prepare executable permissions and bin
+links before replacing live paths; app and bin replacement share rollback so
+failed restoration retains a recovery backup.
 
 ## Prerequisites
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `101a97ad5`
+> Last updated: 2026-09-11 · commit `75a7185dc`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `d44791a21`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -910,6 +910,12 @@ procedure, its inputs and the regeneration flow are in
 **Installer** — `./scripts/test-install-atomic.sh` exercises the atomic
 install/replace path of `scripts/install.sh` in a temp dir (and runs
 `scripts/sync-install-embed.sh check` first).
+
+`python3 -m unittest discover -s scripts -p test_installer_rollback.py` injects
+rename failures into app and legacy-flat commit functions. It checks successful
+restoration and retention of the previous payload if restoration also fails.
+These fixtures use temporary directories without downloads, signing, enrollment,
+or running the provider; Release Integrity CI runs them on Linux.
 
 ### 5. Console UI and Admin UI
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `75a7185dc`
+> Last updated: 2026-09-11 · commit `e9018bb41`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -916,7 +916,8 @@ permission, link, copy and rename failures into app and legacy-flat commit
 functions under conditional invocation (where Bash disables `errexit`). It checks
 unchanged live paths after preparation failures, rollback of both app and bin,
 relative/dangling symlink restoration, retention after rollback failure, unrelated
-bin entries, and private download-file permissions and cleanup.
+bin entries, successful replacement despite obsolete-backup cleanup failure,
+and private download-file permissions and cleanup.
 These fixtures use temporary directories without downloads, signing, enrollment,
 or running the provider; Release Integrity CI runs them on Linux.
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d44791a21`
+> Last updated: 2026-09-11 · commit `101a97ad5`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -912,8 +912,11 @@ install/replace path of `scripts/install.sh` in a temp dir (and runs
 `scripts/sync-install-embed.sh check` first).
 
 `python3 -m unittest discover -s scripts -p test_installer_rollback.py` injects
-rename failures into app and legacy-flat commit functions. It checks successful
-restoration and retention of the previous payload if restoration also fails.
+permission, link, copy and rename failures into app and legacy-flat commit
+functions under conditional invocation (where Bash disables `errexit`). It checks
+unchanged live paths after preparation failures, rollback of both app and bin,
+relative/dangling symlink restoration, retention after rollback failure, unrelated
+bin entries, and private download-file permissions and cleanup.
 These fixtures use temporary directories without downloads, signing, enrollment,
 or running the provider; Release Integrity CI runs them on Linux.
 

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-11 · commit `75a7185dc`
+> Last updated: 2026-09-11 · commit `e9018bb41`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -330,6 +330,11 @@ that directory, resolve the reported filesystem error, and restore its
 `Darkbloom.app` and/or `bin` payload before retrying. Keep relative symlinks as
 symlinks when moving them back to their original path. Installer output does not claim
 that a failed restoration left the live installation unchanged.
+
+If replacement succeeds but obsolete backup cleanup fails, installation continues
+successfully and reports the leftover path. The new app and bin are already
+active: resolve the cleanup error before removing that obsolete backup; this
+warning does not call for restoring the previous installation.
 
 A registered release is immutable (hash-pinned); rollback means **deactivating
 it** so the previous active version becomes "latest" again.

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-11 · commit `7c394fa2b`
+> Last updated: 2026-09-11 · commit `d44791a21`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-11 · commit `d44791a21`
+> Last updated: 2026-09-11 · commit `101a97ad5`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -322,10 +322,13 @@ curl -fsS "$COORD/v1/admin/releases" -H "Authorization: Bearer $ADMIN_KEY" | jq 
 ## Rollback
 
 For a local installer swap failure, `scripts/install.sh` attempts to restore the
-previous app or flat bundle. If that rename also fails, it leaves the old payload
+previous app and bin paths, including directory symlinks. Permissions and bin
+links are prepared before replacement, and unrelated bin entries are preserved.
+If a restoration rename fails, it leaves that old payload
 in the reported `.install-backup-*` directory and exits unsuccessfully. Preserve
 that directory, resolve the reported filesystem error, and restore its
-`Darkbloom.app` or `bin` payload before retrying. Installer output does not claim
+`Darkbloom.app` and/or `bin` payload before retrying. Keep relative symlinks as
+symlinks when moving them back to their original path. Installer output does not claim
 that a failed restoration left the live installation unchanged.
 
 A registered release is immutable (hash-pinned); rollback means **deactivating

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-11 · commit `101a97ad5`
+> Last updated: 2026-09-11 · commit `75a7185dc`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-10 · commit `5f021ba4d`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -320,6 +320,13 @@ curl -fsS "$COORD/v1/admin/releases" -H "Authorization: Bearer $ADMIN_KEY" | jq 
   `binary_hash`.
 
 ## Rollback
+
+For a local installer swap failure, `scripts/install.sh` attempts to restore the
+previous app or flat bundle. If that rename also fails, it leaves the old payload
+in the reported `.install-backup-*` directory and exits unsuccessfully. Preserve
+that directory, resolve the reported filesystem error, and restore its
+`Darkbloom.app` or `bin` payload before retrying. Installer output does not claim
+that a failed restoration left the live installation unchanged.
 
 A registered release is immutable (hash-pinned); rollback means **deactivating
 it** so the previous active version becomes "latest" again.

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -1,6 +1,6 @@
 # Install, update, and uninstall the provider
 
-> Last updated: 2026-09-11 · commit `75a7185dc`
+> Last updated: 2026-09-11 · commit `e9018bb41`
 
 How to put the `darkbloom` CLI on an Apple Silicon Mac with `scripts/install.sh`,
 what the script verifies before it touches an existing install, how the binary
@@ -94,7 +94,9 @@ The script performs these actions in order (`scripts/install.sh`; failures exit
      `.install-backup-*` and prints its recovery location. Keep that directory
      and follow [installer rollback](../operations/provider-release.md#rollback)
      before retrying or removing any backup. Relative and dangling symlink
-     backups are retained and restored as links.
+     backups are retained and restored as links. Once both live paths are installed,
+     backup cleanup failure emits a warning with the obsolete backup path and
+     continues successfully; the new installation remains active.
 4. **PATH.** `ln -sf ~/.darkbloom/bin/darkbloom /usr/local/bin/darkbloom`
    (errors ignored). The rc file is `~/.zshrc`, or `~/.bashrc` only when
    `~/.zshrc` does not exist. If the rc does not already mention

--- a/docs/provider/installation.md
+++ b/docs/provider/installation.md
@@ -1,6 +1,6 @@
 # Install, update, and uninstall the provider
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-11 · commit `75a7185dc`
 
 How to put the `darkbloom` CLI on an Apple Silicon Mac with `scripts/install.sh`,
 what the script verifies before it touches an existing install, how the binary
@@ -78,17 +78,23 @@ The script performs these actions in order (`scripts/install.sh`; failures exit
      `DARKBLOOM_NO_UPDATE_CHECK=1 DARKBLOOM_GEMMA4_PREFILL_CHUNK_EVAL=18 MLX_GEMMA4_FUSED_WEIGHTED_UNSORT=1 MLX_GATHER_QMM_EXPERT_SLICES=1 darkbloom runtime-smoke`
      (`provider-swift/Sources/darkbloom/RuntimeSmokeCommand.swift`,
      `RuntimeSmoke`);
-   - `commit_staged_app` moves any existing `~/.darkbloom/Darkbloom.app` to
-     `~/.darkbloom/.install-backup-<pid>-<random>`, moves the staged app in,
-     writes the symlinks `~/.darkbloom/bin/darkbloom`, `darkbloom-enclave`,
-     `mlx.metallib` → `../Darkbloom.app/Contents/MacOS/*` and the legacy alias
-     `bin/eigeninference-enclave → darkbloom-enclave`, and `chmod +x`. Any
-     failure moves the backup back;
+   - `commit_staged_app` prepares executable permissions and the staged bin
+     symlinks (`darkbloom`, `darkbloom-enclave`, `mlx.metallib` and the legacy
+     `eigeninference-enclave` alias), preserving unrelated existing bin entries.
+     `commit_install_paths` then moves the old app and bin into a private
+     `~/.darkbloom/.install-backup-*` directory and installs the staged paths;
    - a tarball without `Darkbloom.app` (legacy flat layout) gets
      `codesign --verify --strict -R=…` on `bin/darkbloom` and
-     `commit_staged_flat_bundle` swaps `~/.darkbloom/bin` the same way;
-   - the staging directory is removed; on any failure the script prints
-     `Existing installation was left unchanged.` and exits 1.
+     `commit_staged_flat_bundle` prepares and swaps the bin with the same
+     recovery mechanism;
+   - preparation or verification failures leave the live installation unchanged.
+     A replacement failure reverses completed moves before exiting 1. If a
+     restoration rename or candidate removal also fails, the affected live path
+     may be absent or incomplete: the installer retains the previous copy in
+     `.install-backup-*` and prints its recovery location. Keep that directory
+     and follow [installer rollback](../operations/provider-release.md#rollback)
+     before retrying or removing any backup. Relative and dangling symlink
+     backups are retained and restored as links.
 4. **PATH.** `ln -sf ~/.darkbloom/bin/darkbloom /usr/local/bin/darkbloom`
    (errors ignored). The rc file is `~/.zshrc`, or `~/.bashrc` only when
    `~/.zshrc` does not exist. If the rc does not already mention

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -185,12 +185,21 @@ verify_staged_app_payload() {
         && verify_file_hash "$app_bin/mlx.metallib" "$metallib_hash" "App metallib"
 }
 
+restore_install_path() {
+    local previous=$1
+    local destination=$2
+    [ -d "$previous" ] || return 0
+    mv "$previous" "$destination" || {
+        fail_install "Could not restore $destination; previous installation retained at $previous."
+        return 1
+    }
+}
+
 commit_staged_app() {
     local staged_app=$1
     local install_dir=$2
     local backup="$install_dir/.install-backup-$$-$RANDOM"
     local destination="$install_dir/Darkbloom.app"
-    local had_previous=0
     mkdir -p "$backup" "$install_dir/bin"
 
     if [ -d "$destination" ]; then
@@ -198,11 +207,9 @@ commit_staged_app() {
             rm -rf "$backup"
             return 1
         }
-        had_previous=1
     fi
     if ! mv "$staged_app" "$destination"; then
-        [ "$had_previous" -eq 1 ] \
-            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -214,8 +221,7 @@ commit_staged_app() {
         || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
     then
         rm -rf "$destination"
-        [ "$had_previous" -eq 1 ] \
-            && mv "$backup/Darkbloom.app" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -236,7 +242,7 @@ commit_staged_flat_bundle() {
         }
     fi
     if ! mv "$staged_bin" "$destination"; then
-        [ -d "$backup/bin" ] && mv "$backup/bin" "$destination" 2>/dev/null || true
+        restore_install_path "$backup/bin" "$destination" || return 1
         rm -rf "$backup"
         return 1
     fi
@@ -288,7 +294,7 @@ install_bundle_atomically() {
         }
         commit_staged_app "$stage/Darkbloom.app" "$install_dir" || {
             rm -rf "$stage"
-            fail_install "Atomic app swap failed; previous install was restored."
+            fail_install "App swap failed."
             return 1
         }
     else
@@ -308,7 +314,7 @@ install_bundle_atomically() {
         fi
         commit_staged_flat_bundle "$flat_bin" "$install_dir" || {
             rm -rf "$stage"
-            fail_install "Atomic flat-bundle swap failed; previous install was restored."
+            fail_install "Flat-bundle swap failed."
             return 1
         }
     fi
@@ -397,7 +403,8 @@ echo ""
 echo "→ [2/5] Downloading Darkbloom v${VERSION}..."
 mkdir -p "$INSTALL_DIR" "$BIN_DIR"
 
-TARBALL="/tmp/darkbloom-bundle.tar.gz"
+TARBALL=$(mktemp "${TMPDIR:-/tmp}/darkbloom-bundle.XXXXXX")
+trap 'rm -f "$TARBALL"' EXIT
 curl -f#L "$BUNDLE_URL" -o "$TARBALL"
 
 ACTUAL_HASH=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
@@ -406,18 +413,17 @@ if [ "$ACTUAL_HASH" != "$BUNDLE_HASH" ]; then
     echo "  ✗ Bundle hash mismatch — refusing to install possibly-tampered binary."
     echo "    Expected: $BUNDLE_HASH"
     echo "    Got:      $ACTUAL_HASH"
-    rm -f "$TARBALL"
     exit 1
 fi
 echo "  Bundle hash verified ✓"
 
 echo "  Staging and verifying the complete app before touching the live install ..."
 if ! install_bundle_atomically "$TARBALL" "$INSTALL_DIR" "$BINARY_HASH" "$METALLIB_HASH"; then
-    rm -f "$TARBALL"
-    echo "  Existing installation was left unchanged."
+    echo "  Installation failed; check the messages above for any retained recovery backup."
     exit 1
 fi
 rm -f "$TARBALL"
+trap - EXIT
 echo "  Strict signature, runtime resources, and atomic swap verified ✓"
 
 # Make available in PATH. Try /usr/local/bin symlink, fall back to shell rc.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -237,8 +237,11 @@ commit_install_paths() {
         installed[i]=1
     done
     if [ "$i" -eq "${#names[@]}" ]; then
-        rm -rf "$backup"
-        return $?
+        # Both live paths are committed. Cleanup cannot undo that success.
+        if ! rm -rf "$backup"; then
+            echo "  Warning: Installation succeeded, but obsolete backup cleanup failed at $backup. Resolve the filesystem error before removing that directory." >&2
+        fi
+        return 0
     fi
     for ((j=i; j>=0; j--)); do
         if [ "${installed[j]}" -eq 1 ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,67 +188,102 @@ verify_staged_app_payload() {
 restore_install_path() {
     local previous=$1
     local destination=$2
-    [ -d "$previous" ] || return 0
+    [ -e "$previous" ] || [ -L "$previous" ] || return 0
     mv "$previous" "$destination" || {
         fail_install "Could not restore $destination; previous installation retained at $previous."
         return 1
     }
 }
 
+# Preserve entries outside the release's payload (including dangling symlinks).
+# Work only in staging: copying or preparing a link must not change the live bin.
+preserve_extra_bin_entries() (
+    local previous=$1
+    local staged=$2
+    local entry name
+    [ -d "$previous" ] || return 0
+    shopt -s dotglob nullglob
+    for entry in "$previous"/*; do
+        name=${entry##*/}
+        if [ ! -e "$staged/$name" ] && [ ! -L "$staged/$name" ]; then
+            cp -a "$entry" "$staged/$name" || return 1
+        fi
+    done
+)
+
+# Replace the app and bin as one recoverable operation. Preparation has already
+# completed; every successful move is tracked so rollback touches only our paths.
+commit_install_paths() {
+    local install_dir=$1
+    local staged_bin=$2
+    local staged_app=${3:-}
+    local backup i j rollback_failed=0
+    local -a sources=() names=() saved=() installed=()
+    backup=$(mktemp -d "$install_dir/.install-backup-XXXXXX") || return 1
+    if [ -n "$staged_app" ]; then
+        sources+=("$staged_app")
+        names+=("Darkbloom.app")
+    fi
+    sources+=("$staged_bin")
+    names+=("bin")
+    for ((i=0; i<${#names[@]}; i++)); do
+        saved[i]=0
+        installed[i]=0
+        if [ -e "$install_dir/${names[i]}" ] || [ -L "$install_dir/${names[i]}" ]; then
+            mv "$install_dir/${names[i]}" "$backup/${names[i]}" || break
+            saved[i]=1
+        fi
+        mv "${sources[i]}" "$install_dir/${names[i]}" || break
+        installed[i]=1
+    done
+    if [ "$i" -eq "${#names[@]}" ]; then
+        rm -rf "$backup"
+        return $?
+    fi
+    for ((j=i; j>=0; j--)); do
+        if [ "${installed[j]}" -eq 1 ]; then
+            if ! rm -rf "$install_dir/${names[j]}"; then
+                fail_install "Could not remove failed installation at $install_dir/${names[j]}; recovery backup retained at $backup."
+                rollback_failed=1
+                continue
+            fi
+        fi
+        if [ "${saved[j]}" -eq 1 ]; then
+            restore_install_path "$backup/${names[j]}" "$install_dir/${names[j]}" || rollback_failed=1
+        fi
+    done
+    [ "$rollback_failed" -eq 0 ] && rm -rf "$backup"
+    return 1
+}
+
 commit_staged_app() {
     local staged_app=$1
     local install_dir=$2
-    local backup="$install_dir/.install-backup-$$-$RANDOM"
-    local destination="$install_dir/Darkbloom.app"
-    mkdir -p "$backup" "$install_dir/bin"
-
-    if [ -d "$destination" ]; then
-        mv "$destination" "$backup/Darkbloom.app" || {
-            rm -rf "$backup"
-            return 1
-        }
-    fi
-    if ! mv "$staged_app" "$destination"; then
-        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
-    fi
-
-    local app_bin="$destination/Contents/MacOS"
-    if ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom" "$install_dir/bin/darkbloom" \
-        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$install_dir/bin/darkbloom-enclave" \
-        || ! ln -sfn "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$install_dir/bin/mlx.metallib" \
-        || ! ln -sfn "darkbloom-enclave" "$install_dir/bin/eigeninference-enclave"
+    local staged_bin
+    # chmod and symlink failures are checked explicitly: callers use `if`/`||`,
+    # which disables Bash errexit inside the entire function call.
+    chmod +x "$staged_app/Contents/MacOS/darkbloom" "$staged_app/Contents/MacOS/darkbloom-enclave" || return 1
+    staged_bin=$(mktemp -d "$install_dir/.install-bin-XXXXXX") || return 1
+    if ln -s "../Darkbloom.app/Contents/MacOS/darkbloom" "$staged_bin/darkbloom" \
+        && ln -s "../Darkbloom.app/Contents/MacOS/darkbloom-enclave" "$staged_bin/darkbloom-enclave" \
+        && ln -s "../Darkbloom.app/Contents/MacOS/mlx.metallib" "$staged_bin/mlx.metallib" \
+        && ln -s "darkbloom-enclave" "$staged_bin/eigeninference-enclave" \
+        && preserve_extra_bin_entries "$install_dir/bin" "$staged_bin" \
+        && commit_install_paths "$install_dir" "$staged_bin" "$staged_app"
     then
-        rm -rf "$destination"
-        restore_install_path "$backup/Darkbloom.app" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
+        return 0
     fi
-    chmod +x "$app_bin/darkbloom" "$app_bin/darkbloom-enclave"
-    rm -rf "$backup"
+    rm -rf "$staged_bin"
+    return 1
 }
 
 commit_staged_flat_bundle() {
     local staged_bin=$1
     local install_dir=$2
-    local backup="$install_dir/.install-backup-$$-$RANDOM"
-    local destination="$install_dir/bin"
-    mkdir -p "$backup"
-    if [ -d "$destination" ]; then
-        mv "$destination" "$backup/bin" || {
-            rm -rf "$backup"
-            return 1
-        }
-    fi
-    if ! mv "$staged_bin" "$destination"; then
-        restore_install_path "$backup/bin" "$destination" || return 1
-        rm -rf "$backup"
-        return 1
-    fi
-    chmod +x "$destination/darkbloom" "$destination/darkbloom-enclave"
-    ln -sfn "darkbloom-enclave" "$destination/eigeninference-enclave"
-    rm -rf "$backup"
+    chmod +x "$staged_bin/darkbloom" "$staged_bin/darkbloom-enclave" \
+        && ln -sfn "darkbloom-enclave" "$staged_bin/eigeninference-enclave" \
+        && preserve_extra_bin_entries "$install_dir/bin" "$staged_bin" \
+        && commit_install_paths "$install_dir" "$staged_bin"
 }
 
 install_bundle_atomically() {

--- a/scripts/test_installer_rollback.py
+++ b/scripts/test_installer_rollback.py
@@ -244,6 +244,22 @@ sys.exit(subprocess.run(["/bin/" + tool, *sys.argv[1:]]).returncode)
         self.assertEqual(snapshot(installed / "bin"), before[2]["bin"])
         self.assertIn(str(backups[0]), result.stderr)
 
+    def test_backup_cleanup_failure_reports_successful_commit_and_retained_path(self):
+        for kind in ("app", "flat"):
+            with self.subTest(kind=kind):
+                installed, before, result = self.fixture(kind, {"rm": [1]})
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual((installed / "bin" / "darkbloom").read_text(), "new darkbloom")
+                self.assertEqual(snapshot(installed / "bin" / ".user-file"),
+                                 before[2]["bin"][2][".user-file"])
+                backups = list(installed.glob(".install-backup-*"))
+                self.assertEqual(len(backups), 1)
+                self.assertEqual(snapshot(backups[0] / "bin"), before[2]["bin"])
+                if kind == "app":
+                    self.assertEqual(snapshot(backups[0] / "Darkbloom.app"), before[2]["Darkbloom.app"])
+                self.assertIn("Installation succeeded", result.stderr)
+                self.assertIn(str(backups[0]), result.stderr)
+
     def test_first_install_success_and_failed_moves(self):
         for kind in ("app", "flat"):
             for call in range(0, 3 if kind == "app" else 2):

--- a/scripts/test_installer_rollback.py
+++ b/scripts/test_installer_rollback.py
@@ -114,7 +114,7 @@ sys.exit(subprocess.run(["/bin/mv", *sys.argv[1:]]).returncode)
 def snapshot(path):
     """Capture contents, modes and link text without following symlinks."""
     if path.is_symlink():
-        return ("link", os.readlink(path))
+        return ("link", path.lstat().st_mode & 0o777, os.readlink(path))
     if path.is_dir():
         return ("directory", path.stat().st_mode & 0o777,
                 {child.name: snapshot(child) for child in path.iterdir()})

--- a/scripts/test_installer_rollback.py
+++ b/scripts/test_installer_rollback.py
@@ -1,0 +1,110 @@
+"""Inject local rename failures without downloading or running an installer."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+INSTALLER = Path(__file__).resolve().with_name("install.sh")
+
+
+class InstallerRollbackTests(unittest.TestCase):
+    def test_failed_download_uses_private_temporary_files_and_cleans_them(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "downloads.jsonl"
+            curl = root / "curl"
+            curl.write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+path = Path(sys.argv[sys.argv.index("-o") + 1])
+root = Path(os.environ["TMPDIR"])
+# Refuse to write outside the fixture, including an old shared /tmp path.
+if path.parent != root:
+    sys.exit(78)
+with (root / "downloads.jsonl").open("a") as log:
+    log.write(json.dumps({"path": str(path), "mode": path.stat().st_mode & 0o777}) + "\\n")
+path.write_text("partial download")
+sys.exit(22)
+''')
+            curl.chmod(0o755)
+            source = INSTALLER.read_text()
+            phase = source[source.index("TARBALL="):source.index("# Make available in PATH.")]
+            for _ in range(2):
+                result = subprocess.run(["bash", "-euc", phase], capture_output=True, text=True,
+                                        env={**os.environ, "PATH": str(root) + os.pathsep + os.environ["PATH"],
+                                             "TMPDIR": directory, "BUNDLE_URL": "fixture-only"})
+                self.assertEqual(result.returncode, 22, result.stderr)
+            attempts = [json.loads(line) for line in log.read_text().splitlines()]
+            self.assertEqual(len({item["path"] for item in attempts}), 2)
+            self.assertTrue(all(item["mode"] == 0o600 for item in attempts))
+            self.assertTrue(all(not Path(item["path"]).exists() for item in attempts))
+
+    def run_failed_swap(self, kind, fail_restore):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        installed = root / "installed"
+        name = "Darkbloom.app" if kind == "app" else "bin"
+        previous = installed / name
+        previous.mkdir(parents=True)
+        (previous / "original").write_text("previous verified payload")
+        staged = root / "staged"
+        staged.mkdir()
+        (staged / "candidate").write_text("candidate payload")
+        commands = root / "commands"
+        commands.mkdir()
+        mv = commands / "mv"
+        mv.write_text('''#!/usr/bin/env python3
+import os, subprocess, sys
+from pathlib import Path
+counter = Path(os.environ["INSTALL_TEST_MOVES"])
+call = int(counter.read_text()) + 1 if counter.exists() else 1
+counter.write_text(str(call))
+if call == 2 or (call == 3 and os.environ["INSTALL_TEST_RESTORE_FAIL"] == "1"):
+    sys.exit(1)
+sys.exit(subprocess.run(["/bin/mv", *sys.argv[1:]]).returncode)
+''')
+        mv.chmod(0o755)
+        # Only source function definitions. Platform checks, downloads, signing,
+        # shell configuration, enrollment and service operations never execute.
+        functions = INSTALLER.read_text().split(
+            'if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then', 1
+        )[0]
+        function = "commit_staged_app" if kind == "app" else "commit_staged_flat_bundle"
+        result = subprocess.run(
+            ["bash", "-c", functions + '\n' + function + ' "$1" "$2"',
+             "fixture", str(staged), str(installed)],
+            env={**os.environ, "PATH": str(commands) + os.pathsep + os.environ["PATH"],
+                 "INSTALL_TEST_MOVES": str(root / "moves"),
+                 "INSTALL_TEST_RESTORE_FAIL": "1" if fail_restore else "0"},
+            capture_output=True, text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((staged / "candidate").read_text(), "candidate payload")
+        return installed, name, result
+
+    def test_failed_swap_restores_previous_install_and_cleans_backup(self):
+        for kind in ("app", "flat"):
+            with self.subTest(kind=kind):
+                installed, name, _ = self.run_failed_swap(kind, fail_restore=False)
+                self.assertEqual((installed / name / "original").read_text(),
+                                 "previous verified payload")
+                self.assertEqual(list(installed.glob(".install-backup-*")), [])
+
+    def test_failed_rollback_preserves_backup_and_reports_recovery_path(self):
+        for kind in ("app", "flat"):
+            with self.subTest(kind=kind):
+                installed, name, result = self.run_failed_swap(kind, fail_restore=True)
+                backups = list(installed.glob(".install-backup-*"))
+                self.assertEqual(len(backups), 1, "failed rollback must retain the only old copy")
+                original = backups[0] / name
+                self.assertEqual((original / "original").read_text(), "previous verified payload")
+                self.assertIn(str(original), result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_installer_rollback.py
+++ b/scripts/test_installer_rollback.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 from pathlib import Path
 import subprocess
 import tempfile
@@ -55,6 +56,10 @@ sys.exit(22)
         staged = root / "staged"
         staged.mkdir()
         (staged / "candidate").write_text("candidate payload")
+        payload = staged / "Contents" / "MacOS" if kind == "app" else staged
+        payload.mkdir(parents=True, exist_ok=True)
+        for binary in ("darkbloom", "darkbloom-enclave"):
+            (payload / binary).write_text("fixture binary")
         commands = root / "commands"
         commands.mkdir()
         mv = commands / "mv"
@@ -104,6 +109,167 @@ sys.exit(subprocess.run(["/bin/mv", *sys.argv[1:]]).returncode)
                 original = backups[0] / name
                 self.assertEqual((original / "original").read_text(), "previous verified payload")
                 self.assertIn(str(original), result.stderr)
+
+
+def snapshot(path):
+    """Capture contents, modes and link text without following symlinks."""
+    if path.is_symlink():
+        return ("link", os.readlink(path))
+    if path.is_dir():
+        return ("directory", path.stat().st_mode & 0o777,
+                {child.name: snapshot(child) for child in path.iterdir()})
+    if path.exists():
+        return ("file", path.stat().st_mode & 0o777, path.read_bytes())
+    return None
+
+
+class InstallerCommitTests(unittest.TestCase):
+    def fixture(self, kind, failures=None, previous_kind="directory"):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        installed = root / "installed"
+        installed.mkdir()
+        for name in ("Darkbloom.app", "bin"):
+            path = installed / name
+            path.mkdir()
+            (path / "original").write_text("previous " + name)
+        old_bin = installed / "bin"
+        for name in ("darkbloom", "darkbloom-enclave", "mlx.metallib"):
+            (old_bin / name).write_text("old " + name)
+        (old_bin / "eigeninference-enclave").symlink_to("darkbloom-enclave")
+        (old_bin / ".user-file").write_text("unrelated hidden file")
+        (old_bin / "user-link").symlink_to("missing-user-target")
+        (old_bin / "user-directory").mkdir()
+        (old_bin / "user-directory" / "file").write_text("unrelated directory")
+        name = "Darkbloom.app" if kind == "app" else "bin"
+        if previous_kind == "absent":
+            for path in installed.iterdir():
+                shutil.rmtree(path)
+        elif previous_kind != "directory":
+            target = installed / ("previous-" + name)
+            (installed / name).rename(target)
+            (installed / name).symlink_to(
+                target.name if previous_kind == "relative" else "missing-install-target")
+        staged = root / "staged"
+        payload = staged / "Contents" / "MacOS" if kind == "app" else staged
+        payload.mkdir(parents=True)
+        for binary in ("darkbloom", "darkbloom-enclave", "mlx.metallib"):
+            (payload / binary).write_text("new " + binary)
+        before = snapshot(installed)
+        commands = root / "commands"
+        commands.mkdir()
+        for tool in ("mv", "ln", "chmod", "cp", "rm"):
+            shim = commands / tool
+            shim.write_text('''#!/usr/bin/env python3
+import json, os, subprocess, sys
+from pathlib import Path
+tool = Path(sys.argv[0]).name
+counter = Path(os.environ["INSTALL_TEST_ROOT"]) / (tool + "-calls")
+call = int(counter.read_text()) + 1 if counter.exists() else 1
+counter.write_text(str(call))
+if call in json.loads(os.environ["INSTALL_TEST_FAILURES"]).get(tool, []):
+    sys.exit(73)
+sys.exit(subprocess.run(["/bin/" + tool, *sys.argv[1:]]).returncode)
+''')
+            shim.chmod(0o755)
+        functions = INSTALLER.read_text().split(
+            'if [ "${1:-}" = "--verify-staged-app-signature-test" ]; then', 1)[0]
+        function = "commit_staged_app" if kind == "app" else "commit_staged_flat_bundle"
+        result = subprocess.run(
+            ["bash", "-c", functions + '\nif ' + function +
+             ' "$1" "$2"; then exit 0; else exit 1; fi',
+             "fixture", str(staged), str(installed)],
+            env={**os.environ, "PATH": str(commands) + os.pathsep + os.environ["PATH"],
+                 "INSTALL_TEST_ROOT": str(root),
+                 "INSTALL_TEST_FAILURES": json.dumps(failures or {})},
+            capture_output=True, text=True)
+        return installed, before, result
+
+    def test_preparation_failures_leave_both_live_paths_exactly_unchanged(self):
+        for kind in ("app", "flat"):
+            failures = [("chmod", 1), ("cp", 1)]
+            failures += [("ln", n) for n in range(1, 5 if kind == "app" else 2)]
+            for tool, call in failures:
+                with self.subTest(kind=kind, tool=tool, call=call):
+                    installed, before, result = self.fixture(kind, {tool: [call]})
+                    self.assertNotEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(snapshot(installed), before)
+
+    def test_every_commit_rename_failure_restores_both_paths(self):
+        for kind in ("app", "flat"):
+            for call in range(1, 5 if kind == "app" else 3):
+                with self.subTest(kind=kind, call=call):
+                    installed, before, result = self.fixture(kind, {"mv": [call]})
+                    self.assertNotEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(snapshot(installed), before)
+
+    def test_symlink_installations_survive_failed_swap_or_failed_restore(self):
+        for kind in ("app", "flat"):
+            for previous in ("relative", "dangling"):
+                for fail_restore in (False, True):
+                    with self.subTest(kind=kind, previous=previous, restore=fail_restore):
+                        installed, before, result = self.fixture(
+                            kind, {"mv": [2, 3] if fail_restore else [2]}, previous)
+                        self.assertNotEqual(result.returncode, 0, result.stderr)
+                        if not fail_restore:
+                            self.assertEqual(snapshot(installed), before)
+                            continue
+                        backups = list(installed.glob(".install-backup-*"))
+                        self.assertEqual(len(backups), 1)
+                        name = "Darkbloom.app" if kind == "app" else "bin"
+                        retained = backups[0] / name
+                        self.assertEqual(snapshot(retained), before[2][name])
+                        self.assertIn(str(retained), result.stderr)
+
+    def test_app_bin_swap_failure_attempts_both_rollbacks_and_retains_failed_one(self):
+        for restore_call, retained_name, restored_name in ((5, "bin", "Darkbloom.app"),
+                                                          (6, "Darkbloom.app", "bin")):
+            with self.subTest(restore_call=restore_call):
+                installed, before, result = self.fixture("app", {"mv": [4, restore_call]})
+                self.assertNotEqual(result.returncode, 0, result.stderr)
+                backups = list(installed.glob(".install-backup-*"))
+                self.assertEqual(len(backups), 1)
+                retained = backups[0] / retained_name
+                self.assertEqual(snapshot(retained), before[2][retained_name])
+                self.assertEqual(snapshot(installed / restored_name), before[2][restored_name])
+                self.assertIn(str(retained), result.stderr)
+
+    def test_failed_candidate_removal_keeps_old_app_backup_and_restores_bin(self):
+        installed, before, result = self.fixture("app", {"mv": [4], "rm": [1]})
+        self.assertNotEqual(result.returncode, 0, result.stderr)
+        backups = list(installed.glob(".install-backup-*"))
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(snapshot(backups[0] / "Darkbloom.app"), before[2]["Darkbloom.app"])
+        self.assertEqual(snapshot(installed / "bin"), before[2]["bin"])
+        self.assertIn(str(backups[0]), result.stderr)
+
+    def test_first_install_success_and_failed_moves(self):
+        for kind in ("app", "flat"):
+            for call in range(0, 3 if kind == "app" else 2):
+                with self.subTest(kind=kind, call=call):
+                    installed, before, result = self.fixture(
+                        kind, {"mv": [call]} if call else {}, previous_kind="absent")
+                    if call:
+                        self.assertNotEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual(snapshot(installed), before)
+                    else:
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual((installed / "bin" / "darkbloom").read_text(), "new darkbloom")
+                        self.assertEqual(list(installed.glob(".install-*")), [])
+
+    def test_success_installs_payload_and_preserves_unrelated_bin_entries(self):
+        for kind in ("app", "flat"):
+            with self.subTest(kind=kind):
+                installed, before, result = self.fixture(kind)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for name in ("original", ".user-file", "user-link", "user-directory"):
+                    self.assertEqual(snapshot(installed / "bin" / name), before[2]["bin"][2][name])
+                self.assertEqual((installed / "bin" / "darkbloom").read_text(), "new darkbloom")
+                self.assertTrue(os.access(installed / "bin" / "darkbloom", os.X_OK))
+                self.assertEqual(os.readlink(installed / "bin" / "eigeninference-enclave"),
+                                 "darkbloom-enclave")
+                self.assertEqual(list(installed.glob(".install-*")), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Installer failure could lose the old installation: a relocated relative symlink was mistaken for a missing backup, partial app-link updates overwrote old flat binaries, and conditional invocation suppressed Bash failures from chmod/link setup. Prepare permissions, links, and preserved extra bin entries before touching live paths, then share a tracked app/bin replacement and reverse rollback. Failed restoration retains the old path in a private recovery directory and reports its location, including relative or dangling symlinks.

Downloads use a private temporary archive with exit cleanup. The coordinator embedded installer remains byte-for-byte identical. Artifact hash, signing, resource, capability and enrollment checks are unchanged. Build/test guidance and the release rollback runbook describe the resulting behavior.

Before:
```mermaid
flowchart LR
  D[Download into shared temporary archive] --> V[Stage and verify]
  V --> A[commit_staged_app or flat commit]
  A --> L[Replace live path then chmod and update links]
  L -->|Partial failure| F[Old bin entries overwritten or errors ignored]
  A -->|Rename failure| R[Restore only directory backup]
  R --> X[Relative symlink skipped or failed backup removed]
```

After:
```mermaid
flowchart LR
  D[Private archive with exit cleanup] --> V[Same verification]
  V --> P[Prepare permissions and links in staging]
  P --> E[preserve_extra_bin_entries]
  E --> C[commit_install_paths tracks app and bin moves]
  P -->|Failure| U[Live installation unchanged]
  E -->|Failure| U
  C -->|Success| S[New payload with unrelated bin entries preserved]
  C -->|Failure| R[Reverse completed moves via restore_install_path]
  R -->|Restored| F[Return failure with old app and bin restored]
  R -->|Restore fails| K[Retain recovery backup and print path]
```

Validation:
- 11 offline Python fixture tests pass, including conditional invocation, chmod/link/copy failures, each commit rename, reverse-rollback failures, candidate removal failure, first install, symlink recovery, successful replacement, unrelated bin entries, and private download permissions/cleanup.
- The expanded 5-method failure characterization failed in 19 subcases against the pre-fix script (including newly covered transaction seams); direct cases reproduce the symlink loss, partial-link overwrite, and ignored preparation errors.
- Coordinator embedded installer and templating tests pass with Go race detection; shell syntax, byte parity, docs lint (278 pages), and whitespace checks pass. An independent source review found no blocker.
- No real download, install, signing, enrollment, provider/model execution, or deployment was performed. The native signed-artifact fixture remains a separate platform check.

The full coordinator suite passes with the repository-pinned Go 1.25.0 (`GOTOOLCHAIN=go1.25.0 go test ./coordinator/...`). The automatic pre-push hook initially used local Go 1.27.1 and failed four JSON encoding assertions; the same failures reproduce on unchanged master and pass with the pinned toolchain. No Go source is changed by this PR.

Post-commit cleanup: once both live paths are replaced, an obsolete-backup removal failure warns with its path and retains a successful installation result. The new app and flat fixtures reproduce the old false failure and verify retained recovery content. All 11 offline tests pass (37.523s).
