### PR TITLE
fix(coordinator): preserve newer payouts during stale sweep failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — sweep payout ownership
+
+- Preserve newer completed payouts when an old automatic sweep failure arrives concurrently. Reopen withdrawals only while the stored paid state still belongs to that exact sweep, without moving ledger funds.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/api/stripe_payouts_webhooks.go
+++ b/coordinator/api/stripe_payouts_webhooks.go
@@ -435,11 +435,12 @@ func (s *Server) reopenSweepBouncedRows(pe *billing.PayoutEvent) error {
 		if wd.Status != "paid" || wd.Refunded {
 			continue
 		}
-		wd.Status = "transferred"
-		wd.SweepPayoutID = ""
-		wd.FailureReason = "sweep_payout_failed " + pe.FailureCode + ": " + pe.FailureReason +
+		reason := "sweep_payout_failed " + pe.FailureCode + ": " + pe.FailureReason +
 			" (payout " + pe.ID + "; next sweep will retry)"
-		if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+		// The snapshot can outlive another bounce and a newer paid sweep.
+		// Recheck ownership and terminal state atomically inside the store.
+		applied, err := s.billing.Store().ReopenStripeWithdrawalAfterSweepFailure(wd.ID, pe.ID, reason)
+		if err != nil {
 			s.logger.Error("stripe connect webhook: sweep bounce reopen failed",
 				"error", err, "withdrawal_id", wd.ID)
 			if firstErr == nil {
@@ -447,7 +448,9 @@ func (s *Server) reopenSweepBouncedRows(pe *billing.PayoutEvent) error {
 			}
 			continue
 		}
-		reopened++
+		if applied {
+			reopened++
+		}
 	}
 	s.logger.Warn("stripe connect webhook: sweep payout failed — will retry on next schedule",
 		"stripe_account_id", pe.ConnectedAcct, "payout_id", pe.ID,

--- a/coordinator/api/stripe_sweep_bounce_race_test.go
+++ b/coordinator/api/stripe_sweep_bounce_race_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/billing"
+	"github.com/eigeninference/d-inference/coordinator/payments"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Return the old sweep's snapshot after a concurrent bounce delivery has
+// reopened the row and a newer sweep has completed it.
+type replacedSweepStore struct {
+	*store.MemoryStore
+	t *testing.T
+}
+
+func (s *replacedSweepStore) ListStripeWithdrawalsBySweepPayoutID(id string) ([]store.StripeWithdrawal, error) {
+	rows, err := s.MemoryStore.ListStripeWithdrawalsBySweepPayoutID(id)
+	for _, row := range rows {
+		row.Status, row.SweepPayoutID = "transferred", ""
+		if err := s.MemoryStore.UpdateStripeWithdrawal(&row); err != nil {
+			s.t.Fatal(err)
+		}
+		if applied, err := s.MemoryStore.MarkStripeWithdrawalPaid(row.ID, "", "po_new"); err != nil || !applied {
+			s.t.Fatalf("new sweep completion: applied=%v err=%v", applied, err)
+		}
+	}
+	return rows, err
+}
+
+func TestConnectWebhookOldSweepBouncePreservesNewSweepCompletion(t *testing.T) {
+	fakeStripe := accountServingStripe("full")
+	defer fakeStripe.Close()
+	srv, mem := stripePayoutsTestServer(t, false, fakeStripe)
+	st := &replacedSweepStore{MemoryStore: mem, t: t}
+	srv.SetBilling(billing.NewService(st, payments.NewLedger(st), srv.logger, billing.Config{
+		StripeSecretKey: "sk_test_fake", StripeConnectWebhookSecret: "whsec_test",
+		StripeConnectReturnURL: "https://app.test/billing", StripeConnectRefreshURL: "https://app.test/billing",
+		StripeConnectPlatformCountry: "US",
+	}))
+	user := readyUser(t, mem, "acct-sweep-race", "alice@example.com", false)
+	mkWithdrawal(t, mem, store.StripeWithdrawal{
+		ID: "wd-sweep-race", AccountID: user.AccountID, StripeAccountID: user.StripeAccountID,
+		AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "standard", Status: "paid", TransferID: "tr_sweep_race", SweepPayoutID: "po_old",
+	})
+	before := mem.GetBalance(user.AccountID)
+	response := deliverConnectWebhook(t, srv, payoutEventPayload("po_old", user.StripeAccountID, "failed", true, time.Now().Unix()))
+	if response.Code != http.StatusOK {
+		t.Fatalf("webhook returned %d: %s", response.Code, response.Body.String())
+	}
+	wd, err := mem.GetStripeWithdrawal("wd-sweep-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wd.Status != "paid" || wd.SweepPayoutID != "po_new" || mem.GetBalance(user.AccountID) != before {
+		t.Fatalf("new sweep completion overwritten: status=%s sweep=%q balance=%d want=%d", wd.Status, wd.SweepPayoutID, mem.GetBalance(user.AccountID), before)
+	}
+}

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -393,6 +393,12 @@ type BillingStore interface {
 	// overwritten back to sweep-eligible). Returns whether it was applied.
 	ReopenStripeWithdrawalAfterPayoutFailure(id, failureReason string, feeRefunded bool) (bool, error)
 
+	// ReopenStripeWithdrawalAfterSweepFailure reopens only a paid, non-refunded
+	// row still attributed to expectedSweepPayoutID. The matching sweep stamp
+	// is cleared and the failure reason recorded; every other field is kept.
+	// Returns false for a missing row or a stale/ineligible event.
+	ReopenStripeWithdrawalAfterSweepFailure(id, expectedSweepPayoutID, failureReason string) (bool, error)
+
 	// ListStripeWithdrawalsBySweepPayoutID returns the withdrawals a given
 	// automatic sweep payout claimed (SweepPayoutID stamp). Used to reopen
 	// exactly those rows when the sweep later bounces.

--- a/coordinator/store/stripe_sweep_failure.go
+++ b/coordinator/store/stripe_sweep_failure.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+func (s *MemoryStore) ReopenStripeWithdrawalAfterSweepFailure(id, expectedSweepPayoutID, failureReason string) (bool, error) {
+	if id == "" || expectedSweepPayoutID == "" {
+		return false, errors.New("stripe withdrawal and sweep payout ids are required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w, ok := s.stripeWithdrawalsByID[id]
+	if !ok || w.Status != "paid" || w.Refunded || w.SweepPayoutID != expectedSweepPayoutID {
+		return false, nil
+	}
+	w.Status = "transferred"
+	w.SweepPayoutID = ""
+	w.FailureReason = failureReason
+	w.UpdatedAt = time.Now()
+	return true, nil
+}
+
+func (s *PostgresStore) ReopenStripeWithdrawalAfterSweepFailure(id, expectedSweepPayoutID, failureReason string) (bool, error) {
+	if id == "" || expectedSweepPayoutID == "" {
+		return false, errors.New("stripe withdrawal and sweep payout ids are required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE stripe_withdrawals
+		SET status = 'transferred', sweep_payout_id = '', failure_reason = $3, updated_at = NOW()
+		WHERE id = $1 AND sweep_payout_id = $2 AND status = 'paid' AND refunded = FALSE`,
+		id, expectedSweepPayoutID, failureReason)
+	if err != nil {
+		return false, fmt.Errorf("store: reopen stripe withdrawal after sweep failure: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/coordinator/store/stripe_sweep_failure_test.go
+++ b/coordinator/store/stripe_sweep_failure_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripeSweepFailureChecksCurrentOwnership(t *testing.T) {
+	for backend, s := range storeBackends(t) {
+		t.Run(backend, func(t *testing.T) {
+			if err := s.CreateUser(&User{AccountID: "acct-sweep-guard", PrivyUserID: "did:privy:sweep-guard"}); err != nil {
+				t.Fatal(err)
+			}
+			for _, tc := range []struct {
+				id, status, sweep string
+				refunded, applied bool
+			}{
+				{"matching", "paid", "po_old", false, true},
+				{"new-sweep", "paid", "po_new", false, false},
+				{"reopened", "transferred", "", false, false},
+				{"refunded", "paid", "po_old", true, false},
+				{"failed", "failed", "po_old", false, false},
+			} {
+				t.Run(tc.id, func(t *testing.T) {
+					wd := &StripeWithdrawal{ID: tc.id, AccountID: "acct-sweep-guard", StripeAccountID: "acct_stripe_guard",
+						AmountMicroUSD: 5_000_000, NetMicroUSD: 4_500_000, FeeMicroUSD: 500_000,
+						Method: "instant", Status: tc.status, TransferID: "tr_" + tc.id,
+						SweepPayoutID: tc.sweep, Refunded: tc.refunded, FeeRefunded: true}
+					if err := s.CreateStripeWithdrawal(wd); err != nil {
+						t.Fatal(err)
+					}
+					before, err := s.GetStripeWithdrawal(wd.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					applied, err := s.ReopenStripeWithdrawalAfterSweepFailure(wd.ID, "po_old", "sweep bounced")
+					if err != nil || applied != tc.applied {
+						t.Fatalf("applied=%v want=%v err=%v", applied, tc.applied, err)
+					}
+					got, err := s.GetStripeWithdrawal(wd.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if applied {
+						before.Status, before.SweepPayoutID, before.FailureReason = "transferred", "", "sweep bounced"
+						if got.UpdatedAt.Before(before.UpdatedAt) {
+							t.Fatal("updated timestamp moved backwards")
+						}
+						before.UpdatedAt = got.UpdatedAt
+					}
+					if !reflect.DeepEqual(before, got) {
+						t.Fatalf("unexpected state change: expected=%+v actual=%+v", before, got)
+					}
+					if applied, err := s.ReopenStripeWithdrawalAfterSweepFailure(wd.ID, "po_old", "redelivery"); err != nil || applied {
+						t.Fatalf("duplicate/stale delivery applied=%v err=%v", applied, err)
+					}
+					if s.GetBalance(wd.AccountID) != 0 {
+						t.Fatal("sweep bounce moved ledger balance")
+					}
+				})
+			}
+			if applied, err := s.ReopenStripeWithdrawalAfterSweepFailure("missing", "po_old", "bounce"); err != nil || applied {
+				t.Fatalf("missing row applied=%v err=%v", applied, err)
+			}
+			for _, ids := range [][2]string{{"", "po_old"}, {"matching", ""}} {
+				if applied, err := s.ReopenStripeWithdrawalAfterSweepFailure(ids[0], ids[1], "bounce"); err == nil || applied {
+					t.Fatalf("invalid ids accepted: %v applied=%v err=%v", ids, applied, err)
+				}
+			}
+		})
+	}
+}

--- a/docs/architecture/billing.md
+++ b/docs/architecture/billing.md
@@ -1,6 +1,6 @@
 # Billing: pricing, reservations, ledger, and payouts
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-11 · commit `9cf12c433`
 
 Darkbloom is prepaid. A consumer account holds an integer micro-USD balance;
 the coordinator reserves the worst-case cost of a request before dispatch,
@@ -379,6 +379,16 @@ the design record is [`design/base-rewards.md`](../design/base-rewards.md).
     `SumProviderEarningsByKey` excludes from the next epoch's `earned`
     (`coordinator/store/postgres_base_rewards.go`).
 
+16. **A sweep failure only reopens withdrawals still owned by that sweep.**
+    `reopenSweepBouncedRows` passes the event's sweep ID to
+    `ReopenStripeWithdrawalAfterSweepFailure`, which atomically requires
+    `paid`, not refunded, and the same stored `SweepPayoutID`. A stale snapshot
+    cannot clear a newer sweep's paid state. A successful reopen clears only
+    the sweep stamp, records its failure reason, refreshes `UpdatedAt`, and
+    returns the row to `transferred`; it moves no ledger money
+    (`coordinator/api/stripe_payouts_webhooks.go`,
+    `coordinator/store/stripe_sweep_failure.go`).
+
 ## Failure modes
 
 ### Payment-required responses
@@ -436,7 +446,7 @@ help (`coordinator/api/stripe_payouts_webhooks.go`).
 |---|---|
 | `account.updated` | `handleAccountUpdated` mirrors Stripe's view into `users.stripe_*` (`stripeStatusForAccount`: `pending`, `ready`, `restricted`, or `rejected`). Best-effort; the status endpoint re-syncs on page load. |
 | `payout.paid` | `handlePayoutTerminal(success=true)`: matched by payout id → `MarkStripeWithdrawalPaid` (no-op on an already `paid` row; a refunded/terminal row is logged for manual review, never overwritten). Unmatched → `reconcileUnmatchedPayout`: only automatic sweep payouts reconcile; they mark every `transferred` row of that connected account whose funds had become available (`stripeRecipientTransferDelay = 24 * time.Hour` for `recipient` accounts, immediate for `full`) and that has no in-flight payout of its own as `paid`. Amounts are ignored (FX-converted). |
-| `payout.failed`, `payout.canceled` | `handlePayoutTerminal(success=false)`: refund the instant fee via `CreditWithdrawableOnce(stripe_withdraw_fee:<id>)`, detach the payout id, reopen the row as `transferred` so the sweep retries. A refunded+paid row is logged for manual review. |
+| `payout.failed`, `payout.canceled` | `handlePayoutTerminal(success=false)`: refund the instant fee via `CreditWithdrawableOnce(stripe_withdraw_fee:<id>)`, detach the payout id, reopen the row as `transferred` so the sweep retries. A refunded+paid row is logged for manual review. Automatic sweep failures use `reopenSweepBouncedRows` and a guarded store transition (invariant 16) to reopen only rows still paid by that exact sweep. |
 | `transfer.reversed` | `handleTransferFailed`: refund the net principal (`stripe_withdraw:<id>`) and the fee (`stripe_withdraw_fee:<id>`) once each via `CreditWithdrawableOnce`, mark the row `failed`. |
 | anything else | acknowledged, ignored |
 

--- a/docs/consumer/billing.md
+++ b/docs/consumer/billing.md
@@ -1,6 +1,6 @@
 # Billing: fund an account and keep spend under control
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `9cf12c433`
 
 How to add credit, read your balance and usage, cap what a key can spend,
 redeem an invite code, and act on a `402`. Why the coordinator behaves this
@@ -221,6 +221,7 @@ Choose **Unlink Stripe account and start over** to remove the destination curren
 | `401` `auth_error` on `POST /v1/keys`, `/v1/referral/register`, `/v1/referral/apply` | Called with an API key | Use the Privy access token |
 | `429` on `create-session`, key mutations, referral or invite calls | The [financial rate limiter](../reference/pricing-model.md#constants) | Back off for `Retry-After` |
 | Balance dropped by more than the response should cost, then recovered | Reservation debited at admission, refund at settlement | Expected; read balance after the response completes |
+| A Connect withdrawal changes from `paid` back to `transferred` | Its automatic bank payout failed and the existing withdrawal was reopened for the next scheduled sweep | Monitor the same withdrawal in history; do not submit a replacement for those funds. Recovery preserves any newer completed payout; see [Connect sweep recovery](../reference/pricing-model.md#connect-sweep-recovery) |
 | `503` `billing_error` | Stripe or the referral service is not configured on this coordinator | Operator issue |
 
 Mechanism for each error, including the exact functions, is in

--- a/docs/reference/pricing-model.md
+++ b/docs/reference/pricing-model.md
@@ -1,6 +1,6 @@
 # Pricing model reference
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `9cf12c433`
 
 Constants, formulas, enums, routes, and environment variables of the
 coordinator's money path, each row cited to the code that defines it. How the
@@ -283,6 +283,12 @@ Defaults and validation live in [configuration.md](configuration.md); this table
 | `EIGENINFERENCE_ADMIN_KEY`, `EIGENINFERENCE_ADMIN_EMAILS` | admin authorization for admin billing routes (`isAdminAuthorized`, `coordinator/api/release_handlers.go`) | [Auth: admin key, Privy, release key, sender encryption](configuration.md#auth-admin-key-privy-release-key-sender-encryption) |
 | `MODEL_REGISTRY_PUBLISHING_KEY` | bootstrap publishing key accepted by `POST /v1/admin/models/register` (`requirePublishingAPIKey`) | [Model registry, releases and R2/CDN](configuration.md#model-registry-releases-and-r2cdn) |
 | `EIGENINFERENCE_FINANCIAL_RATE_LIMIT_RPS`, `EIGENINFERENCE_FINANCIAL_RATE_LIMIT_BURST`, `EIGENINFERENCE_SERVICE_RATE_LIMIT_RPS`, `EIGENINFERENCE_SERVICE_RATE_LIMIT_BURST` | financial and service limiters; compiled defaults under [Constants](#constants) | [Routing, admission and TTFT](configuration.md#routing-admission-and-ttft) |
+
+### Connect sweep recovery
+
+| Transition | Policy | Citation |
+|---|---|---|
+| `paid → transferred` after an automatic sweep fails | Reopen only an unrefunded row still stamped with the failed sweep ID. A newer sweep's paid state is preserved. No ledger credit or new withdrawal is created. | `coordinator/store/stripe_sweep_failure.go` (`ReopenStripeWithdrawalAfterSweepFailure`); [billing invariants](../architecture/billing.md#invariants) |
 
 ## Global Payouts withdrawals
 

--- a/docs/reference/pricing-model.md
+++ b/docs/reference/pricing-model.md
@@ -150,6 +150,8 @@ rather than "work" earnings on the leaderboard and in `GET /v1/me/summary`
 
 `stripe_withdrawals.status` (`coordinator/api/stripe_withdraw.go`
 `handleStripeWithdraw`): `pending` → `transferred` → `paid` \| `failed`.
+An automatic payout failure can reopen `paid` as `transferred`; see
+[Connect sweep recovery](#connect-sweep-recovery) for the ownership guard.
 Connected-account status `users.stripe_account_status`
 (`coordinator/api/stripe_payouts.go`): `""` → `pending` → `ready` \|
 `restricted` \| `rejected`. Service agreements (`coordinator/billing/stripe_regions.go`):


### PR DESCRIPTION
An old automatic sweep failure can overwrite a newer completed payout: its handler reads the old paid row, another delivery reopens it and a newer sweep marks it paid, then the old handler writes its stale copy back as transferred with no sweep stamp.

`reopenSweepBouncedRows` now calls `ReopenStripeWithdrawalAfterSweepFailure`. Memory and PostgreSQL atomically require the row to remain paid, unrefunded and attributed to the exact failed sweep. A successful reopen changes only status, sweep stamp, failure reason and update time; stale or duplicate events do nothing. Reopened counts include only applied transitions, and store failures still request redelivery. No ledger movement is introduced.

```mermaid
flowchart LR
  subgraph Before
    A[Old sweep failure] --> B[ListStripeWithdrawalsBySweepPayoutID snapshot]
    B --> C[Concurrent bounce then newer sweep marks paid]
    C --> D[UpdateStripeWithdrawal writes stale whole row]
    D --> E[New payout becomes transferred and loses sweep stamp]
  end
  subgraph After
    F[Old sweep failure] --> G[Read snapshot]
    G --> H[ReopenStripeWithdrawalAfterSweepFailure]
    H -->|Same sweep and paid and unrefunded| I[Atomic reopen for sweep retry]
    H -->|New sweep or ineligible state| J[No change]
    H -->|Store error| K[Webhook redelivery]
  end
```

Validation:
- Deterministic webhook interleaving fails on master (`transferred`, empty sweep stamp instead of `paid`, `po_new`) and passes with the guard.
- Focused payout/sweep/bounce/reversal API race tests passed (1.755s).
- Shared memory/PostgreSQL tests cover matching, replaced, reopened, refunded, failed, missing and invalid-ID cases; verify unchanged non-target fields, idempotent redelivery and zero ledger movement.
- Full store race suite passed against an isolated local PostgreSQL16 instance (21.120s). The owned instance was stopped afterward.
- Docs lint passed (278 pages).
- Full coordinator `GOTOOLCHAIN=go1.25.0 go test ./...` passed (API 193.925s); CI also validates the published branch.

Scope is the automatic-sweep failure transition. Generic transfer/payout-creation updates and instant-payout failure transitions remain separate review work; this does not claim that the entire withdrawal lifecycle is concurrency-proven.
