### PR TITLE
Reject special files before verifying released provider artifacts

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-12 · commit `456933f24`
+> Last updated: 2026-09-12 · commit `60bae5844`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `456933f24`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -494,3 +494,7 @@ Candidate native prefix-cache benchmarks must build ProviderCore and
 prompt SPI carries production sampling parameters into each engine request.
 See [native benchmark validation](test.md#resident-prefix-benchmark-validation)
 for sampling scope, regression filters and diagnostic restrictions.
+
+The [released-provider artifact fixtures](test.md#8-end-to-end-suite) check
+bundle validation with local temporary files only; they require Go, not a Swift
+build, released binary, SIP probe or GPU workload.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-12 · commit `456933f24`
+> Last updated: 2026-09-12 · commit `60bae5844`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1011,7 +1011,7 @@ The released-provider artifact gate has CPU-only fixtures that do not launch a
 provider, inspect SIP, or download a release:
 
 ```bash
-go test -race ./e2e -short -run 'TestIntegrationMixedVersionGateContract|TestMixedVersionArtifact' -count=1
+go test -race ./e2e -short -run 'TestIntegrationMixedVersion(GateContract|Artifact)' -count=1
 ```
 
 `e2e/mixed_version_artifacts_test.go` verifies both bundle hashes, executable

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `456933f24`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1006,6 +1006,19 @@ make docs-stamp FILES="docs/developer/test.md"   # refresh a stamp after editing
 ```
 
 ### 8. End-to-end suite
+
+The released-provider artifact gate has CPU-only fixtures that do not launch a
+provider, inspect SIP, or download a release:
+
+```bash
+go test -race ./e2e -short -run 'TestIntegrationMixedVersionGateContract|TestMixedVersionArtifact' -count=1
+```
+
+`e2e/mixed_version_artifacts_test.go` verifies both bundle hashes, executable
+permission and regular-file input before hashing; directories and FIFOs fail
+promptly. The live compatibility endpoint and SIP-tier checks remain in
+`e2e/mixed_version_test.go`. Passing these fixtures does not qualify a real
+released-provider session.
 
 The e2e package (`e2e/`, harness in `e2e/testbed/`) boots ephemeral Postgres,
 a coordinator from the current tree, and one or more **real** `darkbloom`

--- a/e2e/mixed_version_artifacts_test.go
+++ b/e2e/mixed_version_artifacts_test.go
@@ -1,0 +1,154 @@
+package e2e
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// releasedMetallibName is the Metal shader library shipped beside the
+// released executable inside the bundle, per scripts/fetch-v0712-provider.sh
+// (it resolves "$EXTRACTED/Darkbloom.app/Contents/MacOS/mlx.metallib").
+const releasedMetallibName = "mlx.metallib"
+
+// requirePinnedReleasedProvider is the anti-vacuous-pass check for this
+// gate. It proves the lane is running against the exact released v0.7.12
+// artifact the compatibility claim is about.
+//
+// Both halves of the bundle are pinned, because both determine behaviour
+// the gate observes. The executable fixes the wire contract; the metallib
+// fixes the kernels that produce the tokens, and it is a separate file that
+// can be swapped without touching the binary. The fetch script already
+// verifies both (BINARY_SHA256 at :38, METALLIB_SHA256 at :51) — checking
+// only one here would let a hand-assembled bundle through a gate whose
+// entire value is that it cannot be fooled by a local build.
+func requirePinnedReleasedProvider(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, verifyPinnedBundle(path,
+		pinnedReleasedDigest(t, "BINARY_SHA256"),
+		pinnedReleasedDigest(t, "METALLIB_SHA256")),
+		"the bundle at DARKBLOOM_PROVIDER_BINARY is not the hash-pinned released "+
+			"v0.7.12 artifact; re-fetch it with scripts/fetch-v0712-provider.sh")
+}
+
+// verifyPinnedBundle checks both halves of the bundle against their pinned
+// digests and returns the first mismatch. It is split out from
+// requirePinnedReleasedProvider so every rejection path — including a
+// drifted or missing metallib beside a correct executable — is testable
+// without a copy of the real released artifact.
+func verifyPinnedBundle(binaryPath, wantBinary, wantMetallib string) error {
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		return fmt.Errorf("released provider binary is unreadable: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("released provider binary is not a regular file: %s", binaryPath)
+	}
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("released provider binary is not executable: %s", binaryPath)
+	}
+	got, err := fileSHA256(binaryPath)
+	if err != nil {
+		return err
+	}
+	if got != wantBinary {
+		return fmt.Errorf("released provider binary digest %s does not match pinned %s (%s)",
+			got, wantBinary, binaryPath)
+	}
+
+	metallib := filepath.Join(filepath.Dir(binaryPath), releasedMetallibName)
+	metallibInfo, err := os.Stat(metallib)
+	if err != nil {
+		return fmt.Errorf("released v0.7.12 metallib is missing beside the binary: %w", err)
+	}
+	if !metallibInfo.Mode().IsRegular() {
+		return fmt.Errorf("released v0.7.12 metallib is not a regular file: %s", metallib)
+	}
+	got, err = fileSHA256(metallib)
+	if err != nil {
+		return err
+	}
+	if got != wantMetallib {
+		return fmt.Errorf("released v0.7.12 metallib digest %s does not match pinned %s (%s)",
+			got, wantMetallib, metallib)
+	}
+	return nil
+}
+
+// pinnedReleasedDigest reads the named <VAR>_SHA256 assignment out of
+// scripts/fetch-v0712-provider.sh rather than restating it, so each pin has
+// exactly one definition and the test cannot drift away from the fetcher.
+func pinnedReleasedDigest(t *testing.T, variable string) string {
+	t.Helper()
+	root := os.Getenv("DARKBLOOM_REPO_ROOT")
+	if root == "" {
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		root = filepath.Clean(filepath.Join(cwd, ".."))
+	}
+	script := filepath.Join(root, "scripts", "fetch-v0712-provider.sh")
+	contents, err := os.ReadFile(script)
+	require.NoError(t, err,
+		"released-provider fetch script is the single source of truth for the %s pin",
+		variable)
+	for _, line := range strings.Split(string(contents), "\n") {
+		value, found := strings.CutPrefix(strings.TrimSpace(line), variable+"=")
+		if !found {
+			continue
+		}
+		value = strings.Trim(value, `"'`)
+		require.Len(t, value, 64,
+			"%s in %s is not a SHA-256 hex digest", variable, script)
+		return value
+	}
+	require.FailNow(t, "no "+variable+" pin found in "+script)
+	return ""
+}
+
+// Pin verification must reject special files before hashing: opening a FIFO
+// can block the compatibility job indefinitely without a provider ever starting.
+func TestMixedVersionArtifactRejectsNonRegularInputs(t *testing.T) {
+	for _, target := range []string{"darkbloom", releasedMetallibName} {
+		for _, kind := range []string{"directory", "fifo"} {
+			t.Run(target+"/"+kind, func(t *testing.T) {
+				root := t.TempDir()
+				binary := filepath.Join(root, "darkbloom")
+				contents := []byte("verified fixture")
+				digest := sha256.Sum256(contents)
+				expected := hex.EncodeToString(digest[:])
+				for _, name := range []string{"darkbloom", releasedMetallibName} {
+					path := filepath.Join(root, name)
+					if name != target {
+						require.NoError(t, os.WriteFile(path, contents, 0755))
+					} else if kind == "directory" {
+						require.NoError(t, os.Mkdir(path, 0755))
+					} else {
+						require.NoError(t, syscall.Mkfifo(path, 0755))
+					}
+				}
+				require.ErrorContains(t, verifyPinnedBundle(binary, expected, expected), "not a regular file")
+			})
+		}
+	}
+}
+
+func TestMixedVersionArtifactRejectsNonExecutableOrWrongBinary(t *testing.T) {
+	root := t.TempDir()
+	binary := filepath.Join(root, "darkbloom")
+	contents := []byte("verified fixture")
+	digest := sha256.Sum256(contents)
+	expected := hex.EncodeToString(digest[:])
+	require.NoError(t, os.WriteFile(binary, contents, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, releasedMetallibName), contents, 0600))
+	require.ErrorContains(t, verifyPinnedBundle(binary, expected, expected), "not executable")
+	require.NoError(t, os.Chmod(binary, 0755))
+	require.ErrorContains(t, verifyPinnedBundle(binary, strings.Repeat("0", 64), expected), "binary digest")
+	require.NoError(t, verifyPinnedBundle(binary, expected, expected))
+}

--- a/e2e/mixed_version_artifacts_test.go
+++ b/e2e/mixed_version_artifacts_test.go
@@ -114,7 +114,7 @@ func pinnedReleasedDigest(t *testing.T, variable string) string {
 
 // Pin verification must reject special files before hashing: opening a FIFO
 // can block the compatibility job indefinitely without a provider ever starting.
-func TestMixedVersionArtifactRejectsNonRegularInputs(t *testing.T) {
+func TestIntegrationMixedVersionArtifactRejectsNonRegularInputs(t *testing.T) {
 	for _, target := range []string{"darkbloom", releasedMetallibName} {
 		for _, kind := range []string{"directory", "fifo"} {
 			t.Run(target+"/"+kind, func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestMixedVersionArtifactRejectsNonRegularInputs(t *testing.T) {
 	}
 }
 
-func TestMixedVersionArtifactRejectsNonExecutableOrWrongBinary(t *testing.T) {
+func TestIntegrationMixedVersionArtifactRejectsNonExecutableOrWrongBinary(t *testing.T) {
 	root := t.TempDir()
 	binary := filepath.Join(root, "darkbloom")
 	contents := []byte("verified fixture")

--- a/e2e/mixed_version_test.go
+++ b/e2e/mixed_version_test.go
@@ -482,119 +482,6 @@ func hostSIPState(t *testing.T) sipState {
 	}
 }
 
-// releasedMetallibName is the Metal shader library shipped beside the
-// released executable inside the bundle, per scripts/fetch-v0712-provider.sh
-// (it resolves "$EXTRACTED/Darkbloom.app/Contents/MacOS/mlx.metallib").
-const releasedMetallibName = "mlx.metallib"
-
-// requirePinnedReleasedProvider is the anti-vacuous-pass check for this
-// gate. It proves the lane is running against the exact released v0.7.12
-// artifact the compatibility claim is about.
-//
-// Both halves of the bundle are pinned, because both determine behaviour
-// the gate observes. The executable fixes the wire contract; the metallib
-// fixes the kernels that produce the tokens, and it is a separate file that
-// can be swapped without touching the binary. The fetch script already
-// verifies both (BINARY_SHA256 at :38, METALLIB_SHA256 at :51) — checking
-// only one here would let a hand-assembled bundle through a gate whose
-// entire value is that it cannot be fooled by a local build.
-func requirePinnedReleasedProvider(t *testing.T, path string) {
-	t.Helper()
-	require.NoError(t, verifyPinnedBundle(path,
-		pinnedReleasedDigest(t, "BINARY_SHA256"),
-		pinnedReleasedDigest(t, "METALLIB_SHA256")),
-		"the bundle at DARKBLOOM_PROVIDER_BINARY is not the hash-pinned released "+
-			"v0.7.12 artifact; re-fetch it with scripts/fetch-v0712-provider.sh")
-}
-
-// verifyPinnedBundle checks both halves of the bundle against their pinned
-// digests and returns the first mismatch. It is split out from
-// requirePinnedReleasedProvider so every rejection path — including a
-// drifted or missing metallib beside a correct executable — is testable
-// without a copy of the real released artifact.
-func verifyPinnedBundle(binaryPath, wantBinary, wantMetallib string) error {
-	info, err := os.Stat(binaryPath)
-	if err != nil {
-		return fmt.Errorf("released provider binary is unreadable: %w", err)
-	}
-	if info.IsDir() {
-		return fmt.Errorf("released provider binary is a directory: %s", binaryPath)
-	}
-	if info.Mode()&0o111 == 0 {
-		return fmt.Errorf("released provider binary is not executable: %s", binaryPath)
-	}
-	got, err := digestFile(binaryPath)
-	if err != nil {
-		return err
-	}
-	if got != wantBinary {
-		return fmt.Errorf("released provider binary digest %s does not match pinned %s (%s)",
-			got, wantBinary, binaryPath)
-	}
-
-	metallib := filepath.Join(filepath.Dir(binaryPath), releasedMetallibName)
-	metallibInfo, err := os.Stat(metallib)
-	if err != nil {
-		return fmt.Errorf("released v0.7.12 metallib is missing beside the binary: %w", err)
-	}
-	if metallibInfo.IsDir() {
-		return fmt.Errorf("released v0.7.12 metallib is a directory: %s", metallib)
-	}
-	got, err = digestFile(metallib)
-	if err != nil {
-		return err
-	}
-	if got != wantMetallib {
-		return fmt.Errorf("released v0.7.12 metallib digest %s does not match pinned %s (%s)",
-			got, wantMetallib, metallib)
-	}
-	return nil
-}
-
-// digestFile returns the lowercase hex SHA-256 of the file at path.
-func digestFile(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-	digest := sha256.New()
-	if _, err := io.Copy(digest, file); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(digest.Sum(nil)), nil
-}
-
-// pinnedReleasedDigest reads the named <VAR>_SHA256 assignment out of
-// scripts/fetch-v0712-provider.sh rather than restating it, so each pin has
-// exactly one definition and the test cannot drift away from the fetcher.
-func pinnedReleasedDigest(t *testing.T, variable string) string {
-	t.Helper()
-	root := os.Getenv("DARKBLOOM_REPO_ROOT")
-	if root == "" {
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		root = filepath.Clean(filepath.Join(cwd, ".."))
-	}
-	script := filepath.Join(root, "scripts", "fetch-v0712-provider.sh")
-	contents, err := os.ReadFile(script)
-	require.NoError(t, err,
-		"released-provider fetch script is the single source of truth for the %s pin",
-		variable)
-	for _, line := range strings.Split(string(contents), "\n") {
-		value, found := strings.CutPrefix(strings.TrimSpace(line), variable+"=")
-		if !found {
-			continue
-		}
-		value = strings.Trim(value, `"'`)
-		require.Len(t, value, 64,
-			"%s in %s is not a SHA-256 hex digest", variable, script)
-		return value
-	}
-	require.FailNow(t, "no "+variable+" pin found in "+script)
-	return ""
-}
-
 // TestIntegrationMixedVersionGateContract pins the properties whose loss
 // produced blocker B3 and its follow-on: the lane must announce that its
 // booted half cannot run rather than stalling in suite.Start, a runner
@@ -682,7 +569,7 @@ func TestIntegrationMixedVersionGateContract(t *testing.T) {
 			dir = t.TempDir()
 			binary = filepath.Join(dir, "darkbloom")
 			require.NoError(t, os.WriteFile(binary, []byte("released executable"), 0o755))
-			digest, err := digestFile(binary)
+			digest, err := fileSHA256(binary)
 			require.NoError(t, err)
 			if metallib != nil {
 				require.NoError(t,


### PR DESCRIPTION
The released-provider compatibility gate rejected directories but could block indefinitely while opening a FIFO supplied as the executable or colocated metallib. Both paths must now be regular files before hashing, while executable permissions, exact binary/metallib pins and existing error order remain enforced.

Artifact verification now lives in `mixed_version_artifacts_test.go` and reuses the existing `fileSHA256` helper, removing its duplicate streaming SHA256 implementation. The CPU fixture names stay under the existing CI `TestIntegration` filter. Runtime endpoint checks, SIP decisions and artifact/full coverage markers are unchanged.

Before:
```mermaid
flowchart TD
 A[Released bundle path] --> M[Mixed-version integration file]
 M --> D[Reject directories only]
 D --> H[Duplicate digestFile implementation]
 H --> B[Opening a FIFO can block before any tier result]
 H --> V[Verify pins then measure SIP and run endpoints]
```

After:
```mermaid
flowchart TD
 A[Released bundle path] --> M[Focused artifact helper module]
 M --> R{Both inputs regular files?}
 R -->|no| F[Fail promptly before hashing]
 R -->|yes| H[Shared fileSHA256]
 H --> V[Same pin order then unchanged SIP and endpoint gate]
 T[Local file and FIFO fixtures] --> M
```

Validation: three Go CPU test functions / 12 tests including subtests pass with `-race`; existing tier matrix, parse rejection, marker and both-pin tests remain green. New fixtures cover FIFO/directory inputs in either bundle position, missing executable permission, incorrect binary digest and a valid bundle. Restoring the old directory-only check reproduces an actual FIFO hang until the bounded two-second Go test timeout. Docs lint and diff checks pass.

No provider, Swift/model/GPU, actual released binary, SIP probe, database or network endpoint was executed. Fixture FIFO bytes are never opened after the fix. This checks test infrastructure and does not add mixed-version runtime evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763934&installation_model_id=21733&pr_number=932&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F932&signature=c53e670e5246d3a228b4cb3ede521b356e5cad363aadc5579b4e6ab064f8108c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->