### PR TITLE
Unify provider prompt folding and tool instructions

### DIFF
--- a/provider-swift/Sources/ProviderCore/Inference/LeadingSystemMessageNormalizer.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/LeadingSystemMessageNormalizer.swift
@@ -11,39 +11,45 @@ enum LeadingSystemMessageNormalizer {
     static func normalize(
         _ messages: [[String: any Sendable]]
     ) -> [[String: any Sendable]] {
-        let systemIndices = messages.indices.filter {
-            (messages[$0]["role"] as? String) == "system"
-        }
+        normalize(
+            messages,
+            isSystem: { ($0["role"] as? String) == "system" },
+            textContent: { textContent($0["content"]) },
+            replacingContent: { message, text in
+                var message = message
+                message["content"] = text
+                return message
+            })
+    }
+
+    /// Fold either typed or dictionary messages without converting the other
+    /// turns. Keep the first system message's metadata and abandon a multi-turn
+    /// fold if any system content cannot be represented as text.
+    static func normalize<Message>(
+        _ messages: [Message],
+        isSystem: (Message) -> Bool,
+        textContent: (Message) -> String?,
+        replacingContent: (Message, String) -> Message
+    ) -> [Message] {
+        let systemIndices = messages.indices.filter { isSystem(messages[$0]) }
         guard let firstSystemIndex = systemIndices.first else { return messages }
         guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
             return messages
         }
 
-        let nonSystemMessages = messages.filter {
-            ($0["role"] as? String) != "system"
-        }
+        let nonSystemMessages = messages.filter { !isSystem($0) }
         if systemIndices.count == 1 {
             return [messages[firstSystemIndex]] + nonSystemMessages
         }
 
-        let systemMessages = systemIndices.map { messages[$0] }
         var systemTexts: [String] = []
-        systemTexts.reserveCapacity(systemMessages.count)
-        for message in systemMessages {
-            guard let text = textContent(message["content"]) else {
-                // Moving structured media into a text-only template slot would
-                // change request semantics. Leave it untouched so the model's
-                // existing validation remains authoritative.
-                return messages
-            }
-            if !text.isEmpty {
-                systemTexts.append(text)
-            }
+        systemTexts.reserveCapacity(systemIndices.count)
+        for index in systemIndices {
+            guard let text = textContent(messages[index]) else { return messages }
+            if !text.isEmpty { systemTexts.append(text) }
         }
-
-        var mergedSystem = systemMessages[0]
-        mergedSystem["content"] = systemTexts.joined(separator: "\n\n")
-        return [mergedSystem] + nonSystemMessages
+        let merged = replacingContent(messages[firstSystemIndex], systemTexts.joined(separator: "\n\n"))
+        return [merged] + nonSystemMessages
     }
 
     private static func textContent(_ content: (any Sendable)?) -> String? {

--- a/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/Qwen35TemplateFixes.swift
@@ -50,32 +50,15 @@ enum Qwen35TemplateFix {
     static func normalizeMessages(
         _ messages: [OpenAIChatMessage]
     ) -> [OpenAIChatMessage] {
-        let systemIndices = messages.indices.filter {
-            messages[$0].role == .system
-        }
-        guard let firstSystemIndex = systemIndices.first else { return messages }
-        guard systemIndices.count > 1 || firstSystemIndex != messages.startIndex else {
-            return messages
-        }
-
-        let nonSystemMessages = messages.filter { $0.role != .system }
-        if systemIndices.count == 1 {
-            return [messages[firstSystemIndex]] + nonSystemMessages
-        }
-
-        let systemMessages = systemIndices.map { messages[$0] }
-        var systemTexts: [String] = []
-        systemTexts.reserveCapacity(systemMessages.count)
-        for message in systemMessages {
-            guard let text = systemTextContent(message.content) else {
-                return messages
-            }
-            if !text.isEmpty { systemTexts.append(text) }
-        }
-
-        var mergedSystem = systemMessages[0]
-        mergedSystem.content = .text(systemTexts.joined(separator: "\n\n"))
-        return [mergedSystem] + nonSystemMessages
+        LeadingSystemMessageNormalizer.normalize(
+            messages,
+            isSystem: { $0.role == .system },
+            textContent: { systemTextContent($0.content) },
+            replacingContent: { message, text in
+                var message = message
+                message.content = .text(text)
+                return message
+            })
     }
 
     private static func systemTextContent(_ content: OpenAIMessageContent) -> String? {

--- a/provider-swift/Sources/ProviderCore/Inference/ToolChoicePromptPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolChoicePromptPolicy.swift
@@ -145,15 +145,7 @@ enum ToolChoicePromptPolicy {
         guard let userIndex = messages.lastIndex(where: { $0.role == .user }) else {
             return messages
         }
-        switch messages[userIndex].content {
-        case .text(let content):
-            messages[userIndex].content = .text(content + "\n\n" + instruction)
-        case .parts(var parts):
-            parts.append(.text(instruction))
-            messages[userIndex].content = .parts(parts)
-        case .null:
-            messages[userIndex].content = .text(instruction)
-        }
+        appendInstruction(instruction, to: &messages[userIndex])
         return messages
     }
 
@@ -163,20 +155,24 @@ enum ToolChoicePromptPolicy {
     ) -> [OpenAIChatMessage] {
         var messages = messages
         if messages.first?.role == .system {
-            switch messages[0].content {
-            case .text(let content):
-                messages[0].content = .text(content + "\n\n" + instruction)
-            case .parts(var parts):
-                parts.append(.text(instruction))
-                messages[0].content = .parts(parts)
-            case .null:
-                messages[0].content = .text(instruction)
-            }
+            appendInstruction(instruction, to: &messages[0])
         } else {
             messages.insert(
                 OpenAIChatMessage(role: .system, content: .text(instruction)),
                 at: 0)
         }
         return messages
+    }
+
+    private static func appendInstruction(_ instruction: String, to message: inout OpenAIChatMessage) {
+        switch message.content {
+        case .text(let content):
+            message.content = .text(content + "\n\n" + instruction)
+        case .parts(var parts):
+            parts.append(.text(instruction))
+            message.content = .parts(parts)
+        case .null:
+            message.content = .text(instruction)
+        }
     }
 }

--- a/provider-swift/Sources/ProviderCore/Inference/ToolConstraintSchema.swift
+++ b/provider-swift/Sources/ProviderCore/Inference/ToolConstraintSchema.swift
@@ -466,16 +466,7 @@ enum ToolConstraintSchemaCompiler {
         _ object: [String: SchemaJSONValue],
         path: String
     ) throws -> (String, Bool) {
-        guard let value = object["type"] else {
-            if object["properties"] != nil || object["additionalProperties"] != nil {
-                return ("object", false)
-            }
-            if object["items"] != nil {
-                return ("array", false)
-            }
-            return ("string", false)
-        }
-        if value == .null {
+        guard let value = object["type"], value != .null else {
             if object["properties"] != nil || object["additionalProperties"] != nil {
                 return ("object", false)
             }

--- a/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/GemmaToolConstraintTests.swift
@@ -439,12 +439,15 @@ struct GemmaToolConstraintTests {
         }
     }
 
-    @Test("structural schemas infer object and array types like the coordinator")
-    func structuralTypeInferenceMatchesCoordinator() throws {
-        let parameters: MLXLMCommon.JSONValue = .object([
+    @Test("missing and null schema types use the same structural defaults", arguments: [false, true])
+    func structuralTypeInferenceMatchesCoordinator(explicitNull: Bool) throws {
+        func untyped(_ fields: [String: MLXLMCommon.JSONValue]) -> MLXLMCommon.JSONValue {
+            .object(explicitNull ? fields.merging(["type": .null]) { _, new in new } : fields)
+        }
+        let parameters = untyped([
             "properties": .object([
-                "values": .object([
-                    "items": .object(["type": .string("string")]),
+                "values": untyped([
+                    "items": untyped([:]),
                     "maxItems": .int(2),
                 ]),
             ]),
@@ -453,7 +456,18 @@ struct GemmaToolConstraintTests {
             choice: .mode(.required),
             tools: [tool(parameters: parameters)])
         let prepared = try ToolChoicePromptPolicy.prepare(inferred)
-        #expect(prepared.compiledTools?.count == 1)
+        let compiled = try #require(prepared.compiledTools?.first)
+        guard case .object(let properties, true, false) = compiled.parameters,
+            let property = properties.first,
+            case .array(let items, 0, let maxItems, false) = property.schema,
+            case .string(nil, false) = items
+        else {
+            Issue.record("expected a non-null object containing an array of free strings")
+            return
+        }
+        #expect(property.name == "values")
+        #expect(maxItems == 2)
+        #expect(!property.required)
     }
 
     @Test("unimplemented schema assertions never become prompt-only theater")

--- a/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Qwen35TemplateFixesTests.swift
@@ -50,6 +50,28 @@ struct Qwen35TemplateFixesTests {
         messages.compactMap { $0["role"] as? String }
     }
 
+    @Test("system folding keeps first-message metadata and empty-content semantics in both representations")
+    func sharedFoldPreservesMetadataAndEmptyContent() {
+        let dictionaryMessages: [[String: any Sendable]] = [
+            ["role": "user", "content": "question"],
+            ["role": "system", "name": "first", "content": ""],
+            ["role": "assistant", "content": "answer"],
+            ["role": "system", "name": "second", "content": "new policy"],
+        ]
+        let dictionaries = LeadingSystemMessageNormalizer.normalize(dictionaryMessages)
+        #expect(dictionaries.compactMap { $0["role"] as? String } == ["system", "user", "assistant"])
+        #expect(dictionaries[0]["name"] as? String == "first")
+        #expect(dictionaries[0]["content"] as? String == "new policy")
+        let typed = Qwen35TemplateFix.normalizeMessages([
+            OpenAIChatMessage(role: .user, content: .text("question")),
+            .init(role: .system, content: .null),
+            .init(role: .assistant, content: .text("answer")),
+            .init(role: .system, content: .text("new policy")),
+        ])
+        #expect(typed.map(\.role) == [.system, .user, .assistant])
+        #expect(typed.map(\.content) == [.text("new policy"), .text("question"), .text("answer")])
+    }
+
     @Test func appliesOnlyToQwen35Family() {
         #expect(Qwen35TemplateFix.applies(to: qwenContext))
         #expect(Qwen35TemplateFix.applies(

--- a/provider-swift/Tests/ProviderCoreTests/ToolChoicePromptPolicyTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ToolChoicePromptPolicyTests.swift
@@ -76,6 +76,40 @@ struct ToolChoicePromptPolicyTests {
         }
     }
 
+    @Test("forced instructions preserve content parts and leave intermediate turns untouched")
+    func forcedInstructionContentShapes() throws {
+        let image = OpenAIContentPart.imageURL("data:image/png;base64,AAAA")
+        for systemContent in [OpenAIMessageContent.null, .text("policy"), .parts([.text("policy")])] {
+            for userContent in [OpenAIMessageContent.null, .text("question"), .parts([.text("question"), image])] {
+                var input = request(choice: .mode(.required))
+                let earlierUser = OpenAIChatMessage(role: .user, content: .text("earlier question"))
+                let assistant = OpenAIChatMessage(role: .assistant, content: .text("earlier answer"))
+                input.messages = [
+                    .init(role: .system, content: systemContent), earlierUser, assistant,
+                    .init(role: .user, content: userContent),
+                ]
+                let prepared = try ToolChoicePromptPolicy.prepare(input)
+                #expect(prepared.messages.count == 4)
+                #expect(prepared.messages[1].content == earlierUser.content)
+                #expect(prepared.messages[2].content == assistant.content)
+                for (index, original) in [(0, systemContent), (3, userContent)] {
+                    let updated = prepared.messages[index].content
+                    switch (original, updated) {
+                    case (.parts(let before), .parts(let after)):
+                        #expect(Array(after.dropLast()) == before)
+                        #expect(after.count == before.count + 1)
+                    case (.text(let before), .text(let after)):
+                        #expect(after.hasPrefix(before + "\n\nCall one"))
+                    case (.null, .text(let after)):
+                        #expect(after.hasPrefix("Call one"))
+                    default:
+                        Issue.record("instruction changed the content representation")
+                    }
+                }
+            }
+        }
+    }
+
     private func request(choice: OpenAIToolChoice) -> OpenAIChatCompletionRequest {
         OpenAIChatCompletionRequest(
             model: "gemma-4",


### PR DESCRIPTION
Typed Qwen messages and dictionary-based Qwen/Harmony messages separately implemented the same leading-system fold, while forced tool instructions duplicated content-shape handling for system and user turns. They now share these operations: preserve the first system message's metadata, keep all non-system turns in order, retain media that cannot be folded into text, and append the identical instruction to the same slots.

The schema compiler also uses one structural-default path for both missing and explicit-null `type`. This removes 24 production lines across four files. Model applicability, template bytes, tool-choice policy, grammar limits, validation ordering, and prompt-cache identity remain unchanged.

Before:
```mermaid
flowchart TD
  D[Dictionary Qwen or Harmony history] --> DF[Dictionary system fold]
  T[Typed Qwen history] --> TF[Duplicate typed system fold]
  DF --> P[Leading instructions and preserved history]
  TF --> P
  C[Forced tool choice] --> S[System content switch]
  C --> U[Duplicate final-user content switch]
  S --> I[Same instruction in selected slots]
  U --> I
  N[Schema type absent or null] --> A[Two structural-default branches]
  A --> G[Existing constrained schema]
```

After:
```mermaid
flowchart TD
  D[Dictionary Qwen or Harmony history] --> DR[Dictionary content reader and replacement]
  T[Typed Qwen history] --> TR[Typed content reader and replacement]
  DR --> F[Shared LeadingSystemMessageNormalizer fold]
  TR --> F
  F --> P[Same leading instructions and preserved history]
  C[Forced tool choice selects same system and final-user slots] --> H[Shared appendInstruction]
  H --> I[Same instruction and original content representation]
  N[Schema type absent or null] --> A[One structural-default branch]
  A --> G[Same constrained schema]
```

Validation: the combined final source `93c4caa5c6abb73ef9c882c1deae7eee31eef125` passed a dedicated M5 release build and **1,243 Swift Testing cases across 132 suites plus 48 XCTest cases**, with no skipped tests. The run includes the real Gemma QAT tokenizer/constraint fixture and packaged runtime smoke. All 5,093 staged source files and compiled runtime hashes were checked before and after. Provider SHA256: `45c33b44c58228f67a362c7239eda081877c846d568a73bda026e010512af060`; metallib SHA256: `20972c37e53fe6db3b3191a0434f6604c4ffc4f5ac62b370574f9922585b0fdb`.

The run combines #897, #904, #916, #917, #920 and #923 at their current source heads. Model-generation/live benchmark suites were explicitly excluded; this evidence does not claim MTP speed or live HTTP cache qualification. The QAT fixture contains verified tokenizer/config/template files only, and its temporary scanner entry was removed after validation.

System-fold tests cover preserved metadata, empty content and nine text/image combinations. Schema cases cover missing/null structural inference. The real QAT tokenizer accepts the canonical tool envelope and Unicode grammar through the changed preparation path.

Stacked on #904 because that branch already refactors decoding/control extraction in this same prompt pipeline. The full partition review retained the distinct model-specific schema renderers, grammar/stop automata, exact numeric validation, and native channel/tool framing because their accepted inputs and failure contracts differ.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791762435&installation_model_id=21733&pr_number=923&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F923&signature=7374d4ae5aca935e6c3a004843fe9123e1bec94986ec731ffe194fb8655942cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->