### PR TITLE
Simplify heartbeat counter handling and fix fleet version gauge race

### DIFF
--- a/coordinator/registry/clamp_test.go
+++ b/coordinator/registry/clamp_test.go
@@ -164,3 +164,37 @@ func TestClampBackendCapacityPrefillOverflowIgnored(t *testing.T) {
 		t.Errorf("plausible ObservedPrefillTPS = %v, want 1600 (unchanged)", bc.Slots[3].ObservedPrefillTPS)
 	}
 }
+
+func TestClampBackendCapacityIntegerBoundaries(t *testing.T) {
+	for _, reported := range []int64{-1, 0, 7, math.MaxInt64} {
+		bc := &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{{
+			MaxTokensPotential: reported, MaxConcurrency: int(reported),
+			NumRunning: int(reported), NumWaiting: int(reported),
+			ModelLoadTimeMS: reported, ActiveTokenBudgetUsed: reported,
+			ActiveTokenBudgetMax: reported, QueuedTokenBudget: reported,
+		}}}
+		clampBackendCapacity(testLogger(), "boundaries", bc)
+		s := bc.Slots[0]
+		for name, value := range map[string]struct{ got, limit int64 }{
+			"tokens":      {int64(s.MaxTokensPotential), maxTokensPotential},
+			"concurrency": {int64(s.MaxConcurrency), maxReportedMaxConcurrency},
+			"running":     {int64(s.NumRunning), math.MaxInt64},
+			"waiting":     {int64(s.NumWaiting), math.MaxInt64},
+			"load":        {s.ModelLoadTimeMS, maxModelLoadTimeMS},
+			"used":        {s.ActiveTokenBudgetUsed, maxTokenBudgetCap},
+			"maximum":     {s.ActiveTokenBudgetMax, maxTokenBudgetCap},
+			"queued":      {s.QueuedTokenBudget, maxTokenBudgetCap},
+		} {
+			want := reported
+			if want < 0 {
+				want = 0
+			}
+			if want > value.limit {
+				want = value.limit
+			}
+			if value.got != want {
+				t.Errorf("%s report %d: got %d, want %d", name, reported, value.got, want)
+			}
+		}
+	}
+}

--- a/coordinator/registry/fleet_views.go
+++ b/coordinator/registry/fleet_views.go
@@ -160,11 +160,11 @@ func (r *Registry) ProviderCountByVersion() map[string]int {
 	for _, p := range r.providers {
 		p.mu.Lock()
 		online := p.Status != StatusOffline && p.Status != StatusUntrusted
+		ver := p.Version
 		p.mu.Unlock()
 		if !online {
 			continue
 		}
-		ver := p.Version
 		if ver == "" {
 			ver = "unknown"
 		}
@@ -235,9 +235,9 @@ func (r *Registry) ProviderCountByMDMFailure() map[string]int {
 	return counts
 }
 
-// FleetSnapshot is the read-only summary used by metrics polling. We
-// don't lock individual providers — counts may be off-by-one under
-// heavy churn — that's acceptable for gauges.
+// FleetSnapshot is the read-only summary used by metrics polling. Each
+// provider contributes one locked observation; the fleet is not frozen as a
+// whole, so gauges can span concurrent status changes.
 type FleetSnapshot struct {
 	Connected  int
 	Idle       int

--- a/coordinator/registry/fleet_views_test.go
+++ b/coordinator/registry/fleet_views_test.go
@@ -1,0 +1,28 @@
+package registry
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestProviderCountByVersionConcurrentUpdate(t *testing.T) {
+	reg := New(testLogger())
+	provider := reg.Register("versioned", nil, testRegisterMessage())
+	provider.SetVersion("old")
+	var updates sync.WaitGroup
+	updates.Add(1)
+	go func() {
+		defer updates.Done()
+		for i := 0; i < 1000; i++ {
+			provider.SetVersion("new")
+			provider.SetVersion("old")
+		}
+	}()
+	defer updates.Wait()
+	for i := 0; i < 1000; i++ {
+		counts := reg.ProviderCountByVersion()
+		if counts["old"]+counts["new"] != 1 || len(counts) != 1 {
+			t.Fatalf("one connected provider must appear exactly once: %v", counts)
+		}
+	}
+}

--- a/coordinator/registry/heartbeat.go
+++ b/coordinator/registry/heartbeat.go
@@ -86,26 +86,14 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 		if s.MaxTokensPotential < 0 || s.MaxTokensPotential > maxTokensPotential {
 			logger.Warn("provider slot max_tokens_potential out of range, clamping",
 				"provider_id", providerID, "model", s.Model, "reported", s.MaxTokensPotential)
-			if s.MaxTokensPotential < 0 {
-				s.MaxTokensPotential = 0
-			} else {
-				s.MaxTokensPotential = maxTokensPotential
-			}
+			s.MaxTokensPotential = min(max(s.MaxTokensPotential, 0), maxTokensPotential)
 		}
-		if s.NumRunning < 0 {
-			s.NumRunning = 0
-		}
-		if s.NumWaiting < 0 {
-			s.NumWaiting = 0
-		}
+		s.NumRunning = max(s.NumRunning, 0)
+		s.NumWaiting = max(s.NumWaiting, 0)
 		if s.MaxConcurrency < 0 || s.MaxConcurrency > maxReportedMaxConcurrency {
 			logger.Warn("provider slot max_concurrency out of range, clamping",
 				"provider_id", providerID, "model", s.Model, "reported", s.MaxConcurrency)
-			if s.MaxConcurrency < 0 {
-				s.MaxConcurrency = 0
-			} else {
-				s.MaxConcurrency = maxReportedMaxConcurrency
-			}
+			s.MaxConcurrency = min(max(s.MaxConcurrency, 0), maxReportedMaxConcurrency)
 		}
 		if v, changed := clampNonNeg(s.ObservedDecodeTPS, maxDecodeTPS); changed {
 			logger.Warn("provider slot observed_decode_tps out of range, clamping",
@@ -128,33 +116,11 @@ func clampBackendCapacity(logger *slog.Logger, providerID string, bc *protocol.B
 		if s.ModelLoadTimeMS < 0 || s.ModelLoadTimeMS > maxModelLoadTimeMS {
 			logger.Warn("provider slot model_load_time_ms out of range, clamping",
 				"provider_id", providerID, "model", s.Model, "reported", s.ModelLoadTimeMS)
-			if s.ModelLoadTimeMS < 0 {
-				s.ModelLoadTimeMS = 0
-			} else {
-				s.ModelLoadTimeMS = maxModelLoadTimeMS
-			}
+			s.ModelLoadTimeMS = min(max(s.ModelLoadTimeMS, 0), maxModelLoadTimeMS)
 		}
-		if s.ActiveTokenBudgetUsed < 0 || s.ActiveTokenBudgetUsed > maxTokenBudgetCap {
-			if s.ActiveTokenBudgetUsed < 0 {
-				s.ActiveTokenBudgetUsed = 0
-			} else {
-				s.ActiveTokenBudgetUsed = maxTokenBudgetCap
-			}
-		}
-		if s.ActiveTokenBudgetMax < 0 || s.ActiveTokenBudgetMax > maxTokenBudgetCap {
-			if s.ActiveTokenBudgetMax < 0 {
-				s.ActiveTokenBudgetMax = 0
-			} else {
-				s.ActiveTokenBudgetMax = maxTokenBudgetCap
-			}
-		}
-		if s.QueuedTokenBudget < 0 || s.QueuedTokenBudget > maxTokenBudgetCap {
-			if s.QueuedTokenBudget < 0 {
-				s.QueuedTokenBudget = 0
-			} else {
-				s.QueuedTokenBudget = maxTokenBudgetCap
-			}
-		}
+		s.ActiveTokenBudgetUsed = min(max(s.ActiveTokenBudgetUsed, 0), maxTokenBudgetCap)
+		s.ActiveTokenBudgetMax = min(max(s.ActiveTokenBudgetMax, 0), maxTokenBudgetCap)
+		s.QueuedTokenBudget = min(max(s.QueuedTokenBudget, 0), maxTokenBudgetCap)
 		if t := s.Telemetry; t != nil {
 			// System-profiler slot telemetry (measurement only). Silent
 			// clamps, like the token-budget fields above: nothing routes on
@@ -460,31 +426,17 @@ func applyHeartbeatStatsDelta(total *protocol.HeartbeatStats, previous, current 
 
 func mergeHeartbeatSessionStats(previous, current protocol.HeartbeatStats) protocol.HeartbeatStats {
 	merged := current
-	if merged.CancellationsReceived == 0 {
-		merged.CancellationsReceived = previous.CancellationsReceived
-	}
-	if merged.CancellationsBeforeOutput == 0 {
-		merged.CancellationsBeforeOutput = previous.CancellationsBeforeOutput
-	}
-	if merged.CancellationsPartialComplete == 0 {
-		merged.CancellationsPartialComplete = previous.CancellationsPartialComplete
-	}
-	if merged.GenerationErrorsAfterOutput == 0 {
-		merged.GenerationErrorsAfterOutput = previous.GenerationErrorsAfterOutput
-	}
-	if merged.ChunkEncryptionErrors == 0 {
-		merged.ChunkEncryptionErrors = previous.ChunkEncryptionErrors
-	}
-	if merged.StreamClosedWithoutTerminal == 0 {
-		merged.StreamClosedWithoutTerminal = previous.StreamClosedWithoutTerminal
-	}
-	if merged.CancelDuringModelLoad == 0 {
-		merged.CancelDuringModelLoad = previous.CancelDuringModelLoad
-	}
-	if merged.UsageGaps == 0 {
-		merged.UsageGaps = previous.UsageGaps
-	}
+	// Required primary counters may reset to zero; omitted optional counters
+	// retain the previous sample so a legacy heartbeat cannot double-count them.
 	for _, f := range []struct{ cur, prev *int64 }{
+		{&merged.CancellationsReceived, &previous.CancellationsReceived},
+		{&merged.CancellationsBeforeOutput, &previous.CancellationsBeforeOutput},
+		{&merged.CancellationsPartialComplete, &previous.CancellationsPartialComplete},
+		{&merged.GenerationErrorsAfterOutput, &previous.GenerationErrorsAfterOutput},
+		{&merged.ChunkEncryptionErrors, &previous.ChunkEncryptionErrors},
+		{&merged.StreamClosedWithoutTerminal, &previous.StreamClosedWithoutTerminal},
+		{&merged.CancelDuringModelLoad, &previous.CancelDuringModelLoad},
+		{&merged.UsageGaps, &previous.UsageGaps},
 		{&merged.CancelStagePreAcceptTotal, &previous.CancelStagePreAcceptTotal},
 		{&merged.CancelStagePreEngineTotal, &previous.CancelStagePreEngineTotal},
 		{&merged.CancelStagePrefillTotal, &previous.CancelStagePrefillTotal},

--- a/coordinator/registry/heartbeat_stats_test.go
+++ b/coordinator/registry/heartbeat_stats_test.go
@@ -1,0 +1,37 @@
+package registry
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestHeartbeatStatsMergePreservesWireCounterSemantics(t *testing.T) {
+	wire := reflect.TypeOf(protocol.HeartbeatStats{})
+	for field := 0; field < wire.NumField(); field++ {
+		t.Run(wire.Field(field).Name, func(t *testing.T) {
+			for _, sample := range []struct{ current, delta int64 }{{-1, 0}, {0, 0}, {3, 3}, {5, 0}, {9, 4}} {
+				var previous, current, total protocol.HeartbeatStats
+				reflect.ValueOf(&previous).Elem().Field(field).SetInt(5)
+				reflect.ValueOf(&current).Elem().Field(field).SetInt(sample.current)
+				reflect.ValueOf(&total).Elem().Field(field).SetInt(100)
+				applyHeartbeatStatsDelta(&total, previous, current)
+				if got := reflect.ValueOf(total).Field(field).Int(); got != 100+sample.delta {
+					t.Fatalf("sample %d: lifetime counter = %d, want %d", sample.current, got, 100+sample.delta)
+				}
+				merged := mergeHeartbeatSessionStats(previous, current)
+				want := sample.current
+				// Optional additive counters retain the previous reading when a
+				// legacy heartbeat omits them. Required primary counters reset.
+				if want == 0 && strings.Contains(wire.Field(field).Tag.Get("json"), ",omitempty") {
+					want = 5
+				}
+				if got := reflect.ValueOf(merged).Field(field).Int(); got != want {
+					t.Fatalf("sample %d: retained session counter = %d, want %d", sample.current, got, want)
+				}
+			}
+		})
+	}
+}

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -1,6 +1,6 @@
 # Provider ↔ coordinator protocol messages
 
-> Last updated: 2026-09-09 · commit `af7a74126`
+> Last updated: 2026-09-11 · commit `e825fadad`
 
 Every JSON frame on the provider WebSocket (`GET /ws/provider`), with the Go
 type, the Swift type, and the presence rule for each field. Go is the canon
@@ -183,6 +183,14 @@ the sinks of each field are in [`telemetry-inventory.md`](telemetry-inventory.md
 Go `HeartbeatStats` · Swift `ProviderStats`. All `int64` in Go, `UInt64` in
 Swift; cumulative per provider session and delta-merged by the registry.
 `requests_served` and `tokens_generated` are required; the rest are `omitempty`.
+
+`applyHeartbeatStatsDelta` adds positive growth to lifetime totals; a smaller
+positive reading starts a new session contribution. Non-positive readings add
+nothing. `mergeHeartbeatSessionStats` retains the previous optional counter
+when its new reading is zero (including omission by an older provider), while
+the two required counters keep their reported zero. Both helpers are in
+`coordinator/registry/heartbeat.go`; these rules prevent an omitted optional
+counter from being counted again when reporting resumes.
 
 | Group | Keys |
 |---|---|

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `e825fadad`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -184,6 +184,14 @@ have different populations and must not be summed together.
 | `profiler.pruned_rows` | count | — | each hourly retention sweep |
 | `providers.online`, `providers.per_model{model}`, `providers.per_version{version}`, `providers.by_trust_status{…}`, `providers.by_mdm_failure{reason}`, `attestation.code_attested`, `attestation.code_enforced`, `coordinator.min_provider_version_set{min_version}`, `request_queue.depth`, `utilization.network`, `utilization.warm`, `utilization.token_budget`, `utilization.bottleneck`, `utilization.model{model}`, `capacity.tps`, `capacity.demand_concurrency`, `capacity.serving_capacity`, `capacity.spill_arrival_rate` | gauge | as listed | every 15 s from `StartDDGaugeLoop` (`coordinator/api/server.go`), which also pushes the `exact_cache.*` gauges (`emitExactCacheDDGauges`, `coordinator/api/exact_cache_metrics.go`); the loop returns immediately when no Datadog client is configured |
 | `request_queue.depth_by_model`, `request_queue.oldest_age_ms` | gauge | `model` | every gauge-loop tick for served or queued models; a disappearing model gets one final zero for both series and is then forgotten (`coordinator/api/fleet_gauges.go`, `emitPerModelQueueGauges`) |
+
+`providers.per_version` uses `Registry.ProviderCountByVersion`
+(`coordinator/registry/fleet_views.go`): each connected provider's status and
+version are read together under its mutex, excluding offline and untrusted
+providers and grouping an empty version as `unknown`. A concurrent
+`Provider.SetVersion` therefore cannot race with the gauge snapshot. The fleet
+is not frozen across the complete walk; these remain observational counts.
+
 
 ### In-process registry (not Datadog)
 


### PR DESCRIPTION
Fleet version gauges read `Provider.Version` after releasing the mutex, racing with registration's `SetVersion`. Capture status and version together under the existing provider lock. A concurrent test reproduces the race on master and passes after the fix.

Heartbeat ingestion also repeated signed integer clamp branches and optional session-counter retention. Use direct integer bounds and the existing field-pair loop. Float rejection policies remain explicit: invalid load headroom becomes absent and invalid observed prefill becomes zero, preserving conservative routing estimates. Sequence ordering, liveness, snapshot ownership, nil clearing, durability, admission and default values are unchanged.

Before:
```mermaid
flowchart LR
  H[Accepted heartbeat] --> C[Repeated integer bound branches]
  C --> S[Repeated optional counter zero branches]
  S --> P[Publish capacity and lifetime statistics]
  G[ProviderCountByVersion] --> L[Lock and read status]
  L --> U[Unlock then read version]
  V[SetVersion under provider lock] -. can race .-> U
  U --> M[Fleet version gauge]
```

After:
```mermaid
flowchart LR
  H[Same accepted heartbeat] --> C[Direct min and max integer bounds]
  C --> S[One optional counter retention loop]
  S --> P[Same capacity and lifetime statistics]
  G[ProviderCountByVersion] --> L[Lock and copy status plus version]
  V[SetVersion under provider lock] --> L
  L --> U[Unlock and aggregate detached values]
  U --> M[Same gauge without version read race]
```

Reviewed the ten heartbeat, persistence and fleet telemetry production files as one operation group. Kept the two-phase profiler sampling, trust restoration, sticky per-slot KV attribution, accounting identities, public projections and versioned token budgets intact. Production is 48 lines smaller; three regression/characterization tests and documentation increase the overall diff.

Validation:

- The version-update fixture reproduces a Go race on unchanged master (`fleet_views.go` versus `version_reset.go`), then passes on this branch.
- Counter characterization covers all 17 wire counters and their required/optional behavior; integer characterization covers negative, zero, ordinary and maximum signed values. Both pass before and after refactoring.
- `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry -count=1` passes (24.344s).
- Independent source/test review found no blocker; documentation lint and whitespace checks pass.
- No live coordinator, model, deployment or benchmark execution. Broader indirect attestation tests ran in the package suite but are not claimed as a full source audit here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764048&installation_model_id=21733&pr_number=934&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F934&signature=879d87bb781a3180618570994fa5d9bb00d7cdc9c30e6fe363fdc76be4a758a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->