### PR TITLE
Serialize Stripe reversal refunds with payout completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ coordinator and console changes require their own deployments.
 - **Incoming request accounting** — Add an unsampled request-outcome ledger and bounded admin inspection with explicit coverage and completion evidence. Record recovered HTTP errors and parsed streaming mode, and distinguish completed, incomplete and error response terminals after successful writes while preserving contradictory evidence and earlier content progress.
 - **Partial network geography** — Keep the stats overview available when request-location or route analytics time out. Refresh geography independently, expose unavailable sections, preserve valid empty maps and restore geography after recovery.
 
+## Unreleased — Stripe reversal settlement
+
+- Serialize a full transfer-reversal refund with payout completion. Recheck the current withdrawal under its store lock and commit principal/fee refunds with the terminal state, preventing a stale webhook read from refunding an already-paid withdrawal. A failed transaction leaves both balances and withdrawal state unchanged.
+
 ## Unreleased — stats request-flow refresh
 
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.

--- a/coordinator/api/stripe_payouts_fixes_test.go
+++ b/coordinator/api/stripe_payouts_fixes_test.go
@@ -534,8 +534,9 @@ func TestConnectWebhookTransferReversedOnPaidRowNeedsHuman(t *testing.T) {
 // failures into specific operations.
 type flakyPayoutStore struct {
 	*store.MemoryStore
-	failLookups bool
-	failUpdates bool
+	failLookups   bool
+	failUpdates   bool
+	failReversals bool
 }
 
 func (f *flakyPayoutStore) GetStripeWithdrawalByPayoutID(payoutID string) (*store.StripeWithdrawal, error) {
@@ -550,6 +551,13 @@ func (f *flakyPayoutStore) UpdateStripeWithdrawal(wd *store.StripeWithdrawal) er
 		return errors.New("connection reset by peer")
 	}
 	return f.MemoryStore.UpdateStripeWithdrawal(wd)
+}
+
+func (f *flakyPayoutStore) RefundStripeWithdrawalAfterReversal(id, transferID string) (bool, error) {
+	if f.failReversals {
+		return false, errors.New("connection reset by peer")
+	}
+	return f.MemoryStore.RefundStripeWithdrawalAfterReversal(id, transferID)
 }
 
 // newFlakyPayoutServer wires a Server + billing around a flakyPayoutStore.
@@ -572,10 +580,8 @@ func newFlakyPayoutServer(t *testing.T, fakeStripe *httptest.Server) (*Server, *
 	return srv, flaky
 }
 
-// TestConnectWebhookTransferReversedConvergesAcrossPersistFailure: the credit
-// lands but the row persist fails → 500 → Stripe redelivers → the
-// reference-deduped credit no-ops and the persist completes. Exactly one
-// refund, terminal row.
+// A failed reversal transaction returns 500 without changing the balance;
+// webhook redelivery settles it once with both the refund and terminal state.
 func TestConnectWebhookTransferReversedConvergesAcrossPersistFailure(t *testing.T) {
 	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer fakeStripe.Close()
@@ -589,15 +595,15 @@ func TestConnectWebhookTransferReversedConvergesAcrossPersistFailure(t *testing.
 	})
 	balBefore := flaky.GetBalance(user.AccountID)
 
-	flaky.failUpdates = true
+	flaky.failReversals = true
 	if w := deliverConnectWebhook(t, srv, transferReversedPayload("tr_conv")); w.Code != http.StatusInternalServerError {
 		t.Fatalf("got %d, want 500 (persist failed — Stripe must redeliver)", w.Code)
 	}
-	if bal := flaky.GetBalance(user.AccountID); bal != balBefore+5_000_000 {
-		t.Fatalf("credit should have landed once: balance = %d", bal)
+	if bal := flaky.GetBalance(user.AccountID); bal != balBefore {
+		t.Fatalf("failed reversal moved balance: %d, want %d", bal, balBefore)
 	}
 
-	flaky.failUpdates = false
+	flaky.failReversals = false
 	if w := deliverConnectWebhook(t, srv, transferReversedPayload("tr_conv")); w.Code != http.StatusOK {
 		t.Fatalf("redelivery got %d", w.Code)
 	}

--- a/coordinator/api/stripe_payouts_webhooks.go
+++ b/coordinator/api/stripe_payouts_webhooks.go
@@ -524,34 +524,17 @@ func (s *Server) handleTransferFailed(event *billing.WebhookEvent) error {
 			"stripe_account_id", wd.StripeAccountID)
 		return nil
 	}
-	netMicroUSD := wd.AmountMicroUSD - wd.FeeMicroUSD
-	if netMicroUSD > 0 {
-		if _, err := s.billing.Store().CreditWithdrawableOnce(wd.AccountID, netMicroUSD,
-			store.LedgerRefund, "stripe_withdraw:"+wd.ID); err != nil {
-			s.logger.Error("stripe connect webhook: principal refund failed", "error", err, "withdrawal_id", wd.ID)
-			return err // Refunded stays false — redelivery retries idempotently
-		}
-	}
-	if wd.FeeMicroUSD > 0 {
-		// No-ops if the instant-fee path already credited this reference.
-		applied, err := s.billing.Store().CreditWithdrawableOnce(wd.AccountID, wd.FeeMicroUSD,
-			store.LedgerRefund, "stripe_withdraw_fee:"+wd.ID)
-		if err != nil {
-			s.logger.Error("stripe connect webhook: fee refund failed", "error", err, "withdrawal_id", wd.ID)
-			return err
-		}
-		if applied {
-			wd.FeeRefunded = true
-		}
-	}
-	wd.Refunded = true
-	wd.Status = "failed"
-	wd.FailureReason = "transfer_reversed"
-	if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
-		// Credits are reference-idempotent — redelivery skips them and
-		// retries this persist.
-		s.logger.Error("stripe connect webhook: mark failed failed", "error", err)
+	// Recheck the current row while locking it for the whole refund. A
+	// payout.paid that won after the lookup must not receive an automatic
+	// refund, and a credit cannot become visible before the terminal state.
+	applied, err := s.billing.Store().RefundStripeWithdrawalAfterReversal(wd.ID, te.ID)
+	if err != nil {
+		s.logger.Error("stripe connect webhook: reversal settlement failed", "error", err, "withdrawal_id", wd.ID)
 		return err
+	}
+	if !applied {
+		s.logger.Warn("stripe connect webhook: reversal not applied — withdrawal changed concurrently, review current state",
+			"withdrawal_id", wd.ID, "transfer_id", te.ID)
 	}
 	return nil
 }

--- a/coordinator/api/stripe_reversal_race_test.go
+++ b/coordinator/api/stripe_reversal_race_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/billing"
+	"github.com/eigeninference/d-inference/coordinator/payments"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// paidDuringReversalStore makes payout.paid win after reversal reads the row.
+// Returning that old copy models the two independent webhook requests without
+// relying on scheduler timing.
+type paidDuringReversalStore struct {
+	*store.MemoryStore
+	t *testing.T
+}
+
+func (s *paidDuringReversalStore) GetStripeWithdrawalByTransferID(id string) (*store.StripeWithdrawal, error) {
+	wd, err := s.MemoryStore.GetStripeWithdrawalByTransferID(id)
+	if err == nil {
+		applied, markErr := s.MarkStripeWithdrawalPaid(wd.ID, wd.PayoutID, "")
+		if markErr != nil || !applied {
+			s.t.Fatalf("concurrent payout completion: applied=%v err=%v", applied, markErr)
+		}
+	}
+	return wd, err
+}
+
+func TestConnectWebhookReversalDoesNotRefundConcurrentlyPaidWithdrawal(t *testing.T) {
+	fakeStripe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer fakeStripe.Close()
+	srv, mem := stripePayoutsTestServer(t, false, fakeStripe)
+	st := &paidDuringReversalStore{MemoryStore: mem, t: t}
+	srv.SetBilling(billing.NewService(st, payments.NewLedger(st), srv.logger, billing.Config{
+		StripeSecretKey: "sk_test_fake", StripeConnectWebhookSecret: "whsec_test",
+		StripeConnectReturnURL: "https://app.test/billing", StripeConnectRefreshURL: "https://app.test/billing",
+		StripeConnectPlatformCountry: "US",
+	}))
+	user := readyUser(t, mem, "acct-reversal-race", "alice@example.com", false)
+	mkWithdrawal(t, mem, store.StripeWithdrawal{
+		ID: "wd-reversal-race", AccountID: user.AccountID, StripeAccountID: user.StripeAccountID,
+		AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "transferred", TransferID: "tr_reversal_race", PayoutID: "po_reversal_race",
+	})
+	before := mem.GetBalance(user.AccountID)
+	if response := deliverConnectWebhook(t, srv, transferReversedPayload("tr_reversal_race")); response.Code != http.StatusOK {
+		t.Fatalf("webhook returned %d: %s", response.Code, response.Body.String())
+	}
+	wd, err := mem.GetStripeWithdrawal("wd-reversal-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wd.Status != "paid" || wd.Refunded || mem.GetBalance(user.AccountID) != before {
+		t.Fatalf("concurrently paid withdrawal must stay unchanged for manual review: status=%s refunded=%v balance=%d want=%d", wd.Status, wd.Refunded, mem.GetBalance(user.AccountID), before)
+	}
+}

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -385,6 +385,12 @@ type BillingStore interface {
 	// was applied.
 	MarkStripeWithdrawalPaid(id, expectedPayoutID, sweepPayoutID string) (bool, error)
 
+	// RefundStripeWithdrawalAfterReversal atomically checks the current row,
+	// credits principal/fee once by their existing ledger references, and marks
+	// it failed/refunded. Paid or refunded rows and a changed transfer ID are
+	// no-ops. Refund credits and terminal state commit together or not at all.
+	RefundStripeWithdrawalAfterReversal(id, expectedTransferID string) (bool, error)
+
 	// ReopenStripeWithdrawalAfterPayoutFailure atomically reopens a
 	// withdrawal whose own payout failed: status back to "transferred",
 	// payout ID detached, failure reason recorded, FeeRefunded OR-ed in —

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -1392,16 +1392,20 @@ func (s *MemoryStore) CreditWithdrawable(accountID string, amountMicroUSD int64,
 func (s *MemoryStore) CreditWithdrawableOnce(accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.creditWithdrawableOnceLocked(accountID, amountMicroUSD, entryType, reference), nil
+}
+
+func (s *MemoryStore) creditWithdrawableOnceLocked(accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) bool {
 	for i := range s.ledgerEntries {
 		if s.ledgerEntries[i].AccountID == accountID &&
 			s.ledgerEntries[i].Type == entryType &&
 			s.ledgerEntries[i].Reference == reference {
-			return false, nil
+			return false
 		}
 	}
 	s.creditLocked(accountID, amountMicroUSD, entryType, reference, time.Now())
 	s.withdrawable[accountID] += amountMicroUSD
-	return true, nil
+	return true
 }
 
 // DebitWithdrawable subtracts micro-USD from both the total balance and

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -2525,6 +2525,15 @@ func (s *PostgresStore) CreditWithdrawableOnce(accountID string, amountMicroUSD 
 	}
 	defer tx.Rollback(ctx)
 
+	applied, err := creditWithdrawableOnceTx(ctx, tx, accountID, amountMicroUSD, entryType, reference)
+	if err != nil {
+		return false, err
+	}
+	return applied, tx.Commit(ctx)
+}
+
+// creditWithdrawableOnceTx applies one idempotent credit in the caller's transaction.
+func creditWithdrawableOnceTx(ctx context.Context, tx pgx.Tx, accountID string, amountMicroUSD int64, entryType LedgerEntryType, reference string) (bool, error) {
 	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, string(entryType)+":"+reference); err != nil {
 		return false, fmt.Errorf("store: advisory lock: %w", err)
 	}
@@ -2540,12 +2549,12 @@ func (s *PostgresStore) CreditWithdrawableOnce(accountID string, amountMicroUSD 
 		return false, fmt.Errorf("store: check ledger reference: %w", err)
 	}
 	if exists {
-		return false, tx.Commit(ctx)
+		return false, nil
 	}
 	if err := creditWithdrawableBalance(ctx, tx, accountID, amountMicroUSD, entryType, reference, time.Time{}); err != nil {
 		return false, err
 	}
-	return true, tx.Commit(ctx)
+	return true, nil
 }
 
 // Debit subtracts micro-USD from an account. Returns error if insufficient funds.

--- a/coordinator/store/stripe_reversal.go
+++ b/coordinator/store/stripe_reversal.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func (s *MemoryStore) RefundStripeWithdrawalAfterReversal(id, expectedTransferID string) (bool, error) {
+	if id == "" || expectedTransferID == "" {
+		return false, errors.New("stripe withdrawal and transfer ids are required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	wd, ok := s.stripeWithdrawalsByID[id]
+	if !ok {
+		return false, fmt.Errorf("stripe withdrawal %q: %w", id, ErrNotFound)
+	}
+	if wd.Status == "paid" || wd.Refunded || wd.TransferID != expectedTransferID {
+		return false, nil
+	}
+	for _, refund := range stripeReversalRefunds(wd) {
+		if refund.amount > 0 {
+			s.creditWithdrawableOnceLocked(wd.AccountID, refund.amount, LedgerRefund, refund.reference)
+		}
+	}
+	wd.Status, wd.Refunded = "failed", true
+	wd.FeeRefunded = wd.FeeRefunded || wd.FeeMicroUSD > 0
+	wd.FailureReason, wd.UpdatedAt = "transfer_reversed", time.Now()
+	return true, nil
+}
+
+func (s *PostgresStore) RefundStripeWithdrawalAfterReversal(id, expectedTransferID string) (bool, error) {
+	if id == "" || expectedTransferID == "" {
+		return false, errors.New("stripe withdrawal and transfer ids are required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("store: begin reversal: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	wd, err := scanStripeWithdrawal(tx.QueryRow(ctx,
+		`SELECT `+stripeWithdrawalSelectColumns+` FROM stripe_withdrawals WHERE id = $1 FOR UPDATE`, id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, fmt.Errorf("stripe withdrawal %q: %w", id, ErrNotFound)
+		}
+		return false, fmt.Errorf("store: lock reversal withdrawal: %w", err)
+	}
+	if wd.Status == "paid" || wd.Refunded || wd.TransferID != expectedTransferID {
+		return false, nil
+	}
+	refunds := stripeReversalRefunds(wd)
+	// Lock both references before touching the account balance. Otherwise an
+	// independent fee refund could hold its reference while waiting for our
+	// balance lock, as this transaction waits for that same fee reference.
+	for _, refund := range refunds {
+		if refund.amount > 0 {
+			if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, string(LedgerRefund)+":"+refund.reference); err != nil {
+				return false, fmt.Errorf("store: lock reversal refund: %w", err)
+			}
+		}
+	}
+	for _, refund := range refunds {
+		if refund.amount > 0 {
+			if _, err := creditWithdrawableOnceTx(ctx, tx, wd.AccountID, refund.amount, LedgerRefund, refund.reference); err != nil {
+				return false, err
+			}
+		}
+	}
+	if _, err := tx.Exec(ctx, `UPDATE stripe_withdrawals
+		SET status = 'failed', refunded = TRUE,
+		    fee_refunded = (fee_refunded OR fee_micro_usd > 0),
+		    failure_reason = 'transfer_reversed', updated_at = NOW()
+		WHERE id = $1`, id); err != nil {
+		return false, fmt.Errorf("store: persist reversal: %w", err)
+	}
+	return true, tx.Commit(ctx)
+}
+
+type stripeReversalRefund struct {
+	amount    int64
+	reference string
+}
+
+func stripeReversalRefunds(wd *StripeWithdrawal) [2]stripeReversalRefund {
+	return [2]stripeReversalRefund{
+		{wd.AmountMicroUSD - wd.FeeMicroUSD, "stripe_withdraw:" + wd.ID},
+		{wd.FeeMicroUSD, "stripe_withdraw_fee:" + wd.ID},
+	}
+}

--- a/coordinator/store/stripe_reversal_test.go
+++ b/coordinator/store/stripe_reversal_test.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func stripeReversalFixture(t *testing.T, s Store, id string) *StripeWithdrawal {
+	t.Helper()
+	wd := &StripeWithdrawal{ID: id, AccountID: "acct-" + id, StripeAccountID: "acct_stripe_" + id,
+		AmountMicroUSD: 5_000_000, FeeMicroUSD: 500_000, NetMicroUSD: 4_500_000,
+		Method: "instant", Status: "transferred", TransferID: "tr_" + id, PayoutID: "po_" + id}
+	if err := s.CreateUser(&User{AccountID: wd.AccountID, PrivyUserID: "did:privy:" + wd.AccountID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateStripeWithdrawal(wd); err != nil {
+		t.Fatal(err)
+	}
+	return wd
+}
+
+func TestStripeReversalSerializesWithPaidAndFeeRefund(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			for i := 0; i < 12; i++ {
+				wd := stripeReversalFixture(t, s, fmt.Sprintf("reversal-race-%d", i))
+				var wg sync.WaitGroup
+				start := make(chan struct{})
+				for _, operation := range []func() error{
+					func() error { _, err := s.MarkStripeWithdrawalPaid(wd.ID, wd.PayoutID, ""); return err },
+					func() error { _, err := s.RefundStripeWithdrawalAfterReversal(wd.ID, wd.TransferID); return err },
+				} {
+					wg.Add(1)
+					go func(fn func() error) {
+						defer wg.Done()
+						<-start
+						if err := fn(); err != nil {
+							t.Error(err)
+						}
+					}(operation)
+				}
+				close(start)
+				wg.Wait()
+				got, err := s.GetStripeWithdrawal(wd.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				balance, withdrawable := s.GetBalanceWithWithdrawable(wd.AccountID)
+				if got.Status == "paid" {
+					if got.Refunded || balance != 0 || withdrawable != 0 {
+						t.Fatalf("paid row was refunded: %+v balance=%d/%d", got, balance, withdrawable)
+					}
+				} else if got.Status != "failed" || !got.Refunded || balance != wd.AmountMicroUSD || withdrawable != balance {
+					t.Fatalf("reversal not atomic: %+v balance=%d/%d", got, balance, withdrawable)
+				}
+			}
+			wd := stripeReversalFixture(t, s, "reversal-fee-race")
+			var wg sync.WaitGroup
+			for i := 0; i < 12; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					if _, err := s.RefundStripeWithdrawalAfterReversal(wd.ID, wd.TransferID); err != nil {
+						t.Error(err)
+					}
+				}()
+				go func() {
+					defer wg.Done()
+					if _, err := s.CreditWithdrawableOnce(wd.AccountID, wd.FeeMicroUSD, LedgerRefund, "stripe_withdraw_fee:"+wd.ID); err != nil {
+						t.Error(err)
+					}
+				}()
+			}
+			wg.Wait()
+			got, err := s.GetStripeWithdrawal(wd.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if balance := s.GetBalance(wd.AccountID); balance != wd.AmountMicroUSD || !got.Refunded || !got.FeeRefunded {
+				t.Fatalf("fee/refund replay double-credited: balance=%d row=%+v", balance, got)
+			}
+		})
+	}
+}
+
+func TestPostgresStripeReversalRollsBackCreditsWhenRowWriteFails(t *testing.T) {
+	s := testPostgresStore(t)
+	wd := stripeReversalFixture(t, s, "reversal-rollback")
+	ctx := context.Background()
+	_, err := s.pool.Exec(ctx, `ALTER TABLE stripe_withdrawals ADD CONSTRAINT test_reversal_write CHECK (id <> 'reversal-rollback' OR NOT refunded)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.pool.Exec(ctx, `ALTER TABLE stripe_withdrawals DROP CONSTRAINT IF EXISTS test_reversal_write`)
+	})
+	if _, err := s.RefundStripeWithdrawalAfterReversal(wd.ID, wd.TransferID); err == nil {
+		t.Fatal("expected row constraint failure")
+	}
+	got, err := s.GetStripeWithdrawal(wd.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if balance := s.GetBalance(wd.AccountID); balance != 0 || got.Refunded || got.Status != "transferred" {
+		t.Fatalf("failed commit left partial refund: balance=%d row=%+v", balance, got)
+	}
+	if _, err := s.pool.Exec(ctx, `ALTER TABLE stripe_withdrawals DROP CONSTRAINT test_reversal_write`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := s.RefundStripeWithdrawalAfterReversal(wd.ID, wd.TransferID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if balance, withdrawable := s.GetBalanceWithWithdrawable(wd.AccountID); balance != wd.AmountMicroUSD || withdrawable != balance {
+		t.Fatalf("retry refund = %d/%d", balance, withdrawable)
+	}
+}

--- a/docs/architecture/billing.md
+++ b/docs/architecture/billing.md
@@ -1,6 +1,6 @@
 # Billing: pricing, reservations, ledger, and payouts
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-11 · commit `d15c4a08a`
 
 Darkbloom is prepaid. A consumer account holds an integer micro-USD balance;
 the coordinator reserves the worst-case cost of a request before dispatch,
@@ -101,7 +101,7 @@ and which balance column moves:
 | Entry type | Written by | Column(s) |
 |---|---|---|
 | `charge` | reservation, overage, and direct debits — `payments.Ledger.Charge` → `store.Debit` | both (withdrawable capped, invariant 8) |
-| `refund` | reservation refund, settlement refund, withdrawal refunds (`refundReservedBalance`, `handleCompleteAt`, `CreditWithdrawableOnce` in `coordinator/api/stripe_payouts_webhooks.go`) | `balance` for reservation/settlement refunds; both for withdrawal refunds |
+| `refund` | reservation refund, settlement refund, withdrawal refunds (`refundReservedBalance`, `handleCompleteAt`, `CreditWithdrawableOnce`, and `RefundStripeWithdrawalAfterReversal`) | `balance` for reservation/settlement refunds; both for withdrawal refunds |
 | `payout` | `provider_earnings` credit path (`CreditProviderAccount` ledger CTE) | both |
 | `platform_fee` | `handleCompleteAt` → `store.Credit("platform", …)` | `balance` |
 | `referral_reward` | `coordinator/billing/referral.go` `DistributeReferralReward` → `CreditWithdrawable` | both |
@@ -348,7 +348,13 @@ the design record is [`design/base-rewards.md`](../design/base-rewards.md).
     (`coordinator/api/stripe_withdraw.go` `creditRefundOnceWithRetry`;
     `coordinator/api/stripe_payouts_webhooks.go` `handlePayoutTerminal`,
     `handleTransferFailed`; `coordinator/store/postgres.go`
-    `CreditWithdrawableOnce`).
+    `CreditWithdrawableOnce`). Full transfer reversals call
+    `RefundStripeWithdrawalAfterReversal` in `coordinator/store/stripe_reversal.go`:
+    the current withdrawal is locked, a paid/refunded row or changed transfer ID
+    is rejected, and both reference-idempotent credits commit with the failed/
+    refunded state. A payout completion that wins the row lock receives no
+    automatic reversal refund. Both refund references are locked before balance
+    writes to avoid a lock cycle with an independent instant-fee refund.
 11. **A capped key never debits.** `checkKeySpendCap` runs before the `Debit`
     in `reserveInferenceBalance`, `topUpReservationForInlinedMedia`, and
     `reserveAdditionalForProvider`, so a rejected request leaves no ledger
@@ -437,7 +443,7 @@ help (`coordinator/api/stripe_payouts_webhooks.go`).
 | `account.updated` | `handleAccountUpdated` mirrors Stripe's view into `users.stripe_*` (`stripeStatusForAccount`: `pending`, `ready`, `restricted`, or `rejected`). Best-effort; the status endpoint re-syncs on page load. |
 | `payout.paid` | `handlePayoutTerminal(success=true)`: matched by payout id → `MarkStripeWithdrawalPaid` (no-op on an already `paid` row; a refunded/terminal row is logged for manual review, never overwritten). Unmatched → `reconcileUnmatchedPayout`: only automatic sweep payouts reconcile; they mark every `transferred` row of that connected account whose funds had become available (`stripeRecipientTransferDelay = 24 * time.Hour` for `recipient` accounts, immediate for `full`) and that has no in-flight payout of its own as `paid`. Amounts are ignored (FX-converted). |
 | `payout.failed`, `payout.canceled` | `handlePayoutTerminal(success=false)`: refund the instant fee via `CreditWithdrawableOnce(stripe_withdraw_fee:<id>)`, detach the payout id, reopen the row as `transferred` so the sweep retries. A refunded+paid row is logged for manual review. |
-| `transfer.reversed` | `handleTransferFailed`: refund the net principal (`stripe_withdraw:<id>`) and the fee (`stripe_withdraw_fee:<id>`) once each via `CreditWithdrawableOnce`, mark the row `failed`. |
+| `transfer.reversed` | `handleTransferFailed`: full reversals call `RefundStripeWithdrawalAfterReversal` to check the current row, refund net principal (`stripe_withdraw:<id>`) and fee (`stripe_withdraw_fee:<id>`) once, and mark it `failed`/refunded in one transaction. Paid rows remain for manual review; partial reversals do not refund automatically. |
 | anything else | acknowledged, ignored |
 
 ### Settlement anomalies
@@ -488,7 +494,7 @@ Names are written without the Datadog namespace prefix, which is owned by [telem
 | Settlement | `coordinator/api/provider.go` (`handleCompleteAt`); `coordinator/api/consumer.go` (`refundReservedBalance`, `refundProviderExtra`); `coordinator/api/settlement.go` (`settlementHolder`, `holdForSettlement`, `defaultTerminalSettleGrace`); `coordinator/registry/pending_request.go` (`PendingRequest.FinalizeReservation`, `MarkReservationFinalized`); `coordinator/payments/payments.go` (`Ledger.Charge`, `Ledger.RecordUsage`) | `GET /v1/payments/balance`, `GET /v1/payments/usage` |
 | Ledger and balances | `coordinator/store/interface.go` (`LedgerEntryType`, `RewardLedgerTypes`); `coordinator/store/postgres.go` (`balances`, `ledger_entries`, `provider_earnings`, `creditTx`, `creditWithdrawableTx`, `CreditWithdrawableOnce`, `Debit`, `CreditProviderAccount`, `idx_provider_earnings_job`) | `GET /v1/provider/earnings`, `GET /v1/provider/account-earnings`, `GET /v1/me/summary` |
 | Deposits | `coordinator/billing/stripe.go` (`CreateCheckoutSession`, `VerifyWebhookSignature`, `ParseCheckoutSession`); `coordinator/billing/billing.go` (`CreditDeposit`, `IsExternalIDProcessed`); `coordinator/api/billing_handlers.go` (`handleStripeCreateSession`, `handleStripeWebhook`, `handleStripeSessionStatus`, `handleWalletBalance`, `handleBillingMethods`) | `POST /v1/billing/stripe/create-session`, `POST /v1/billing/stripe/webhook`, `GET /v1/billing/stripe/session`, `GET /v1/billing/wallet/balance`, `GET /v1/billing/methods` |
-| Payouts | `coordinator/billing/stripe_connect.go` (`MinWithdrawMicroUSD`, `InstantFeeBps`, `InstantFeeMinMicroUSD`, `FeeForMethodMicroUSD`); `coordinator/billing/stripe_regions.go` (`RequiredServiceAgreement`); `coordinator/api/stripe_payouts.go` (`handleStripeOnboard`, `handleStripeStatus`, `handleStripeWithdrawals`, `handleStripeDashboardLink`, `handleStripeUnlink`, `microUSDToCents`); `coordinator/api/stripe_withdraw.go` (`handleStripeWithdraw`, `creditRefundOnceWithRetry`); `coordinator/api/stripe_payouts_webhooks.go` (`handleStripeConnectWebhook`, `stripeRecipientTransferDelay`); `coordinator/api/stripe_reconcile.go` (`StartStripePayoutReconciler`); `coordinator/store/postgres.go` (`CreateStripeWithdrawalWithDebit`) | `POST /v1/billing/stripe/onboard`, `GET /v1/billing/stripe/status`, `POST /v1/billing/withdraw/stripe`, `GET /v1/billing/stripe/withdrawals`, `POST /v1/billing/stripe/dashboard`, `DELETE /v1/billing/stripe/account`, `POST /v1/billing/stripe/connect/webhook` |
+| Payouts | `coordinator/billing/stripe_connect.go` (`MinWithdrawMicroUSD`, `InstantFeeBps`, `InstantFeeMinMicroUSD`, `FeeForMethodMicroUSD`); `coordinator/billing/stripe_regions.go` (`RequiredServiceAgreement`); `coordinator/api/stripe_payouts.go` (`handleStripeOnboard`, `handleStripeStatus`, `handleStripeWithdrawals`, `handleStripeDashboardLink`, `handleStripeUnlink`, `microUSDToCents`); `coordinator/api/stripe_withdraw.go` (`handleStripeWithdraw`, `creditRefundOnceWithRetry`); `coordinator/api/stripe_payouts_webhooks.go` (`handleStripeConnectWebhook`, `stripeRecipientTransferDelay`); `coordinator/api/stripe_reconcile.go` (`StartStripePayoutReconciler`); `coordinator/store/postgres.go` (`CreateStripeWithdrawalWithDebit`); `coordinator/store/stripe_reversal.go` (`RefundStripeWithdrawalAfterReversal`) | `POST /v1/billing/stripe/onboard`, `GET /v1/billing/stripe/status`, `POST /v1/billing/withdraw/stripe`, `GET /v1/billing/stripe/withdrawals`, `POST /v1/billing/stripe/dashboard`, `DELETE /v1/billing/stripe/account`, `POST /v1/billing/stripe/connect/webhook` |
 | Referral | `coordinator/billing/referral.go` (`ReferralService`, `Register`, `Apply`, `DistributeReferralReward`, `validateReferralCode`); `coordinator/billing/config.go` (`ReferralSharePercent`) | `POST /v1/referral/register`, `POST /v1/referral/apply`, `GET /v1/referral/stats`, `GET /v1/referral/info` |
 | Invite codes and admin credits | `coordinator/api/invite_handlers.go` (`handleAdminCreateInviteCode`, `handleAdminListInviteCodes`, `handleAdminDeactivateInviteCode`, `handleRedeemInviteCode`, `requireAdminKey`); `coordinator/store/postgres.go` (`RedeemInviteCode`); `coordinator/api/billing_handlers.go` (`handleAdminCredit`, `handleAdminReward`) | `POST /v1/admin/invite-codes`, `GET /v1/admin/invite-codes`, `DELETE /v1/admin/invite-codes`, `POST /v1/invite/redeem`, `POST /v1/admin/credit`, `POST /v1/admin/reward` |
 | Roles and fee overrides | `coordinator/api/billing_handlers.go` (`handleAdminSetUserRole`, `handleAdminSetUserPlatformFee`); `coordinator/store/postgres.go` (`SetUserRole`, `SetUserPlatformFeePercent`) | `PUT /v1/admin/users/role`, `PUT /v1/admin/users/platform-fee` |


### PR DESCRIPTION
A `transfer.reversed` webhook could read a transferred withdrawal, race with `payout.paid`, and then refund that now-paid withdrawal from its stale copy. The reproduced interleaving changes a paid $5 withdrawal to failed/refunded and credits $5 despite the existing manual-review policy for paid rows.

Move full reversal settlement into `RefundStripeWithdrawalAfterReversal`: lock the current withdrawal, reject paid/refunded rows or a changed transfer ID, credit net principal and fee using the existing idempotent ledger references, then commit the failed/refunded state with those credits. Memory and PostgreSQL stores share the same boundary. PostgreSQL acquires both refund-reference locks before any balance write, avoiding a lock cycle with an independent instant-fee refund. Partial reversals remain manual; webhook failures still request redelivery.

Before:
```mermaid
flowchart TD
  R[Transfer reversed] --> C[Read copied withdrawal]
  C --> P[Concurrent payout.paid marks row paid]
  P --> N[Credit principal and fee separately]
  N --> U[Unconditional stale row update]
  U --> B[Paid withdrawal becomes refunded]
```

After:
```mermaid
flowchart TD
  R[Transfer reversed] --> S[RefundStripeWithdrawalAfterReversal]
  S --> L[Lock current withdrawal]
  L --> G{Paid, refunded, or transfer changed?}
  G -->|Yes| K[Keep current state and balance]
  G -->|No| A[Lock refund references, deduplicate credits]
  A --> T[Commit credits and failed/refunded row together]
  A -->|Any failure| X[Roll back and request webhook redelivery]
  P[Concurrent payout.paid] --> L
```

Validation:

- Deterministic stale-copy API regression fails on master and passes after the fix.
- Stripe withdrawal/payout/webhook API race tests pass (3.515s).
- Full store race suite passes against isolated PostgreSQL 16 (21.863s), including paid-versus-refund concurrency, concurrent fee refunds, and an actual row-constraint failure proving credit rollback followed by exactly-once retry. The isolated cluster was stopped afterward.
- Documentation checks pass for all 278 pages.
- Full `GOTOOLCHAIN=go1.25.0 go test ./coordinator/...` passes (API package 193.612s).
- Independent review found no blocking issue in this focused transaction change.

The existing persist-failure test now injects failure at the atomic settlement operation and expects the pre-refund balance; redelivery still completes exactly one refund. The new database test verifies actual rollback instead of relying on that wrapper. No schema, dependency, fee policy, external Stripe operation, or deployment change.
