### PR TITLE
Share provider release signing checks and safely encode tag metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         run: |
           ./scripts/check-release-version.sh
           python3 scripts/test-provider-release-resolution.py
+          python3 scripts/test-provider-signing-validation.py
+          python3 scripts/test_release_workflow.py
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
       - name: Test startup observer against local stubs

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -345,69 +345,7 @@ jobs:
           # passes codesign but fails at runtime → silent attestation break.
           security cms -D -i /tmp/embedded.provisionprofile > /tmp/profile.plist
 
-          python3 - <<'PY'
-          import plistlib, sys
-          from datetime import datetime, timezone
-
-          with open('/tmp/profile.plist', 'rb') as f:
-              p = plistlib.load(f)
-
-          errors = []
-          team = p.get('TeamIdentifier', [])
-          if 'SLDQ2GJ6TL' not in team:
-              errors.append(f"TeamIdentifier missing SLDQ2GJ6TL: {team}")
-
-          ents = p.get('Entitlements', {})
-          groups = ents.get('keychain-access-groups', [])
-          # Accept exact match or wildcard (SLDQ2GJ6TL.*) which covers
-          # SLDQ2GJ6TL.io.darkbloom.provider at runtime.
-          has_group = any(
-              g == 'SLDQ2GJ6TL.io.darkbloom.provider' or g == 'SLDQ2GJ6TL.*'
-              for g in groups
-          )
-          if not has_group:
-              errors.append(f"keychain-access-groups missing SLDQ2GJ6TL.io.darkbloom.provider or wildcard: {groups}")
-
-          app_id = ents.get('application-identifier', '')
-          # Developer ID profiles may omit application-identifier entirely;
-          # accept empty or wildcard alongside exact match.
-          if app_id and not (app_id.endswith('io.darkbloom.provider') or app_id.endswith('*')):
-              errors.append(f"application-identifier mismatch: {app_id}")
-
-          # v0.6.0 APNs code-identity: the embedded profile MUST grant
-          # aps-environment=production, or the signed binary AMFI-kills at launch
-          # (restricted entitlement without an authorizing profile). This is the
-          # only build-time guard against shipping the entitlement with a stale,
-          # non-push profile. Profiles key it short ('aps-environment') or long.
-          aps = ents.get('aps-environment') or ents.get('com.apple.developer.aps-environment')
-          if aps != 'production':
-              errors.append(
-                  f"profile does not grant aps-environment=production (got {aps!r}); "
-                  "regenerate the push-enabled provisioning profile and update PROVISIONING_PROFILE_BASE64"
-              )
-
-          expiry = p.get('ExpirationDate')
-          if expiry is not None:
-              # ExpirationDate is a naive UTC datetime from plistlib.
-              now = datetime.utcnow()
-              days_left = (expiry - now).days
-              if days_left < 30:
-                  errors.append(f"Profile expires in {days_left} days (renew before cutover): {expiry}")
-              else:
-                  print(f"Profile valid for {days_left} more days")
-          else:
-              print("::warning::Provisioning profile has no ExpirationDate field")
-
-          name = p.get('Name', '<unknown>')
-          uuid = p.get('UUID', '<unknown>')
-          print(f"Profile: name={name!r} uuid={uuid} team={team} app_id={app_id}")
-
-          if errors:
-              for e in errors:
-                  print(f"::error::{e}", file=sys.stderr)
-              sys.exit(1)
-          print("Provisioning profile verification passed")
-          PY
+          python3 scripts/provider-signing-validation.py profile --profile /tmp/profile.plist
 
           echo "profile_available=true" >> "$GITHUB_OUTPUT"
         id: profile
@@ -534,48 +472,10 @@ jobs:
           printf '%s\n' "$SIGNED_BENCHMARK_HELP" \
             | grep -F -- '--scheduler-prefill-decision'
 
-          # Persistent Secure Enclave key requires keychain-access-groups
-          # bound to the team-scoped access group. If the entitlement is
-          # missing, providers fall back to ephemeral SE keys and PR #146
-          # silently no-ops. Fail the build instead of shipping a broken
-          # attestation.
-          EXPECTED_ACCESS_GROUP="SLDQ2GJ6TL.io.darkbloom.provider"
-          ENTITLEMENTS=$(codesign -d --entitlements - --xml "$APP/Contents/MacOS/$CLI_NAME" 2>&1 || true)
-          if ! echo "$ENTITLEMENTS" | grep -q "keychain-access-groups"; then
-            echo "::error::Signed CLI is missing keychain-access-groups entitlement"
-            echo "$ENTITLEMENTS"
-            exit 1
-          fi
-          if ! echo "$ENTITLEMENTS" | grep -q "$EXPECTED_ACCESS_GROUP"; then
-            echo "::error::Signed CLI is missing access group $EXPECTED_ACCESS_GROUP"
-            echo "$ENTITLEMENTS"
-            exit 1
-          fi
-          # v0.6.0 APNs code-identity assertions on the signed CLI:
-          #   (a) aps-environment present AND == production (parse the value, not a
-          #       bare grep — a dev profile would set 'development' and silently
-          #       register against the wrong APNs host).
-          #   (b) get-task-allow ABSENT — its absence (not "hardened runtime" per
-          #       se) is what blocks even-root debugger attach / dylib injection;
-          #       Developer ID + notarization strips it.
-          rm -f /tmp/cli-ents.plist
-          codesign -d --entitlements /tmp/cli-ents.plist --xml "$APP/Contents/MacOS/$CLI_NAME" 2>/dev/null || true
-          # Fail loudly if extraction produced nothing — otherwise the
-          # get-task-allow check below would pass vacuously on an empty file.
-          if [ ! -s /tmp/cli-ents.plist ]; then
-            echo "::error::Failed to extract entitlements from signed CLI for APNs/get-task-allow verification"
-            exit 1
-          fi
-          APS_ENV=$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.aps-environment' /tmp/cli-ents.plist 2>/dev/null || echo "")
-          if [ "$APS_ENV" != "production" ]; then
-            echo "::error::Signed CLI aps-environment must be 'production' (got '${APS_ENV:-<absent>}'). Regenerate the push provisioning profile + entitlements (v0.6.0 APNs code-identity)."
-            exit 1
-          fi
-          if /usr/libexec/PlistBuddy -c 'Print :com.apple.security.get-task-allow' /tmp/cli-ents.plist 2>/dev/null | grep -qi true; then
-            echo "::error::Signed CLI has get-task-allow=true — defeats even-root injection resistance. It must be absent (Developer ID + notarized strips it)."
-            exit 1
-          fi
-          echo "APNs code-identity entitlements verified: aps-environment=production, get-task-allow absent"
+          # Apply the same parsed entitlement contract as signing validation:
+          # provider keychain group, production APNs and no enabled debug task.
+          codesign -d --entitlements - --xml "$APP/Contents/MacOS/$CLI_NAME" > /tmp/cli-ents.plist
+          python3 scripts/provider-signing-validation.py cli-entitlements --plist /tmp/cli-ents.plist
           if [ "${{ steps.profile.outputs.profile_available }}" = "true" ]; then
             if [ ! -f "$APP/Contents/embedded.provisionprofile" ]; then
               echo "::error::Provisioning profile secret set but not embedded in app bundle"
@@ -585,7 +485,7 @@ jobs:
             echo "::error::PROVISIONING_PROFILE_BASE64 secret is required to authorize the keychain-access-groups entitlement on provider machines"
             exit 1
           fi
-          echo "Entitlement verification passed: $EXPECTED_ACCESS_GROUP authorized via embedded provisioning profile"
+          echo "Provider entitlements authorized via embedded provisioning profile"
 
           # Flat layout alongside the .app bundle. Coordinator's release
           # artifact verifier (release_handlers.go:413) requires bin/darkbloom
@@ -858,7 +758,8 @@ jobs:
           # provider could ever echo — registering them armed a coordinator
           # gate that zeroed fleet routing (2026-08-31 incident). Register
           # only facts the provider actually reports.
-          python3 - <<PY > /tmp/release-payload.json
+          export BUNDLE_URL TAG_MSG
+          python3 - <<'PY' > /tmp/release-payload.json
           import json, os
           payload = {
               "version":         os.environ["VERSION"],
@@ -867,8 +768,8 @@ jobs:
               "binary_hash":     os.environ["BINARY_HASH"],
               "bundle_hash":     os.environ["BUNDLE_HASH"],
               "metallib_hash":   os.environ["METALLIB_HASH"],
-              "url":             "${BUNDLE_URL}",
-              "changelog":       """${TAG_MSG}""".strip(),
+              "url":             os.environ["BUNDLE_URL"],
+              "changelog":       os.environ["TAG_MSG"].strip(),
           }
           print(json.dumps(payload))
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Provider releases use the same profile and signed CLI entitlement checks as signing validation, rejecting unrelated app identities and missing profile expiry before publication. Release registration encodes quoted and multiline tag text as JSON data.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `4e4cabb59`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -187,6 +187,8 @@ continues to reject divergent copies.
 
 The separate [signing-validation workflow](../operations/provider-release.md#environment-free-signing-validation)
 checks packaging and Apple signing without selecting a deployment environment.
+It shares profile and signed CLI entitlement validators with the release workflow;
+the same authorization checks run before either workflow proceeds to notarization.
 
 Release configuration, as the release workflow builds it:
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `4e4cabb59`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -922,6 +922,12 @@ node --test landing/earn-calculator-core.test.js
 ```
 
 ### 6. Scripts and release integrity
+
+`python3 scripts/test-provider-signing-validation.py` checks signing-input
+contracts. `python3 scripts/test_release_workflow.py` runs the release workflow's
+profile and JSON-payload steps against local fixtures, including invalid app
+identities, missing expiry, and quoted multiline tag text. Both run in Release
+Integrity CI without signing, notarizing, publishing or executing a provider.
 
 ```bash
 make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contbatch/tests -t .   (in scripts/)

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-10 · commit `5f021ba4d`
+> Last updated: 2026-09-11 · commit `4e4cabb59`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -47,6 +47,12 @@ coordinator `build_commit`; its build `version` can remain 0.9.1 while
 provider auto-update; it is not a limited canary rollout by itself.
 
 ## Environment-free signing validation
+
+Both signing workflows use `scripts/provider-signing-validation.py` for decoded
+profile and signed CLI entitlement checks. Profiles must authorize the provider
+team/app, keychain group and production APNs, with at least 30 days until expiry.
+The signed CLI must have the provider keychain group, production APNs and no
+enabled or malformed debug-task entitlement (`profile`, `cli_entitlements`).
 
 [`provider-signing-validation.yml`](../../.github/workflows/provider-signing-validation.yml)
 is a separate manual workflow for a reviewed full `source_sha` and its existing
@@ -243,8 +249,8 @@ shown in the run):
 | 5 | Verify production prompt parity | `scripts/verify-prompt-parity.sh` |
 | 6 | Build source-matched mlx.metallib through root helper | `scripts/fetch-metallib.sh "$RUNNER_TEMP/metallib"` with `MLX_METALLIB_DEPLOYMENT_TARGET=26.2`; cached by MLX source SHA + helper SHA |
 | 7 | Build provider-swift (release) | `swift build -c release --product darkbloom`, `darkbloom-enclave`, `darkbloom-fan-helper`; the built binary's `--version` is checked with `check-release-version.sh "$VERSION" "$REPORTED"` |
-| 8 | Embed provisioning profile | decodes `PROVISIONING_PROFILE_BASE64`; fails unless the profile grants `aps-environment=production` and has no `get-task-allow` |
-| 9 | Stage and sign bundle | stages `Darkbloom.app` (CLI, enclave, fan helper, `mlx.metallib`, every SwiftPM resource bundle via `scripts/stage-swiftpm-resource-bundles.sh`) plus a flat `bin/` layout; `codesign --options runtime --timestamp` on the metallib first, then each binary, then the bundle; `codesign --verify --deep --strict`; tars to `darkbloom-bundle-macos-arm64.tar.gz` |
+| 8 | Embed provisioning profile | decodes `PROVISIONING_PROFILE_BASE64`; runs the shared `profile` validator for team/app authorization, keychain group, production APNs and expiry |
+| 9 | Stage and sign bundle | stages `Darkbloom.app` (CLI, enclave, fan helper, `mlx.metallib`, every SwiftPM resource bundle via `scripts/stage-swiftpm-resource-bundles.sh`) plus a flat `bin/` layout; signs and verifies the components and bundle; runs the shared `cli-entitlements` validator before creating `darkbloom-bundle-macos-arm64.tar.gz` |
 | 10 | Notarize bundle | `xcrun notarytool submit --wait --timeout 15m`; on failure prints `notarytool log`; then `xcrun stapler staple` + `stapler validate`, re-verifies codesign, **rebuilds the tar**, and asserts the file list contains `./bin/darkbloom`, `./bin/darkbloom-enclave`, `./bin/mlx.metallib`, every resource bundle and `pagedattention.metal`. A smoke extract runs the CLI and re-checks the version |
 | 11 | Hashes | computed **after** signing, notarizing, stapling and the tar rebuild: `BINARY_HASH = sha256(bin/darkbloom)` from the extracted tar, `BUNDLE_HASH = sha256(tar.gz)`, `METALLIB_HASH = sha256(flat mlx.metallib)` |
 | 12 | Upload bundle to R2 | `s3://$R2_BUCKET/releases/v$VERSION/darkbloom-bundle-macos-arm64.tar.gz`, plus `releases/latest/darkbloom-bundle-macos-arm64.tar.gz` and the legacy `releases/latest/eigeninference-bundle-macos-arm64.tar.gz` |

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -1,0 +1,95 @@
+"""Run release input handling against local fixtures, without signing or publishing."""
+
+import base64
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import plistlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def release_step(name):
+    workflow = (ROOT / ".github/workflows/release-swift.yml").read_text()
+    step = workflow.split("      - name: " + name + "\n", 1)[1]
+    script = step.split("        run: |\n", 1)[1]
+    lines = []
+    for line in script.splitlines():
+        if line and not line.startswith("          "):
+            break
+        lines.append(line[10:])
+    return "\n".join(lines) + "\n"
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_profile_validation_authorizes_this_app_before_embedding(self):
+        for scenario in ("valid", "wrong-long-app", "wrong-short-team", "unrelated-wildcard",
+                         "missing-expiry", "short-expiry", "development-push"):
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                app = "SLDQ2GJ6TL.io.darkbloom.provider"
+                profile = {
+                    "TeamIdentifier": ["SLDQ2GJ6TL"],
+                    "ExpirationDate": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=60),
+                    "Entitlements": {"keychain-access-groups": [app], "aps-environment": "production"},
+                }
+                entitlements = profile["Entitlements"]
+                if scenario == "wrong-long-app":
+                    entitlements["com.apple.application-identifier"] = "SLDQ2GJ6TL.other"
+                if scenario == "wrong-short-team":
+                    entitlements["application-identifier"] = "OTHERTEAM.io.darkbloom.provider"
+                if scenario == "unrelated-wildcard":
+                    entitlements["application-identifier"] = "SLDQ2GJ6TL.unrelated.*"
+                if scenario == "missing-expiry":
+                    profile.pop("ExpirationDate")
+                if scenario == "short-expiry":
+                    profile["ExpirationDate"] = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=2)
+                if scenario == "development-push":
+                    entitlements["aps-environment"] = "development"
+                fixture = root / "fixture.plist"
+                fixture.write_bytes(plistlib.dumps(profile))
+                security = root / "security"
+                security.write_text('#!/bin/sh\nexec cat "$RELEASE_PROFILE_FIXTURE"\n')
+                security.chmod(0o755)
+                # Redirect the old workflow's fixed /tmp paths into this fixture
+                # too, so the regression can run safely against its baseline.
+                script = release_step("Embed provisioning profile").replace("/tmp/", directory + "/")
+                result = subprocess.run(["bash", "-c", script], cwd=ROOT,
+                    env={**os.environ, "PATH": directory + os.pathsep + os.environ["PATH"],
+                         "RUNNER_TEMP": directory, "GITHUB_OUTPUT": str(root / "outputs"),
+                         "PROVISIONING_PROFILE_BASE64": base64.b64encode(b"fixture CMS").decode(),
+                         "RELEASE_PROFILE_FIXTURE": str(fixture)},
+                    capture_output=True, text=True, timeout=10)
+                if scenario == "valid":
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertIn("profile_available=true", (root / "outputs").read_text())
+                else:
+                    self.assertNotEqual(result.returncode, 0, result.stdout)
+                    self.assertFalse((root / "outputs").exists())
+
+    def test_release_payload_preserves_tag_text_as_json_data(self):
+        step = release_step("Register release with coordinator")
+        phase = step[step.index("python3 - <<"):step.index("curl -fsSL -X POST")]
+        for message in ('Ordinary release', 'Quotes: """; backslash: \\n; literal: $HOME\nSecond line\tend'):
+            with self.subTest(message=message), tempfile.TemporaryDirectory() as directory:
+                script = phase.replace("/tmp/", directory + "/")
+                result = subprocess.run(["bash", "-euc", script], cwd=ROOT,
+                    env={**os.environ, "VERSION": "fixture-version", "TAG_MSG": message,
+                         "BUNDLE_URL": "https://example.invalid/bundle", "BINARY_HASH": "binary",
+                         "BUNDLE_HASH": "bundle", "METALLIB_HASH": "metallib"},
+                    capture_output=True, text=True, timeout=10)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                payload = json.loads((Path(directory) / "release-payload.json").read_text())
+                self.assertEqual(payload, {"version": "fixture-version", "platform": "macos-arm64",
+                    "backend": "mlx-swift", "binary_hash": "binary", "bundle_hash": "bundle",
+                    "metallib_hash": "metallib", "url": "https://example.invalid/bundle",
+                    "changelog": message})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The release workflow duplicated weaker versions of the signing-validation checks: it accepted unrelated app identifiers, ignored the macOS identifier key, and only warned about missing profile expiry. Both workflows now use the existing parsed profile and signed CLI entitlement validators. Release registration also reads tag text as environment data when encoding JSON, so quotes, backslashes and multiline notes retain their values.

This removes 99 lines from the release workflow while preserving its build, signature verification, runtime smoke, notarization and publication order. Invalid profile identities and missing expiry now stop the release path before signing; both debug-task entitlement spellings are checked on the signed CLI. No release was dispatched or published.

```mermaid
flowchart LR
  subgraph Before
    P[Decoded profile] --> W[Inline release validator: weaker identity and expiry checks]
    S[Signed CLI] --> G[Separate grep and PlistBuddy checks]
    T[Tag text] --> I[Interpolate into Python source]
    I --> F[Quoted notes can break JSON generation]
  end
  subgraph After
    P2[Decoded profile] --> V[provider-signing-validation.py profile]
    S2[Signed CLI] --> C[provider-signing-validation.py cli-entitlements]
    V --> N[Existing signing and notarization sequence]
    C --> N
    T2[Tag text] --> E[Environment values and json.dumps]
    E --> R[Valid registration JSON with original note text]
  end
```

Validation: nine signing-helper tests and two workflow fixture tests pass. The workflow fixtures exercise seven profile scenarios and two tag-text scenarios; five assertions fail against master and pass with this change. They execute only profile/payload steps with local CMS fixtures, with no signing, model execution, network request or publication. YAML and changed shell steps parse; docs lint passes (278 pages). Release Integrity CI now runs these checks.
