### PR TITLE
Share queue rejection cleanup and warm-pool rate collection

### DIFF
--- a/coordinator/registry/queue.go
+++ b/coordinator/registry/queue.go
@@ -206,10 +206,19 @@ func (r *QueuedRequest) rejectAssignment() {
 func (r *QueuedRequest) failWithReason(reason error) {
 	r.init()
 	r.FailureReason = reason
+	r.finishWithoutProvider()
+}
+
+// finishWithoutProvider releases any offered reservation before publishing the
+// nil sentinel. Report whether this call notified the waiter so model-wide
+// rejection counts keep excluding channels which were already signaled.
+func (r *QueuedRequest) finishWithoutProvider() bool {
 	r.markDone()
 	select {
 	case r.ResponseCh <- nil:
+		return true
 	default:
+		return false
 	}
 }
 
@@ -384,11 +393,7 @@ func (q *RequestQueue) PopNextFresh(model string) *QueuedRequest {
 			delete(q.queues, model)
 		}
 		if now.Sub(req.EnqueuedAt) > q.maxWait {
-			req.markDone()
-			select {
-			case req.ResponseCh <- nil:
-			default:
-			}
+			req.finishWithoutProvider()
 			continue
 		}
 		return req
@@ -586,11 +591,8 @@ func (q *RequestQueue) FailQueuedRequestsForModel(model string, preferOwnerEligi
 				continue
 			}
 		}
-		req.markDone()
-		select {
-		case req.ResponseCh <- nil:
+		if req.finishWithoutProvider() {
 			failed++
-		default:
 		}
 	}
 	if len(survivors) == 0 {
@@ -642,12 +644,8 @@ func (q *RequestQueue) cleanStaleLocked(model string) {
 	var fresh []*QueuedRequest
 	for _, req := range queue {
 		if now.Sub(req.EnqueuedAt) > q.maxWait {
-			// Close the response channel to signal timeout
-			req.markDone()
-			select {
-			case req.ResponseCh <- nil:
-			default:
-			}
+			// Publish the nil sentinel to signal timeout.
+			req.finishWithoutProvider()
 		} else {
 			fresh = append(fresh, req)
 		}

--- a/coordinator/registry/queue_test.go
+++ b/coordinator/registry/queue_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -421,5 +422,66 @@ func TestFailQueuedRequestsForModelFailsOwnerlessPreferWaiter(t *testing.T) {
 		}
 	default:
 		t.Fatal("owner-less prefer waiter was not failed")
+	}
+}
+
+func TestQueueRejectionReleasesAssignmentBeforeNotification(t *testing.T) {
+	for _, path := range []string{"explicit-reason", "stale-pop", "stale-sweep", "unservable-model"} {
+		for _, buffered := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/buffered=%v", path, buffered), func(t *testing.T) {
+				q := NewRequestQueue(2, time.Minute)
+				req := &QueuedRequest{RequestID: "rejected", Model: "model"}
+				if err := q.Enqueue(req); err != nil {
+					t.Fatal(err)
+				}
+				req.EnqueuedAt = time.Now().Add(-2 * time.Minute)
+				if buffered {
+					req.ResponseCh <- nil
+				}
+				cleanupCalls := 0
+				if !req.offerAssignment(&Provider{ID: "reserved"}, func() {
+					cleanupCalls++
+					select {
+					case <-req.Done():
+					default:
+						t.Error("rejection must mark done before releasing its assignment")
+					}
+					if !buffered && len(req.ResponseCh) != 0 {
+						t.Error("waiter notified before reservation cleanup")
+					}
+				}) {
+					t.Fatal("fixture assignment refused")
+				}
+				want := ErrQueueTimeout
+				switch path {
+				case "explicit-reason":
+					want = ErrQueueToolConstraintUnavailable
+					req.failWithReason(want)
+				case "stale-pop":
+					if got := q.PopNextFresh(req.Model); got != nil {
+						t.Fatal("stale request returned as fresh")
+					}
+				case "stale-sweep":
+					if got := q.QueuedModels(); len(got) != 0 {
+						t.Fatal("stale model survived sweep")
+					}
+				case "unservable-model":
+					wantFailed := 1
+					if buffered {
+						wantFailed = 0
+					}
+					if got := q.FailQueuedRequestsForModel(req.Model, nil); got != wantFailed {
+						t.Fatalf("new notifications=%d, want %d", got, wantFailed)
+					}
+				}
+				if provider, err := q.WaitForProviderContext(context.Background(), req); provider != nil || !errors.Is(err, want) {
+					t.Fatalf("waiter got (%v,%v), want nil,%v", provider, err, want)
+				}
+				req.markDone()
+				if cleanupCalls != 1 {
+					t.Fatalf("cleanup ran %d times, want 1", cleanupCalls)
+				}
+			})
+		}
 	}
 }

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -501,7 +501,8 @@ func (c *warmPoolController) targetInputs(fleet warmPoolModelSnapshot, pressure 
 // this window. It consumes ALL signals fed to the controller — capacity rejects,
 // TTFT misses, cold dispatches, speculative starts/wins (now including the W3
 // preflight-fed near-misses), an aged coordinator queue, and a saturated warm set
-// under any external pressure. With no demand pressure the pool is left as-is.
+// under any external pressure. Proactive headroom and configured minimums can
+// still grow the pool without a pressure event.
 func (c *warmPoolController) hasDemandPressure(fleet warmPoolModelSnapshot, pressure warmPoolPressureBucket, queue warmPoolQueuePressure) bool {
 	if pressure.capacityRejects >= c.config.CapacityRejectThreshold ||
 		pressure.ttftMisses >= c.config.TTFTMissThreshold ||
@@ -606,60 +607,43 @@ func (r *Registry) warmPoolFleetSnapshot(now time.Time) map[string]warmPoolModel
 		}
 		for _, model := range models {
 			warm := r.providerHasWarmModelLocked(p, model, now)
+			s := out[model]
+			s.model = model
 			if warm {
-				s := out[model]
-				s.model = model
 				s.warm++
 				running, waiting := warmPoolModelLoadLocked(p, model)
 				s.running += running
 				s.waiting += waiting
 				if !r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, model) || warmPoolBackendSlotBusyLocked(p) {
 					s.warmSaturated++
-					// Saturated while serving NONE of this model's requests means
-					// a co-resident model is holding the capacity. That load is
-					// invisible in s.running/s.waiting, so the warm-pool target
-					// must not treat this provider as usable capacity for this
-					// model (see headroomTarget).
+					// Only foreign load is missing from this model's running/waiting
+					// counts; adding self-saturated providers would double-count it.
 					if running+waiting == 0 {
 						s.warmForeignBlocked++
 					}
 				}
-				out[model] = s
-				// decodeSamples feed soloDecodeTPS → qualityConcurrency in the
-				// warm target. Use the SAME solo resolver as the admission cap
-				// (solo median / seed → provider benchmark), NOT the per-slot
-				// observed EWMA: the EWMA is a contended rate, and planning warm
-				// targets from it while admission caps from the solo rate would
-				// let the two disagree. The observed-EWMA chain
-				// (resolvedModelTPSLocked) still feeds serviceSamples/prefill —
-				// E[S] wants the load-inclusive rate a request actually sees.
-				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
-				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
-				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
-				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
-				continue
-			}
-			candidate, reason := r.warmPoolCandidateReasonLocked(p, model, now)
-			s := out[model]
-			s.model = model
-			if reason == warmColdEligible {
-				s.eligibleCold = append(s.eligibleCold, candidate)
-				out[model] = s
-				// Same solo-resolver / service-rate split as the warm branch above.
-				serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
-				decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
-				serviceSamples[model] = append(serviceSamples[model], serviceTPS)
-				prefillSamples[model] = append(prefillSamples[model], prefillTPS)
-				concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 			} else {
-				if s.coldDisq == nil {
-					s.coldDisq = make(map[warmColdReason]int)
+				candidate, reason := r.warmPoolCandidateReasonLocked(p, model, now)
+				if reason != warmColdEligible {
+					if s.coldDisq == nil {
+						s.coldDisq = make(map[warmColdReason]int)
+					}
+					s.coldDisq[reason]++
+					s.coldIneligible++
+					out[model] = s
+					continue
 				}
-				s.coldDisq[reason]++
-				s.coldIneligible++
-				out[model] = s
+				s.eligibleCold = append(s.eligibleCold, candidate)
 			}
+			out[model] = s
+			// Both warm and eligible-cold providers contribute to the same cohort.
+			// The static solo resolver matches admission's quality cap; the observed
+			// service rate separately estimates the duration a request will see.
+			serviceTPS, prefillTPS := resolvedModelTPSLocked(p, model)
+			decodeSamples[model] = append(decodeSamples[model], r.resolvedSoloModelTPSLocked(p, model).tps)
+			serviceSamples[model] = append(serviceSamples[model], serviceTPS)
+			prefillSamples[model] = append(prefillSamples[model], prefillTPS)
+			concSamples[model] = append(concSamples[model], float64(p.maxConcurrencyForModelLocked(model)))
 		}
 		p.mu.Unlock()
 	}

--- a/coordinator/registry/warm_pool_controller_test.go
+++ b/coordinator/registry/warm_pool_controller_test.go
@@ -826,3 +826,26 @@ func TestWarmPoolRampBoundedByCeiling(t *testing.T) {
 		t.Fatalf("sent loads = %d, want 5 (ceiling-bounded)", len(*sent))
 	}
 }
+
+func TestWarmPoolFleetRatesIncludeWarmAndEligibleColdOnly(t *testing.T) {
+	reg := New(testLogger())
+	model := "warm-pool-rate-cohort"
+	warm := makeSchedulerProvider(t, reg, "warm", model, 23)
+	warm.mu.Lock()
+	warm.BackendCapacity.Slots[0].ObservedDecodeTPS = 73
+	warm.BackendCapacity.Slots[0].ObservedPrefillTPS = 1000
+	warm.mu.Unlock()
+	makeWarmPoolColdProvider(t, reg, "cold", model, 57, 64, 8)
+	ineligible := makeWarmPoolColdProvider(t, reg, "overheated", model, 1000, 64, 8)
+	ineligible.mu.Lock()
+	ineligible.SystemMetrics.ThermalState = "critical"
+	ineligible.mu.Unlock()
+
+	snap := reg.warmPoolFleetSnapshot(time.Now())[model]
+	if snap.warm != 1 || len(snap.eligibleCold) != 1 || snap.coldIneligible != 1 || snap.coldDisq[warmColdThermal] != 1 {
+		t.Fatalf("unexpected warm/cold classification: %+v", snap)
+	}
+	if snap.soloDecodeTPS != 40 || snap.serviceDecodeTPS != 65 || snap.prefillTPS != (1000+57*PrefillToDecodeRatio())/2 {
+		t.Fatalf("rate medians must include warm and eligible cold providers only: %+v", snap)
+	}
+}

--- a/coordinator/registry/warm_pool_state.go
+++ b/coordinator/registry/warm_pool_state.go
@@ -49,9 +49,8 @@ type warmPoolPressureBucket struct {
 	// rate, NOT the absolute arrival rate (which would size headroom to total
 	// traffic and demand far more hardware than exists).
 	//
-	// Only INCREASES are folded. A falling occupancy is not negative demand
-	// growth, and letting it pull the EWMA down would shrink headroom fastest
-	// right after a spike drains — exactly when the next one is most likely.
+	// Negative deltas are clamped to zero: a falling occupancy is not negative
+	// demand growth. Zero-growth samples still decay the EWMA normally.
 	//
 	// lastOccupancyAt timestamps the baseline so a fold can normalize the delta
 	// to one control interval, and so staleness is judged on the OCCUPANCY
@@ -217,7 +216,7 @@ func (s *warmPoolState) foldArrivalRates(now time.Time, minInterval time.Duratio
 // interval <= 0 or minInterval <= 0 disables the normalization and gate (every
 // call folds its raw delta), which keeps the pure-unit-test path simple.
 //
-// Only positive deltas are folded (see occupancyRampEWMA). Models absent from the
+// Negative deltas become zero-growth samples (see occupancyRampEWMA). Models absent from the
 // map this tick are left untouched rather than decayed, so a model that stops
 // being reported does not silently lose its measured ramp.
 func (s *warmPoolState) foldOccupancyRamp(occupancy map[string]int, now time.Time, interval, minInterval time.Duration, alpha float64) {

--- a/coordinator/registry/warm_pool_target.go
+++ b/coordinator/registry/warm_pool_target.go
@@ -113,7 +113,8 @@ type warmTargetInputs struct {
 	PrefillTPS      float64 // representative prefill tok/s
 	MaxProviderConc int     // representative per-provider concurrency cap (0 = unknown)
 	// DemandPressure is true when any pressure signal crossed its threshold this
-	// window. With no demand pressure the pool is left as-is (no growth).
+	// window. Without pressure, the purely reactive mode retains the warm count;
+	// proactive headroom mode still sizes to observed load.
 	DemandPressure bool
 }
 

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-10 · commit `213b8c2b6`
+> Last updated: 2026-09-11 · commit `5c5789018`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -93,10 +93,19 @@ active update or shutdown barrier remains authoritative
 `setRetirementReconnectBarrier`).
 
 `PopNextFresh` skips stale entries as it pops; `RequeueFront` returns a
-waiter that could not be placed; `PreferWaiterOwners` lets a drain favour
-waiters that own the provider that just freed. `FailQueuedRequestsForModel`
-fails every waiter for a model with a specific error (used for
-capability-unavailable and disconnect outcomes).
+waiter that could not be placed. `PreferWaiterOwners` gathers owner IDs before
+the registry computes their eligibility outside the queue lock.
+`FailQueuedRequestsForModel` reports timeout to public waiters while preserving
+exclusive self-route waiters and prefer-owner waiters whose owners remain
+eligible. Specific deadline, TTFT and tool-constraint causes use
+`QueuedRequest.failWithReason` instead.
+
+Both rejection paths and stale cleanup share `finishWithoutProvider`: mark the
+waiter done, release any scheduler-owned assignment, then publish a nonblocking
+nil sentinel. A full response channel does not count as a new notification.
+Successful assignment transfers cleanup ownership only when
+`WaitForProviderContext` accepts it; cancellation still releases an unaccepted
+offer (`coordinator/registry/queue.go`).
 
 **Lazy stale sweep.** There is no background timer. `cleanStaleLocked` runs
 inside `Enqueue` and `QueuedModels`, dropping entries older than `maxWait`
@@ -330,24 +339,40 @@ warm-saturated fraction (`warmSaturated / warm`) reaches
 `WarmSaturationThreshold`. A warm provider is *saturated* when it has no
 concurrency headroom for the model or its backend slot is busy.
 
-**Target** (`warmTarget`, `coordinator/registry/warm_pool_target.go`) applies
-Little's Law when pressure is present and otherwise holds the current warm
-count:
+**Rate cohort.** `warmPoolFleetSnapshot` collects rates from warm providers and
+eligible cold providers. Rejected cold providers contribute reason counts but
+no rate sample. Static solo rates size quality concurrency; observed service
+rates estimate request duration. Each uses the same eligible cohort and its
+median (`coordinator/registry/warm_pool_controller.go`).
+
+**Target** (`warmTarget`, `coordinator/registry/warm_pool_target.go`) sizes to
+observed load when proactive headroom is enabled. Disabling headroom restores
+the purely reactive mode, which holds the current warm count until pressure
+appears:
 
 ```text
 serviceTime  = clamp(AssumedPromptTokens / prefillTPS + AssumedCompletionTokens / decodeTPS,
                      warmPoolMinServiceTime, warmPoolMaxServiceTime)   # 500 * time.Millisecond … 2 * time.Minute
 L            = running + waiting + queueDepth + spillArrivalRate × serviceTime
 target       = ceil(L / qualityConcurrency) + BurstBuffer
-target       = max(target, warm + 1)              # reactive: pressure always earns one more
+target       = max(target, headroomTarget)        # proactive floor when enabled
+target       = max(target, warm + 1)              # only when demand pressure is present
 target       = clamp(target, warm, warm + eligibleCold)
 ```
 
 `spillArrivalRate` is an EWMA of arrivals the warm set could not absorb,
 `warmPoolArrivalEWMAAlpha = 0.3` (`coordinator/registry/warm_pool_state.go`).
+The proactive floor covers occupied capacity plus growth expected during a
+cold load, with a correction for providers blocked by a co-resident model.
+`headroomProviders` derives spare providers from the measured occupancy ramp,
+load windows and quality concurrency, subject to the configured override/cap.
+Negative occupancy deltas become zero-growth samples; they do not subtract
+from the ramp, but still apply ordinary EWMA decay. Pressure and occupancy
+observations retain separate expiry clocks.
 `targetWarm` then applies anti-flap and floors: a target lower than the last
 one is held for `MinDwell`, and `MinWarmByModel` raises the target (both
-capped at `warm + eligibleCold`).
+capped at `warm + eligibleCold`). For a dedicated build under demand pressure,
+it targets the entire eligible pool; the ramp below still bounds issued loads.
 
 **Ramp.** The gap between target and warm is closed at
 `rampLoadsThisTick(gap, MaxLoadsPerTick, MaxLoadsPerTickCeiling,


### PR DESCRIPTION
Queue rejection repeated completion, assignment cleanup and notification in four places; warm-pool snapshots repeated rate collection for warm and eligible cold providers. Share these operations so their ordering and inclusion rules have one implementation.

Queue completion still closes `Done` and releases an offered assignment before publishing a nonblocking nil sentinel. Existing locks, rejection reasons, owner-route exceptions and notification counts are preserved. Warm-pool classification still excludes rejected cold providers and retains the distinction between static quality rates and observed service rates. Admission gates, deadlines, target math, defaults and load reservations are unchanged.

Before:
```mermaid
flowchart LR
  A[Explicit rejection] --> X[Repeated completion and cleanup]
  B[Stale pop or sweep] --> Y[Repeated completion and cleanup]
  C[Model unavailable] --> Z[Repeated completion and cleanup]
  X --> N[Nonblocking nil notification]
  Y --> N
  Z --> N
  W[Warm provider] --> R[Rate collection copy]
  E[Eligible cold provider] --> S[Rate collection copy]
  R --> M[Fleet medians]
  S --> M
```

After:
```mermaid
flowchart LR
  A[Same four rejection paths] --> F[finishWithoutProvider]
  F --> D[Close Done and release assignment]
  D --> N[Same nonblocking nil notification]
  P[Classify provider with existing gates] --> W[Warm or eligible cold]
  P --> X[Rejected cold: record reason and skip]
  W --> R[Shared ordered rate collection]
  R --> M[Same quality and service medians]
```

Reviewed all seven production files and six associated test/benchmark files in the queue and warm-pool operation groups. The scheduling documentation now describes actual proactive sizing, occupancy-ramp decay and queue error behavior; stale comments were corrected without changing those policies. Production is 18 lines smaller; characterization tests and documentation increase the overall diff.

Validation:

- New cleanup/notification ordering and fleet-rate cohort tests pass against the unchanged master implementation and the refactor.
- `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry -count=1` passes (24.489s).
- An independent source review found no blocking issue.
- Docs lint passes for 278 pages; whitespace checks and commit signatures pass.
- No model, live fleet, deployment or benchmark execution. This PR makes no new performance claim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763692&installation_model_id=21733&pr_number=930&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F930&signature=90d7c4f780565786035c2703de911e83564040f301e2971c04bda3b17315c502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->