### PR TITLE
Exclude private providers from public model datacenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ coordinator and console changes require their own deployments.
 - **Incoming request accounting** — Add an unsampled request-outcome ledger and bounded admin inspection with explicit coverage and completion evidence. Record recovered HTTP errors and parsed streaming mode, and distinguish completed, incomplete and error response terminals after successful writes while preserving contradictory evidence and earlier content progress.
 - **Partial network geography** — Keep the stats overview available when request-location or route analytics time out. Refresh geography independently, expose unavailable sections, preserve valid empty maps and restore geography after recovery.
 
+## Unreleased — public model datacenters
+
+- Exclude private-only self-route providers from public model datacenter countries. Model counts and country metadata now share the same provider eligibility check.
+
 ## Unreleased — stats request-flow refresh
 
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.

--- a/coordinator/registry/model_country_codes_test.go
+++ b/coordinator/registry/model_country_codes_test.go
@@ -32,3 +32,33 @@ func TestModelCountryCodesOnlyEligibleProviders(t *testing.T) {
 		t.Fatalf("country codes = %v, want [US] (the DE provider is not routing-eligible)", got)
 	}
 }
+
+func TestModelCountryCodesExcludesPrivateOnlyProviders(t *testing.T) {
+	reg := New(testLogger())
+	const model = "mlx-community/Qwen3.5-9B-Instruct-4bit"
+	for _, row := range []struct {
+		id, country string
+		private     bool
+	}{
+		{"public", "us", false},
+		{"private", "IN", true},
+	} {
+		p := reg.Register(row.id, nil, testRegisterMessage())
+		testMakeTextRoutable(p)
+		p.mu.Lock()
+		p.PrivateOnly = row.private
+		p.Location = &store.ProviderLocation{CountryCode: row.country}
+		p.mu.Unlock()
+	}
+	if codes := reg.ModelCountryCodes(model); len(codes) != 1 || codes[0] != "US" {
+		t.Fatalf("public datacenters include a private self-route provider: %v", codes)
+	}
+	// When every eligible provider becomes private, no country is advertised.
+	p := reg.GetProvider("public")
+	p.mu.Lock()
+	p.PrivateOnly = true
+	p.mu.Unlock()
+	if codes := reg.ModelCountryCodes(model); len(codes) != 0 {
+		t.Fatalf("private-only model has public datacenters: %v", codes)
+	}
+}

--- a/coordinator/registry/model_views.go
+++ b/coordinator/registry/model_views.go
@@ -26,6 +26,15 @@ type AggregateModel struct {
 	Attestation       *AttestationSummary `json:"attestation,omitempty"`
 }
 
+// publicModelProviderEligibleLocked is the provider-level gate shared by public
+// model counts and datacenter metadata. Private-only nodes serve their owners
+// and must not contribute to either public surface. Caller holds r.mu and p.mu.
+func (r *Registry) publicModelProviderEligibleLocked(p *Provider) bool {
+	return p.Status != StatusOffline && p.Status != StatusUntrusted &&
+		!p.PrivateOnly && r.trustMeetsMinimum(p.TrustLevel) &&
+		r.providerSupportsPrivateTextLocked(p)
+}
+
 // ListModels returns deduplicated models from all online providers.
 func (r *Registry) ListModels() []AggregateModel {
 	r.mu.RLock()
@@ -59,10 +68,7 @@ func (r *Registry) ListModels() []AggregateModel {
 		// and a handful of field reads — never a walk of its inventory.
 		// Private-only providers serve only their owner's self-route traffic, so
 		// they must not appear in or inflate the public /v1/models aggregation.
-		if p.Status == StatusOffline || p.Status == StatusUntrusted ||
-			p.PrivateOnly ||
-			!r.trustMeetsMinimum(p.TrustLevel) ||
-			!r.providerSupportsPrivateTextLocked(p) {
+		if !r.publicModelProviderEligibleLocked(p) {
 			p.mu.Unlock()
 			continue
 		}
@@ -226,9 +232,10 @@ func (r *Registry) ModelCountryCodes(modelID string) []string {
 	seen := make(map[string]bool)
 	for _, p := range r.providers {
 		p.mu.Lock()
-		status := p.Status
-		trust := p.TrustLevel
-		privateReady := r.providerSupportsPrivateTextLocked(p)
+		if !r.publicModelProviderEligibleLocked(p) {
+			p.mu.Unlock()
+			continue
+		}
 		var cc string
 		if p.Location != nil {
 			cc = strings.ToUpper(strings.TrimSpace(p.Location.CountryCode))
@@ -236,13 +243,6 @@ func (r *Registry) ModelCountryCodes(modelID string) []string {
 		serves := cc != "" && r.providerServesCatalogModelLocked(p, modelID)
 		p.mu.Unlock()
 		if !serves {
-			continue
-		}
-		// Apply the same routing-eligibility gates as ListModels.
-		if status == StatusOffline || status == StatusUntrusted {
-			continue
-		}
-		if !r.trustMeetsMinimum(trust) || !privateReady {
 			continue
 		}
 		seen[cc] = true

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-08 · commit `0c162cdae`
+> Last updated: 2026-09-11 · commit `0e2972839`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -160,6 +160,12 @@ Two request policies relax the gate for the caller's **own** machines only:
 `providerServesRoutableModelReasonLocked` waives dedicated-catalog isolation.
 Every other gate — runtime verification, private-text attestation, challenge
 freshness, slot state, memory — still applies to owned machines.
+
+Public model counts and OpenRouter datacenter countries share
+`publicModelProviderEligibleLocked` in `coordinator/registry/model_views.go`.
+It excludes private-only providers before either view aggregates them; public
+country metadata therefore describes the public fleet, while owner self-route
+continues to use the separate owner eligibility path.
 
 ### Challenge freshness
 
@@ -699,6 +705,9 @@ must not run in parallel with other scheduler tests in the same process.
     `tryClaimCapacityProbeLocked` is check-and-claim under `gate.mu`: a
     second commit within `capacityProbeOutcomeWindow` of an outstanding claim
     is rejected instead of leaking a second probe.
+15. **Private-only providers contribute neither public model counts nor
+    datacenter countries** — `ListModels` and `ModelCountryCodes` share
+    `publicModelProviderEligibleLocked` under the registry and provider locks.
 
 ## Failure modes
 


### PR DESCRIPTION
A private-only provider could add its country to OpenRouter's public model datacenters even though public model counts and dispatch excluded that provider. With a public provider in the US and a private provider in India, `ModelCountryCodes` returned `[IN US]`.

Share the existing `ListModels` provider gate with `ModelCountryCodes`. Both public views now exclude private-only, offline, untrusted, below-floor and private-text-ineligible providers under the same locks. Per-model catalog checks and country normalization/sorting remain unchanged. Owner self-route and inventory-oriented snapshots retain their separate policies.

Before:
```mermaid
flowchart TD
  P[Public and private provider inventory] --> L[ListModels gate includes PrivateOnly]
  P --> C[Separate country gate omits PrivateOnly]
  L --> M[Public model count excludes private node]
  C --> D[Datacenters incorrectly includes private country]
```

After:
```mermaid
flowchart TD
  P[Public and private provider inventory] --> G[publicModelProviderEligibleLocked]
  G --> L[ListModels plus per-model catalog gate]
  G --> C[ModelCountryCodes plus per-model catalog gate]
  L --> M[Same public model count]
  C --> D[Only public eligible countries, sorted]
  O[Owner self-route request] --> S[Existing separate owner policy]
```

Validation: the regression fails on master with `[IN US]` and passes after the fix, including the all-private case returning no countries. Full registry and routing-simulation race suites pass (24.527s / 3.721s). Documentation checks pass for all 278 pages. No dependency, model default, routing policy or deployment change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763345&installation_model_id=21733&pr_number=928&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F928&signature=c28ade4ad39df5eefb015b9c97789694c5b17e0c073a9241bdd58ec555c6dc0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->