### PR TITLE
Correlate cache evidence and avoid repeated SSE transcript copies

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `b8d26a28c`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -494,3 +494,7 @@ Candidate native prefix-cache benchmarks must build ProviderCore and
 prompt SPI carries production sampling parameters into each engine request.
 See [native benchmark validation](test.md#resident-prefix-benchmark-validation)
 for sampling scope, regression filters and diagnostic restrictions.
+
+[Connected capture and evidence fixtures](test.md#connected-coordinatorprovider-http-cache-gate)
+run with Go and owned loopback HTTP stubs; they do not need provider compilation,
+model downloads, Postgres or a sidecar.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `b8d26a28c`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1262,6 +1262,20 @@ construction suite does not replace the real-checkpoint fixture above. Live test
 skips must be reported as unrun qualification.
 
 ## Connected coordinator/provider HTTP cache gate
+
+The local capture/input/evidence fixtures need no provider or model:
+
+```bash
+go test -race ./e2e -short -run 'TestConnected|TestIntegrationConnected(Capture|InputRejects|EvidenceRequires)' -count=1
+```
+
+`e2e/connected_cache_stream_test.go` (`postConnectedStream`) retains the exact
+bounded SSE bytes once on return, including cancellation and failure prefixes.
+Request-scoped lookup/terminal evidence must carry the dispatched request ID;
+background observations need none. Malformed null catalog rows return a normal
+input error. The CPU loopback `BenchmarkConnectedCapture` measures capture
+allocation overhead only, not model decode or TTFT performance. Its original
+output bound, finish/DONE checks and report schema are unchanged.
 
 For a focused release-default check, use
 `e2e/release_defaults_http_test.go` (`TestIntegrationReleaseDefaultsHTTP`).

--- a/e2e/connected_cache_capture_test.go
+++ b/e2e/connected_cache_capture_test.go
@@ -1,0 +1,123 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationConnectedCapturePreservesEveryReturnPath(t *testing.T) {
+	complete := "data: {\"choices\":[{\"delta\":{\"content\":\"answer\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]"
+	for _, test := range []struct {
+		name, body, failure string
+		status              int
+	}{
+		{"complete without final newline", complete, "", http.StatusOK},
+		{"malformed JSON", "data: invalid\n", "invalid character", http.StatusOK},
+		{"provider error", "data: {\"error\":{\"message\":\"failed\"}}\n", "SSE error", http.StatusOK},
+		{"missing done", strings.TrimSuffix(complete, "data: [DONE]"), "without finish and DONE", http.StatusOK},
+		{"missing finish", "data: [DONE]\n", "without finish and DONE", http.StatusOK},
+		{"HTTP error", "bounded failure body", "HTTP status 503", http.StatusServiceUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Provider-Id", "fixture-provider")
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			out, err := postConnectedStream(context.Background(), server.URL, "fixture-key", []byte(`{}`), false)
+			if test.failure == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.failure)
+			}
+			require.Equal(t, test.body, out.RawSSE, "partial evidence must survive every return path")
+			require.Equal(t, test.status, out.HTTPStatus)
+			require.Equal(t, "fixture-provider", out.ProviderID)
+			require.Positive(t, out.TotalMS)
+			if test.failure == "" {
+				require.Equal(t, "answer", out.Content)
+				require.Equal(t, "stop", out.Finish)
+				require.True(t, out.Done)
+				require.Positive(t, out.FirstContentMS)
+			}
+		})
+	}
+}
+
+func TestIntegrationConnectedCaptureBoundsEvidence(t *testing.T) {
+	body := strings.Repeat("x", (8<<20)+2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = io.WriteString(w, body) }))
+	defer server.Close()
+	out, err := postConnectedStream(context.Background(), server.URL, "fixture-key", []byte(`{}`), false)
+	require.ErrorContains(t, err, "bounded 8 MiB")
+	require.Equal(t, body[:(8<<20)+1], out.RawSSE)
+}
+
+func TestIntegrationConnectedCaptureRetainsCancelledPrefix(t *testing.T) {
+	line := "data: {\"choices\":[{\"delta\":{\"content\":\"first\"}}]}\n"
+	closed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, line)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+		close(closed)
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := postConnectedStream(ctx, server.URL, "fixture-key", []byte(`{}`), true)
+	require.NoError(t, err)
+	require.Equal(t, line, out.RawSSE)
+	require.Equal(t, "first", out.Content)
+	require.True(t, out.CancelledByClient)
+	require.False(t, out.Done)
+	require.Empty(t, out.Finish)
+	select {
+	case <-closed:
+	case <-ctx.Done():
+		t.Fatal("cancelled response did not close its owned HTTP request")
+	}
+}
+
+// CPU capture overhead only; these comments carry no model/tokenizer work.
+func BenchmarkConnectedCapture(b *testing.B) {
+	for _, lines := range []int{64, 256} {
+		b.Run(fmt.Sprint(lines), func(b *testing.B) {
+			body := strings.Repeat(":"+strings.Repeat("x", 4094)+"\n", lines) + "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\ndata: [DONE]\n"
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = io.WriteString(w, body) }))
+			defer server.Close()
+			b.ReportAllocs()
+			b.SetBytes(int64(len(body)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := postConnectedStream(context.Background(), server.URL, "fixture-key", []byte(`{}`), false)
+				if err != nil || len(out.RawSSE) != len(body) {
+					b.Fatalf("capture: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestIntegrationConnectedCapturePreservesTruncatedRead(t *testing.T) {
+	body := "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(len(body)+100))
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+	out, err := postConnectedStream(context.Background(), server.URL, "fixture-key", []byte(`{}`), false)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.Equal(t, body, out.RawSSE)
+	require.Equal(t, "partial", out.Content)
+	require.False(t, out.Done)
+}

--- a/e2e/connected_cache_evidence_test.go
+++ b/e2e/connected_cache_evidence_test.go
@@ -61,7 +61,12 @@ func validateConnectedCase(row connectedCase, cache, mtp, expect string) error {
 		return fmt.Errorf("expected exactly one correlated dispatch, got %d", dispatches)
 	}
 	for _, event := range row.Wire {
-		if event.RequestID != "" && event.RequestID != requestID {
+		if event.RequestID == "" {
+			switch event.Type {
+			case "inference_request", "prefix_cache_lookup_v2", "cancel", "inference_complete", "inference_error":
+				return fmt.Errorf("request-scoped %s event is missing its request ID", event.Type)
+			}
+		} else if event.RequestID != requestID {
 			return fmt.Errorf("unrelated attempt contaminated sequential case")
 		}
 	}

--- a/e2e/connected_cache_helpers_test.go
+++ b/e2e/connected_cache_helpers_test.go
@@ -142,3 +142,16 @@ func TestConnectedReasoningOnlyCompletionIsRetained(t *testing.T) {
 	row.HTTP.Finish = "length"
 	require.NoError(t, validateConnectedCase(row, "ssd", "on", "hit"))
 }
+
+func TestIntegrationConnectedEvidenceRequiresIDsOnRequestEvents(t *testing.T) {
+	for _, index := range []int{0, 1, 2} {
+		row := syntheticConnectedRow()
+		t.Run(row.Wire[index].Type, func(t *testing.T) {
+			row.Wire[index].RequestID = ""
+			require.Error(t, validateConnectedCase(row, "ssd", "on", "hit"), "uncorrelated request event cannot qualify a hit")
+		})
+	}
+	row := syntheticConnectedRow()
+	row.Wire = append(row.Wire, testbed.ProviderWireEvent{Connection: 1, Type: "heartbeat"})
+	require.NoError(t, validateConnectedCase(row, "ssd", "on", "hit"), "background observations need no request ID")
+}

--- a/e2e/connected_cache_input_binding_test.go
+++ b/e2e/connected_cache_input_binding_test.go
@@ -51,7 +51,10 @@ func canonicalConnectedInput(raw []byte) ([]byte, []map[string]any, error) {
 	consumedCatalog := after["catalog"].([]any)
 	notes := []map[string]any{}
 	for index, model := range input.Catalog {
-		original := rawCatalog[index].(map[string]any)
+		original, ok := rawCatalog[index].(map[string]any)
+		if !ok {
+			return nil, nil, fmt.Errorf("catalog model object required")
+		}
 		consumed := consumedCatalog[index].(map[string]any)
 		originalEntry, ok := original["Entry"].(map[string]any)
 		if !ok {
@@ -189,4 +192,11 @@ func TestPrepareConnectedInputBindings(t *testing.T) {
 	proof, err := json.MarshalIndent(map[string]any{"results": results, "host_or_model_calls": false}, "", "  ")
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(plan.OutputDirectory, "roundtrip-proof.json"), append(proof, '\n'), 0600))
+}
+
+func TestIntegrationConnectedInputRejectsNullCatalogWithoutPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		_, _, err := canonicalConnectedInput([]byte(`{"catalog":[null]}`))
+		require.Error(t, err)
+	})
 }

--- a/e2e/connected_cache_stream_test.go
+++ b/e2e/connected_cache_stream_test.go
@@ -125,10 +125,11 @@ func postConnectedStream(ctx context.Context, url, apiKey string, body []byte, c
 	out.ProviderID = resp.Header.Get("X-Provider-Id")
 	reader := bufio.NewReaderSize(io.LimitReader(resp.Body, (8<<20)+1), 64<<10)
 	var raw bytes.Buffer
+	// Preserve partial evidence on every return without copying every growing prefix.
+	defer func() { out.RawSSE = raw.String() }()
 	for {
 		line, readErr := reader.ReadBytes('\n')
 		raw.Write(line)
-		out.RawSSE = raw.String()
 		if raw.Len() > 8<<20 {
 			return out, fmt.Errorf("SSE evidence exceeds bounded 8 MiB")
 		}


### PR DESCRIPTION
The connected-cache evidence validator could accept a lookup or completion with no request ID, despite claiming a correlated accepted hit. Canonical input projection also panicked on `catalog: [null]`. Request-scoped events now require the dispatched ID, background observations remain valid without one, and malformed catalog rows return a normal input error.

HTTP capture now materializes `RawSSE` once on return instead of copying the entire growing transcript after each line. This preserves exact partial bytes on success, cancellation, parse/HTTP errors, truncated reads and the existing 8 MiB bound, while removing quadratic copying from recorded request timings. Model policy, report schema, output comparisons, cache/receipt/MTP gates and owned-host lifecycle remain unchanged.

Before:
```mermaid
flowchart TD
 I[Null catalog row] --> P[Unchecked object assertion panics]
 W[Lookup or completion without ID] --> V[Only nonempty mismatches rejected]
 V --> H[Uncorrelated event can count as hit proof]
 S[SSE line] --> C[Copy all accumulated bytes after every line]
 C --> T[Capture overhead inflates recorded timing]
```

After:
```mermaid
flowchart TD
 I[Null catalog row] --> P[Checked object shape returns input error]
 W[Request-scoped wire event] --> V[Require the dispatched request ID]
 V --> H[Existing accepted-hit and terminal checks]
 S[SSE line] --> B[Append to bounded buffer]
 B --> R[Materialize RawSSE once on every return]
 R --> E[Preserve complete or partial evidence]
```

Validation: 24 Go CPU test functions / 78 tests including subtests pass with `-race`. The null-row panic and missing lookup/completion-ID acceptance were reproduced on master before correction. Owned loopback HTTP fixtures cover complete/no-final-newline streams, malformed/error events, missing finish/DONE, non-200 responses, 8 MiB refusal, cancellation/request closure and truncated reads. Existing reasoning-alias raw replay, tool fragments, host/input binding, runtime-copy, cancellation and hit-evidence tests remain green. New regression/capture test names match the existing CI `TestIntegration` filter. Docs lint and whitespace checks pass.

The model-free loopback `BenchmarkConnectedCapture` (`-benchtime=3x`, M3 Max) measured approximately 143.8 MB allocated per 1 MiB/256-line transcript before, versus 6.45 MB after. At 64 lines it measured 10.9 MB versus 1.72 MB. This characterizes capture allocation work, not model TTFT/decode speed or a release benchmark.

No Swift/model/GPU, actual provider, sidecar, database, remote host or production endpoint was executed. Frozen reports and original fixtures are unchanged. This is evidence-reader validation, not new native/model qualification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764202&installation_model_id=21733&pr_number=935&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F935&signature=d18b63aa53cb1bb5118c23412e9f6a3e15b49bc2e9c4097479148b6b01768aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->