### PR TITLE
Retain and reap testbed commands before lifecycle cleanup

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `d353f8cb0`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -31,6 +31,8 @@ Go/Swift fixture and focused checks are described in [test.md](test.md) and
 
 - **macOS on Apple Silicon** for anything under `provider-swift/` (MLX + Metal).
   The coordinator, sidecar, e2e harness, and UIs build on macOS or Linux.
+  The [local process cleanup fixtures](test.md#local-process-cleanup-fixtures)
+  need only Go, Python and harmless child stubs; they do not need a provider build or database.
 - **Xcode Command Line Tools + `cmake`** (`brew install cmake`) — the metallib
   helper compiles MLX's Metal kernels with cmake.
 - **Git submodules** checked out: `libs/mlx-swift`, `libs/mlx-swift-lm`,

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `d353f8cb0`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -110,6 +110,26 @@ Store tests that need Postgres skip themselves when `DATABASE_URL` is unset
 `postgres:16` service with user/password/db `testbed`. The pre-push hook runs
 `go test $(go list ./... | grep -v /internal/api)` from `coordinator/` to skip
 the slow WebSocket integration tests; run the full set before merging.
+
+#### Local process cleanup fixtures
+
+The testbed's local-provider and native-Postgres lifecycle checks use harmless
+child executables and PATH stubs. They verify output draining before provider
+completion, retained child ownership, graceful shutdown and forced termination,
+temporary-data cleanup after initialization/readiness failures, and rejected
+helper-stream cleanup before waiting for its process. They start
+no Swift provider, database, Docker daemon or remote connection.
+
+```bash
+go test -race ./e2e/testbed ./e2e/testbed/deps -short -run 'TestLocalProviderWait|TestNativePostgres|TestPostgres|TestOwnedMalformedStream' -count=1
+```
+
+`e2e/testbed/provider_local.go` waits through `exec.Cmd.Wait` so command output
+and context cleanup finish before completion. `e2e/testbed/deps/postgres.go`
+retains its native child command, waits for it to be reaped and only then removes
+its owned data directory. Unconfirmed termination retains that directory for
+inspection. The [owned-host helper](../../e2e/testbed/OWNED_HOSTS.md) keeps its
+separate process-group, control-lease and receipt contract.
 
 #### Provider config cleanup
 

--- a/e2e/testbed/OWNED_HOSTS.md
+++ b/e2e/testbed/OWNED_HOSTS.md
@@ -78,7 +78,9 @@ and writes `terminal.json` with the group identity, signals, exit code, cleanup
 status, and failure. A cleanup error retains an incomplete receipt. The Go
 adapter requires terminal and host-cleanup evidence; it reports an unconfirmed
 shutdown as an error. Failed startup and fixture assertions still run cleanup and
-retain cleanup errors. Runtime, state, logs, cache, and terminal evidence remain
+retain cleanup errors. A malformed helper event closes both control pipes before
+waiting for the helper, so a rejected output stream cannot block teardown on a
+full pipe. Runtime, state, logs, cache, and terminal evidence remain
 under the owned root; the private fixture token is removed after confirmed
 shutdown.
 

--- a/e2e/testbed/deps/postgres.go
+++ b/e2e/testbed/deps/postgres.go
@@ -22,6 +22,8 @@ type PostgresLifecycle struct {
 
 	dataDir string
 	native  bool
+	command *exec.Cmd
+	done    chan struct{}
 }
 
 func NewPostgresLifecycle(logger *slog.Logger, port int) *PostgresLifecycle {
@@ -38,14 +40,22 @@ func (p *PostgresLifecycle) Start(ctx context.Context) error {
 	return p.startNative(ctx)
 }
 
+func (p *PostgresLifecycle) resolvePort() error {
+	if p.Port != 0 {
+		return nil
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("testbed/deps: find free port: %w", err)
+	}
+	defer listener.Close()
+	p.Port = listener.Addr().(*net.TCPAddr).Port
+	return nil
+}
+
 func (p *PostgresLifecycle) startDocker(ctx context.Context) error {
-	if p.Port == 0 {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			return fmt.Errorf("testbed/deps: find free port: %w", err)
-		}
-		p.Port = listener.Addr().(*net.TCPAddr).Port
-		listener.Close()
+	if err := p.resolvePort(); err != nil {
+		return err
 	}
 
 	p.DatabaseURL = fmt.Sprintf("postgres://testbed:testbed@127.0.0.1:%d/testbed?sslmode=disable", p.Port)
@@ -85,19 +95,21 @@ func (p *PostgresLifecycle) startNative(ctx context.Context) error {
 		return fmt.Errorf("testbed/deps: neither docker nor postgres found in PATH (need one for ephemeral Postgres)")
 	}
 
-	if p.Port == 0 {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			return fmt.Errorf("testbed/deps: find free port: %w", err)
-		}
-		p.Port = listener.Addr().(*net.TCPAddr).Port
-		listener.Close()
+	if err := p.resolvePort(); err != nil {
+		return err
 	}
 
-	p.dataDir = filepath.Join(os.TempDir(), fmt.Sprintf("testbed-pg-%d-%04d", time.Now().UnixMilli(), rand.Intn(10000)))
-	if err := os.MkdirAll(p.dataDir, 0755); err != nil {
+	p.dataDir, err = os.MkdirTemp("", "testbed-pg-")
+	if err != nil {
 		return fmt.Errorf("testbed/deps: create data dir: %w", err)
 	}
+	p.native = true
+	started := false
+	defer func() {
+		if !started {
+			p.stopNative()
+		}
+	}()
 
 	initdb, _ := exec.LookPath("initdb")
 	if initdb == "" {
@@ -124,10 +136,14 @@ func (p *PostgresLifecycle) startNative(ctx context.Context) error {
 	}
 
 	p.ContainerID = fmt.Sprintf("native:%d", cmd.Process.Pid)
-	p.native = true
+	p.command = cmd
+	p.done = make(chan struct{})
+	go func(command *exec.Cmd, done chan struct{}) {
+		defer close(done)
+		_ = command.Wait()
+	}(cmd, p.done)
 
 	if err := p.waitForReadyNative(ctx); err != nil {
-		p.Stop()
 		return fmt.Errorf("testbed/deps: postgres readiness: %w", err)
 	}
 
@@ -145,24 +161,17 @@ func (p *PostgresLifecycle) startNative(ctx context.Context) error {
 		p.Logger.Warn("createdb failed (may already exist)", "error", string(out))
 	}
 
+	started = true
 	p.Logger.Info("ephemeral postgres started (native)", "port", p.Port, "dataDir", p.dataDir)
 	return nil
 }
 
 func (p *PostgresLifecycle) waitForReadyDocker(ctx context.Context) error {
-	for i := 0; i < 30; i++ {
+	return waitForPostgres(ctx, func() bool {
 		cmd := exec.CommandContext(ctx, "docker", "exec", p.ContainerID,
 			"pg_isready", "-U", "testbed", "-d", "testbed")
-		if err := cmd.Run(); err == nil && p.hostDatabaseReady(ctx) {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(500 * time.Millisecond):
-		}
-	}
-	return fmt.Errorf("testbed/deps: postgres did not become ready within 15s")
+		return cmd.Run() == nil && p.hostDatabaseReady(ctx)
+	})
 }
 
 func (p *PostgresLifecycle) hostDatabaseReady(ctx context.Context) bool {
@@ -177,13 +186,16 @@ func (p *PostgresLifecycle) hostDatabaseReady(ctx context.Context) bool {
 }
 
 func (p *PostgresLifecycle) waitForReadyNative(ctx context.Context) error {
-	for i := 0; i < 30; i++ {
+	return waitForPostgres(ctx, func() bool {
 		cmd := exec.CommandContext(ctx, "pg_isready",
-			"-h", "127.0.0.1",
-			"-p", fmt.Sprintf("%d", p.Port),
-			"-U", "testbed",
-		)
-		if err := cmd.Run(); err == nil {
+			"-h", "127.0.0.1", "-p", fmt.Sprintf("%d", p.Port), "-U", "testbed")
+		return cmd.Run() == nil
+	})
+}
+
+func waitForPostgres(ctx context.Context, ready func() bool) error {
+	for i := 0; i < 30; i++ {
+		if ready() {
 			return nil
 		}
 		select {
@@ -217,25 +229,30 @@ func (p *PostgresLifecycle) stopDocker() {
 }
 
 func (p *PostgresLifecycle) stopNative() {
-	if p.ContainerID == "" {
-		return
-	}
-	var pid int
-	fmt.Sscanf(p.ContainerID, "native:%d", &pid)
-	if pid > 0 {
-		proc, err := os.FindProcess(pid)
-		if err == nil {
-			proc.Signal(os.Interrupt)
-			time.Sleep(500 * time.Millisecond)
-			proc.Kill()
+	if p.command != nil {
+		// Retain the actual child handle: a display PID must never authorize a kill.
+		_ = p.command.Process.Signal(os.Interrupt)
+		select {
+		case <-p.done:
+		case <-time.After(500 * time.Millisecond):
+			_ = p.command.Process.Kill()
+			select {
+			case <-p.done:
+			case <-time.After(5 * time.Second):
+				p.Logger.Error("postgres termination unconfirmed; retaining owned data", "dataDir", p.dataDir)
+				return
+			}
 		}
+		p.command, p.done = nil, nil
 	}
 	if p.dataDir != "" {
-		os.RemoveAll(p.dataDir)
+		if err := os.RemoveAll(p.dataDir); err != nil {
+			p.Logger.Error("failed to remove postgres data", "dataDir", p.dataDir, "error", err)
+			return
+		}
+		p.Logger.Info("ephemeral postgres removed (native)", "dataDir", p.dataDir)
 	}
-	p.Logger.Info("ephemeral postgres removed (native)", "dataDir", p.dataDir)
-	p.ContainerID = ""
-	p.dataDir = ""
+	p.ContainerID, p.dataDir = "", ""
 }
 
 func (p *PostgresLifecycle) SetEnv() {

--- a/e2e/testbed/deps/postgres_test.go
+++ b/e2e/testbed/deps/postgres_test.go
@@ -1,0 +1,194 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The PATH commands below only re-execute this test binary. No database,
+// Docker daemon, network connection or production executable is started.
+func TestPostgresHelperProcess(t *testing.T) {
+	if os.Getenv("TESTBED_PG_HELPER") != "1" {
+		return
+	}
+	var operation string
+	for i, arg := range os.Args {
+		if arg == "--" && i+1 < len(os.Args) {
+			operation = os.Args[i+1]
+			break
+		}
+	}
+	switch operation {
+	case "initdb":
+		if os.Getenv("TESTBED_PG_INIT_FAIL") == "1" {
+			os.Exit(1)
+		}
+	case "postgres":
+		stop := make(chan os.Signal, 1)
+		ignoreInterrupt := os.Getenv("TESTBED_PG_IGNORE_INTERRUPT") == "1"
+		if ignoreInterrupt {
+			signal.Ignore(os.Interrupt)
+		} else {
+			signal.Notify(stop, os.Interrupt)
+		}
+		if err := os.WriteFile(os.Getenv("TESTBED_PG_READY"), []byte("ready"), 0o600); err != nil {
+			os.Exit(2)
+		}
+		if ignoreInterrupt {
+			for {
+				time.Sleep(time.Hour)
+			}
+		}
+		<-stop
+	case "pg_isready":
+		if os.Getenv("TESTBED_PG_READINESS_FAIL") == "1" {
+			os.Exit(1)
+		}
+		if _, err := os.Stat(os.Getenv("TESTBED_PG_READY")); err != nil {
+			os.Exit(1)
+		}
+	case "createdb":
+	default:
+		os.Exit(3)
+	}
+	os.Exit(0)
+}
+
+func postgresFixture(t *testing.T) *PostgresLifecycle {
+	t.Helper()
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := t.TempDir()
+	for _, command := range []string{"postgres", "initdb", "pg_isready", "createdb"} {
+		body := "#!/bin/sh\nexec \"$TESTBED_PG_BINARY\" -test.run=^TestPostgresHelperProcess$ -- " + command + " \"$@\"\n"
+		if err := os.WriteFile(filepath.Join(bin, command), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin)
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("TESTBED_PG_BINARY", binary)
+	t.Setenv("TESTBED_PG_HELPER", "1")
+	// Do not let the race runtime's exit delay impersonate a stuck database.
+	t.Setenv("GORACE", "atexit_sleep_ms=0")
+	t.Setenv("TESTBED_PG_READY", filepath.Join(t.TempDir(), "ready"))
+	return NewPostgresLifecycle(slog.New(slog.NewTextHandler(io.Discard, nil)), 55432)
+}
+
+func TestNativePostgresRetainsAndReapsOnlyItsChild(t *testing.T) {
+	p := postgresFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	defer p.Stop()
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	command, done, dataDir := p.command, p.done, p.dataDir
+	if command == nil {
+		t.Fatal("started database has no owned command")
+	}
+	// This public display field must not become the source of signal authority.
+	p.ContainerID = "invalid-display-only-identity"
+	p.Stop()
+	select {
+	case <-done:
+	default:
+		t.Fatal("Stop returned without reaping its native child")
+	}
+	if command.ProcessState == nil || !command.ProcessState.Exited() {
+		t.Fatal("native command did not exit gracefully and reap")
+	}
+	if _, err := os.Stat(dataDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("owned data remained after confirmed exit: %v", err)
+	}
+	if p.command != nil || p.ContainerID != "" || p.dataDir != "" {
+		t.Fatal("stopped lifecycle retained live ownership fields")
+	}
+	p.Stop() // Idempotent after confirmed cleanup.
+}
+
+func TestNativePostgresEscalatesForAnUnresponsiveOwnedChild(t *testing.T) {
+	p := postgresFixture(t)
+	t.Setenv("TESTBED_PG_IGNORE_INTERRUPT", "1")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	defer p.Stop()
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	command := p.command
+	p.Stop()
+	if command.ProcessState == nil {
+		t.Fatal("child was not reaped")
+	}
+	status := command.ProcessState.Sys().(syscall.WaitStatus)
+	if !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		t.Fatalf("unresponsive child was not killed: %v", status)
+	}
+}
+
+func TestNativePostgresReadinessFailureCleansStartedChild(t *testing.T) {
+	p := postgresFixture(t)
+	t.Setenv("TESTBED_PG_READINESS_FAIL", "1")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	defer p.Stop()
+	err := p.Start(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "postgres readiness") {
+		t.Fatalf("expected post-launch readiness failure, got %v", err)
+	}
+	if p.command != nil || p.dataDir != "" || p.ContainerID != "" {
+		t.Fatal("failed readiness retained owned command or data")
+	}
+}
+
+func TestNativePostgresInitializationFailureRemovesOwnedDirectory(t *testing.T) {
+	p := postgresFixture(t)
+	t.Setenv("TESTBED_PG_INIT_FAIL", "1")
+	if err := p.Start(context.Background()); err == nil {
+		t.Fatal("failed initdb unexpectedly started")
+	}
+	if p.dataDir != "" || p.command != nil {
+		t.Fatal("failed initialization retained owned state")
+	}
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("failed initialization leaked temporary data: %v %v", entries, err)
+	}
+}
+
+func TestPostgresReadinessCancellationAndSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	probes := 0
+	if err := waitForPostgres(ctx, func() bool { probes++; return false }); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled readiness returned %v", err)
+	}
+	if probes != 1 {
+		t.Fatalf("canceled readiness probed %d times", probes)
+	}
+	if err := waitForPostgres(context.Background(), func() bool { return true }); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNativePostgresStopWithoutStartedCommandNeverSignalsPID(t *testing.T) {
+	// A malformed/external display identifier is not an owned native child.
+	p := NewPostgresLifecycle(slog.New(slog.NewTextHandler(io.Discard, nil)), 0)
+	p.native, p.ContainerID = true, "native:invalid"
+	p.Stop()
+	if p.ContainerID != "" {
+		t.Fatal("empty native lifecycle was not reset")
+	}
+}

--- a/e2e/testbed/provider_local.go
+++ b/e2e/testbed/provider_local.go
@@ -90,13 +90,13 @@ func (p *Provider) Start(ctx context.Context, coordinatorURL string, cfg Provide
 
 	go func(done chan struct{}) {
 		defer close(done)
-		state, err := cmd.Process.Wait()
-		if err != nil {
+		err := cmd.Wait()
+		if err != nil && cmd.ProcessState == nil {
 			p.Logger.Warn("provider process wait failed", "error", err)
 			return
 		}
-		if state != nil && state.ExitCode() >= 0 {
-			p.Logger.Warn("provider process exited", "exit_code", state.ExitCode())
+		if cmd.ProcessState != nil && cmd.ProcessState.ExitCode() >= 0 {
+			p.Logger.Warn("provider process exited", "exit_code", cmd.ProcessState.ExitCode())
 		}
 	}(p.done)
 

--- a/e2e/testbed/provider_local_lifecycle_test.go
+++ b/e2e/testbed/provider_local_lifecycle_test.go
@@ -1,0 +1,67 @@
+package testbed
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Block only the child's output, so a completed provider must also finish the
+// exec.Cmd copy goroutine before Running reports false or cleanup can proceed.
+type blockedProviderOutput struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (h *blockedProviderOutput) Enabled(context.Context, slog.Level) bool { return true }
+func (h *blockedProviderOutput) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *blockedProviderOutput) WithGroup(string) slog.Handler            { return h }
+func (h *blockedProviderOutput) Handle(_ context.Context, record slog.Record) error {
+	if record.Message == "provider:stdout" {
+		h.once.Do(func() { close(h.entered) })
+		<-h.release
+	}
+	return nil
+}
+
+func TestLocalProviderWaitIncludesOutputDrain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	binary := filepath.Join(t.TempDir(), "fixture-provider")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf 'fixture output\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	handler := &blockedProviderOutput{entered: make(chan struct{}), release: make(chan struct{})}
+	provider := &Provider{BinaryPath: binary, Logger: slog.New(handler), StateDir: t.TempDir()}
+	var release sync.Once
+	defer func() {
+		release.Do(func() { close(handler.release) })
+		provider.Stop()
+	}()
+	if err := provider.Start(context.Background(), "http://127.0.0.1:1", ProviderConfig{}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handler.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fixture output never reached the logger")
+	}
+	select {
+	case <-provider.done:
+		t.Fatal("provider completion skipped command output drain")
+	case <-time.After(100 * time.Millisecond):
+	}
+	release.Do(func() { close(handler.release) })
+	select {
+	case <-provider.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider did not finish after output drained")
+	}
+	if provider.Running() {
+		t.Fatal("completed provider still reported running")
+	}
+}

--- a/e2e/testbed/provider_owned.go
+++ b/e2e/testbed/provider_owned.go
@@ -222,6 +222,9 @@ func startOwnedProvider(ctx context.Context, target ProviderTarget, spec Provide
 		}
 		if scanErr != nil {
 			_ = o.stdin.Close()
+			// Stop reading a rejected protocol stream without leaving its writer
+			// blocked on a full pipe while Wait waits for that same helper.
+			_ = stdout.Close()
 		}
 		waitErr := command.Wait()
 		o.mu.Lock()

--- a/e2e/testbed/provider_start_ack_test.go
+++ b/e2e/testbed/provider_start_ack_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -115,4 +116,25 @@ send({'event':'cleanup','observation':observation})
 	require.NotEqual(t, row.Terminal.PID, row.ProviderPID)
 	require.NotEmpty(t, row.StartupIdentityError)
 	require.Contains(t, row.ControlError, "contradictory provider startup identity")
+}
+
+func TestOwnedMalformedStreamClosesReaderBeforeWaitingForHelper(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	script := `import sys,json
+json.loads(sys.stdin.readline())
+print('{"event":"unknown"}',flush=True)
+for _ in range(2048):
+ print('x'*4096,flush=True)
+`
+	owner, err := startOwnedProvider(ctx, targetFixture(t), ProviderStartSpec{}, []byte("fixture-token"), "nonce", "http://127.0.0.1:1", func(string, ...string) *exec.Cmd {
+		// The deadline bounds the deliberately malformed local fixture even
+		// on the prior implementation, which left its stdout writer blocked.
+		return exec.CommandContext(ctx, "python3", "-u", "-c", script)
+	})
+	require.ErrorContains(t, err, "unknown owned helper event")
+	require.NoError(t, ctx.Err(), "protocol rejection waited for the helper deadline")
+	require.NotNil(t, owner)
+	require.False(t, owner.running())
+	require.ErrorContains(t, owner.stop(), "unknown owned helper event")
 }


### PR DESCRIPTION
Local testbed completion could race outstanding provider log output because it waited directly on `os.Process`, and native Postgres reconstructed a display PID at shutdown without reaping the command it started. A malformed owned-helper event could also leave the helper blocked writing stdout while its controller waited for exit.

The lifecycle now waits through `exec.Cmd`, retains the native database's actual child handle, and closes a rejected helper stream before waiting. Native startup creates an exclusive temporary directory and cleans it on initialization/readiness failures; stop waits for graceful exit or escalates to kill, then removes owned data only after reaping. An unconfirmed termination retains the data and ownership record. Docker/native setup share the duplicate free-port and readiness loops, retaining their distinct probes and existing cadence.

Before:
```mermaid
flowchart TD
  P[Local provider child] --> PW[Process.Wait]
  PW --> D[Completion may precede log drain]
  N[Native Postgres] --> ID[Display PID string]
  ID --> K[FindProcess and signals without Cmd.Wait]
  K --> RM[Remove data without reaping]
  H[Malformed helper event] --> S[Stop scanning stdout]
  S --> W[Wait while helper can block on full stdout pipe]
  A[Docker and native startup] --> DUP[Separate free-port and readiness loops]
```

After:
```mermaid
flowchart TD
  P[Local provider child] --> PW[Cmd.Wait drains output and context cleanup]
  PW --> D[Confirmed command completion]
  N[Native Postgres] --> O[Retained command and done channel]
  O --> K[Interrupt then bounded kill fallback]
  K --> C{Reaped?}
  C -->|yes| RM[Remove only owned temporary data]
  C -->|unconfirmed| KEEP[Retain owned data and command for recovery]
  H[Malformed helper event] --> CL[Close control and rejected stdout pipes]
  CL --> W[Wait without blocking helper output]
  A[Docker and native startup] --> SH[Shared port allocation and readiness loop]
  SH --> PR[Existing backend-specific readiness probe]
```

Validation: scoped provider/owned-host/config/KV/Postgres Go suites pass with `-race`; all native lifecycle fixtures use harmless copies of the Go test binary behind PATH stubs, and all 18 Python owned-host fixtures pass. The new provider output-drain and malformed-stream regressions both fail on master and pass on this source. Additional fixtures cover graceful/forced native child retirement, init/readiness failure cleanup, display-ID independence and cancellation. Formatting, diff checks and docs lint pass.

No Swift, model, GPU, actual database/Docker service, signing operation, production endpoint or SSH session was executed. Existing model/cache/measurement/config/environment policy and the owned-host lease/process-group/receipt protocol are preserved. This PR changes test infrastructure; it supplies no new model-performance or real two-host release evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763307&installation_model_id=21733&pr_number=927&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F927&signature=7ec16306bdbf6da590820a820c6c7ae27a011e35573c76a72809df5cb1bffb6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->