### PR TITLE
Fill warm-pool load deficits across competing models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Coordinator
+
+- Fill warm-pool load allowances from remaining eligible providers when models share preferred machines or a reservation loses a race. Observe-only planning also assigns each machine to at most one model per tick.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/registry/warm_pool_allocation.go
+++ b/coordinator/registry/warm_pool_allocation.go
@@ -1,0 +1,46 @@
+package registry
+
+import "time"
+
+// allocateWarmPoolLoads fills a model's bounded load allowance from the whole
+// eligible shortlist. Fleet snapshots overlap across models: a machine claimed
+// earlier in this planning pass must not consume another model's allowance.
+// Reservation can also lose a race to a heartbeat-triggered load, so rejected
+// candidates are replaced from the remaining shortlist without rescanning it.
+// The observe-only path applies the same per-provider exclusivity locally.
+func allocateWarmPoolLoads(
+	model string,
+	candidates []warmPoolCandidate,
+	need int,
+	assigned map[string]struct{},
+	reserve func([]modelLoadAction, time.Time) []modelLoadAction,
+	now time.Time,
+) []modelLoadAction {
+	if need <= 0 {
+		return nil
+	}
+	actions := make([]modelLoadAction, 0, need)
+	for cursor := 0; cursor < len(candidates) && len(actions) < need; {
+		remaining := need - len(actions)
+		batch := make([]modelLoadAction, 0, remaining)
+		for cursor < len(candidates) && len(batch) < remaining {
+			candidate := candidates[cursor]
+			cursor++
+			if _, used := assigned[candidate.providerID]; used {
+				continue
+			}
+			batch = append(batch, modelLoadAction{providerID: candidate.providerID, modelID: model})
+		}
+		if len(batch) == 0 {
+			break
+		}
+		if reserve != nil {
+			batch = reserve(batch, now)
+		}
+		for _, action := range batch {
+			assigned[action.providerID] = struct{}{}
+			actions = append(actions, action)
+		}
+	}
+	return actions
+}

--- a/coordinator/registry/warm_pool_allocation_test.go
+++ b/coordinator/registry/warm_pool_allocation_test.go
@@ -1,0 +1,89 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestWarmPoolAllocationReplacesLostReservations(t *testing.T) {
+	candidates := []warmPoolCandidate{{providerID: "lost-a"}, {providerID: "a"}, {providerID: "lost-b"}, {providerID: "b"}}
+	visited := make(map[string]int)
+	reserve := func(batch []modelLoadAction, _ time.Time) []modelLoadAction {
+		out := batch[:0]
+		for _, action := range batch {
+			visited[action.providerID]++
+			if action.providerID == "a" || action.providerID == "b" {
+				out = append(out, action)
+			}
+		}
+		return out
+	}
+	actions := allocateWarmPoolLoads("demand", candidates, 2, make(map[string]struct{}), reserve, time.Now())
+	if len(actions) != 2 || actions[0].providerID != "a" || actions[1].providerID != "b" {
+		t.Fatalf("lost reservations stranded eligible alternatives: %+v", actions)
+	}
+	for id, count := range visited {
+		if count != 1 {
+			t.Fatalf("candidate %s revisited %d times", id, count)
+		}
+	}
+}
+
+func TestWarmPoolAllocationExhaustionIsBounded(t *testing.T) {
+	visits := 0
+	candidates := []warmPoolCandidate{{providerID: "a"}, {providerID: "b"}, {providerID: "c"}}
+	actions := allocateWarmPoolLoads("demand", candidates, 2, make(map[string]struct{}),
+		func(batch []modelLoadAction, _ time.Time) []modelLoadAction { visits += len(batch); return nil }, time.Now())
+	if len(actions) != 0 || visits != len(candidates) {
+		t.Fatalf("actions=%v visits=%d; want one bounded pass", actions, visits)
+	}
+}
+
+// Both models have the same ranked cold machines. The first consumes the two
+// best machines; the second must use the next two within the SAME tick, rather
+// than reserve the already-claimed pair and leave its warm deficit unchanged.
+func TestWarmPoolSharedColdFleetFillsBothModels(t *testing.T) {
+	for _, observe := range []bool{false, true} {
+		t.Run(fmt.Sprintf("observe=%t", observe), func(t *testing.T) {
+			r := New(testLogger())
+			models := []string{"demand-a", "demand-b"}
+			for _, model := range models {
+				warm := makeSchedulerProvider(t, r, "warm-"+model, model, 20)
+				warm.BackendCapacity.Slots[0].NumRunning = 3
+			}
+			for i := 0; i < 4; i++ {
+				provider := makeWarmPoolColdProvider(t, r, fmt.Sprintf("cold-%d", i), models[0], 20, 64, float64(8+i))
+				provider.Models = append(provider.Models, r.GetProvider("warm-" + models[1]).Models[0])
+			}
+			cfg := testWarmPoolConfig()
+			cfg.ObserveOnly = observe
+			cfg.DecodeFloorTPS = 15
+			cfg.MaxLoadsPerTick = 2
+			cfg.MaxLoadsPerTickCeiling = 4
+			cfg.RampGapFraction = 1
+			cfg.MaxGlobalPendingLoads = 4
+			r.ConfigureWarmPool(cfg)
+			sent := captureWarmPoolLoads(r)
+			for _, model := range models {
+				r.RecordWarmPoolCapacityReject(model)
+			}
+			snapshots := r.warmPool.tick(time.Now())
+			claimed := make(map[string]bool)
+			for _, snapshot := range snapshots {
+				if len(snapshot.Actions) != 2 {
+					t.Fatalf("model %s planned %d loads, want 2: %+v", snapshot.Model, len(snapshot.Actions), snapshot)
+				}
+				for _, action := range snapshot.Actions {
+					if claimed[action.providerID] {
+						t.Fatalf("two models claimed provider %s", action.providerID)
+					}
+					claimed[action.providerID] = true
+				}
+			}
+			if len(claimed) != 4 || (!observe && len(*sent) != 4) || (observe && len(*sent) != 0) {
+				t.Fatalf("claimed=%d sent=%d observe=%v", len(claimed), len(*sent), observe)
+			}
+		})
+	}
+}

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -368,6 +368,7 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 
 	params := c.targetParams()
 	var out []WarmPoolSnapshot
+	assignedProviders := make(map[string]struct{})
 	for _, model := range ordered {
 		p := pressure[model]
 		q := queue[model]
@@ -401,13 +402,11 @@ func (c *warmPoolController) planObserveOnly(now time.Time, reserve func([]model
 		if need < 0 {
 			need = 0
 		}
-		actions := make([]modelLoadAction, 0, need)
-		for i := 0; i < need; i++ {
-			actions = append(actions, modelLoadAction{providerID: f.eligibleCold[i].providerID, modelID: model})
+		reserveLoads := reserve
+		if c.config.ObserveOnly {
+			reserveLoads = nil
 		}
-		if reserve != nil && !c.config.ObserveOnly {
-			actions = reserve(actions, now)
-		}
+		actions := allocateWarmPoolLoads(model, f.eligibleCold, need, assignedProviders, reserveLoads, now)
 		loadsRemaining -= len(actions)
 		c.state.rememberTarget(model, target, now)
 		// Surface why cold boxes aren't warmable (counts only). For a dedicated pool

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-10 · commit `213b8c2b6`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -359,6 +359,14 @@ reason (`offline_untrusted_private`, `pending_load_or_cooldown`, `not_idle`,
 `thermal_critical`, `trust_or_runtime`, `stale_challenge`,
 `not_serving_catalog`, `dedicated_excluded`, `model_too_large`,
 `no_free_for_load`, `state_restoring`).
+
+Models share cold providers. `allocateWarmPoolLoads`
+(`coordinator/registry/warm_pool_allocation.go`) assigns a provider to at most
+one model per planning pass, including observe-only passes. If another model
+already claimed a preferred provider, or a pending-load reservation loses a
+race, the allocator tries the remaining ranked candidates within the original
+per-model and per-tick allowance. It visits each candidate at most once and
+leaves any unfillable deficit for a later tick.
 
 **`WarmPoolSnapshot`.** Every tick produces one per model, logged as
 `warm_pool_tick` and retained as the controller's latest state

--- a/docs/reports/2026-09-11-routing-performance-study.md
+++ b/docs/reports/2026-09-11-routing-performance-study.md
@@ -1,0 +1,77 @@
+# Routing performance investigation and first allocation fix
+
+> Last updated: 2026-09-11 · commit `7c394fa2b`
+
+Production measurements show request-admission and placement problems larger than the measured coordinator scan overhead. This report separates observed outcomes, incomplete counterfactuals, and a reproduced warm-pool allocation defect. Only the allocation correction is implemented with this report; the broader ranking and cache proposals remain experimental.
+
+## Evidence contract
+
+The deployed coordinator is v0.9.2 at `ef7b5a9aa`; the analysis checkout is `7c394fa2b`. The intervening commit enables provider GPT-OSS caching and is not deployed. Source behavior is checked at the deployed routing implementation. Datadog queries use `env:production,service:d-inference-coordinator`.
+
+The Datadog scorecard uses complete five-minute buckets in **22:25–23:25 UTC**. Request profiles use received-time **23:13–23:28 UTC** and a deterministic 10% request sample. The initial GPT-OSS export hit the 50,000-row cap and was replaced with six status-filtered exports; none of those was truncated. Provider attempts, logical request terminals, accepted cache receipts and provider completion usage are distinct populations. The direct read replica timed out; the request-level data came through the documented authenticated, read-only admin exports.
+
+Committed [aggregate evidence](evidence/routing-performance-20260911/provenance.json) includes raw-artifact hashes and sampling details. Raw request/provider identifiers stay in operator-local artifacts.
+
+## First principles
+
+A useful routing objective is successful delivery within the first-content deadline, followed by sustained decoding quality. An HTTP admission or a successful cache lookup alone is not successful delivery.
+
+Time to first content consists of coordinator preparation, transport, work ahead at the provider, this request's prefill or cache restore, and the first decode step. Remaining decode work matters for completion latency and contention. A maximum output allowance is a memory promise; it is not a measurement of expected output length. KV residency is a memory constraint; it is not necessarily serial decode work that must drain before another request can emit content.
+
+Cache benefit requires an exact compatible prefix, valid identity-bound evidence, an available holder, a restore cheaper than recomputation, and successful execution. Increasing the count of stored prefixes does not by itself prove lower latency. Model residency is another resource allocation problem: warming one model can reclaim another model's idle weights, and that transition must account for active work, user-selected models, load time and future demand.
+
+## Observed network results
+
+| Model | Successful request terminals | Rate-limited terminals | Provider deadline-refusal attempts |
+|---|---:|---:|---:|
+| Gemma QAT 26B | 124,495 | 1,931 | 75,427 |
+| GPT-OSS 20B | 42,511 | 5,362 | 124,239 |
+| Qwen 3.6 35B | 6,799 | 950 | 1,066 |
+| Qwen 3.5 9B | 1,922 | 487 | 8,524 |
+| Qwen 3.5 35B | 1,551 | 7 | 33 |
+| Qwen 3.8 27B | 1,203 | 155 | 1,136 |
+| Nemotron Lightning | 540 | 249 | 779 |
+
+Source: [Datadog hour aggregates](evidence/routing-performance-20260911/datadog-hour-summary.json). The table omits other terminal classes for readability; the evidence retains them. Attempt refusals can precede a successful retry and must not be added to request failures. These are terminal-event counts, not a joined arrival cohort.
+
+For sampled winning attempts, GPT-OSS first-content latency was 3.35 s median and 10.35 s p95; Gemma was 3.67 s median and 7.66 s p95. GPT-OSS routing scan time was 1.21 ms median and 1.93 ms p95; Gemma was 1.40 ms and 2.23 ms. Time from handler entry to the winning attempt reached 3.55 s p95 for GPT-OSS and 2.96 s for Gemma. That latter interval can include failed earlier attempts; it is not pure coordinator processing time. Source: [profile aggregates](evidence/routing-performance-20260911/profile-summary.json).
+
+The shadow router recorded 170,546 selections with an eligible loaded-idle alternative and 178,130 without one. The signal means a busy winner had an admissible idle peer, not that the peer would have completed faster. The current route scorer accounts for full completion cost and health as well as first-token latency.
+
+## Ranking proposal: test expected work separately from output limits
+
+`coordinator/registry/scheduler.go` (`buildCandidateInto`) uses the requested maximum output tokens in the new request's decode-cost term. Budget-reporting candidates also receive a backlog term derived from active and queued token budgets. Both deserve measurement against actual work rather than a blind constant increase in concurrency.
+
+Among 467 deterministically sampled successful GPT-OSS attempts with a 32,768-token allowance, median engine decode steps were 511; p90 was 2,089 and p99 was 12,442. This is a successful-completion cohort, so it does not establish the output distribution of rejected or failed requests.
+
+An exploratory replay capped only the new request's decode ranking term at 2,048 tokens while leaving all admission constraints and other score terms intact. It changed 1,400 of 2,869 retained GPT-OSS candidate decisions, including 891 moves from busy to idle and 19 moves in the opposite direction. The unchanged-policy replay admits the observed winner for every included row; 14 Gemma rows with a baseline mismatch were excluded. This is a **retained-top-four shortlist replay**, not a full fleet replay or a measurement of hypothetical completion latency. Some changes worsened predicted first-content time, and Nemotron's small cohort did not favor this policy.
+
+Proposal: evaluate an opt-in, model-specific expected-decode horizon and deadline-aware soft preference. Preserve full output reservations and all trust, capacity, context and deadline gates. Require an actual controlled serving comparison before broad enablement. Do not apply a global 2,048-token cap or claim the predicted differences as saved time. [Replay aggregates](evidence/routing-performance-20260911/shortlist-replay.json).
+
+## Cache proposal: availability before larger limits
+
+Earlier same-process counters at 22:59 UTC recorded 58,034 provider-reported cache hits and 122,615,808 avoided prefill tokens. The recent Datadog hour shows Gemma's accepted lookup receipts at 993 hits versus 111,729 absent-prefix misses. These different cohorts must not be combined into a single hit percentage.
+
+The deployed allowlist still contains four artifacts: Gemma QAT and Qwen 3.5/3.6/3.8. Nemotron is not allowlisted. Provider GPT-OSS default cache support exists only in the newer source commit. Enabling either model needs exact artifact/contract qualification and a separately approved rollout.
+
+`coordinator/registry/cache_receipts_v2_lookup.go` validates the dispatched identity, expected prompt/boundaries and receipt sequence before publishing a holder. `provider-swift/Sources/ProviderCore/KVCacheSSD/SSDHybridCheckpointStore+Maintenance.swift` rotates the cache epoch for destructive changes; `SSDHybridCheckpointStore+Write.swift` rejects a queued donation if that epoch changed. Whole-root maintenance can therefore remove one entry and invalidate holder evidence and queued donations for that model. This mechanism is intentional evidence revocation; removing the barrier would weaken correctness.
+
+Proposal: measure cache loss by model and lifecycle reason, distinguish unique useful prefixes from repeated donation attempts, and evaluate batching maintenance or explicit per-entry withdrawal with unchanged evidence guarantees. Investigate restore-budget refusals and write-rate limits separately. Do not turn unreported cache usage into misses, or increase SSD write rates solely because the blocked-attempt count is large.
+
+## Model residency and the implemented correction
+
+The provider already supports the user's requested behavior. A coordinator `load_model` for an advertised downloaded model can cause `ProviderLoop.evictUntilAvailable` to unload least-recently-used idle models. Active requests, local reservations, unloading models and retained MTP upgrade targets are protected. The feasibility check refuses an impossible load before evicting useful models. Downloaded files and the user's selected model catalog are preserved.
+
+The warm-pool planner had a reproducible allocation defect before that path: multiple models took their first N candidates from the same fleet snapshot. After model A reserved the best machines, model B tried the same machines and accepted fewer loads without trying its remaining eligible candidates. Observe-only planning even assigned the same machine to both models.
+
+The correction in `coordinator/registry/warm_pool_allocation.go` assigns each provider once per planning pass and replaces lost reservations from the remaining ranked shortlist. It preserves each model's allowance and the current per-tick/global-pending allowance, does not rescan the fleet, and visits each candidate at most once per model. Existing reservation and send-failure cleanup paths remain in use.
+
+In the regression scenario, two models each need two loads and share four eligible cold machines. Before: A receives two loads and B receives zero. After: each receives two loads in the same tick. The observe-only plan now matches that exclusive allocation. This proves the defect and correction; production telemetry does not currently quantify how many historical load opportunities were lost this way.
+
+Longer-term proposal: prioritize residency changes by measured demand deficit and displacement cost, retain a warm floor for models still receiving demand, and apply a dwell period before reversing a placement. Do not unload quiet models merely to maximize an aggregate utilization number.
+
+## Validation and rollout gates
+
+The regression test fails on the original controller in both active and observe-only modes and passes after the correction. The focused warm-pool suite, all coordinator packages (`go test ./... -p 4`), and the warm-pool race suite (`go test -race ./registry -run TestWarmPool -count=1`) pass. The change is source-validated and not deployed.
+
+The allocation fix requires only a coordinator rollout and uses the existing provider protocol. Compare per-model planned/accepted loads, target deficits, pending-load duration, load failures, model churn and successful delivery under similar offered load. Keep the current bounded load limits. Revert the coordinator image if loading churn or serving outcomes regress; do not change trust policy, output limits, catalog choices or provider release as part of this narrow fix.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-11 · commit `6938e8547`
+> Last updated: 2026-09-11 · commit `7c394fa2b`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -222,3 +222,5 @@ Machine-generated; kept as evidence for the reports above.
 - [Gemma MTP review fixes](2026-09-08-gemma-mtp-review-fixes.md) — reproduced request-ID reuse and verification-shape findings, generation isolation fixes and regression evidence.
 
 - [Gemma QAT September 10 merge and validation](2026-09-10-gemma-qat-review-sync.md) — review fixes, merged-source tests, new artifact identity and model/HTTP revalidation status.
+
+- [Routing performance study](2026-09-11-routing-performance-study.md) — production outcomes, ranking and cache hypotheses, and a reproduced cross-model warm-pool allocation fix.

--- a/docs/reports/evidence/routing-performance-20260911/datadog-hour-summary.json
+++ b/docs/reports/evidence/routing-performance-20260911/datadog-hour-summary.json
@@ -1,0 +1,160 @@
+{
+  "outcomes": {
+    "since": "2026-09-11T22:25:00+00:00",
+    "until": "2026-09-11T23:25:00+00:00",
+    "models": {
+      "gpt-oss-20b": {
+        "provider_5xx": 28.0,
+        "mid_stream": 54.0,
+        "rate_limited": 5362.0,
+        "client_gone": 890.0,
+        "success": 42511.0,
+        "client_error": 2.0
+      },
+      "qwen3.5-9b": {
+        "rate_limited": 487.0,
+        "success": 1922.0,
+        "client_gone": 88.0
+      },
+      "unknown": {
+        "provider_5xx": 1.0
+      },
+      "qwen3.6-35b-a3b-vl-mtp-mxfp8": {
+        "client_gone": 11.0,
+        "client_error": 2.0,
+        "rate_limited": 950.0,
+        "mid_stream": 1.0,
+        "provider_5xx": 1.0,
+        "success": 6799.0
+      },
+      "gemma-4-26b-qat-4bit": {
+        "rate_limited": 1931.0,
+        "provider_5xx": 19.0,
+        "success": 124495.0,
+        "mid_stream": 6.0,
+        "client_error": 75.0,
+        "client_gone": 261.0
+      },
+      "qwen3.5-35b-a3b": {
+        "rate_limited": 7.0,
+        "client_gone": 1.0,
+        "success": 1551.0
+      },
+      "nvidia-nemotron-3.5-lightning": {
+        "success": 540.0,
+        "client_gone": 35.0,
+        "rate_limited": 249.0
+      },
+      "eigenlabs/qwen3.8-27b-4bit-mtp": {
+        "success": 1203.0,
+        "client_gone": 70.0,
+        "mid_stream": 4.0,
+        "rate_limited": 155.0
+      },
+      "auto": {
+        "client_error": 3.0
+      }
+    }
+  },
+  "attempts": {
+    "since": "2026-09-11T22:25:00+00:00",
+    "until": "2026-09-11T23:25:00+00:00",
+    "models": {
+      "gpt-oss-20b": {
+        "disconnect": 38.0,
+        "speculative_loser": 262.0,
+        "deadline_unreachable": 124239.0,
+        "success": 43457.0,
+        "send_failed": 4.0,
+        "first_chunk_timeout": 5502.0,
+        "capacity": 413.0
+      },
+      "nvidia-nemotron-3.5-lightning": {
+        "deadline_unreachable": 779.0,
+        "success": 575.0,
+        "first_chunk_timeout": 253.0,
+        "speculative_loser": 19.0,
+        "disconnect": 1.0,
+        "capacity": 35.0
+      },
+      "qwen3.5-35b-a3b": {
+        "deadline_unreachable": 33.0,
+        "speculative_loser": 1.0,
+        "first_chunk_timeout": 7.0,
+        "success": 1552.0
+      },
+      "qwen3.6-35b-a3b-vl-mtp-mxfp8": {
+        "client_gone": 2.0,
+        "speculative_loser": 51.0,
+        "disconnect": 1.0,
+        "deadline_unreachable": 1066.0,
+        "success": 6811.0,
+        "first_chunk_timeout": 234.0,
+        "client_error": 2.0,
+        "capacity": 2342.0
+      },
+      "gemma-4-26b-qat-4bit": {
+        "send_failed": 28.0,
+        "client_error": 75.0,
+        "capacity": 35.0,
+        "disconnect": 36.0,
+        "speculative_loser": 1206.0,
+        "success": 124762.0,
+        "deadline_unreachable": 75427.0,
+        "first_chunk_timeout": 2033.0
+      },
+      "qwen3.5-9b": {
+        "disconnect": 1.0,
+        "speculative_loser": 2.0,
+        "capacity": 19.0,
+        "first_chunk_timeout": 99.0,
+        "success": 2010.0,
+        "deadline_unreachable": 8524.0
+      },
+      "eigenlabs/qwen3.8-27b-4bit-mtp": {
+        "send_failed": 1.0,
+        "deadline_unreachable": 1136.0,
+        "first_chunk_timeout": 158.0,
+        "success": 1277.0,
+        "speculative_loser": 11.0,
+        "capacity": 14.0
+      }
+    }
+  },
+  "cache_lookup": {
+    "since": "2026-09-11T22:25:00+00:00",
+    "until": "2026-09-11T23:25:00+00:00",
+    "models": {
+      "gemma-4-26b-qat-4bit": {
+        "miss_absent": 111729.0,
+        "skipped_capacity": 485.0,
+        "skipped_policy": 153.0,
+        "hit": 993.0
+      },
+      "eigenlabs/qwen3.8-27b-4bit-mtp": {
+        "skipped_capacity": 3.0,
+        "hit": 24.0,
+        "miss_absent": 846.0
+      },
+      "qwen3.6-35b-a3b-vl-mtp-mxfp8": {
+        "miss_absent": 3429.0,
+        "skipped_capacity": 24.0,
+        "hit": 28.0
+      },
+      "qwen3.5-35b-a3b": {
+        "miss_absent": 240.0,
+        "hit": 90.0
+      }
+    }
+  },
+  "shadow_spread": {
+    "since": "2026-09-11T22:25:00+00:00",
+    "until": "2026-09-11T23:25:00+00:00",
+    "models": {
+      "all": {
+        "false": 178130.0,
+        "true": 170546.0
+      }
+    }
+  }
+}

--- a/docs/reports/evidence/routing-performance-20260911/profile-summary.json
+++ b/docs/reports/evidence/routing-performance-20260911/profile-summary.json
@@ -1,0 +1,979 @@
+{
+  "at": "2026-09-11T23:30:22.327591+00:00",
+  "since": "2026-09-11T23:13:00+00:00",
+  "until": "2026-09-11T23:28:00+00:00",
+  "sample_rate": 0.1,
+  "models": [
+    {
+      "id": "gpt-oss-20b",
+      "export_count": 88809,
+      "truncated": false,
+      "sampled_attempts": 5668,
+      "sampled_logical_requests": 894,
+      "sampled_winners": 789,
+      "attempt_status": {
+        "success:": 765,
+        "partial_success:client_gone_after_commit_provider_completed": 24,
+        "error:deadline_unreachable": 2580,
+        "error:provider_error": 8,
+        "rejected:provider_error": 2178,
+        "timeout:first_chunk_timeout": 110,
+        "cancelled:speculative_loser": 3
+      },
+      "idle_alternative": 2161,
+      "faster_estimated_idle": 2971,
+      "selected_cost_above_best": 420,
+      "selected_extra_cost_ms": {
+        "n": 420,
+        "p50": 1686.0840526498214,
+        "p95": 2901.4223239194835,
+        "p99": 2973.2111003428,
+        "mean": 1635.1184623222648
+      },
+      "selection_paths": {
+        "unique_min": 2420,
+        "random": 311,
+        "tie_queue": 319,
+        "none": 2598,
+        "tie_pending": 20
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 789,
+          "p50": 3345.098,
+          "p95": 10349.727,
+          "p99": 19887.0,
+          "mean": 4276.433457541191
+        },
+        "predicted_ttft": {
+          "n": 789,
+          "p50": 3360.6782148698053,
+          "p95": 50415.5632151066,
+          "p99": 79307.55993462699,
+          "mean": 11444.220836931874
+        },
+        "prompt_tokens": {
+          "n": 789,
+          "p50": 1510,
+          "p95": 10498,
+          "p99": 29089,
+          "mean": 3264.4283903675537
+        },
+        "route_lock": {
+          "n": 789,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0,
+          "mean": 2.4081115335868188e-05
+        },
+        "route_scan": {
+          "n": 789,
+          "p50": 1.207,
+          "p95": 1.933,
+          "p99": 2.453,
+          "mean": 1.1764778200253485
+        },
+        "before_attempt": {
+          "n": 789,
+          "p50": 7.39,
+          "p95": 3547.846,
+          "p99": 6553.085,
+          "mean": 606.108124207858
+        },
+        "routing": {
+          "n": 789,
+          "p50": 1.834,
+          "p95": 3.334,
+          "p99": 5.025,
+          "mean": 1.8520506970849178
+        },
+        "socket_write": {
+          "n": 789,
+          "p50": 0.084,
+          "p95": 0.198,
+          "p99": 0.454,
+          "mean": 0.10222813688212928
+        },
+        "dispatch_to_first_content": {
+          "n": 789,
+          "p50": 3060.83,
+          "p95": 8288.072,
+          "p99": 19285.905,
+          "mean": 3668.077771863118
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 789,
+          "p50": 2.036,
+          "p95": 10.867,
+          "p99": 18.586,
+          "mean": 5.9614917617237015
+        }
+      },
+      "gates": {
+        "free_memory": 480860,
+        "private_text": 129158,
+        "untrusted": 128636,
+        "trust_floor": 86601,
+        "no_headroom": 44856,
+        "excluded": 28598,
+        "capacity_cooldown": 12636,
+        "model_too_large": 3069,
+        "thermal_critical": 3069,
+        "allowlist": 1617,
+        "dispatch_load_cooldown": 1085,
+        "ejection": 689,
+        "error_cooldown": 666,
+        "breaker": 255,
+        "slot_crashed": 114,
+        "offline": 2,
+        "state_restoring": 1
+      }
+    },
+    {
+      "id": "Qwen3.5-9B",
+      "export_count": 1420,
+      "truncated": false,
+      "sampled_attempts": 93,
+      "sampled_logical_requests": 26,
+      "sampled_winners": 26,
+      "attempt_status": {
+        "success:": 25,
+        "error:deadline_unreachable": 38,
+        "rejected:provider_error": 29,
+        "partial_success:client_gone_after_commit_provider_completed": 1
+      },
+      "idle_alternative": 27,
+      "faster_estimated_idle": 45,
+      "selected_cost_above_best": 16,
+      "selected_extra_cost_ms": {
+        "n": 16,
+        "p50": 2226.4685734671657,
+        "p95": 2561.4026190843433,
+        "p99": 2561.4026190843433,
+        "mean": 1838.750305582911
+      },
+      "selection_paths": {
+        "none": 38,
+        "unique_min": 32,
+        "random": 15,
+        "tie_queue": 8
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 26,
+          "p50": 1383.306,
+          "p95": 4001.775,
+          "p99": 4434.354,
+          "mean": 1583.7692307692307
+        },
+        "predicted_ttft": {
+          "n": 26,
+          "p50": 737.0752396950895,
+          "p95": 3255.335887016823,
+          "p99": 3585.5217735636215,
+          "mean": 1479.243527984935
+        },
+        "prompt_tokens": {
+          "n": 26,
+          "p50": 961,
+          "p95": 2205,
+          "p99": 4068,
+          "mean": 1157.0384615384614
+        },
+        "route_lock": {
+          "n": 26,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0,
+          "mean": 0.0
+        },
+        "route_scan": {
+          "n": 26,
+          "p50": 0.246,
+          "p95": 0.41,
+          "p99": 0.414,
+          "mean": 0.2346923076923077
+        },
+        "before_attempt": {
+          "n": 26,
+          "p50": 4.924,
+          "p95": 2096.974,
+          "p99": 3068.634,
+          "mean": 452.9981153846154
+        },
+        "routing": {
+          "n": 26,
+          "p50": 0.32,
+          "p95": 0.491,
+          "p99": 0.522,
+          "mean": 0.3048076923076923
+        },
+        "socket_write": {
+          "n": 26,
+          "p50": 0.077,
+          "p95": 0.114,
+          "p99": 0.116,
+          "mean": 0.08053846153846153
+        },
+        "dispatch_to_first_content": {
+          "n": 26,
+          "p50": 1169.296,
+          "p95": 1915.383,
+          "p99": 2372.743,
+          "mean": 1130.1116153846156
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 26,
+          "p50": 2.845,
+          "p95": 3.574,
+          "p99": 3.755,
+          "mean": 2.375423076923077
+        }
+      },
+      "gates": {
+        "untrusted": 1827,
+        "free_memory": 555,
+        "private_text": 374,
+        "excluded": 274,
+        "no_headroom": 171,
+        "trust_floor": 131,
+        "ejection": 53
+      }
+    },
+    {
+      "id": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+      "export_count": 2341,
+      "truncated": false,
+      "sampled_attempts": 264,
+      "sampled_logical_requests": 152,
+      "sampled_winners": 129,
+      "attempt_status": {
+        "success:": 129,
+        "error:provider_error": 59,
+        "rejected:provider_error": 32,
+        "timeout:first_chunk_timeout": 5,
+        "error:deadline_unreachable": 37,
+        "cancelled:speculative_loser": 2
+      },
+      "idle_alternative": 37,
+      "faster_estimated_idle": 168,
+      "selected_cost_above_best": 55,
+      "selected_extra_cost_ms": {
+        "n": 55,
+        "p50": 1952.5007233483484,
+        "p95": 2775.7624139871914,
+        "p99": 2910.8342204784512,
+        "mean": 1610.8523191889894
+      },
+      "selection_paths": {
+        "unique_min": 101,
+        "random": 56,
+        "none": 80,
+        "tie_queue": 13,
+        "tie_pending": 14
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 129,
+          "p50": 3127.859,
+          "p95": 8929.457,
+          "p99": 11658.715,
+          "mean": 3897.209899224806
+        },
+        "predicted_ttft": {
+          "n": 129,
+          "p50": 3575.4903810689743,
+          "p95": 13495.673585642795,
+          "p99": 16357.623581398131,
+          "mean": 4994.7178899338105
+        },
+        "prompt_tokens": {
+          "n": 129,
+          "p50": 3442,
+          "p95": 14262,
+          "p99": 16117,
+          "mean": 5477.007751937985
+        },
+        "route_lock": {
+          "n": 129,
+          "p50": 0.02,
+          "p95": 0.115,
+          "p99": 0.144,
+          "mean": 0.03534108527131783
+        },
+        "route_scan": {
+          "n": 129,
+          "p50": 1.983,
+          "p95": 2.839,
+          "p99": 3.04,
+          "mean": 1.869046511627907
+        },
+        "before_attempt": {
+          "n": 129,
+          "p50": 29.117,
+          "p95": 1500.186,
+          "p99": 2539.499,
+          "mean": 243.31817829457364
+        },
+        "routing": {
+          "n": 129,
+          "p50": 2.214,
+          "p95": 4.063,
+          "p99": 4.357,
+          "mean": 2.2691860465116283
+        },
+        "socket_write": {
+          "n": 129,
+          "p50": 0.114,
+          "p95": 2.492,
+          "p99": 6.911,
+          "mean": 0.5070387596899225
+        },
+        "dispatch_to_first_content": {
+          "n": 129,
+          "p50": 3051.599,
+          "p95": 8724.711,
+          "p99": 11629.246,
+          "mean": 3650.379441860465
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 129,
+          "p50": 3.942,
+          "p95": 70.083,
+          "p99": 135.087,
+          "mean": 18.319240310077518
+        }
+      },
+      "gates": {
+        "free_memory": 56901,
+        "untrusted": 9698,
+        "private_text": 7349,
+        "trust_floor": 5776,
+        "capacity_cooldown": 1201,
+        "dispatch_load_cooldown": 494,
+        "ejection": 330,
+        "excluded": 278,
+        "thermal_critical": 184,
+        "no_headroom": 94
+      }
+    },
+    {
+      "id": "qwen3-vl-30b-a3b-instruct",
+      "export_count": 0,
+      "truncated": false,
+      "sampled_attempts": 0,
+      "sampled_logical_requests": 0,
+      "sampled_winners": 0,
+      "attempt_status": {},
+      "idle_alternative": 0,
+      "faster_estimated_idle": 0,
+      "selected_cost_above_best": 0,
+      "selected_extra_cost_ms": {
+        "n": 0
+      },
+      "selection_paths": {},
+      "timings_ms": {
+        "client_first_content": {
+          "n": 0
+        },
+        "predicted_ttft": {
+          "n": 0
+        },
+        "prompt_tokens": {
+          "n": 0
+        },
+        "route_lock": {
+          "n": 0
+        },
+        "route_scan": {
+          "n": 0
+        },
+        "before_attempt": {
+          "n": 0
+        },
+        "routing": {
+          "n": 0
+        },
+        "socket_write": {
+          "n": 0
+        },
+        "dispatch_to_first_content": {
+          "n": 0
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 0
+        }
+      },
+      "gates": {}
+    },
+    {
+      "id": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+      "export_count": 1113,
+      "truncated": false,
+      "sampled_attempts": 185,
+      "sampled_logical_requests": 36,
+      "sampled_winners": 30,
+      "attempt_status": {
+        "success:": 28,
+        "rejected:provider_error": 67,
+        "error:deadline_unreachable": 82,
+        "timeout:first_chunk_timeout": 6,
+        "partial_success:client_gone_after_commit_provider_completed": 2
+      },
+      "idle_alternative": 8,
+      "faster_estimated_idle": 99,
+      "selected_cost_above_best": 18,
+      "selected_extra_cost_ms": {
+        "n": 18,
+        "p50": 1136.297704143828,
+        "p95": 2829.3816482670372,
+        "p99": 2829.3816482670372,
+        "mean": 1464.2270429181492
+      },
+      "selection_paths": {
+        "unique_min": 69,
+        "none": 82,
+        "random": 27,
+        "tie_queue": 3,
+        "tie_pending": 4
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 30,
+          "p50": 2058.655,
+          "p95": 7864.794,
+          "p99": 9969.263,
+          "mean": 3371.7362333333335
+        },
+        "predicted_ttft": {
+          "n": 30,
+          "p50": 2260.354086331346,
+          "p95": 9344.971980681155,
+          "p99": 9492.376403349546,
+          "mean": 3697.5363440643514
+        },
+        "prompt_tokens": {
+          "n": 30,
+          "p50": 1133,
+          "p95": 5027,
+          "p99": 5067,
+          "mean": 1709.0666666666666
+        },
+        "route_lock": {
+          "n": 30,
+          "p50": 0.0,
+          "p95": 0.038,
+          "p99": 0.043,
+          "mean": 0.011266666666666666
+        },
+        "route_scan": {
+          "n": 30,
+          "p50": 0.339,
+          "p95": 0.394,
+          "p99": 0.398,
+          "mean": 0.3015333333333333
+        },
+        "before_attempt": {
+          "n": 30,
+          "p50": 24.467,
+          "p95": 561.81,
+          "p99": 1459.859,
+          "mean": 280.8831666666667
+        },
+        "routing": {
+          "n": 30,
+          "p50": 0.418,
+          "p95": 0.565,
+          "p99": 0.625,
+          "mean": 0.3762666666666667
+        },
+        "socket_write": {
+          "n": 30,
+          "p50": 0.077,
+          "p95": 1.447,
+          "p99": 6.241,
+          "mean": 0.7913
+        },
+        "dispatch_to_first_content": {
+          "n": 30,
+          "p50": 2025.483,
+          "p95": 6633.009,
+          "p99": 7099.291,
+          "mean": 3088.7519666666662
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 30,
+          "p50": 2.245,
+          "p95": 53.444,
+          "p99": 87.972,
+          "mean": 14.086966666666665
+        }
+      },
+      "gates": {
+        "not_serving_model": 947,
+        "excluded": 654,
+        "free_memory": 603
+      }
+    },
+    {
+      "id": "gemma-4-26b",
+      "export_count": 2,
+      "truncated": false,
+      "sampled_attempts": 0,
+      "sampled_logical_requests": 0,
+      "sampled_winners": 0,
+      "attempt_status": {},
+      "idle_alternative": 0,
+      "faster_estimated_idle": 0,
+      "selected_cost_above_best": 0,
+      "selected_extra_cost_ms": {
+        "n": 0
+      },
+      "selection_paths": {},
+      "timings_ms": {
+        "client_first_content": {
+          "n": 0
+        },
+        "predicted_ttft": {
+          "n": 0
+        },
+        "prompt_tokens": {
+          "n": 0
+        },
+        "route_lock": {
+          "n": 0
+        },
+        "route_scan": {
+          "n": 0
+        },
+        "before_attempt": {
+          "n": 0
+        },
+        "routing": {
+          "n": 0
+        },
+        "socket_write": {
+          "n": 0
+        },
+        "dispatch_to_first_content": {
+          "n": 0
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 0
+        }
+      },
+      "gates": {}
+    },
+    {
+      "id": "gemma-4-26b-qat-4bit",
+      "export_count": 30548,
+      "truncated": false,
+      "sampled_attempts": 4391,
+      "sampled_logical_requests": 2321,
+      "sampled_winners": 2301,
+      "attempt_status": {
+        "success:": 2298,
+        "error:deadline_unreachable": 1267,
+        "partial_success:client_gone_after_commit_provider_completed": 3,
+        "cancelled:speculative_loser": 10,
+        "rejected:provider_error": 791,
+        "timeout:first_chunk_timeout": 22
+      },
+      "idle_alternative": 915,
+      "faster_estimated_idle": 3101,
+      "selected_cost_above_best": 1630,
+      "selected_extra_cost_ms": {
+        "n": 1630,
+        "p50": 2064.5906908126562,
+        "p95": 2939.3872579197596,
+        "p99": 2984.8523997526645,
+        "mean": 1873.4845372284062
+      },
+      "selection_paths": {
+        "unique_min": 993,
+        "random": 1523,
+        "tie_queue": 573,
+        "none": 1279,
+        "tie_pending": 23
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 2301,
+          "p50": 3667.465,
+          "p95": 7664.568,
+          "p99": 10109.828,
+          "mean": 3890.3052885701873
+        },
+        "predicted_ttft": {
+          "n": 2301,
+          "p50": 3372.313519351916,
+          "p95": 8136.722274428716,
+          "p99": 12106.919815767122,
+          "mean": 3702.543880858266
+        },
+        "prompt_tokens": {
+          "n": 2301,
+          "p50": 3659,
+          "p95": 6840,
+          "p99": 8871,
+          "mean": 3623.6875271621034
+        },
+        "route_lock": {
+          "n": 2301,
+          "p50": 0.037,
+          "p95": 0.083,
+          "p99": 0.189,
+          "mean": 0.04557322903085615
+        },
+        "route_scan": {
+          "n": 2301,
+          "p50": 1.401,
+          "p95": 2.23,
+          "p99": 3.333,
+          "mean": 1.4149169926119078
+        },
+        "before_attempt": {
+          "n": 2301,
+          "p50": 25.945,
+          "p95": 2958.888,
+          "p99": 5741.263,
+          "mean": 418.2990317253368
+        },
+        "routing": {
+          "n": 2301,
+          "p50": 1.681,
+          "p95": 3.524,
+          "p99": 4.965,
+          "mean": 1.8377522816166882
+        },
+        "socket_write": {
+          "n": 2301,
+          "p50": 0.102,
+          "p95": 0.174,
+          "p99": 0.785,
+          "mean": 0.17558843980877878
+        },
+        "dispatch_to_first_content": {
+          "n": 2301,
+          "p50": 3316.667,
+          "p95": 6583.518,
+          "p99": 8495.808,
+          "mean": 3469.6157070838763
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 2276,
+          "p50": 3.425,
+          "p95": 8.274,
+          "p99": 127.878,
+          "mean": 9.248400702987698
+        }
+      },
+      "gates": {
+        "private_text": 129108,
+        "untrusted": 125675,
+        "free_memory": 124894,
+        "trust_floor": 59198,
+        "no_headroom": 34076,
+        "model_too_large": 16286,
+        "excluded": 6236,
+        "capacity_cooldown": 1019,
+        "allowlist": 535,
+        "error_cooldown": 138,
+        "slot_crashed": 24
+      }
+    },
+    {
+      "id": "qwen3.5-35b-a3b",
+      "export_count": 95,
+      "truncated": false,
+      "sampled_attempts": 38,
+      "sampled_logical_requests": 38,
+      "sampled_winners": 38,
+      "attempt_status": {
+        "success:": 38
+      },
+      "idle_alternative": 0,
+      "faster_estimated_idle": 32,
+      "selected_cost_above_best": 25,
+      "selected_extra_cost_ms": {
+        "n": 25,
+        "p50": 1706.488016948827,
+        "p95": 2772.4971100180815,
+        "p99": 2904.1523254325184,
+        "mean": 1643.8083819554834
+      },
+      "selection_paths": {
+        "random": 33,
+        "unique_min": 5
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 38,
+          "p50": 1092.995,
+          "p95": 2534.779,
+          "p99": 3290.192,
+          "mean": 1495.8027368421053
+        },
+        "predicted_ttft": {
+          "n": 38,
+          "p50": 996.1299002548586,
+          "p95": 4276.078166521018,
+          "p99": 5209.062226806658,
+          "mean": 1498.4305448284715
+        },
+        "prompt_tokens": {
+          "n": 38,
+          "p50": 1392,
+          "p95": 8099,
+          "p99": 8110,
+          "mean": 2824.342105263158
+        },
+        "route_lock": {
+          "n": 38,
+          "p50": 0.023,
+          "p95": 0.089,
+          "p99": 0.125,
+          "mean": 0.03647368421052631
+        },
+        "route_scan": {
+          "n": 38,
+          "p50": 0.932,
+          "p95": 1.243,
+          "p99": 1.348,
+          "mean": 0.9595263157894738
+        },
+        "before_attempt": {
+          "n": 38,
+          "p50": 15.047,
+          "p95": 232.612,
+          "p99": 242.314,
+          "mean": 52.44244736842106
+        },
+        "routing": {
+          "n": 38,
+          "p50": 1.03,
+          "p95": 1.431,
+          "p99": 1.445,
+          "mean": 1.0540526315789474
+        },
+        "socket_write": {
+          "n": 38,
+          "p50": 0.104,
+          "p95": 0.628,
+          "p99": 1.017,
+          "mean": 0.3267631578947368
+        },
+        "dispatch_to_first_content": {
+          "n": 38,
+          "p50": 1077.172,
+          "p95": 2508.917,
+          "p99": 3158.361,
+          "mean": 1441.4487894736842
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 38,
+          "p50": 3.427,
+          "p95": 40.806,
+          "p99": 84.782,
+          "mean": 12.13515789473684
+        }
+      },
+      "gates": {
+        "untrusted": 1082,
+        "free_memory": 681,
+        "private_text": 480,
+        "trust_floor": 32,
+        "no_headroom": 29
+      }
+    },
+    {
+      "id": "nvidia-nemotron-3.5-lightning",
+      "export_count": 502,
+      "truncated": false,
+      "sampled_attempts": 48,
+      "sampled_logical_requests": 13,
+      "sampled_winners": 8,
+      "attempt_status": {
+        "success:": 8,
+        "timeout:first_chunk_timeout": 6,
+        "error:deadline_unreachable": 21,
+        "rejected:provider_error": 12,
+        "error:provider_error": 1
+      },
+      "idle_alternative": 11,
+      "faster_estimated_idle": 10,
+      "selected_cost_above_best": 1,
+      "selected_extra_cost_ms": {
+        "n": 1,
+        "p50": 2270.636835274403,
+        "p95": 2270.636835274403,
+        "p99": 2270.636835274403,
+        "mean": 2270.636835274403
+      },
+      "selection_paths": {
+        "unique_min": 24,
+        "none": 23,
+        "random": 1
+      },
+      "timings_ms": {
+        "client_first_content": {
+          "n": 8,
+          "p50": 1500.928,
+          "p95": 2205.686,
+          "p99": 2205.686,
+          "mean": 1614.048875
+        },
+        "predicted_ttft": {
+          "n": 8,
+          "p50": 806.5323272229389,
+          "p95": 3474.421755676967,
+          "p99": 3474.421755676967,
+          "mean": 1811.7875249393562
+        },
+        "prompt_tokens": {
+          "n": 8,
+          "p50": 201,
+          "p95": 2536,
+          "p99": 2536,
+          "mean": 1080.0
+        },
+        "route_lock": {
+          "n": 8,
+          "p50": 0.0,
+          "p95": 0.0,
+          "p99": 0.0,
+          "mean": 0.0
+        },
+        "route_scan": {
+          "n": 8,
+          "p50": 0.166,
+          "p95": 0.203,
+          "p99": 0.203,
+          "mean": 0.344125
+        },
+        "before_attempt": {
+          "n": 8,
+          "p50": 11.757,
+          "p95": 906.216,
+          "p99": 906.216,
+          "mean": 287.4095
+        },
+        "routing": {
+          "n": 8,
+          "p50": 0.218,
+          "p95": 0.244,
+          "p99": 0.244,
+          "mean": 0.385625
+        },
+        "socket_write": {
+          "n": 8,
+          "p50": 0.058,
+          "p95": 0.105,
+          "p99": 0.105,
+          "mean": 0.07425
+        },
+        "dispatch_to_first_content": {
+          "n": 8,
+          "p50": 502.025,
+          "p95": 2193.213,
+          "p99": 2193.213,
+          "mean": 1325.890625
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 8,
+          "p50": 0.812,
+          "p95": 3.647,
+          "p99": 3.647,
+          "mean": 1.901375
+        }
+      },
+      "gates": {
+        "free_memory": 262,
+        "private_text": 125,
+        "no_headroom": 97,
+        "excluded": 78,
+        "untrusted": 77,
+        "trust_floor": 2
+      }
+    },
+    {
+      "id": "gemma-4-26b-8bit",
+      "export_count": 0,
+      "truncated": false,
+      "sampled_attempts": 0,
+      "sampled_logical_requests": 0,
+      "sampled_winners": 0,
+      "attempt_status": {},
+      "idle_alternative": 0,
+      "faster_estimated_idle": 0,
+      "selected_cost_above_best": 0,
+      "selected_extra_cost_ms": {
+        "n": 0
+      },
+      "selection_paths": {},
+      "timings_ms": {
+        "client_first_content": {
+          "n": 0
+        },
+        "predicted_ttft": {
+          "n": 0
+        },
+        "prompt_tokens": {
+          "n": 0
+        },
+        "route_lock": {
+          "n": 0
+        },
+        "route_scan": {
+          "n": 0
+        },
+        "before_attempt": {
+          "n": 0
+        },
+        "routing": {
+          "n": 0
+        },
+        "socket_write": {
+          "n": 0
+        },
+        "dispatch_to_first_content": {
+          "n": 0
+        },
+        "queue": {
+          "n": 0
+        },
+        "provider_prepare": {
+          "n": 0
+        }
+      },
+      "gates": {}
+    }
+  ]
+}

--- a/docs/reports/evidence/routing-performance-20260911/provenance.json
+++ b/docs/reports/evidence/routing-performance-20260911/provenance.json
@@ -1,0 +1,33 @@
+{
+  "captured_at": "2026-09-11T23:30:22.327591Z",
+  "deployed_commit": "ef7b5a9aa69e62374c83d8f2baddb2957e38c9a8",
+  "analysis_base": "7c394fa2b51e4ee0626e3b103458f5350988a937",
+  "sampling": "FNV1a32(coord_request_id)/2^32 < 0.1, including all retained attempts of sampled requests",
+  "replica": "connection timed out; no direct SQL analysis completed",
+  "raw_artifacts": [
+    {
+      "file": "production-capture.json",
+      "bytes": 432840680,
+      "sha256": "0dd1de87255887a04c0fcd885edd6975602ef1e7e71555556aedb0bae23f6805",
+      "access": "operator-local; request/provider identifiers excluded from committed aggregates"
+    },
+    {
+      "file": "gpt-profiles-complete.json",
+      "bytes": 324507603,
+      "sha256": "eb63541a6b510cdb30d5bf3554ca36456bd2c32b463108afbd7002e4021227d6",
+      "access": "operator-local; request/provider identifiers excluded from committed aggregates"
+    },
+    {
+      "file": "dd-outcomes.json",
+      "bytes": 327006,
+      "sha256": "fd4c5583c62810954ddf0eccee1c1ab57007deb9311251ec9a1707bfea3f2fcf",
+      "access": "operator-local; request/provider identifiers excluded from committed aggregates"
+    },
+    {
+      "file": "dd-attempts.json",
+      "bytes": 357515,
+      "sha256": "6172f253d1e5d02cdd0b94a2666963b38b5a317726f5ef2b99a10d80a8faeb7d",
+      "access": "operator-local; request/provider identifiers excluded from committed aggregates"
+    }
+  ]
+}

--- a/docs/reports/evidence/routing-performance-20260911/shortlist-replay.json
+++ b/docs/reports/evidence/routing-performance-20260911/shortlist-replay.json
@@ -1,0 +1,406 @@
+[
+  {
+    "model": "gpt-oss-20b",
+    "horizon": 512,
+    "rows": 2869,
+    "changed": 1660,
+    "busy_to_idle": 1074,
+    "idle_to_busy": 24,
+    "predicted_ttft_reduction_ms_p50": 9536.825774423405,
+    "predicted_ttft_reduction_ms_p10": -11705.762389589616
+  },
+  {
+    "model": "gpt-oss-20b",
+    "horizon": 1024,
+    "rows": 2869,
+    "changed": 1568,
+    "busy_to_idle": 1022,
+    "idle_to_busy": 22,
+    "predicted_ttft_reduction_ms_p50": 10022.660660619342,
+    "predicted_ttft_reduction_ms_p10": -12532.91908020997
+  },
+  {
+    "model": "gpt-oss-20b",
+    "horizon": 2048,
+    "rows": 2869,
+    "changed": 1400,
+    "busy_to_idle": 891,
+    "idle_to_busy": 19,
+    "predicted_ttft_reduction_ms_p50": 10595.136850651643,
+    "predicted_ttft_reduction_ms_p10": -13301.288702564332
+  },
+  {
+    "model": "gpt-oss-20b",
+    "horizon": 4096,
+    "rows": 2869,
+    "changed": 1152,
+    "busy_to_idle": 708,
+    "idle_to_busy": 17,
+    "predicted_ttft_reduction_ms_p50": 11559.159511446816,
+    "predicted_ttft_reduction_ms_p10": -16098.495807656025
+  },
+  {
+    "model": "gpt-oss-20b",
+    "horizon": 1000000,
+    "rows": 2869,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "Qwen3.5-9B",
+    "horizon": 512,
+    "rows": 55,
+    "changed": 25,
+    "busy_to_idle": 19,
+    "predicted_ttft_reduction_ms_p50": 10877.605369336923,
+    "predicted_ttft_reduction_ms_p10": -1995.8640021561623
+  },
+  {
+    "model": "Qwen3.5-9B",
+    "horizon": 1024,
+    "rows": 55,
+    "changed": 25,
+    "busy_to_idle": 19,
+    "predicted_ttft_reduction_ms_p50": 10877.605369336923,
+    "predicted_ttft_reduction_ms_p10": -1995.8640021561623
+  },
+  {
+    "model": "Qwen3.5-9B",
+    "horizon": 2048,
+    "rows": 55,
+    "changed": 21,
+    "busy_to_idle": 16,
+    "predicted_ttft_reduction_ms_p50": 5263.587045153682,
+    "predicted_ttft_reduction_ms_p10": -1026.421905458863
+  },
+  {
+    "model": "Qwen3.5-9B",
+    "horizon": 4096,
+    "rows": 55,
+    "changed": 12,
+    "busy_to_idle": 9,
+    "predicted_ttft_reduction_ms_p50": 5401.487771866642,
+    "predicted_ttft_reduction_ms_p10": -14514.548789606391
+  },
+  {
+    "model": "Qwen3.5-9B",
+    "horizon": 1000000,
+    "rows": 55,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+    "horizon": 512,
+    "rows": 184,
+    "changed": 47,
+    "busy_to_idle": 29,
+    "idle_to_busy": 2,
+    "new_cache_holder": 2,
+    "predicted_ttft_reduction_ms_p50": 4447.487144088154,
+    "predicted_ttft_reduction_ms_p10": -982.5467214128748
+  },
+  {
+    "model": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+    "horizon": 1024,
+    "rows": 184,
+    "changed": 45,
+    "busy_to_idle": 27,
+    "idle_to_busy": 2,
+    "new_cache_holder": 2,
+    "predicted_ttft_reduction_ms_p50": 5055.443449669369,
+    "predicted_ttft_reduction_ms_p10": -1192.2353734446488
+  },
+  {
+    "model": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+    "horizon": 2048,
+    "rows": 184,
+    "changed": 34,
+    "busy_to_idle": 21,
+    "idle_to_busy": 2,
+    "new_cache_holder": 2,
+    "predicted_ttft_reduction_ms_p50": 6436.798316362505,
+    "predicted_ttft_reduction_ms_p10": 12.516158436806336
+  },
+  {
+    "model": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+    "horizon": 4096,
+    "rows": 184,
+    "changed": 16,
+    "busy_to_idle": 11,
+    "new_cache_holder": 1,
+    "predicted_ttft_reduction_ms_p50": 7111.646482657356,
+    "predicted_ttft_reduction_ms_p10": -487.85401463884887
+  },
+  {
+    "model": "qwen3.6-35b-a3b-vl-mtp-mxfp8",
+    "horizon": 1000000,
+    "rows": 184,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3-vl-30b-a3b-instruct",
+    "horizon": 512,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3-vl-30b-a3b-instruct",
+    "horizon": 1024,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3-vl-30b-a3b-instruct",
+    "horizon": 2048,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3-vl-30b-a3b-instruct",
+    "horizon": 4096,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3-vl-30b-a3b-instruct",
+    "horizon": 1000000,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+    "horizon": 512,
+    "rows": 103,
+    "changed": 26,
+    "busy_to_idle": 8,
+    "predicted_ttft_reduction_ms_p50": 5783.96568925889,
+    "predicted_ttft_reduction_ms_p10": -2500.826639795392
+  },
+  {
+    "model": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+    "horizon": 1024,
+    "rows": 103,
+    "changed": 23,
+    "busy_to_idle": 8,
+    "predicted_ttft_reduction_ms_p50": 6403.336708170635,
+    "predicted_ttft_reduction_ms_p10": -2500.826639795392
+  },
+  {
+    "model": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+    "horizon": 2048,
+    "rows": 103,
+    "changed": 20,
+    "busy_to_idle": 8,
+    "predicted_ttft_reduction_ms_p50": 4946.346468140118,
+    "predicted_ttft_reduction_ms_p10": -5251.626440328997
+  },
+  {
+    "model": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+    "horizon": 4096,
+    "rows": 103,
+    "changed": 15,
+    "busy_to_idle": 7,
+    "predicted_ttft_reduction_ms_p50": 6403.336708170635,
+    "predicted_ttft_reduction_ms_p10": -1672.8224847179335
+  },
+  {
+    "model": "EigenLabs/Qwen3.8-27B-4bit-mtp",
+    "horizon": 1000000,
+    "rows": 103,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b",
+    "horizon": 512,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b",
+    "horizon": 1024,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b",
+    "horizon": 2048,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b",
+    "horizon": 4096,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b",
+    "horizon": 1000000,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-qat-4bit",
+    "horizon": 512,
+    "rows": 2929,
+    "changed": 404,
+    "busy_to_idle": 231,
+    "baseline_mismatch_excluded": 14,
+    "new_cache_holder": 6,
+    "idle_to_busy": 14,
+    "predicted_ttft_reduction_ms_p50": 1345.1724393910326,
+    "predicted_ttft_reduction_ms_p10": -1859.449376398114
+  },
+  {
+    "model": "gemma-4-26b-qat-4bit",
+    "horizon": 1024,
+    "rows": 2929,
+    "changed": 152,
+    "busy_to_idle": 82,
+    "baseline_mismatch_excluded": 14,
+    "new_cache_holder": 6,
+    "predicted_ttft_reduction_ms_p50": 724.3695236431965,
+    "predicted_ttft_reduction_ms_p10": -1821.8382867367172
+  },
+  {
+    "model": "gemma-4-26b-qat-4bit",
+    "horizon": 2048,
+    "rows": 2929,
+    "changed": 135,
+    "busy_to_idle": 76,
+    "baseline_mismatch_excluded": 14,
+    "new_cache_holder": 4,
+    "predicted_ttft_reduction_ms_p50": 1014.3204355387265,
+    "predicted_ttft_reduction_ms_p10": -2135.8086298451
+  },
+  {
+    "model": "gemma-4-26b-qat-4bit",
+    "horizon": 4096,
+    "rows": 2929,
+    "changed": 105,
+    "busy_to_idle": 62,
+    "baseline_mismatch_excluded": 14,
+    "new_cache_holder": 4,
+    "predicted_ttft_reduction_ms_p50": 1211.3799100770987,
+    "predicted_ttft_reduction_ms_p10": -1740.6389291341816
+  },
+  {
+    "model": "gemma-4-26b-qat-4bit",
+    "horizon": 1000000,
+    "rows": 2929,
+    "baseline_mismatch_excluded": 14,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.5-35b-a3b",
+    "horizon": 512,
+    "rows": 38,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.5-35b-a3b",
+    "horizon": 1024,
+    "rows": 38,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.5-35b-a3b",
+    "horizon": 2048,
+    "rows": 38,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.5-35b-a3b",
+    "horizon": 4096,
+    "rows": 38,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "qwen3.5-35b-a3b",
+    "horizon": 1000000,
+    "rows": 38,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "nvidia-nemotron-3.5-lightning",
+    "horizon": 512,
+    "rows": 25,
+    "changed": 9,
+    "busy_to_idle": 7,
+    "predicted_ttft_reduction_ms_p50": -434.32574509366003,
+    "predicted_ttft_reduction_ms_p10": -1797.7905073748261
+  },
+  {
+    "model": "nvidia-nemotron-3.5-lightning",
+    "horizon": 1024,
+    "rows": 25,
+    "changed": 8,
+    "busy_to_idle": 7,
+    "predicted_ttft_reduction_ms_p50": -434.32574509366003,
+    "predicted_ttft_reduction_ms_p10": -934.2142259769297
+  },
+  {
+    "model": "nvidia-nemotron-3.5-lightning",
+    "horizon": 2048,
+    "rows": 25,
+    "changed": 8,
+    "busy_to_idle": 7,
+    "predicted_ttft_reduction_ms_p50": -434.32574509366003,
+    "predicted_ttft_reduction_ms_p10": -934.2142259769297
+  },
+  {
+    "model": "nvidia-nemotron-3.5-lightning",
+    "horizon": 4096,
+    "rows": 25,
+    "changed": 7,
+    "busy_to_idle": 6,
+    "predicted_ttft_reduction_ms_p50": -434.32574509366003,
+    "predicted_ttft_reduction_ms_p10": -934.2142259769297
+  },
+  {
+    "model": "nvidia-nemotron-3.5-lightning",
+    "horizon": 1000000,
+    "rows": 25,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-8bit",
+    "horizon": 512,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-8bit",
+    "horizon": 1024,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-8bit",
+    "horizon": 2048,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-8bit",
+    "horizon": 4096,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  },
+  {
+    "model": "gemma-4-26b-8bit",
+    "horizon": 1000000,
+    "predicted_ttft_reduction_ms_p50": null,
+    "predicted_ttft_reduction_ms_p10": null
+  }
+]

--- a/docs/reports/evidence/routing-performance-20260911/warm-pool-regression-before.txt
+++ b/docs/reports/evidence/routing-performance-20260911/warm-pool-regression-before.txt
@@ -1,0 +1,8 @@
+--- FAIL: TestWarmPoolSharedColdFleetFillsBothModels (0.00s)
+    --- FAIL: TestWarmPoolSharedColdFleetFillsBothModels/observe=false (0.00s)
+        warm_pool_allocation_test.go:75: model demand-b planned 0 loads, want 2: {Model:demand-b TargetWarm:3 WarmProviders:1 EligibleCold:4 QueueDepth:0 OldestQueueAge:0s CapacityRejects:1 TTFTMisses:0 SpeculativeStarted:0 SpeculativeWon:0 ColdDispatches:0 LoadDurationEWMA:0s ObserveOnly:false Actions:[] RunningRequests:3 WaitingRequests:0 WarmSaturated:1 WarmForeignBlocked:0 SpillArrivalRate:0 OccupancyRamp:0 HeadroomProviders:0 ServiceTime:500ms QualityConcurrency:1 DemandConcurrency:3 ColdIneligible:0 ColdDisqualifiers:map[]}
+    --- FAIL: TestWarmPoolSharedColdFleetFillsBothModels/observe=true (0.00s)
+        warm_pool_allocation_test.go:79: two models claimed provider cold-0
+FAIL
+FAIL	github.com/eigeninference/d-inference/coordinator/registry	0.938s
+FAIL


### PR DESCRIPTION
When two models need warm capacity and prefer the same cold machines, the controller currently reserves those machines for the first model, then leaves the second model short even when other eligible machines remain. This change continues through the existing ranked shortlist after a collision or lost reservation. Observe-only planning also assigns each machine to only one model per tick.

The regression scenario has two models needing two loads each and four shared idle machines. Before: two loads for A, zero for B. After: two loads for each in the same tick. Existing load allowances, model eligibility, pending-load reservations, and send-failure cleanup stay in use. The provider's existing load path can reclaim idle model weights when necessary; this PR adds no new unload command or provider protocol.

**Before**
```mermaid
flowchart TD
  D[Demand for models A and B] --> P[planObserveOnly: take first N candidates per model]
  P --> A[reservePendingModelLoads: A reserves machines 1 and 2]
  A --> B[B retries machines 1 and 2]
  B --> R[Reservations rejected]
  R --> S[B receives no load commands; machines 3 and 4 stay unused]
```

**After**
```mermaid
flowchart TD
  D[Demand for models A and B] --> P[planObserveOnly: preserve bounded model allowances]
  P --> A[allocateWarmPoolLoads: track assigned machines]
  A --> B[reservePendingModelLoads: A reserves machines 1 and 2]
  B --> C[B skips claimed machines and reserves machines 3 and 4]
  C --> L[sendModelLoadActions: both models gain warm capacity]
  A --> R[Lost reservation: try remaining ranked candidates]
  R --> C
```

Validation:
- New integration regression fails against the original controller in both active and observe-only modes, then passes with the fix.
- All coordinator packages: `go test ./... -p 4`.
- Warm-pool race tests: `go test -race ./registry -run TestWarmPool -count=1`.
- `make docs-check` and `git diff --check`.

The [routing study](https://github.com/Layr-Labs/d-inference/blob/8c2f49053/docs/reports/2026-09-11-routing-performance-study.md) contains scoped Datadog outcomes, deterministically sampled request profiles, aggregate evidence and follow-up proposals for ranking, cache availability and demand-aware residency. It explicitly separates observed delivery, attempt refusals, cache receipts and hypothetical shortlist choices. The direct replica connection timed out; request-level data came from authenticated read-only telemetry exports. Raw request/provider identifiers are excluded from committed evidence.

This PR fixes a reproduced allocation defect. It does not claim a measured production latency or cache-hit improvement and has not been deployed. Production rollout should compare per-model warm deficits, loads, churn and successful delivery with the existing load limits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791762417&installation_model_id=21733&pr_number=922&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F922&signature=917cca2d6fb180c907f2e82a4fa0a02aba880f453c4fcb4bcc806e9d7c2ced91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->