### PR TITLE
Add opt-in workload-aware model loading and unloading

### DIFF
--- a/coordinator/api/autopilot_demand.go
+++ b/coordinator/api/autopilot_demand.go
@@ -1,0 +1,214 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+type autopilotDemandKey struct{}
+
+// autopilotDemandRequest is owned by one logical HTTP request. Retries, queue
+// transitions and speculative attempts annotate this object; only the handler
+// exit consumes it. There is no request-ID set, content, or identity retention.
+type autopilotDemandRequest struct {
+	mu       sync.Mutex
+	sample   registry.AutopilotDemandSample
+	profile  *registry.RequestProfile
+	reason   string
+	armed    bool
+	finished bool
+}
+
+func autopilotDemandFromContext(ctx context.Context) *autopilotDemandRequest {
+	if ctx == nil {
+		return nil
+	}
+	d, _ := ctx.Value(autopilotDemandKey{}).(*autopilotDemandRequest)
+	return d
+}
+
+func (s *Server) beginAutopilotDemand(r *http.Request, receivedAt time.Time) (*http.Request, *autopilotDemandRequest) {
+	if s == nil || s.registry == nil || !inferenceOutcomeEndpoint(r) || !s.registry.AutopilotEnabled() {
+		return r, nil
+	}
+	d := &autopilotDemandRequest{sample: registry.AutopilotDemandSample{ReceivedAt: receivedAt}}
+	return r.WithContext(context.WithValue(r.Context(), autopilotDemandKey{}, d)), d
+}
+
+// armAutopilotDemand runs only after the public handler's authentication,
+// account/token limits, balance and request parsing checks. Further validation
+// failures are excluded at finish. Scoped owner/serial traffic is not demand for
+// the public fleet. An honest short request still counts; token length alone is
+// not evidence of abuse.
+func armAutopilotDemand(r *http.Request, p inferenceAdmissionParams) {
+	d := autopilotDemandFromContext(r.Context())
+	if d == nil || p.policy.enabled || p.policy.prefer || len(p.allowedProviderSerials) > 0 ||
+		p.model == "" || len(p.model) > 256 || p.estimatedPromptTokens <= 0 || p.requestedMaxTokens <= 0 {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.armed || d.finished {
+		return
+	}
+	d.sample.Model = p.model
+	d.sample.PromptTokens = p.estimatedPromptTokens
+	d.sample.RequestedMaxTokens = p.requestedMaxTokens
+	d.sample.RequiresVision = p.requiresVision
+	d.sample.HasTools = p.hasTools
+	if p.traits != nil {
+		d.sample.RequiresToolConstraint = p.traits.RequiresToolConstraint
+	} else if p.traitsForModel != nil {
+		d.sample.RequiresToolConstraint = p.traitsForModel(p.model).RequiresToolConstraint
+	}
+	d.armed = true
+}
+
+func setAutopilotDemandModel(r *http.Request, model string) {
+	d := autopilotDemandFromContext(r.Context())
+	if d == nil || model == "" || len(model) > 256 {
+		return
+	}
+	d.mu.Lock()
+	if !d.finished {
+		d.sample.Model = model
+	}
+	d.mu.Unlock()
+}
+
+func bindAutopilotDemandProfile(r *http.Request, rp *registry.RequestProfile) {
+	if d := autopilotDemandFromContext(r.Context()); d != nil {
+		d.mu.Lock()
+		d.profile = rp
+		d.mu.Unlock()
+	}
+}
+
+func annotateAutopilotDemandRejection(info rejectionInfo) {
+	if info.r == nil {
+		return
+	}
+	d := autopilotDemandFromContext(info.r.Context())
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.finished {
+		return
+	}
+	// Coordinator-owned reasons are immediately folded into a closed vocabulary.
+	// A free-form provider error, account ID, or request ID never enters state.
+	d.reason = autopilotTerminalReason(info.reasonCode, info.httpStatus)
+	if info.resolvedModel != "" && len(info.resolvedModel) <= 256 {
+		d.sample.Model = info.resolvedModel
+	}
+}
+
+func autopilotTerminalReason(reason string, status int) string {
+	switch reason {
+	case "machine_busy", "queue_full", "queue_timeout":
+		return "capacity_shed"
+	case "queue_deadline", "deadline_unreachable", "first_chunk_timeout", "ttft_too_slow":
+		return "deadline"
+	case "routing_saturated":
+		return "routing_saturated"
+	case "context_exceeded", "prompt_too_long", "oversized_request", "unservable_token_budget", "model_too_large":
+		return "intrinsic_unservable"
+	case "no_provider", "no_eligible_provider":
+		return "no_eligible_provider"
+	default:
+		if status == http.StatusTooManyRequests {
+			return "other_rate_limit"
+		}
+		if status >= http.StatusInternalServerError {
+			return "provider_fault"
+		}
+		return "unknown"
+	}
+}
+
+// finish consumes exactly once. This is offered logical demand, not a request
+// success counter. Valid requests that fail or depart still consumed demand;
+// intrinsic request limits and coordinator saturation are explicitly labeled so
+// the controller must not mistake them for a removable model-placement deficit.
+func (d *autopilotDemandRequest) finish(status int, clientDeparted bool) (registry.AutopilotDemandSample, bool) {
+	if d == nil {
+		return registry.AutopilotDemandSample{}, false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.finished {
+		return registry.AutopilotDemandSample{}, false
+	}
+	d.finished = true
+	if !d.armed || d.sample.Model == "" || (status >= 400 && status < 500 && status != http.StatusTooManyRequests && status != 499) {
+		return registry.AutopilotDemandSample{}, false
+	}
+	sample := d.sample
+	sample.Reason = d.reason
+	if sample.Reason == "" {
+		sample.Reason = autopilotTerminalReason("", status)
+	}
+	// Unknown/account 429s are not actionable arrival pressure. Recognized
+	// intrinsic/coordinator rejections remain separately diagnosable.
+	if sample.Reason == "other_rate_limit" {
+		return registry.AutopilotDemandSample{}, false
+	}
+	if clientDeparted || status == 499 {
+		sample.Reason = "client_departure"
+		return sample, true
+	}
+	sample.CapacityShed = status == http.StatusTooManyRequests &&
+		(sample.Reason == "capacity_shed" || sample.Reason == "deadline")
+	if status >= 200 && status < 300 {
+		sample.Reason = "admitted"
+		observeAutopilotCompletion(&sample, d.profile)
+	}
+	return sample, true
+}
+
+// A 200 header does not prove stream completion. Only a successful winning
+// provider terminal plus completed consumer output supplies work/service data.
+// Service time includes provider waiting and inference, but excludes coordinator
+// queue/retry time and cold loading (which the placement controller costs apart).
+func observeAutopilotCompletion(sample *registry.AutopilotDemandSample, rp *registry.RequestProfile) {
+	if rp == nil || rp.ClientWriteErr.Load() || rp.ClientGoneUS.Load() > 0 || rp.DoneFlushedUS.Load() <= 0 {
+		return
+	}
+	for _, ap := range rp.Attempts() {
+		if !ap.Winning.Load() {
+			continue
+		}
+		status, _, _, provider, _ := ap.Outcome()
+		if status != "success" || provider != "completed" || !ap.ProviderCompleteObserved.Load() {
+			return
+		}
+		prompt, output, ok := ap.TerminalUsage()
+		if !ok || prompt < 0 || output < 0 {
+			return
+		}
+		sample.Completed = true
+		sample.Reason = "completed"
+		sample.ObservedPromptTokens = prompt
+		sample.ObservedOutputTokens = output
+		accepted, complete := ap.AcceptedUS.Load(), ap.CompleteIngressUS.Load()
+		if ap.DecisionSet && ap.Decision.StateMs == 0 && accepted > 0 && complete > accepted {
+			sample.ServiceTime = time.Duration(complete-accepted) * time.Microsecond
+		}
+		return
+	}
+}
+
+func (s *Server) finishAutopilotDemand(r *http.Request, d *autopilotDemandRequest, status int) {
+	if d == nil || s == nil || s.registry == nil {
+		return
+	}
+	if sample, ok := d.finish(status, r.Context().Err() != nil); ok {
+		s.registry.RecordAutopilotDemand(sample)
+	}
+}

--- a/coordinator/api/autopilot_demand_test.go
+++ b/coordinator/api/autopilot_demand_test.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+func autopilotRequestFixture() (*http.Request, *autopilotDemandRequest, inferenceAdmissionParams) {
+	d := &autopilotDemandRequest{sample: registry.AutopilotDemandSample{ReceivedAt: time.Now()}}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	r = r.WithContext(context.WithValue(r.Context(), autopilotDemandKey{}, d))
+	return r, d, inferenceAdmissionParams{model: "model-build", estimatedPromptTokens: 27, requestedMaxTokens: 64}
+}
+
+func TestAutopilotDemandCountsOneLogicalRequestAcrossRetrySignals(t *testing.T) {
+	r, d, p := autopilotRequestFixture()
+	armAutopilotDemand(r, p)
+	// Repeated annotations are not arrivals. Alias fallback must attribute the
+	// single result to the final build even if initial admission chose another.
+	for range 8 {
+		annotateAutopilotDemandRejection(rejectionInfo{r: r, resolvedModel: p.model, reasonCode: "machine_busy", httpStatus: 429})
+	}
+	setAutopilotDemandModel(r, "fallback-build")
+	annotateAutopilotDemandRejection(rejectionInfo{r: r, resolvedModel: "fallback-build", reasonCode: "queue_deadline", httpStatus: 429})
+	sample, ok := d.finish(429, false)
+	if !ok || sample.Model != "fallback-build" || !sample.CapacityShed || sample.Reason != "deadline" {
+		t.Fatalf("wrong logical terminal: %+v, recorded=%v", sample, ok)
+	}
+	if sample.PromptTokens != 27 || sample.RequestedMaxTokens != 64 {
+		t.Fatalf("honest short input was excluded or envelope changed: %+v", sample)
+	}
+	if _, ok := d.finish(429, false); ok {
+		t.Fatal("logical request counted twice")
+	}
+}
+
+func TestAutopilotDemandExcludesUnvalidatedAndScopedTraffic(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*inferenceAdmissionParams)
+		arm    bool
+		status int
+	}{
+		{"auth before admission", func(*inferenceAdmissionParams) {}, false, 401},
+		{"account rate limit before admission", func(*inferenceAdmissionParams) {}, false, 429},
+		{"validation after admission", func(*inferenceAdmissionParams) {}, true, 400},
+		{"balance topup after admission", func(*inferenceAdmissionParams) {}, true, 402},
+		{"self route", func(p *inferenceAdmissionParams) { p.policy.enabled = true }, true, 200},
+		{"prefer owner", func(p *inferenceAdmissionParams) { p.policy.prefer = true }, true, 200},
+		{"serial restricted", func(p *inferenceAdmissionParams) { p.allowedProviderSerials = []string{"private-serial"} }, true, 200},
+		{"invalid prompt envelope", func(p *inferenceAdmissionParams) { p.estimatedPromptTokens = 0 }, true, 200},
+		{"invalid output envelope", func(p *inferenceAdmissionParams) { p.requestedMaxTokens = -1 }, true, 200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, d, p := autopilotRequestFixture()
+			tc.change(&p)
+			if tc.arm {
+				armAutopilotDemand(r, p)
+			}
+			if sample, ok := d.finish(tc.status, false); ok {
+				t.Fatalf("non-public/non-valid arrival recorded: %+v", sample)
+			}
+		})
+	}
+}
+
+func TestAutopilotDemandSeparatesCapacityFromIntrinsicAndCoordinatorLimits(t *testing.T) {
+	for _, tc := range []struct {
+		raw, reason string
+		capacity    bool
+		recorded    bool
+	}{
+		{"machine_busy", "capacity_shed", true, true},
+		{"queue_timeout", "capacity_shed", true, true},
+		{"first_chunk_timeout", "deadline", true, true},
+		{"ttft_too_slow", "deadline", true, true},
+		{"routing_saturated", "routing_saturated", false, true},
+		{"context_exceeded", "intrinsic_unservable", false, true},
+		{"oversized_request", "intrinsic_unservable", false, true},
+		{"rate_limit_exceeded", "", false, false},
+		{"provider-controlled secret", "", false, false},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			r, d, p := autopilotRequestFixture()
+			armAutopilotDemand(r, p)
+			annotateAutopilotDemandRejection(rejectionInfo{r: r, resolvedModel: p.model, reasonCode: tc.raw, httpStatus: 429})
+			sample, ok := d.finish(429, false)
+			if ok != tc.recorded || (ok && (sample.Reason != tc.reason || sample.CapacityShed != tc.capacity)) {
+				t.Fatalf("terminal %+v recorded=%v; want reason=%q capacity=%v recorded=%v", sample, ok, tc.reason, tc.capacity, tc.recorded)
+			}
+		})
+	}
+}
+
+func autopilotCompletedProfile() (*registry.RequestProfile, *registry.AttemptProfile) {
+	rp := registry.NewRequestProfile(time.Now(), "test-only-id", nil, time.Second)
+	rp.DoneFlushedUS.Store(20_000_000)
+	// A failed/speculative attempt must never become a second service sample.
+	loser := rp.NewAttempt("loser", 0, "")
+	loser.ProviderCompleteObserved.Store(true)
+	loser.SetOutcome("success", "", "", "completed", "")
+	loser.SetTerminalUsage(9999, 9999)
+	winning := rp.NewAttempt("winner", 1, "loser")
+	winning.Winning.Store(true)
+	winning.ProviderCompleteObserved.Store(true)
+	winning.AcceptedUS.Store(5_000_000)
+	winning.CompleteIngressUS.Store(15_000_000)
+	winning.DecisionSet = true
+	winning.SetOutcome("success", "", "", "completed", "")
+	winning.SetTerminalUsage(25, 2)
+	return rp, winning
+}
+
+func TestAutopilotDemandUsesOnlyCompletedWarmWinnerService(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		change    func(*registry.RequestProfile, *registry.AttemptProfile)
+		completed bool
+		service   time.Duration
+	}{
+		{"warm winner", func(*registry.RequestProfile, *registry.AttemptProfile) {}, true, 10 * time.Second},
+		{"cold winner", func(_ *registry.RequestProfile, ap *registry.AttemptProfile) { ap.Decision.StateMs = 30000 }, true, 0},
+		{"unknown placement", func(_ *registry.RequestProfile, ap *registry.AttemptProfile) { ap.DecisionSet = false }, true, 0},
+		{"output incomplete", func(rp *registry.RequestProfile, _ *registry.AttemptProfile) { rp.DoneFlushedUS.Store(0) }, false, 0},
+		{"write failed", func(rp *registry.RequestProfile, _ *registry.AttemptProfile) { rp.ClientWriteErr.Store(true) }, false, 0},
+		{"provider terminal missing", func(_ *registry.RequestProfile, ap *registry.AttemptProfile) {
+			ap.ProviderCompleteObserved.Store(false)
+		}, false, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r, d, p := autopilotRequestFixture()
+			armAutopilotDemand(r, p)
+			rp, winner := autopilotCompletedProfile()
+			tc.change(rp, winner)
+			bindAutopilotDemandProfile(r, rp)
+			sample, ok := d.finish(200, false)
+			if !ok || sample.Completed != tc.completed || sample.ServiceTime != tc.service {
+				t.Fatalf("bad completion sample %+v, recorded=%v", sample, ok)
+			}
+			if tc.completed && (sample.ObservedPromptTokens != 25 || sample.ObservedOutputTokens != 2) {
+				t.Fatalf("winning usage lost or loser used: %+v", sample)
+			}
+		})
+	}
+}
+
+func TestAutopilotDemandDepartureDoesNotClaimCapacityOrCompletion(t *testing.T) {
+	r, d, p := autopilotRequestFixture()
+	armAutopilotDemand(r, p)
+	annotateAutopilotDemandRejection(rejectionInfo{r: r, reasonCode: "machine_busy", httpStatus: 429})
+	sample, ok := d.finish(429, true)
+	if !ok || sample.Reason != "client_departure" || sample.CapacityShed || sample.Completed || sample.ServiceTime != 0 {
+		t.Fatalf("departed request attributed to a later terminal: %+v, recorded=%v", sample, ok)
+	}
+}
+
+func TestAutopilotDemandHTTP499RetainsValidArrival(t *testing.T) {
+	r, d, p := autopilotRequestFixture()
+	armAutopilotDemand(r, p)
+	sample, ok := d.finish(499, false)
+	if !ok || sample.Reason != "client_departure" || sample.CapacityShed {
+		t.Fatalf("valid departure lost or treated as capacity: %+v, recorded=%v", sample, ok)
+	}
+}
+
+func TestAutopilotDemandCompactProfileWorksWithoutAnalyticsSink(t *testing.T) {
+	r, d, _ := autopilotRequestFixture()
+	srv := &Server{}
+	rp := srv.newRequestProfile(r, "model-build", "model", true)
+	if rp == nil || !rp.CompactOnly || d.profile != rp {
+		t.Fatal("enabled demand observation needs a compact completion source")
+	}
+}
+
+func TestAutopilotDemandDisabledLeavesExistingProfilerBehavior(t *testing.T) {
+	srv := &Server{}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	got, d := srv.beginAutopilotDemand(r, time.Now())
+	if got != r || d != nil || autopilotDemandFromContext(got.Context()) != nil {
+		t.Fatal("disabled controller created demand state")
+	}
+	if rp := srv.newRequestProfile(r, "m", "m", false); rp != nil {
+		t.Fatal("disabled controller enabled profiling")
+	}
+}

--- a/coordinator/api/inference_admission.go
+++ b/coordinator/api/inference_admission.go
@@ -242,6 +242,8 @@ func preflightScanWait(deadline time.Duration) time.Duration {
 // prefer modes short-circuit the public capacity gate exactly as before.
 func (s *Server) runInferenceAdmission(w http.ResponseWriter, r *http.Request, parsed map[string]any, p inferenceAdmissionParams) (string, bool) {
 	model := p.model
+	armAutopilotDemand(r, p)
+	defer func() { setAutopilotDemandModel(r, model) }()
 	publicModel := p.publicModel
 	refundReservation := p.refundReservation
 	requestTraits := func() registry.RequestTraits {

--- a/coordinator/api/profiler.go
+++ b/coordinator/api/profiler.go
@@ -130,10 +130,11 @@ func (s *Server) profilerEnabled() bool {
 
 // newRequestProfile creates the request-level profile at inference-handler
 // entry (lazily, never in the middleware) and copies the pre-handler stamps.
-// With heavy profiling off, only accounted inference requests create compact
-// lifecycle evidence. Other call sites remain nil-safe and allocation-free.
+// With heavy profiling off, accounted inference requests and enabled autopilot
+// observations create compact lifecycle evidence. Other call sites remain
+// nil-safe and allocation-free.
 func (s *Server) newRequestProfile(r *http.Request, model, publicModel string, stream bool) *registry.RequestProfile {
-	if r == nil || (!s.profilerEnabled() && requestOutcomeFromContext(r.Context()) == nil) {
+	if r == nil || (!s.profilerEnabled() && requestOutcomeFromContext(r.Context()) == nil && autopilotDemandFromContext(r.Context()) == nil) {
 		return nil
 	}
 	setOutcomeStage(r, "validation")
@@ -149,6 +150,7 @@ func (s *Server) newRequestProfile(r *http.Request, model, publicModel string, s
 		o.attemptFinalized(rp, ap)
 		s.finalizeAttemptProfile(rp, ap)
 	}, profileFallbackGrace)
+	bindAutopilotDemandProfile(r, rp)
 	rp.CompactOnly = !s.profilerEnabled()
 	if o != nil {
 		o.mu.Lock()

--- a/coordinator/api/provider.go
+++ b/coordinator/api/provider.go
@@ -759,6 +759,14 @@ func (s *Server) providerReadLoop(ctx context.Context, conn *websocket.Conn, pro
 			// goroutine or the original connection (reconnect).
 			s.handleCodeAttestationResponse(providerID, provider, respMsg)
 
+		case protocol.TypeModelAutopilotStatus:
+			statusMsg := msg.Payload.(*protocol.ModelAutopilotStatusMessage)
+			if s.registry.HandleAutopilotStatus(providerID, provider, statusMsg) {
+				s.ddIncr("provider.model_autopilot_status", []string{"status:" + statusMsg.Status})
+			} else {
+				s.ddIncr("provider.model_autopilot_status_rejected", nil)
+			}
+
 		case protocol.TypeLoadModelStatus:
 			statusMsg := msg.Payload.(*protocol.LoadModelStatusMessage)
 			if !validLoadModelStatus(statusMsg.Status) {

--- a/coordinator/api/rejection_telemetry.go
+++ b/coordinator/api/rejection_telemetry.go
@@ -66,6 +66,7 @@ type rejectionInfo struct {
 // blocks or fails the request.
 func (s *Server) recordRejection(info rejectionInfo) {
 	annotateOutcomeRejection(info)
+	annotateAutopilotDemandRejection(info)
 	if s == nil || s.store == nil {
 		return
 	}

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -3622,8 +3622,10 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 			ctx = context.WithValue(ctx, requestMetaKey{}, meta)
 		}
 		r = r.WithContext(ctx)
+		r, autopilotDemand := s.beginAutopilotDemand(r, start)
 
 		next.ServeHTTP(sw, r)
+		s.finishAutopilotDemand(r, autopilotDemand, sw.status)
 
 		dur := time.Since(start)
 

--- a/coordinator/cmd/coordinator/main.go
+++ b/coordinator/cmd/coordinator/main.go
@@ -237,6 +237,8 @@ func main() {
 	)
 	stopWarmPool := reg.StartWarmPoolController(ctx, cfg.RegistryCfg.WarmPool)
 	defer stopWarmPool()
+	stopAutopilot := reg.StartAutopilotController(ctx, cfg.RegistryCfg.Autopilot)
+	defer stopAutopilot()
 	if cfg.RegistryCfg.WarmPool.Enabled {
 		logger.Info("warm-pool controller enabled", "observe_only", cfg.RegistryCfg.WarmPool.ObserveOnly, "interval", cfg.RegistryCfg.WarmPool.Interval.String())
 	}

--- a/coordinator/protocol/messages.go
+++ b/coordinator/protocol/messages.go
@@ -217,6 +217,7 @@ type PrefixCacheDonationOutcomeCount struct {
 
 // RegisterMessage is sent when a provider first connects.
 type RegisterMessage struct {
+	ModelAutopilot              *ModelAutopilotState               `json:"model_autopilot,omitempty"`
 	Type                        string                             `json:"type"`
 	Hardware                    Hardware                           `json:"hardware"`
 	Models                      []ModelInfo                        `json:"models"`
@@ -270,13 +271,14 @@ type PrivacyCapabilities struct {
 
 // HeartbeatMessage is sent periodically by connected providers.
 type HeartbeatMessage struct {
-	Type            string           `json:"type"`
-	Status          string           `json:"status"`
-	ActiveModel     *string          `json:"active_model"`
-	Stats           HeartbeatStats   `json:"stats"`
-	WarmModels      []string         `json:"warm_models,omitempty"`      // models currently loaded in memory
-	SystemMetrics   SystemMetrics    `json:"system_metrics"`             // live resource utilization
-	BackendCapacity *BackendCapacity `json:"backend_capacity,omitempty"` // live backend capacity (nil for old providers)
+	ModelAutopilot  *ModelAutopilotState `json:"model_autopilot,omitempty"`
+	Type            string               `json:"type"`
+	Status          string               `json:"status"`
+	ActiveModel     *string              `json:"active_model"`
+	Stats           HeartbeatStats       `json:"stats"`
+	WarmModels      []string             `json:"warm_models,omitempty"`      // models currently loaded in memory
+	SystemMetrics   SystemMetrics        `json:"system_metrics"`             // live resource utilization
+	BackendCapacity *BackendCapacity     `json:"backend_capacity,omitempty"` // live backend capacity (nil for old providers)
 	// Pointer preserves the distinction between an old provider that omitted
 	// v2 capabilities and a v2 provider authoritatively clearing its live set.
 	PrefixCacheProtocol     int                        `json:"prefix_cache_protocol,omitempty"`
@@ -1061,6 +1063,12 @@ func (pm *ProviderMessage) UnmarshalJSON(data []byte) error {
 		var msg LoadModelStatusMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
 			return fmt.Errorf("protocol: failed to unmarshal load_model_status: %w", err)
+		}
+		pm.Payload = &msg
+	case TypeModelAutopilotStatus:
+		var msg ModelAutopilotStatusMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			return fmt.Errorf("protocol: failed to unmarshal model_autopilot_status: %w", err)
 		}
 		pm.Payload = &msg
 

--- a/coordinator/protocol/model_autopilot.go
+++ b/coordinator/protocol/model_autopilot.go
@@ -1,0 +1,55 @@
+package protocol
+
+// Autopilot is an explicit, connection-scoped opt-in. Missing snapshots mean
+// disabled; protocol negotiation never relies on a provider version string.
+const (
+	TypeModelAutopilot       = "model_autopilot"
+	TypeModelAutopilotStatus = "model_autopilot_status"
+	ModelAutopilotProtocol   = 1
+)
+
+type ModelAutopilotResident struct {
+	ModelID         string   `json:"model_id"`
+	ResidentSeconds float64  `json:"resident_seconds"`
+	IdleSeconds     float64  `json:"idle_seconds"`
+	WeightsGB       float64  `json:"weights_gb"`
+	ResidentGB      *float64 `json:"resident_gb,omitempty"`
+}
+
+type ModelAutopilotState struct {
+	Protocol             int                      `json:"protocol"`
+	Enabled              bool                     `json:"enabled"`
+	CachedOnly           bool                     `json:"cached_only"`
+	MinDwellSeconds      int                      `json:"min_dwell_seconds"`
+	PinnedModels         []string                 `json:"pinned_models"`
+	MaxModelSlots        int                      `json:"max_model_slots"`
+	ResidentModels       []ModelAutopilotResident `json:"resident_models"`
+	FreeForLoadNoEvictGB *float64                 `json:"free_for_load_no_evict_gb,omitempty"`
+	ActiveCommandID      string                   `json:"active_command_id,omitempty"`
+	LastCommandID        string                   `json:"last_command_id,omitempty"`
+	LastCommandStatus    string                   `json:"last_command_status,omitempty"`
+}
+
+// A command grants permission to unload ONLY the named victims. The provider
+// must validate the full resident-set precondition, local work, dwell, pins,
+// slot/memory feasibility and expiration before mutating residency. It must
+// never invoke implicit LRU eviction to make this operation fit.
+type ModelAutopilotMessage struct {
+	Type                   string   `json:"type"`
+	CommandID              string   `json:"command_id"`
+	LoadModelID            string   `json:"load_model_id,omitempty"`
+	UnloadModelIDs         []string `json:"unload_model_ids"`
+	ExpectedResidentModels []string `json:"expected_resident_models"`
+	ExpiresAtMS            int64    `json:"expires_at_ms"`
+	LeaseSeconds           int      `json:"lease_seconds"`
+}
+
+// Status is an acknowledgement, not authoritative scheduler capacity. Only a
+// fresh sequenced heartbeat can reconcile the resulting BackendCapacity slots.
+type ModelAutopilotStatusMessage struct {
+	Type           string               `json:"type"`
+	CommandID      string               `json:"command_id"`
+	Status         string               `json:"status"`
+	Error          string               `json:"error,omitempty"`
+	ModelAutopilot *ModelAutopilotState `json:"model_autopilot,omitempty"`
+}

--- a/coordinator/protocol/model_autopilot_test.go
+++ b/coordinator/protocol/model_autopilot_test.go
@@ -1,0 +1,51 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestModelAutopilotCommandWire(t *testing.T) {
+	command := ModelAutopilotMessage{Type: TypeModelAutopilot, CommandID: "command-1", LoadModelID: "model-a", UnloadModelIDs: []string{}, ExpectedResidentModels: []string{}, ExpiresAtMS: 1900000000000, LeaseSeconds: 1800}
+	b, err := json.Marshal(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]json.RawMessage
+	if err = json.Unmarshal(b, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"unload_model_ids", "expected_resident_models"} {
+		if string(fields[key]) != "[]" {
+			t.Fatalf("%s must be an empty array for strict Swift decode: %s", key, fields[key])
+		}
+	}
+	var decoded ModelAutopilotMessage
+	if err = json.Unmarshal(b, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.CommandID != command.CommandID || decoded.ExpiresAtMS != command.ExpiresAtMS || decoded.LeaseSeconds != 1800 {
+		t.Fatalf("wire contract changed: %+v", decoded)
+	}
+}
+
+func TestModelAutopilotStatusWireAndOptInOmission(t *testing.T) {
+	var message ProviderMessage
+	if err := json.Unmarshal([]byte(`{"type":"model_autopilot_status","command_id":"command-1","status":"succeeded","model_autopilot":{"protocol":1,"enabled":true,"cached_only":true,"min_dwell_seconds":1800,"pinned_models":[],"max_model_slots":3,"resident_models":[{"model_id":"model-a","resident_seconds":2,"idle_seconds":0,"weights_gb":12,"resident_gb":10}],"free_for_load_no_evict_gb":4,"last_command_id":"command-1","last_command_status":"succeeded"}}`), &message); err != nil {
+		t.Fatal(err)
+	}
+	status, ok := message.Payload.(*ModelAutopilotStatusMessage)
+	if !ok || status.CommandID != "command-1" || status.ModelAutopilot == nil || !status.ModelAutopilot.Enabled {
+		t.Fatalf("bad status payload: %#v", message.Payload)
+	}
+	if got := status.ModelAutopilot.ResidentModels[0].ResidentGB; got == nil || *got != 10 {
+		t.Fatalf("actual reclaim credit lost: %v", got)
+	}
+	var legacy RegisterMessage
+	if err := json.Unmarshal([]byte(`{"type":"register","models":[],"backend":"mlx-swift"}`), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.ModelAutopilot != nil {
+		t.Fatal("missing opt-in must remain disabled")
+	}
+}

--- a/coordinator/registry/autopilot_commands.go
+++ b/coordinator/registry/autopilot_commands.go
@@ -1,0 +1,139 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"github.com/google/uuid"
+)
+
+func (r *Registry) reserveAutopilotAction(c *modelAutopilotController, a autopilotAction, now time.Time) (protocol.ModelAutopilotMessage, bool) {
+	// Demand is leaf-locked independently. It may increase after planning, so
+	// re-evaluate donor coverage and benefit using a current observation.
+	demand := c.demand.snapshot(now, c.config.DemandWindow)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.autopilot != c || !c.config.Enabled || c.config.ObserveOnly {
+		return protocol.ModelAutopilotMessage{}, false
+	}
+	// Exclusive registry lock prevents new admissions and binds all existing
+	// p.mu updates before recomputing the donor ledger. Nothing is sent here.
+	f := r.autopilotFleetSnapshotLocked(c, demand, now)
+	active := f.LegacyPending
+	for _, n := range f.Nodes {
+		if n.Pending {
+			active++
+		}
+	}
+	if active >= c.config.MaxConcurrentOperations {
+		return protocol.ModelAutopilotMessage{}, false
+	}
+	var node *autopilotNode
+	for i := range f.Nodes {
+		if f.Nodes[i].ID == a.Node.ID {
+			node = &f.Nodes[i]
+			break
+		}
+	}
+	if node == nil || node.Session != a.Node.Session || node.Seq != a.Node.Seq || !node.Managed || !node.Idle || node.Pending || !slices.Equal(autopilotResidentIDs(node.State), autopilotResidentIDs(a.Node.State)) {
+		return protocol.ModelAutopilotMessage{}, false
+	}
+	// Restrict replanning to this recipient, while retaining all other nodes'
+	// real coverage. This validates the exact proposed replacement anew.
+	for i := range f.Nodes {
+		if f.Nodes[i].ID != a.Node.ID {
+			f.Nodes[i].Idle = false
+		}
+	}
+	fresh := planAutopilotAction(f, c.config, now)
+	if fresh == nil || fresh.Load != a.Load || !slices.Equal(sortedAutopilotStrings(fresh.Unload), sortedAutopilotStrings(a.Unload)) {
+		return protocol.ModelAutopilotMessage{}, false
+	}
+	cmd := protocol.ModelAutopilotMessage{Type: protocol.TypeModelAutopilot, CommandID: uuid.NewString(), LoadModelID: fresh.Load, UnloadModelIDs: append([]string{}, fresh.Unload...), ExpectedResidentModels: autopilotResidentIDs(node.State), ExpiresAtMS: now.Add(c.config.CommandAcceptTimeout).UnixMilli(), LeaseSeconds: int(c.config.MinDwell.Seconds())}
+	p := node.Session
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Same-snapshot authority is still required at the exact reservation point.
+	if p.capacitySeq != node.Seq || providerAutopilotTransitionLocked(p) || p.pendingCount() != 0 || !providerAutopilotManagedLocked(p) {
+		return protocol.ModelAutopilotMessage{}, false
+	}
+	p.autopilotPending = &autopilotPendingCommand{Command: cmd, SentAt: now, CapacitySeq: p.capacitySeq, Status: "reserved", LastSentAt: now, Attempts: 1, FailureBackoff: c.config.FailureBackoff}
+	return cmd, true
+}
+
+func (r *Registry) sendAutopilotCommand(p *Provider, command protocol.ModelAutopilotMessage) {
+	if r.logger != nil {
+		r.logger.Info("model autopilot command", "provider_id", p.ID, "command_id", command.CommandID, "load_model", command.LoadModelID, "unload_models", command.UnloadModelIDs)
+	}
+	var err error
+	if r.autopilotSender != nil {
+		err = r.autopilotSender(p.ID, command)
+	} else {
+		var body []byte
+		body, err = json.Marshal(command)
+		if err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), providerControlWriteTimeout)
+			err = p.WriteText(ctx, body)
+			cancel()
+		}
+	}
+	if err != nil {
+		// A write error is ambiguous: the provider might already have received
+		// the command. Never restore donor capacity or issue another command
+		// merely because the sender timed out.
+		p.mu.Lock()
+		if pending := p.autopilotPending; pending != nil && pending.Command.CommandID == command.CommandID {
+			if errors.Is(err, ErrProviderWriterQueueFull) && pending.Attempts == 1 && pending.Status == "reserved" && !pending.Uncertain {
+				p.autopilotBackoffUntil = time.Now().Add(pending.FailureBackoff)
+				p.autopilotPending = nil // the writer proved this command was never enqueued
+			} else {
+				pending.Uncertain = true
+			}
+		}
+		p.mu.Unlock()
+		if r.logger != nil {
+			r.logger.Warn("model autopilot command write failed", "provider_id", p.ID, "command_id", command.CommandID, "error", err)
+		}
+	}
+}
+
+func (r *Registry) HandleAutopilotStatus(providerID string, session *Provider, msg *protocol.ModelAutopilotStatusMessage) bool {
+	if msg == nil || (msg.Status != protocol.LoadModelStatusStarted && msg.Status != protocol.LoadModelStatusSucceeded && msg.Status != protocol.LoadModelStatusFailed) {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p := r.providers[providerID]
+	if p == nil || p != session {
+		return false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.autopilotPending == nil || p.autopilotPending.Command.CommandID != msg.CommandID {
+		return false
+	}
+	if (p.autopilotPending.Status == protocol.LoadModelStatusSucceeded || p.autopilotPending.Status == protocol.LoadModelStatusFailed) && msg.Status != p.autopilotPending.Status {
+		return false
+	}
+	p.autopilotPending.Status = msg.Status
+	return true
+}
+
+func (r *Registry) markAutopilotWatchdogs(cfg AutopilotConfig, now time.Time) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.providers {
+		p.mu.Lock()
+		if pending := p.autopilotPending; pending != nil && now.Sub(pending.SentAt) > cfg.CommandWatchdog {
+			if !pending.Uncertain && r.logger != nil {
+				r.logger.Warn("model autopilot command watchdog", "provider_id", p.ID, "command_id", pending.Command.CommandID, "age", now.Sub(pending.SentAt))
+			}
+			pending.Uncertain = true
+		}
+		p.mu.Unlock()
+	}
+}

--- a/coordinator/registry/autopilot_config.go
+++ b/coordinator/registry/autopilot_config.go
@@ -1,0 +1,81 @@
+package registry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/env"
+)
+
+// Autopilot requires BOTH an operator rollout flag and provider consent. Shadow
+// mode never adds command reservations/fences or sends commands. Provider opt-in
+// independently changes the provider contract to managed, warm-only serving.
+type AutopilotConfig struct {
+	Enabled                 bool
+	ObserveOnly             bool
+	Interval                time.Duration
+	DemandWindow            time.Duration
+	MinDwell                time.Duration
+	IdleUnloadAfter         time.Duration
+	MaxSnapshotAge          time.Duration
+	CommandAcceptTimeout    time.Duration
+	CommandWatchdog         time.Duration
+	FailureBackoff          time.Duration
+	LoadTimePrior           time.Duration
+	MaxActionsPerTick       int
+	MaxConcurrentOperations int
+	TargetUtilization       float64
+	MinBenefitSeconds       float64
+	AllowIdleUnload         bool
+}
+
+func DefaultAutopilotConfig() AutopilotConfig {
+	return AutopilotConfig{
+		ObserveOnly: true, Interval: 10 * time.Second, DemandWindow: 5 * time.Minute,
+		MinDwell: 30 * time.Minute, IdleUnloadAfter: time.Hour,
+		MaxSnapshotAge: 30 * time.Second, CommandAcceptTimeout: 20 * time.Second,
+		CommandWatchdog: 5 * time.Minute, FailureBackoff: 2 * time.Minute,
+		LoadTimePrior:     30 * time.Second,
+		MaxActionsPerTick: 2, MaxConcurrentOperations: 4,
+		TargetUtilization: .7, MinBenefitSeconds: 30,
+	}
+}
+
+func autopilotConfigFromEnv() AutopilotConfig {
+	c := DefaultAutopilotConfig()
+	p := env.EnvPrefix + "_AUTOPILOT_"
+	c.Enabled = env.EnvBool(p+"ENABLED", false)
+	c.ObserveOnly = env.EnvBool(p+"OBSERVE_ONLY", true)
+	c.Interval = envDuration(p+"INTERVAL", c.Interval)
+	c.DemandWindow = envDuration(p+"DEMAND_WINDOW", c.DemandWindow)
+	c.MinDwell = envDuration(p+"MIN_DWELL", c.MinDwell)
+	c.IdleUnloadAfter = envDuration(p+"IDLE_UNLOAD_AFTER", c.IdleUnloadAfter)
+	c.LoadTimePrior = envDuration(p+"LOAD_TIME_PRIOR", c.LoadTimePrior)
+	c.MaxActionsPerTick = env.EnvInt(p+"MAX_ACTIONS_PER_TICK", c.MaxActionsPerTick)
+	c.MaxConcurrentOperations = env.EnvInt(p+"MAX_CONCURRENT_OPERATIONS", c.MaxConcurrentOperations)
+	c.TargetUtilization = env.EnvFloat(p+"TARGET_UTILIZATION", c.TargetUtilization)
+	c.AllowIdleUnload = env.EnvBool(p+"ALLOW_IDLE_UNLOAD", false)
+	return c
+}
+
+func (c AutopilotConfig) Check() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Interval < time.Second || c.Interval > time.Minute || c.DemandWindow < time.Minute || c.DemandWindow > 30*time.Minute {
+		return fmt.Errorf("registry: autopilot interval must be 1s..1m and demand window 1m..30m")
+	}
+	if c.MinDwell < time.Minute || c.MinDwell > 24*time.Hour || c.IdleUnloadAfter < c.MinDwell || c.IdleUnloadAfter > 24*time.Hour {
+		return fmt.Errorf("registry: autopilot dwell must be 1m..24h and idle unload after dwell, at most 24h")
+	}
+	if c.MaxActionsPerTick < 1 || c.MaxActionsPerTick > 32 || c.MaxConcurrentOperations < 1 || c.MaxConcurrentOperations > 64 {
+		return fmt.Errorf("registry: autopilot operation limits are out of range")
+	}
+	if c.MaxSnapshotAge < time.Second || c.MaxSnapshotAge > time.Minute || c.CommandAcceptTimeout < time.Second || c.CommandAcceptTimeout > 5*time.Minute || c.CommandWatchdog < c.CommandAcceptTimeout || c.CommandWatchdog > 30*time.Minute || c.FailureBackoff < time.Second || c.FailureBackoff > time.Hour || c.LoadTimePrior < time.Second || c.LoadTimePrior > 5*time.Minute {
+		return fmt.Errorf("registry: autopilot freshness, deadline, watchdog, backoff or load prior is out of range")
+	}
+	if !(c.TargetUtilization >= .1 && c.TargetUtilization <= .9) || !(c.MinBenefitSeconds >= 0 && c.MinBenefitSeconds <= 3600) {
+		return fmt.Errorf("registry: autopilot utilization/benefit settings are out of range")
+	}
+	return nil
+}

--- a/coordinator/registry/autopilot_controller.go
+++ b/coordinator/registry/autopilot_controller.go
@@ -1,0 +1,176 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+)
+
+func (r *Registry) ConfigureAutopilot(cfg AutopilotConfig) error {
+	if err := cfg.Check(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Startup-only, like routing policy configuration. A running controller is
+	// never replaced underneath in-flight command ownership.
+	if r.autopilot != nil {
+		if r.autopilot.config != cfg {
+			return fmt.Errorf("autopilot is already configured; restart to change rollout settings")
+		}
+		return nil
+	}
+	r.autopilot = &modelAutopilotController{registry: r, config: cfg}
+	return nil
+}
+
+func (r *Registry) StartAutopilotController(ctx context.Context, cfg AutopilotConfig) func() {
+	if err := r.ConfigureAutopilot(cfg); err != nil {
+		r.logger.Error("invalid autopilot configuration", "error", err)
+		return func() {}
+	}
+	if !cfg.Enabled {
+		return func() {}
+	}
+	r.mu.Lock()
+	c := r.autopilot
+	if c.running {
+		r.mu.Unlock()
+		return func() {}
+	}
+	c.running = true
+	r.mu.Unlock()
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer func() { r.mu.Lock(); c.running = false; r.mu.Unlock() }()
+		ticker := time.NewTicker(cfg.Interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				c.tick(now)
+			}
+		}
+	}()
+	return cancel
+}
+
+func (r *Registry) TriggerAutopilot() AutopilotSummary {
+	r.mu.RLock()
+	c := r.autopilot
+	r.mu.RUnlock()
+	if c == nil || !c.config.Enabled {
+		return AutopilotSummary{}
+	}
+	return c.tick(time.Now())
+}
+
+func (r *Registry) AutopilotSnapshot() AutopilotSummary {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.autopilot == nil {
+		return AutopilotSummary{}
+	}
+	s := r.autopilot.lastSummary
+	s.Models = append([]AutopilotModelSummary(nil), s.Models...)
+	s.Excluded = map[string]int{}
+	for k, v := range r.autopilot.lastSummary.Excluded {
+		s.Excluded[k] = v
+	}
+	return s
+}
+
+func (c *modelAutopilotController) tick(now time.Time) AutopilotSummary {
+	started := time.Now()
+	c.tickMu.Lock()
+	defer c.tickMu.Unlock()
+	if !c.config.ObserveOnly {
+		c.registry.markAutopilotWatchdogs(c.config, now)
+		c.registry.retryAutopilotCommands(now)
+	}
+	f := c.registry.autopilotFleetSnapshot(c, now)
+	summary := autopilotSummary(f, c.config, now)
+	remaining := c.config.MaxConcurrentOperations - summary.Pending - f.LegacyPending
+	limit := min(c.config.MaxActionsPerTick, max(0, remaining))
+	for range limit {
+		action := planAutopilotAction(f, c.config, now)
+		if action == nil {
+			break
+		}
+		summary.Proposed++
+		if c.config.ObserveOnly {
+			// Hypothetical state stays in this copy. It never reaches routing,
+			// pending maps, donor protection of another controller or telemetry of
+			// actual capacity. Simulate the debit for this pass only.
+			for i := range f.Nodes {
+				if f.Nodes[i].ID == action.Node.ID {
+					f.Nodes[i].Pending = true
+					f.Nodes[i].Future = action.Future
+					f.Nodes[i].FutureResidents = []string{}
+					for _, m := range action.Node.Residents {
+						if !slices.Contains(action.Unload, m) {
+							f.Nodes[i].FutureResidents = append(f.Nodes[i].FutureResidents, m)
+						}
+					}
+					if action.Load != "" {
+						f.Nodes[i].FutureResidents = append(f.Nodes[i].FutureResidents, action.Load)
+					}
+				}
+			}
+			continue
+		}
+		command, ok := c.registry.reserveAutopilotAction(c, *action, now)
+		if !ok { // State moved since the snapshot. Try again on the next bounded tick.
+			break
+		}
+		summary.Issued++
+		c.registry.sendAutopilotCommand(action.Node.Session, command)
+		f = c.registry.autopilotFleetSnapshot(c, now)
+	}
+	c.registry.mu.Lock()
+	c.lastSummary = summary
+	c.registry.mu.Unlock()
+	if c.registry.logger != nil {
+		c.registry.logger.Info("model autopilot tick", "duration_ms", float64(time.Since(started).Microseconds())/1000, "observe_only", summary.ObserveOnly, "opted_in", summary.OptedIn, "pending", summary.Pending, "uncertain", summary.Uncertain, "proposed", summary.Proposed, "issued", summary.Issued, "excluded", summary.Excluded, "models", summary.Models)
+	}
+	return summary
+}
+
+func autopilotSummary(f autopilotFleet, cfg AutopilotConfig, now time.Time) AutopilotSummary {
+	s := AutopilotSummary{At: now, ObserveOnly: cfg.ObserveOnly, Excluded: f.Excluded}
+	coverage := autopilotCoverage(f)
+	models := make([]string, 0, len(f.Demand)+len(f.Floors))
+	for m := range f.Demand {
+		models = append(models, m)
+	}
+	for m := range f.Floors {
+		if !slices.Contains(models, m) {
+			models = append(models, m)
+		}
+	}
+	slices.Sort(models)
+	for _, n := range f.Nodes {
+		if n.Managed {
+			s.OptedIn++
+		}
+		if n.Pending {
+			s.Pending++
+			if n.Uncertain {
+				s.Uncertain++
+			}
+		}
+	}
+	for _, m := range models {
+		eligible := 0
+		for _, n := range f.Nodes {
+			if n.Managed && n.Idle && !n.Pending && n.Fits[m].MeetsDeadline {
+				eligible++
+			}
+		}
+		s.Models = append(s.Models, AutopilotModelSummary{Model: m, LogicalRequests: f.Demand[m].Requests, OfferedRPS: f.Demand[m].Rate, CapacityRPS: coverage.Ready[m], PendingRPS: coverage.Future[m], ProtectedFloor: autopilotFloor(f, m), WarmProviders: coverage.Warm[m], EligibleIdle: eligible, DeficitRPS: max(0, coverage.Need[m]-coverage.Ready[m]-coverage.Future[m])})
+	}
+	return s
+}

--- a/coordinator/registry/autopilot_controller_benchmark_test.go
+++ b/coordinator/registry/autopilot_controller_benchmark_test.go
@@ -1,0 +1,92 @@
+package registry
+
+import (
+	"fmt"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+	"sort"
+	"testing"
+	"time"
+)
+
+// These benchmarks report operation wall time without contention. Reserve's
+// expensive snapshot/replan currently runs under the exclusive registry lock,
+// so its p95 approximates an upper bound on that write-lock hold (it also
+// includes the small pre-lock demand snapshot). This is not a production tail
+// latency claim. Eight cached builds and 1,000 heterogeneous-consent providers
+// exercise the actual registry gates/rate resolution rather than pure fixtures.
+func BenchmarkAutopilotControllerFleet1000(b *testing.B) {
+	for _, operation := range []string{"reserve", "tick"} {
+		b.Run(operation, func(b *testing.B) {
+			reg := New(testLogger())
+			var catalog []CatalogEntry
+			var advertised []protocol.ModelInfo
+			for i := range 8 {
+				model := fmt.Sprintf("bench-model-%d", i)
+				catalog = append(catalog, CatalogEntry{ID: model, SizeGB: 8, MinRAMGB: 16})
+				advertised = append(advertised, protocol.ModelInfo{ID: model, SizeBytes: 8_000_000_000, ModelType: "chat"})
+			}
+			reg.SetModelCatalog(catalog)
+			warm := testWarmPoolConfig()
+			warm.MinWarmByModel = map[string]int{catalog[0].ID: 1}
+			reg.ConfigureWarmPool(warm)
+			cfg := DefaultAutopilotConfig()
+			cfg.Enabled, cfg.ObserveOnly = true, false
+			if err := reg.ConfigureAutopilot(cfg); err != nil {
+				b.Fatal(err)
+			}
+			reg.autopilotSender = func(string, protocol.ModelAutopilotMessage) error { return nil }
+			now := time.Now()
+			var providers []*Provider
+			for i := range 1000 {
+				msg := testRegisterMessage()
+				msg.Models, msg.DecodeTPS, msg.PrefillTPS = advertised, 100, 2000
+				p := reg.Register(fmt.Sprintf("bench-%04d", i), nil, msg)
+				p.mu.Lock()
+				p.Hardware.MemoryGB = 64
+				p.TrustLevel, p.RuntimeVerified, p.RuntimeManifestChecked, p.ChallengeVerifiedSIP = TrustHardware, true, true, true
+				p.LastChallengeVerified = now
+				p.SystemMetrics = protocol.SystemMetrics{ThermalState: "nominal", CPUUsage: .1, MemoryPressure: .1}
+				p.capacitySeq, p.capacitySamplesAt = 10, now
+				p.BackendCapacity = autopilotControllerCapacity(10, catalog[1].ID)
+				if i%2 == 0 {
+					p.ModelAutopilot = autopilotControllerState(catalog[1].ID)
+				}
+				p.mu.Unlock()
+				providers = append(providers, p)
+			}
+			c := reg.autopilot
+			a := planAutopilotAction(reg.autopilotFleetSnapshot(c, now), cfg, now)
+			if a == nil {
+				b.Fatal("benchmark fixture did not produce a load plan")
+			}
+			elapsed := make([]time.Duration, 0, min(b.N, 10000))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				start := time.Now()
+				if operation == "reserve" {
+					if _, ok := reg.reserveAutopilotAction(c, *a, now); !ok {
+						b.Fatal("reserve failed")
+					}
+				} else if s := c.tick(now); s.Issued != 1 {
+					b.Fatalf("tick issued=%d", s.Issued)
+				}
+				duration := time.Since(start)
+				if len(elapsed) < cap(elapsed) {
+					elapsed = append(elapsed, duration)
+				}
+				b.StopTimer()
+				for _, p := range providers {
+					p.mu.Lock()
+					p.autopilotPending = nil
+					p.mu.Unlock()
+				}
+				b.StartTimer()
+			}
+			b.StopTimer()
+			sort.Slice(elapsed, func(i, j int) bool { return elapsed[i] < elapsed[j] })
+			if len(elapsed) > 0 {
+				b.ReportMetric(float64(elapsed[min(len(elapsed)-1, len(elapsed)*95/100)].Microseconds())/1000, "p95-ms")
+			}
+		})
+	}
+}

--- a/coordinator/registry/autopilot_controller_recovery_test.go
+++ b/coordinator/registry/autopilot_controller_recovery_test.go
@@ -1,0 +1,240 @@
+package registry
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestAutopilotControllerPendingFutureLosesCreditWhenRecipientStopsQualifying(t *testing.T) {
+	for _, mutation := range []string{"stale", "private", "runtime", "catalog"} {
+		t.Run(mutation, func(t *testing.T) {
+			reg, c, now := newAutopilotControllerTest(t, false)
+			p := autopilotControllerProvider(t, reg, "provider", now)
+			if _, ok := reg.reserveAutopilotAction(c, autopilotControllerPlan(t, reg, c, now), now); !ok {
+				t.Fatal("reserve failed")
+			}
+			if got := autopilotCoverage(reg.autopilotFleetSnapshot(c, now)).Future[autopilotTestTarget]; got <= 0 {
+				t.Fatalf("valid pending command has no future credit: %g", got)
+			}
+			if mutation == "catalog" {
+				reg.SetModelCatalog([]CatalogEntry{{ID: autopilotTestTarget, SizeGB: 8, MinRAMGB: 16, RequiredProviderCapabilities: []string{"missing-required-capability"}}})
+			} else {
+				p.mu.Lock()
+				switch mutation {
+				case "stale":
+					p.capacitySamplesAt = now.Add(-c.config.MaxSnapshotAge - time.Second)
+				case "private":
+					p.PrivateOnly = true
+				case "runtime":
+					p.RuntimeVerified = false
+				}
+				p.mu.Unlock()
+			}
+			f := reg.autopilotFleetSnapshot(c, now)
+			if got := autopilotCoverage(f).Future[autopilotTestTarget]; got != 0 {
+				t.Fatalf("invalid recipient still promises %g rps", got)
+			}
+			p.mu.Lock()
+			pending := p.autopilotPending != nil
+			p.mu.Unlock()
+			if !pending {
+				t.Fatal("loss of future credit must not erase unresolved command ownership")
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerRecoveryRetriesExactGenerationWithBound(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	var sent []protocol.ModelAutopilotMessage
+	reg.autopilotSender = func(_ string, command protocol.ModelAutopilotMessage) error {
+		sent = append(sent, command)
+		return errors.New("delivery is unknown")
+	}
+	c.tick(now)
+	for _, tc := range []struct {
+		after time.Duration
+		want  int
+	}{
+		{29 * time.Second, 1}, {30 * time.Second, 2}, {31 * time.Second, 2}, {60 * time.Second, 3}, {120 * time.Second, 3},
+	} {
+		reg.retryAutopilotCommands(now.Add(tc.after))
+		if len(sent) != tc.want {
+			t.Fatalf("after %s sent=%d want=%d", tc.after, len(sent), tc.want)
+		}
+	}
+	for _, command := range sent {
+		if !reflect.DeepEqual(command, sent[0]) {
+			t.Fatalf("retry changed generation or expiry: first=%+v retry=%+v", sent[0], command)
+		}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.autopilotPending == nil || p.autopilotPending.Attempts != 3 || !p.autopilotPending.Uncertain {
+		t.Fatalf("retry lost bounded uncertain ownership: %+v", p.autopilotPending)
+	}
+}
+
+func TestAutopilotControllerOnlyInitialProvenQueueFullReleasesReservation(t *testing.T) {
+	for _, retry := range []bool{false, true} {
+		t.Run(map[bool]string{false: "initial queue full", true: "retry queue full"}[retry], func(t *testing.T) {
+			reg, c, now := newAutopilotControllerTest(t, false)
+			p := autopilotControllerProvider(t, reg, "provider", now)
+			calls := 0
+			reg.autopilotSender = func(string, protocol.ModelAutopilotMessage) error {
+				calls++
+				if retry && calls == 1 {
+					return errors.New("first delivery uncertain")
+				}
+				return ErrProviderWriterQueueFull
+			}
+			c.tick(now)
+			if retry {
+				reg.retryAutopilotCommands(now.Add(30 * time.Second))
+			}
+			p.mu.Lock()
+			pending := p.autopilotPending
+			backoff := p.autopilotBackoffUntil
+			p.mu.Unlock()
+			if retry && (pending == nil || !pending.Uncertain) {
+				t.Fatal("retry queue failure erased uncertain first delivery")
+			}
+			if !retry && (pending != nil || !backoff.After(now)) {
+				t.Fatalf("initial unqueued command should release with backoff: pending=%+v backoff=%v", pending, backoff)
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerTerminalStatusCannotFlipBeforeHeartbeat(t *testing.T) {
+	for _, first := range []string{protocol.LoadModelStatusSucceeded, protocol.LoadModelStatusFailed} {
+		t.Run(first, func(t *testing.T) {
+			reg, c, now := newAutopilotControllerTest(t, false)
+			p := autopilotControllerProvider(t, reg, "provider", now)
+			command, ok := reg.reserveAutopilotAction(c, autopilotControllerPlan(t, reg, c, now), now)
+			if !ok {
+				t.Fatal("reserve failed")
+			}
+			status := func(value string) bool {
+				return reg.HandleAutopilotStatus(p.ID, p, &protocol.ModelAutopilotStatusMessage{CommandID: command.CommandID, Status: value})
+			}
+			if !status(first) || !status(first) {
+				t.Fatal("same terminal and identical duplicate must be accepted")
+			}
+			other := protocol.LoadModelStatusSucceeded
+			if first == other {
+				other = protocol.LoadModelStatusFailed
+			}
+			if status(other) || status(protocol.LoadModelStatusStarted) {
+				t.Fatal("terminal command was reopened by a contradictory status")
+			}
+			p.mu.Lock()
+			pending := p.autopilotPending
+			p.mu.Unlock()
+			if pending == nil || pending.Status != first {
+				t.Fatalf("terminal ownership changed before authoritative heartbeat: %+v", pending)
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerConfigRejectsUnsafeTimingAndNumericSettings(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*AutopilotConfig)
+	}{
+		{"zero snapshot freshness", func(c *AutopilotConfig) { c.MaxSnapshotAge = 0 }},
+		{"long stale snapshot", func(c *AutopilotConfig) { c.MaxSnapshotAge = time.Hour }},
+		{"expired acceptance", func(c *AutopilotConfig) { c.CommandAcceptTimeout = 0 }},
+		{"watchdog before acceptance", func(c *AutopilotConfig) { c.CommandWatchdog = time.Second }},
+		{"unbounded watchdog", func(c *AutopilotConfig) { c.CommandWatchdog = time.Hour }},
+		{"zero backoff", func(c *AutopilotConfig) { c.FailureBackoff = 0 }},
+		{"zero load prior", func(c *AutopilotConfig) { c.LoadTimePrior = 0 }},
+		{"nan utilization", func(c *AutopilotConfig) { c.TargetUtilization = math.NaN() }},
+		{"infinite benefit", func(c *AutopilotConfig) { c.MinBenefitSeconds = math.Inf(1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := DefaultAutopilotConfig()
+			c.Enabled = true
+			tc.change(&c)
+			if c.Check() == nil {
+				t.Fatal("invalid active control policy accepted")
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerNormalUnloadIsNotReportedAsUncertain(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "provider", now, autopilotTestDonor)
+	p.mu.Lock()
+	p.autopilotPending = &autopilotPendingCommand{Command: protocol.ModelAutopilotMessage{CommandID: "unload", ExpectedResidentModels: []string{autopilotTestDonor}, UnloadModelIDs: []string{autopilotTestDonor}}, SentAt: now, CapacitySeq: 10, Status: "reserved"}
+	p.mu.Unlock()
+	summary := autopilotSummary(reg.autopilotFleetSnapshot(c, now), c.config, now)
+	if summary.Pending != 1 || summary.Uncertain != 0 {
+		t.Fatalf("normal unload falsely reported as uncertain: %+v", summary)
+	}
+	reg.markAutopilotWatchdogs(c.config, now.Add(c.config.CommandWatchdog+time.Second))
+	summary = autopilotSummary(reg.autopilotFleetSnapshot(c, now), c.config, now)
+	if summary.Uncertain != 1 {
+		t.Fatalf("watchdog uncertainty was not surfaced: %+v", summary)
+	}
+}
+
+func TestAutopilotControllerFailedHeartbeatUsesReservedBackoff(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	c.config.FailureBackoff = 7 * time.Minute
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	command, ok := reg.reserveAutopilotAction(c, autopilotControllerPlan(t, reg, c, now), now)
+	if !ok {
+		t.Fatal("reserve failed")
+	}
+	state := autopilotControllerState()
+	state.LastCommandID, state.LastCommandStatus = command.CommandID, protocol.LoadModelStatusFailed
+	p.mu.Lock()
+	p.capacitySeq = 11
+	p.BackendCapacity = autopilotControllerCapacity(11)
+	reg.reconcileAutopilotHeartbeatLocked(p, state, now.Add(time.Second))
+	pending, until := p.autopilotPending, p.autopilotBackoffUntil
+	p.mu.Unlock()
+	if pending != nil || !until.Equal(now.Add(time.Second+7*time.Minute)) {
+		t.Fatalf("configured backoff lost on reconciliation: pending=%+v until=%v", pending, until)
+	}
+}
+
+func TestAutopilotControllerFutureUsesOccupancyOnlyCoResidentWork(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "pending", now, autopilotTestDonor)
+	busy := autopilotControllerProvider(t, reg, "busy-donor", now, autopilotTestDonor)
+	for range 100 {
+		c.demand.record(AutopilotDemandSample{Model: autopilotTestTarget, ReceivedAt: now.Add(-time.Minute), PromptTokens: 32, RequestedMaxTokens: 64}, now, c.config.DemandWindow)
+	}
+	p.mu.Lock()
+	p.autopilotPending = &autopilotPendingCommand{Command: protocol.ModelAutopilotMessage{CommandID: "pending-load", LoadModelID: autopilotTestTarget, ExpectedResidentModels: []string{autopilotTestDonor}, UnloadModelIDs: []string{}}, SentAt: now, CapacitySeq: 10, Status: "reserved"}
+	p.mu.Unlock()
+	busy.mu.Lock()
+	busy.BackendCapacity.Slots[0].NumRunning = 8
+	busy.mu.Unlock()
+	f := reg.autopilotFleetSnapshot(c, now)
+	coverage := autopilotCoverage(f)
+	var pending autopilotNode
+	for _, node := range f.Nodes {
+		if node.ID == p.ID {
+			pending = node
+		}
+	}
+	if !slices.Contains(pending.FutureResidents, autopilotTestTarget) || !slices.Contains(pending.FutureResidents, autopilotTestDonor) {
+		t.Fatalf("runtime lost exact future serving set: %+v", pending.FutureResidents)
+	}
+	naive := autopilotNodeContribution(pending, pending.FutureResidents, f.Demand)
+	if coverage.Future[autopilotTestDonor] <= 0 || coverage.Future[autopilotTestTarget] >= naive[autopilotTestTarget] {
+		t.Fatalf("pending target was overcredited by ignoring unfinished co-resident work: future=%+v raw-demand-only=%+v", coverage.Future, naive)
+	}
+}

--- a/coordinator/registry/autopilot_controller_test.go
+++ b/coordinator/registry/autopilot_controller_test.go
@@ -1,0 +1,343 @@
+package registry
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+const (
+	autopilotTestTarget = "controller-target"
+	autopilotTestDonor  = "controller-donor"
+)
+
+func newAutopilotControllerTest(t *testing.T, observe bool) (*Registry, *modelAutopilotController, time.Time) {
+	t.Helper()
+	reg := New(testLogger())
+	reg.SetModelCatalog([]CatalogEntry{{ID: autopilotTestTarget, SizeGB: 8, MinRAMGB: 16}, {ID: autopilotTestDonor, SizeGB: 8, MinRAMGB: 16}})
+	warmCfg := testWarmPoolConfig()
+	warmCfg.MinWarmByModel = map[string]int{autopilotTestTarget: 1}
+	reg.ConfigureWarmPool(warmCfg)
+	cfg := DefaultAutopilotConfig()
+	cfg.Enabled, cfg.ObserveOnly = true, observe
+	if err := reg.ConfigureAutopilot(cfg); err != nil {
+		t.Fatal(err)
+	}
+	return reg, reg.autopilot, time.Now()
+}
+
+func autopilotControllerProvider(t *testing.T, reg *Registry, id string, now time.Time, residents ...string) *Provider {
+	t.Helper()
+	p := makeSchedulerProvider(t, reg, id, autopilotTestTarget, 100)
+	p.mu.Lock()
+	p.Hardware.MemoryGB = 64
+	p.PrefillTPS = 2000
+	p.Models = []protocol.ModelInfo{{ID: autopilotTestTarget, SizeBytes: 8_000_000_000, ModelType: "chat"}, {ID: autopilotTestDonor, SizeBytes: 8_000_000_000, ModelType: "chat"}}
+	p.syncModelIndexLocked()
+	p.capacitySeq = 10
+	p.capacitySamplesAt = now
+	p.BackendCapacity = autopilotControllerCapacity(10, residents...)
+	p.ModelAutopilot = autopilotControllerState(residents...)
+	p.WarmModels = append([]string{}, residents...)
+	p.mu.Unlock()
+	return p
+}
+
+func autopilotControllerState(residents ...string) *protocol.ModelAutopilotState {
+	free := 48.0
+	s := &protocol.ModelAutopilotState{Protocol: 1, Enabled: true, CachedOnly: true, MaxModelSlots: 3, MinDwellSeconds: 60, FreeForLoadNoEvictGB: &free, ResidentModels: []protocol.ModelAutopilotResident{}, PinnedModels: []string{}}
+	for _, m := range residents {
+		resident := 8.0
+		s.ResidentModels = append(s.ResidentModels, protocol.ModelAutopilotResident{ModelID: m, ResidentSeconds: 7200, IdleSeconds: 7200, WeightsGB: 9, ResidentGB: &resident})
+	}
+	return s
+}
+
+func autopilotControllerCapacity(seq uint64, residents ...string) *protocol.BackendCapacity {
+	bc := &protocol.BackendCapacity{TotalMemoryGB: 64, CapacitySeq: seq, Slots: []protocol.BackendSlotCapacity{}}
+	for _, m := range residents {
+		bc.Slots = append(bc.Slots, protocol.BackendSlotCapacity{Model: m, State: "idle", ActiveTokenBudgetMax: 100000, KVBytesPerToken: 65536, MaxConcurrency: 8})
+	}
+	return bc
+}
+
+func autopilotControllerPlan(t *testing.T, reg *Registry, c *modelAutopilotController, now time.Time) autopilotAction {
+	t.Helper()
+	f := reg.autopilotFleetSnapshot(c, now)
+	a := planAutopilotAction(f, c.config, now)
+	if a == nil {
+		t.Fatalf("fixture should plan a target load: fleet=%+v summary=%+v", f, autopilotSummary(f, c.config, now))
+	}
+	return *a
+}
+
+func TestAutopilotControllerObserveOnlyNeverReservesOrSends(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, true)
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	var sent int
+	reg.autopilotSender = func(string, protocol.ModelAutopilotMessage) error { sent++; return nil }
+	before := reg.AutopilotSnapshot()
+	s := c.tick(now)
+	p.mu.Lock()
+	pending := p.autopilotPending
+	active := p.ModelAutopilot.ActiveCommandID
+	seq := p.capacitySeq
+	p.mu.Unlock()
+	if s.Proposed != 1 || s.Issued != 0 || sent != 0 || pending != nil || active != "" || seq != 10 {
+		t.Fatalf("observe-only mutated control state: summary=%+v sent=%d pending=%+v active=%q seq=%d", s, sent, pending, active, seq)
+	}
+	if !before.At.IsZero() || reg.AutopilotSnapshot().Proposed != 1 {
+		t.Fatal("observation summary was not published independently")
+	}
+	// Consent's warm-only fence is real provider policy; the hypothetical plan
+	// itself must not turn a warm node into a transition fence.
+	p.mu.Lock()
+	p.BackendCapacity = autopilotControllerCapacity(11, autopilotTestTarget)
+	p.ModelAutopilot = autopilotControllerState(autopilotTestTarget)
+	blocked := providerAutopilotRoutingBlockedLocked(p, autopilotTestTarget)
+	p.mu.Unlock()
+	if blocked {
+		t.Fatal("hypothetical reservation leaked into routing")
+	}
+}
+
+func TestAutopilotControllerActiveReservesAndEncodesEmptyArrays(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	var commands []protocol.ModelAutopilotMessage
+	reg.autopilotSender = func(_ string, cmd protocol.ModelAutopilotMessage) error { commands = append(commands, cmd); return nil }
+	s := c.tick(now)
+	if s.Issued != 1 || len(commands) != 1 {
+		t.Fatalf("active tick did not issue one operation: summary=%+v commands=%+v", s, commands)
+	}
+	cmd := commands[0]
+	p.mu.Lock()
+	pending := p.autopilotPending
+	blocked := providerAutopilotRoutingBlockedLocked(p, autopilotTestTarget)
+	p.mu.Unlock()
+	if pending == nil || pending.Command.CommandID != cmd.CommandID || !blocked || cmd.LoadModelID != autopilotTestTarget {
+		t.Fatalf("command was not reserved before send: command=%+v pending=%+v blocked=%v", cmd, pending, blocked)
+	}
+	body, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"expected_resident_models":[]`) || !strings.Contains(string(body), `"unload_model_ids":[]`) {
+		t.Fatalf("Swift requires concrete arrays, including empty: %s", body)
+	}
+	if !slices.Equal(cmd.ExpectedResidentModels, []string{}) || cmd.ExpiresAtMS <= now.UnixMilli() {
+		t.Fatalf("invalid command preconditions: %+v", cmd)
+	}
+}
+
+func TestAutopilotControllerReservationRevalidatesSessionSequenceAndState(t *testing.T) {
+	for _, mutation := range []string{"session", "sequence", "residency", "optout", "pending_work", "stale_capacity", "pin"} {
+		t.Run(mutation, func(t *testing.T) {
+			reg, c, now := newAutopilotControllerTest(t, false)
+			p := autopilotControllerProvider(t, reg, "provider", now, autopilotTestDonor)
+			p.mu.Lock()
+			p.ModelAutopilot.MaxModelSlots = 1 // replacement requires explicit victim
+			p.mu.Unlock()
+			a := autopilotControllerPlan(t, reg, c, now)
+			if mutation == "session" {
+				reg.Disconnect(p.ID)
+				autopilotControllerProvider(t, reg, p.ID, now, autopilotTestDonor)
+			} else {
+				p.mu.Lock()
+				switch mutation {
+				case "sequence":
+					p.capacitySeq++
+				case "residency":
+					p.ModelAutopilot.ResidentModels = nil
+				case "optout":
+					p.ModelAutopilot.Enabled = false
+				case "pending_work":
+					p.BackendCapacity.Slots[0].NumRunning = 1
+				case "stale_capacity":
+					p.capacitySamplesAt = now.Add(-c.config.MaxSnapshotAge - time.Second)
+				case "pin":
+					p.ModelAutopilot.PinnedModels = []string{autopilotTestDonor}
+				}
+				p.mu.Unlock()
+			}
+			if cmd, ok := reg.reserveAutopilotAction(c, a, now); ok {
+				t.Fatalf("stale %s plan reserved: %+v", mutation, cmd)
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerSequentialActionsCannotSpendSameDonorFloor(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	reg.warmPool.config.MinWarmByModel[autopilotTestDonor] = 1
+	autopilotControllerProvider(t, reg, "first", now, autopilotTestDonor)
+	autopilotControllerProvider(t, reg, "second", now, autopilotTestDonor)
+	for range 1000 {
+		c.demand.record(AutopilotDemandSample{Model: autopilotTestTarget, ReceivedAt: now.Add(-time.Minute), PromptTokens: 32, RequestedMaxTokens: 64}, now, c.config.DemandWindow)
+	}
+	var sent int
+	reg.autopilotSender = func(string, protocol.ModelAutopilotMessage) error { sent++; return nil }
+	s := c.tick(now)
+	if s.Issued != 1 || sent != 1 {
+		t.Fatalf("one donor must remain outside transitions: summary=%+v sent=%d", s, sent)
+	}
+	c.tick(now.Add(time.Second))
+	if sent != 1 {
+		t.Fatalf("next tick reused donor capacity awaiting heartbeat: sent=%d", sent)
+	}
+}
+
+func TestAutopilotControllerPendingNeedsMatchingFreshAuthoritativeHeartbeat(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	a := autopilotControllerPlan(t, reg, c, now)
+	cmd, ok := reg.reserveAutopilotAction(c, a, now)
+	if !ok {
+		t.Fatal("reservation failed")
+	}
+	if !reg.HandleAutopilotStatus(p.ID, p, &protocol.ModelAutopilotStatusMessage{CommandID: cmd.CommandID, Status: protocol.LoadModelStatusSucceeded}) {
+		t.Fatal("matching status was rejected")
+	}
+	p.mu.Lock()
+	if p.autopilotPending == nil || len(p.BackendCapacity.Slots) != 0 || len(p.WarmModels) != 0 {
+		t.Fatal("status manufactured warm capacity or released pending")
+	}
+	p.mu.Unlock()
+	for _, tc := range []struct {
+		name        string
+		seq         uint64
+		command     string
+		active      string
+		residents   []string
+		capacity    []string
+		wantPending bool
+	}{
+		{"same sequence", 10, cmd.CommandID, "", []string{autopilotTestTarget}, []string{autopilotTestTarget}, true},
+		{"different command", 11, "other-command", "", []string{autopilotTestTarget}, []string{autopilotTestTarget}, true},
+		{"still active", 12, cmd.CommandID, cmd.CommandID, []string{autopilotTestTarget}, []string{autopilotTestTarget}, true},
+		{"resident mismatch", 13, cmd.CommandID, "", []string{autopilotTestTarget}, nil, true},
+		{"matched fresh", 14, cmd.CommandID, "", []string{autopilotTestTarget}, []string{autopilotTestTarget}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := autopilotControllerState(tc.residents...)
+			state.LastCommandID, state.LastCommandStatus, state.ActiveCommandID = tc.command, protocol.LoadModelStatusSucceeded, tc.active
+			reg.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle", BackendCapacity: autopilotControllerCapacity(tc.seq, tc.capacity...), ModelAutopilot: state, WarmModels: tc.capacity})
+			p.mu.Lock()
+			pending := p.autopilotPending != nil
+			p.mu.Unlock()
+			if pending != tc.wantPending {
+				t.Fatalf("pending=%v want=%v", pending, tc.wantPending)
+			}
+		})
+	}
+	if reg.HandleAutopilotStatus(p.ID, p, &protocol.ModelAutopilotStatusMessage{CommandID: cmd.CommandID, Status: protocol.LoadModelStatusFailed}) {
+		t.Fatal("late completed-command status was accepted")
+	}
+}
+
+func TestAutopilotControllerSendAmbiguityAndWatchdogRetainFence(t *testing.T) {
+	for _, sendFailure := range []bool{false, true} {
+		t.Run(map[bool]string{false: "watchdog", true: "ambiguous send"}[sendFailure], func(t *testing.T) {
+			reg, c, now := newAutopilotControllerTest(t, false)
+			p := autopilotControllerProvider(t, reg, "provider", now)
+			reg.autopilotSender = func(string, protocol.ModelAutopilotMessage) error {
+				if sendFailure {
+					return errors.New("write completion unknown")
+				}
+				return nil
+			}
+			c.tick(now)
+			if !sendFailure {
+				reg.markAutopilotWatchdogs(c.config, now.Add(c.config.CommandWatchdog+time.Second))
+			}
+			p.mu.Lock()
+			pending := p.autopilotPending
+			fenced := providerAutopilotTransitionLocked(p)
+			p.mu.Unlock()
+			if pending == nil || !pending.Uncertain || !fenced {
+				t.Fatalf("uncertainty restored capacity/ownership: pending=%+v fenced=%v", pending, fenced)
+			}
+			coverage := autopilotCoverage(reg.autopilotFleetSnapshot(c, now))
+			if coverage.Future[autopilotTestTarget] != 0 {
+				t.Fatalf("uncertain operation still credited projected capacity: %+v", coverage.Future)
+			}
+		})
+	}
+}
+
+func TestAutopilotControllerReconnectAndOptOutDoNotAcceptStaleAcknowledgements(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	p := autopilotControllerProvider(t, reg, "provider", now)
+	cmd, ok := reg.reserveAutopilotAction(c, autopilotControllerPlan(t, reg, c, now), now)
+	if !ok {
+		t.Fatal("reservation failed")
+	}
+	state := autopilotControllerState()
+	state.Enabled, state.LastCommandID, state.LastCommandStatus = false, cmd.CommandID, protocol.LoadModelStatusFailed
+	reg.Heartbeat(p.ID, &protocol.HeartbeatMessage{Status: "idle", BackendCapacity: autopilotControllerCapacity(11), ModelAutopilot: state})
+	p.mu.Lock()
+	if p.autopilotPending != nil || providerAutopilotManagedLocked(p) {
+		t.Fatal("matching opt-out completion did not release management")
+	}
+	p.mu.Unlock()
+	reg.Disconnect(p.ID)
+	newSession := autopilotControllerProvider(t, reg, p.ID, now)
+	if reg.HandleAutopilotStatus(p.ID, p, &protocol.ModelAutopilotStatusMessage{CommandID: cmd.CommandID, Status: protocol.LoadModelStatusSucceeded}) {
+		t.Fatal("old-session acknowledgement accepted after reconnect")
+	}
+	newSession.mu.Lock()
+	defer newSession.mu.Unlock()
+	if newSession.autopilotPending != nil || len(newSession.BackendCapacity.Slots) != 0 {
+		t.Fatal("old command leaked into fresh connection")
+	}
+}
+
+func TestAutopilotControllerConcurrentReservationsHonorBudgetWithObservedLegacyLoads(t *testing.T) {
+	reg, c, now := newAutopilotControllerTest(t, false)
+	c.config.MaxConcurrentOperations = 2
+	for _, id := range []string{"a", "b", "c", "d"} {
+		autopilotControllerProvider(t, reg, id, now)
+	}
+	for range 1000 {
+		c.demand.record(AutopilotDemandSample{Model: autopilotTestTarget, ReceivedAt: now.Add(-time.Minute), PromptTokens: 32, RequestedMaxTokens: 64}, now, c.config.DemandWindow)
+	}
+	key := modelLoadKey{ProviderID: "legacy", ModelID: autopilotTestTarget}
+	reg.pendingModelLoads[key], reg.pendingModelLoadStarted[key] = now.Add(time.Minute), now
+	f := reg.autopilotFleetSnapshot(c, now)
+	var actions []autopilotAction
+	for _, node := range f.Nodes {
+		one := f
+		one.Nodes = append([]autopilotNode(nil), f.Nodes...)
+		for i := range one.Nodes {
+			one.Nodes[i].Idle = one.Nodes[i].ID == node.ID
+		}
+		if a := planAutopilotAction(one, c.config, now); a != nil {
+			actions = append(actions, *a)
+		}
+	}
+	if len(actions) != 4 {
+		t.Fatalf("fixture needs four eligible recipients: %d", len(actions))
+	}
+	var accepted atomic.Int32
+	var wg sync.WaitGroup
+	for _, action := range actions {
+		wg.Add(1)
+		go func(a autopilotAction) {
+			defer wg.Done()
+			if _, ok := reg.reserveAutopilotAction(c, a, now); ok {
+				accepted.Add(1)
+			}
+		}(action)
+	}
+	wg.Wait()
+	if accepted.Load() != 1 {
+		t.Fatalf("shared operation budget permits one managed + one legacy, got %d managed", accepted.Load())
+	}
+}

--- a/coordinator/registry/autopilot_demand.go
+++ b/coordinator/registry/autopilot_demand.go
@@ -1,0 +1,262 @@
+package registry
+
+import (
+	"math"
+	"sort"
+	"sync"
+	"time"
+)
+
+// AutopilotDemandSample is one validated PUBLIC logical HTTP request, never a
+// dispatch attempt. The API's request-owned terminal consumer enforces once-only
+// delivery; this tracker deliberately retains no identity or deduplication set.
+// Terminal delivery enriches the original arrival's window. It cannot see an
+// unfinished request: the planner must independently use live occupancy as a
+// lower bound on demand, not add occupancy to this same workload a second time.
+type AutopilotDemandSample struct {
+	Model                  string
+	ReceivedAt             time.Time
+	PromptTokens           int
+	RequestedMaxTokens     int
+	RequiresVision         bool
+	HasTools               bool
+	RequiresToolConstraint bool
+	CapacityShed           bool
+	Completed              bool
+	ServiceTime            time.Duration
+	ObservedPromptTokens   int
+	ObservedOutputTokens   int
+	Reason                 string
+}
+
+const (
+	autopilotDemandBucketWidth = 10 * time.Second
+	autopilotDemandMaxWindow   = 30 * time.Minute
+	autopilotDemandMaxModels   = 256
+	autopilotDemandMaxTokens   = 1048576
+	autopilotDemandMinSamples  = 8
+)
+
+var autopilotPromptBounds = [...]int{64, 256, 1024, 4096, 16384, 65536, 262144, autopilotDemandMaxTokens}
+
+type autopilotDemandBucket struct {
+	at                                               time.Time
+	requests, shed, completed, serviceSamples        int
+	promptSum, requestedOutputSum, observedOutputSum float64
+	serviceSeconds                                   float64
+	prompts                                          [8]int
+	vision, tools, grammar                           bool
+}
+type autopilotModelDemand struct {
+	first, last time.Time               // accepted arrival times, never terminal refresh times
+	buckets     []autopilotDemandBucket // sorted; one entry per ten-second interval
+}
+type autopilotDemandTracker struct {
+	mu     sync.Mutex
+	models map[string]*autopilotModelDemand
+}
+type autopilotDemandView struct {
+	Rate                                              float64
+	PromptTokens, TailPromptTokens                    int
+	OutputTokens, RequestedMaxTokens                  int
+	ServiceSeconds                                    float64
+	Requests, CapacityShed, Completed, ServiceSamples int
+	RequiresVision, HasTools, RequiresToolConstraint  bool
+	LastDemand                                        time.Time
+}
+
+func (r *Registry) AutopilotEnabled() bool {
+	r.mu.RLock()
+	c := r.autopilot
+	r.mu.RUnlock()
+	return c != nil && c.config.Enabled
+}
+
+func (r *Registry) RecordAutopilotDemand(sample AutopilotDemandSample) {
+	r.mu.RLock()
+	c := r.autopilot
+	r.mu.RUnlock()
+	if c == nil || !c.config.Enabled {
+		return
+	}
+	c.demand.record(sample, time.Now(), c.config.DemandWindow)
+}
+
+func (d *autopilotDemandTracker) record(s AutopilotDemandSample, now time.Time, window time.Duration) {
+	if window <= 0 || window > autopilotDemandMaxWindow || now.IsZero() ||
+		s.Model == "" || len(s.Model) > 256 || s.PromptTokens <= 0 || s.PromptTokens > autopilotDemandMaxTokens ||
+		s.RequestedMaxTokens < 0 || s.RequestedMaxTokens > autopilotDemandMaxTokens {
+		return
+	}
+	// Intrinsically invalid work and scheduler lock exhaustion are not demand
+	// that another loaded model can serve. Short input alone is never excluded.
+	if s.Reason == "intrinsic_unservable" || s.Reason == "routing_saturated" {
+		return
+	}
+	arrival := s.ReceivedAt
+	if arrival.IsZero() {
+		// Compatibility fallback for callers without an arrival clock. Known old
+		// or future timestamps are never rewritten into fresh demand.
+		arrival = now
+	}
+	if arrival.After(now) || arrival.Before(now.Add(-window)) {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.models == nil {
+		d.models = make(map[string]*autopilotModelDemand)
+	}
+	m := d.models[s.Model]
+	if m != nil && m.last.Before(now.Add(-2*window)) {
+		delete(d.models, s.Model)
+		m = nil
+	}
+	if m == nil {
+		d.pruneModels(now, window)
+		if len(d.models) >= autopilotDemandMaxModels {
+			return
+		}
+		m = &autopilotModelDemand{first: arrival, last: arrival}
+		d.models[s.Model] = m
+	}
+	if arrival.Before(m.first) {
+		m.first = arrival
+	}
+	if arrival.After(m.last) {
+		m.last = arrival
+	}
+	m.pruneBuckets(now.Add(-window))
+
+	at := arrival.Truncate(autopilotDemandBucketWidth)
+	// Completions arrive out of order. Insert into the arrival interval rather
+	// than append another copy or attribute its work to the terminal interval.
+	i := sort.Search(len(m.buckets), func(i int) bool { return !m.buckets[i].at.Before(at) })
+	if i == len(m.buckets) || !m.buckets[i].at.Equal(at) {
+		m.buckets = append(m.buckets, autopilotDemandBucket{})
+		copy(m.buckets[i+1:], m.buckets[i:])
+		m.buckets[i] = autopilotDemandBucket{at: at}
+	}
+	b := &m.buckets[i]
+	b.requests++
+	if s.CapacityShed {
+		b.shed++
+	}
+	b.promptSum += float64(s.PromptTokens)
+	b.requestedOutputSum += float64(s.RequestedMaxTokens)
+	for i, bound := range autopilotPromptBounds {
+		if s.PromptTokens <= bound {
+			b.prompts[i]++
+			break
+		}
+	}
+	b.vision = b.vision || s.RequiresVision
+	b.tools = b.tools || s.HasTools
+	b.grammar = b.grammar || s.RequiresToolConstraint
+	if s.Completed && s.ObservedOutputTokens >= 0 && s.ObservedOutputTokens <= autopilotDemandMaxTokens {
+		// A real completion supplies output even when cold loading, unknown
+		// timing, or a very long request makes warm service time unusable.
+		b.completed++
+		b.observedOutputSum += float64(s.ObservedOutputTokens)
+		if s.ServiceTime > 0 && s.ServiceTime <= 10*time.Minute {
+			b.serviceSamples++
+			b.serviceSeconds += s.ServiceTime.Seconds()
+		}
+	}
+}
+
+// pruneModels runs under d.mu. Arrival-based expiry prevents delayed terminals
+// from keeping stale demand alive or filling the bounded model map forever.
+func (d *autopilotDemandTracker) pruneModels(now time.Time, window time.Duration) {
+	for model, m := range d.models {
+		if m.last.Before(now.Add(-2 * window)) {
+			delete(d.models, model)
+		}
+	}
+}
+
+// Keep the interval intersecting the cutoff. Counts therefore have ten-second
+// resolution: an unaligned snapshot can retain <10s of old work, but never loses
+// the valid part of that interval. At aligned ticks the cutoff is exact. New
+// samples still pass the exact arrival cutoff before insertion. There are at
+// most ceil(window/10s)+1 occupied intervals, independent of request volume.
+func (m *autopilotModelDemand) pruneBuckets(cutoff time.Time) {
+	at := cutoff.Truncate(autopilotDemandBucketWidth)
+	i := sort.Search(len(m.buckets), func(i int) bool { return !m.buckets[i].at.Before(at) })
+	if i > 0 {
+		copy(m.buckets, m.buckets[i:])
+		clear(m.buckets[len(m.buckets)-i:])
+		m.buckets = m.buckets[:len(m.buckets)-i]
+	}
+}
+
+func (d *autopilotDemandTracker) snapshot(now time.Time, window time.Duration) map[string]autopilotDemandView {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make(map[string]autopilotDemandView)
+	if window <= 0 || window > autopilotDemandMaxWindow || now.IsZero() {
+		return out
+	}
+	d.pruneModels(now, window)
+	for model, m := range d.models {
+		m.pruneBuckets(now.Add(-window))
+		var sum autopilotDemandBucket
+		fast := 0
+		fastCutoff := now.Add(-time.Minute).Truncate(autopilotDemandBucketWidth)
+		for _, b := range m.buckets {
+			if b.at.After(now) {
+				continue // a backwards clock adjustment must not count future work
+			}
+			sum.requests += b.requests
+			sum.shed += b.shed
+			sum.completed += b.completed
+			sum.serviceSamples += b.serviceSamples
+			sum.promptSum += b.promptSum
+			sum.requestedOutputSum += b.requestedOutputSum
+			sum.observedOutputSum += b.observedOutputSum
+			sum.serviceSeconds += b.serviceSeconds
+			sum.vision = sum.vision || b.vision
+			sum.tools = sum.tools || b.tools
+			sum.grammar = sum.grammar || b.grammar
+			for i, count := range b.prompts {
+				sum.prompts[i] += count
+			}
+			if !b.at.Before(fastCutoff) {
+				fast += b.requests
+			}
+		}
+		v := autopilotDemandView{
+			LastDemand: m.last, Requests: sum.requests, CapacityShed: sum.shed,
+			Completed: sum.completed, ServiceSamples: sum.serviceSamples,
+			RequiresVision: sum.vision, HasTools: sum.tools, RequiresToolConstraint: sum.grammar,
+		}
+		if sum.requests > 0 {
+			elapsed := math.Max(autopilotDemandBucketWidth.Seconds(), math.Min(window.Seconds(), now.Sub(m.first).Seconds()))
+			v.Rate = math.Max(float64(sum.requests)/elapsed, float64(fast)/math.Min(60, elapsed))
+			// Arithmetic mean prices throughput work. The histogram tail must
+			// not inflate every arrival's expected prefill cost.
+			v.PromptTokens = int(math.Ceil(sum.promptSum / float64(sum.requests)))
+			v.RequestedMaxTokens = int(math.Ceil(sum.requestedOutputSum / float64(sum.requests)))
+			v.OutputTokens = min(256, max(1, v.RequestedMaxTokens))
+			if sum.completed >= autopilotDemandMinSamples {
+				v.OutputTokens = max(1, int(math.Ceil(sum.observedOutputSum/float64(sum.completed))))
+			}
+			if sum.serviceSamples >= autopilotDemandMinSamples {
+				v.ServiceSeconds = sum.serviceSeconds / float64(sum.serviceSamples)
+			}
+			// Deadline fit uses the p90 histogram upper bound, at least the
+			// mean. This is a conservative shape, not an observed token count.
+			quantile := int(math.Ceil(float64(sum.requests) * .9))
+			for i, count := range sum.prompts {
+				quantile -= count
+				if quantile <= 0 {
+					v.TailPromptTokens = max(v.PromptTokens, autopilotPromptBounds[i])
+					break
+				}
+			}
+		}
+		out[model] = v
+	}
+	return out
+}

--- a/coordinator/registry/autopilot_demand_test.go
+++ b/coordinator/registry/autopilot_demand_test.go
@@ -1,0 +1,295 @@
+package registry
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+func autopilotDemandTestClock() time.Time {
+	return time.Date(2026, 9, 11, 23, 0, 0, 0, time.UTC)
+}
+
+func autopilotDemandTestSample(at time.Time) AutopilotDemandSample {
+	return AutopilotDemandSample{
+		Model: "model", ReceivedAt: at, PromptTokens: 27, RequestedMaxTokens: 1024,
+	}
+}
+
+func TestAutopilotDemandArrivalWindowDoesNotShiftToTerminal(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := 5 * time.Minute
+	var d autopilotDemandTracker
+	s := autopilotDemandTestSample(now.Add(-4 * time.Minute))
+	s.CapacityShed, s.Reason = true, "deadline"
+	d.record(s, now, window)
+	v := d.snapshot(now, window)["model"]
+	if v.Requests != 1 || v.CapacityShed != 1 || !v.LastDemand.Equal(s.ReceivedAt) {
+		t.Fatalf("terminal replaced arrival: %+v", v)
+	}
+	// No fast-window request: a delayed terminal must not create a fresh spike.
+	if math.Abs(v.Rate-1.0/240) > 1e-12 {
+		t.Fatalf("delayed terminal rate=%g, want 1/240", v.Rate)
+	}
+	v = d.snapshot(now.Add(time.Minute+autopilotDemandBucketWidth), window)["model"]
+	if v.Requests != 0 || v.Rate != 0 || !v.LastDemand.Equal(s.ReceivedAt) {
+		t.Fatalf("expired arrival was renewed by its terminal: %+v", v)
+	}
+}
+
+func TestAutopilotDemandOutOfOrderCompletionsCoalesceArrivalBuckets(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := 5 * time.Minute
+	offsets := []time.Duration{-3 * time.Minute, -time.Second, -4 * time.Minute, -2 * time.Second, -2 * time.Minute}
+	var forward, reverse autopilotDemandTracker
+	for i := range offsets {
+		forward.record(autopilotDemandTestSample(now.Add(offsets[i])), now, window)
+		reverse.record(autopilotDemandTestSample(now.Add(offsets[len(offsets)-1-i])), now, window)
+	}
+	a, b := forward.snapshot(now, window), reverse.snapshot(now, window)
+	if !reflect.DeepEqual(a, b) || a["model"].Requests != len(offsets) {
+		t.Fatalf("completion order changed demand: forward=%+v reverse=%+v", a, b)
+	}
+	buckets := forward.models["model"].buckets
+	if len(buckets) != 4 || buckets[len(buckets)-1].requests != 2 {
+		t.Fatalf("same arrival interval was duplicated: %+v", buckets)
+	}
+	for i := 1; i < len(buckets); i++ {
+		if !buckets[i-1].at.Before(buckets[i].at) {
+			t.Fatalf("arrival buckets are not strictly sorted: %+v", buckets)
+		}
+	}
+}
+
+func TestAutopilotDemandArrivalClockBoundaryAndFallback(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := 5 * time.Minute
+	for _, tc := range []struct {
+		name    string
+		arrival time.Time
+		want    int
+	}{
+		{"exact old boundary", now.Add(-window), 1},
+		{"older than window", now.Add(-window - time.Nanosecond), 0},
+		{"future clock", now.Add(time.Nanosecond), 0},
+		{"exact current time", now, 1},
+		{"missing clock fallback", time.Time{}, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var d autopilotDemandTracker
+			d.record(autopilotDemandTestSample(tc.arrival), now, window)
+			v := d.snapshot(now, window)["model"]
+			if v.Requests != tc.want {
+				t.Fatalf("requests=%d, want %d", v.Requests, tc.want)
+			}
+			if tc.arrival.IsZero() && !v.LastDemand.Equal(now) {
+				t.Fatalf("missing arrival did not use explicit fallback: %+v", v)
+			}
+		})
+	}
+}
+
+func TestAutopilotDemandPartialBucketRetentionIsBounded(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := time.Minute
+	var d autopilotDemandTracker
+	d.record(autopilotDemandTestSample(now), now, window)
+	// An unaligned cutoff retains the intersecting interval, at most <10s.
+	if got := d.snapshot(now.Add(window+9*time.Second), window)["model"].Requests; got != 1 {
+		t.Fatalf("intersecting bucket discarded: %d", got)
+	}
+	if got := d.snapshot(now.Add(window+10*time.Second), window)["model"].Requests; got != 0 {
+		t.Fatalf("old bucket survived its upper bound: %d", got)
+	}
+}
+
+func TestAutopilotDemandOutputAndWarmServiceHaveIndependentSamples(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := 5 * time.Minute
+	var d autopilotDemandTracker
+	for i := 0; i < 8; i++ {
+		s := autopilotDemandTestSample(now)
+		s.Completed, s.ObservedOutputTokens = true, 2000
+		// Both unknown/cold timing and overly long service retain actual output.
+		if i%2 == 0 {
+			s.ServiceTime = 11 * time.Minute
+		}
+		d.record(s, now, window)
+	}
+	v := d.snapshot(now, window)["model"]
+	if v.Completed != 8 || v.OutputTokens != 2000 || v.ServiceSamples != 0 || v.ServiceSeconds != 0 {
+		t.Fatalf("valid outputs depended on warm timing: %+v", v)
+	}
+	for i := 0; i < 8; i++ {
+		s := autopilotDemandTestSample(now)
+		s.Completed, s.ObservedOutputTokens, s.ServiceTime = true, 1000, 10*time.Second
+		d.record(s, now, window)
+	}
+	v = d.snapshot(now, window)["model"]
+	if v.Completed != 16 || v.OutputTokens != 1500 || v.ServiceSamples != 8 || v.ServiceSeconds != 10 {
+		t.Fatalf("service mean used output-sample denominator: %+v", v)
+	}
+}
+
+func TestAutopilotDemandCompletionBoundsAndSparsePriors(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := 5 * time.Minute
+	var d autopilotDemandTracker
+	for i := 0; i < 7; i++ {
+		s := autopilotDemandTestSample(now)
+		s.Completed, s.ObservedOutputTokens, s.ServiceTime = true, 0, 2*time.Second
+		d.record(s, now, window)
+	}
+	v := d.snapshot(now, window)["model"]
+	if v.Completed != 7 || v.ServiceSamples != 7 || v.OutputTokens != 256 || v.ServiceSeconds != 0 {
+		t.Fatalf("sparse observations replaced conservative priors: %+v", v)
+	}
+	for _, output := range []int{-1, autopilotDemandMaxTokens + 1} {
+		s := autopilotDemandTestSample(now)
+		s.Completed, s.ObservedOutputTokens, s.ServiceTime = true, output, time.Second
+		d.record(s, now, window)
+	}
+	s := autopilotDemandTestSample(now)
+	s.Completed, s.ObservedOutputTokens, s.ServiceTime = true, 0, 2*time.Second
+	d.record(s, now, window)
+	v = d.snapshot(now, window)["model"]
+	if v.Completed != 8 || v.ServiceSamples != 8 || v.OutputTokens != 1 || v.ServiceSeconds != 2 {
+		t.Fatalf("invalid/zero output or service handling changed: %+v", v)
+	}
+}
+
+func TestAutopilotDemandMeanWorkIsSeparateFromTailFit(t *testing.T) {
+	now := autopilotDemandTestClock()
+	var d autopilotDemandTracker
+	for i := 0; i < 10; i++ {
+		s := autopilotDemandTestSample(now)
+		s.PromptTokens = 25
+		if i >= 8 {
+			s.PromptTokens = 4096
+		}
+		d.record(s, now, 5*time.Minute)
+	}
+	v := d.snapshot(now, 5*time.Minute)["model"]
+	if v.PromptTokens != 840 || v.TailPromptTokens != 4096 {
+		t.Fatalf("tail inflated average work or tail lost: %+v", v)
+	}
+}
+
+func TestAutopilotDemandLogicalTerminalReasonsDoNotMultiplyArrivals(t *testing.T) {
+	now := autopilotDemandTestClock()
+	var d autopilotDemandTracker
+	for _, reason := range []string{"deadline", "capacity_shed", "completed", "client_departure"} {
+		s := autopilotDemandTestSample(now)
+		s.Reason = reason
+		s.CapacityShed = reason == "deadline" || reason == "capacity_shed"
+		d.record(s, now, 5*time.Minute)
+	}
+	v := d.snapshot(now, 5*time.Minute)["model"]
+	// API owns once-only delivery across retries; this layer never turns an
+	// exhausted ladder or a shed flag into additional logical arrival counts.
+	if v.Requests != 4 || v.CapacityShed != 2 || v.PromptTokens != 27 || v.TailPromptTokens != 64 {
+		t.Fatalf("reason changed logical count or excluded honest short input: %+v", v)
+	}
+}
+
+func TestAutopilotDemandExcludesIntrinsicAndCoordinatorSaturation(t *testing.T) {
+	now := autopilotDemandTestClock()
+	var d autopilotDemandTracker
+	for _, reason := range []string{"intrinsic_unservable", "routing_saturated"} {
+		s := autopilotDemandTestSample(now)
+		s.Reason, s.CapacityShed = reason, true
+		d.record(s, now, 5*time.Minute)
+	}
+	if len(d.models) != 0 || len(d.snapshot(now, 5*time.Minute)) != 0 {
+		t.Fatal("excluded reasons created a model target")
+	}
+}
+
+func TestAutopilotDemandBoundedCardinalityAndExpiredReplacement(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := time.Minute
+	var d autopilotDemandTracker
+	for i := 0; i < autopilotDemandMaxModels+1; i++ {
+		s := autopilotDemandTestSample(now)
+		s.Model = fmt.Sprintf("model-%03d", i)
+		d.record(s, now, window)
+	}
+	if len(d.models) != autopilotDemandMaxModels {
+		t.Fatalf("unbounded model count: %d", len(d.models))
+	}
+	later := now.Add(2*window + time.Second)
+	s := autopilotDemandTestSample(later)
+	s.Model = "model-000" // renewal must expire even if snapshot has not run
+	d.record(s, later, window)
+	v := d.snapshot(later, window)[s.Model]
+	if len(d.models) != 1 || v.Requests != 1 || !d.models[s.Model].first.Equal(later) {
+		t.Fatalf("old model state biased renewed demand: models=%d view=%+v", len(d.models), v)
+	}
+}
+
+func TestAutopilotDemandBoundedBucketsOverLongRun(t *testing.T) {
+	now := autopilotDemandTestClock()
+	window := time.Minute
+	var d autopilotDemandTracker
+	for i := 0; i < 3600; i++ {
+		at := now.Add(time.Duration(i) * time.Second)
+		d.record(autopilotDemandTestSample(at), at, window)
+		if n := len(d.models["model"].buckets); n > int(window/autopilotDemandBucketWidth)+1 {
+			t.Fatalf("unbounded arrival intervals after %d seconds: %d", i, n)
+		}
+	}
+	later := now.Add(time.Hour + 2*window)
+	if len(d.snapshot(later, window)) != 0 || len(d.models) != 0 {
+		t.Fatal("idle model storage was not reclaimed")
+	}
+}
+
+func TestAutopilotDemandRejectsInvalidWindowAndEnvelope(t *testing.T) {
+	now := autopilotDemandTestClock()
+	for _, window := range []time.Duration{0, -time.Second, autopilotDemandMaxWindow + time.Second} {
+		var d autopilotDemandTracker
+		d.record(autopilotDemandTestSample(now), now, window)
+		if len(d.models) != 0 || len(d.snapshot(now, window)) != 0 {
+			t.Fatalf("invalid window retained state: %s", window)
+		}
+	}
+	for _, change := range []func(*AutopilotDemandSample){
+		func(s *AutopilotDemandSample) { s.Model = "" },
+		func(s *AutopilotDemandSample) { s.PromptTokens = 0 },
+		func(s *AutopilotDemandSample) { s.PromptTokens = autopilotDemandMaxTokens + 1 },
+		func(s *AutopilotDemandSample) { s.RequestedMaxTokens = -1 },
+		func(s *AutopilotDemandSample) { s.RequestedMaxTokens = autopilotDemandMaxTokens + 1 },
+	} {
+		var d autopilotDemandTracker
+		s := autopilotDemandTestSample(now)
+		change(&s)
+		d.record(s, now, time.Minute)
+		if len(d.models) != 0 {
+			t.Fatalf("invalid envelope retained: %+v", s)
+		}
+	}
+}
+
+func TestAutopilotDemandConcurrentRecordAndSnapshot(t *testing.T) {
+	now := autopilotDemandTestClock()
+	var d autopilotDemandTracker
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				d.record(autopilotDemandTestSample(now.Add(-time.Duration(g)*time.Second)), now, time.Minute)
+				d.snapshot(now, time.Minute)
+			}
+		}(g)
+	}
+	wg.Wait()
+	v := d.snapshot(now, time.Minute)["model"]
+	if v.Requests != 800 || math.IsNaN(v.Rate) || math.IsInf(v.Rate, 0) {
+		t.Fatalf("concurrent demand lost or became nonfinite: %+v", v)
+	}
+}

--- a/coordinator/registry/autopilot_planner.go
+++ b/coordinator/registry/autopilot_planner.go
@@ -1,0 +1,311 @@
+package registry
+
+import (
+	"math"
+	"slices"
+	"sort"
+	"time"
+)
+
+type autopilotCoverageView struct {
+	Ready, Future, Need map[string]float64
+	Warm                map[string]int
+	Contribution        map[string]map[string]float64
+	Reference           map[string]float64
+	Workload            map[string]autopilotDemandView
+}
+
+// A shared GPU contributes at most one machine's execution time. Residency is
+// not independent compute. Unqualified resident work can consume time, but it
+// must not receive useful capacity credit or hide a deadline-qualified deficit.
+func autopilotNodeContribution(n autopilotNode, residents []string, demand map[string]autopilotDemandView) map[string]float64 {
+	out := make(map[string]float64)
+	weights := make(map[string]float64)
+	total := 0.0
+	for _, model := range residents {
+		fit := n.Fits[model]
+		if !finiteAutopilotNonnegative(fit.Rate) || fit.Rate <= 0 {
+			continue
+		}
+		rate := demand[model].Rate
+		if !finiteAutopilotNonnegative(rate) {
+			rate = 0
+		}
+		weight := rate / fit.Rate
+		weights[model] = weight
+		total += weight
+	}
+	if total == 0 {
+		for model := range weights {
+			weights[model] = 1
+		}
+		total = float64(len(weights))
+	}
+	if total > 0 && finiteAutopilotNonnegative(total) {
+		for model, weight := range weights {
+			if n.Fits[model].MeetsDeadline {
+				out[model] = n.Fits[model].Rate * weight / total
+			}
+		}
+	}
+	return out
+}
+
+func autopilotCoverage(f autopilotFleet) autopilotCoverageView {
+	c := autopilotCoverageView{
+		Ready: map[string]float64{}, Future: map[string]float64{}, Need: map[string]float64{},
+		Warm: map[string]int{}, Contribution: map[string]map[string]float64{},
+		Reference: map[string]float64{}, Workload: map[string]autopilotDemandView{},
+	}
+	// Resolve once per model, not once per node/model (the fallback scans the
+	// fleet). One reference prices the same recovered work on every recipient.
+	models := make(map[string]bool)
+	for m := range f.Demand {
+		models[m] = true
+	}
+	for m := range f.Occupancy {
+		models[m] = true
+	}
+	for m := range f.Floors {
+		models[m] = true
+	}
+	for _, n := range f.Nodes {
+		for m := range n.Fits {
+			models[m] = true
+		}
+	}
+	for m := range models {
+		c.Reference[m] = autopilotReferenceService(f, m)
+	}
+	for m := range models {
+		d := f.Demand[m]
+		rate := d.Rate
+		if !finiteAutopilotNonnegative(rate) {
+			rate = 0
+		}
+		// Occupancy and offered-work estimates overlap. Use max, NEVER sum.
+		// Include occupancy-only models whose first logical terminal has not
+		// arrived yet, both in demand and in shared-GPU time allocation.
+		c.Need[m] = math.Max(rate, float64(max(0, f.Occupancy[m]))/c.Reference[m])
+		d.Rate = c.Need[m]
+		c.Workload[m] = d
+	}
+	for _, node := range f.Nodes {
+		if node.Pending {
+			future := node.Future
+			if node.FutureResidents != nil {
+				future = autopilotNodeContribution(node, node.FutureResidents, c.Workload)
+			}
+			for m, rate := range future {
+				if finiteAutopilotNonnegative(rate) {
+					c.Future[m] += rate
+				}
+			}
+			continue
+		}
+		contribution := autopilotNodeContribution(node, node.Residents, c.Workload)
+		c.Contribution[node.ID] = contribution
+		for model, rate := range contribution {
+			c.Ready[model] += rate
+			c.Warm[model]++
+		}
+	}
+	return c
+}
+
+func autopilotFloor(f autopilotFleet, model string) int {
+	floor := max(0, f.Floors[model])
+	d := f.Demand[model]
+	if d.Rate > 0 && (d.Requests >= 3 || d.CapacityShed > 0) {
+		floor = max(1, floor)
+	}
+	return floor
+}
+
+func autopilotDonorsProtected(f autopilotFleet, c autopilotCoverageView, n autopilotNode) bool {
+	// Loading fences the entire device, including retained co-residents. Debit
+	// every contribution for the whole transition; future capacity cannot protect
+	// a currently needed donor. Other commands are already absent from Ready.
+	for _, m := range n.Residents {
+		contribution, credited := c.Contribution[n.ID][m]
+		if !credited {
+			continue
+		} // no useful capacity was credited to this resident
+		if c.Warm[m]-1 < autopilotFloor(f, m) {
+			return false
+		}
+		if c.Ready[m]-contribution+1e-9 < c.Need[m] {
+			return false
+		}
+	}
+	return true
+}
+
+func autopilotVictims(n autopilotNode, model string, cfg AutopilotConfig) ([]string, bool) {
+	state := n.State
+	if state == nil || state.FreeForLoadNoEvictGB == nil || state.MaxModelSlots < 1 {
+		return nil, false
+	}
+	free := *state.FreeForLoadNoEvictGB
+	slots := state.MaxModelSlots - len(state.ResidentModels)
+	need := n.Fits[model].WeightsGiB
+	if !finiteAutopilotNonnegative(free) || !finiteAutopilotNonnegative(need) || need <= 0 {
+		return nil, false
+	}
+	if free >= need && slots > 0 {
+		return []string{}, true
+	}
+	ordered := append([]string(nil), n.Residents...)
+	byID := make(map[string]int)
+	for i, m := range state.ResidentModels {
+		if _, exists := byID[m.ModelID]; exists {
+			return nil, false
+		}
+		byID[m.ModelID] = i
+	}
+	for _, id := range ordered {
+		if _, exists := byID[id]; !exists {
+			return nil, false
+		}
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		a, b := state.ResidentModels[byID[ordered[i]]].IdleSeconds, state.ResidentModels[byID[ordered[j]]].IdleSeconds
+		if a == b {
+			return ordered[i] < ordered[j]
+		}
+		return a > b
+	})
+	dwell := math.Max(cfg.MinDwell.Seconds(), float64(state.MinDwellSeconds))
+	var victims []string
+	for _, id := range ordered {
+		m := state.ResidentModels[byID[id]]
+		if slices.Contains(state.PinnedModels, id) || m.ResidentSeconds < dwell || m.IdleSeconds < dwell {
+			continue
+		}
+		victims = append(victims, id)
+		slots++
+		// Only actual provider-authoritative reclaim credit, NEVER scanner padding.
+		if m.ResidentGB != nil && finiteAutopilotNonnegative(*m.ResidentGB) {
+			free += *m.ResidentGB
+		}
+		if free >= need && slots > 0 {
+			return victims, true
+		}
+	}
+	return nil, false
+}
+
+func planAutopilotAction(f autopilotFleet, cfg AutopilotConfig, now time.Time) *autopilotAction {
+	c := autopilotCoverage(f)
+	reference := c.Reference
+	var best *autopilotAction
+	models := make([]string, 0, len(c.Need))
+	for m := range c.Need {
+		models = append(models, m)
+	}
+	slices.Sort(models)
+	for _, n := range f.Nodes {
+		if !n.Managed || !n.Idle || n.Pending || !autopilotDonorsProtected(f, c, n) {
+			continue
+		}
+		for _, m := range models {
+			fit, eligible := n.Fits[m]
+			if !eligible || !fit.MeetsDeadline || fit.Rate <= 0 || slices.Contains(n.Residents, m) {
+				continue
+			}
+			floorShort := c.Warm[m] < autopilotFloor(f, m) && c.Future[m] == 0
+			gap := c.Need[m] - c.Ready[m] - c.Future[m]
+			if gap <= 0 && !floorShort {
+				continue
+			}
+			victims, ok := autopilotVictims(n, m, cfg)
+			if !ok {
+				continue
+			}
+			futureResidents := []string{m}
+			for _, old := range n.Residents {
+				if !slices.Contains(victims, old) {
+					futureResidents = append(futureResidents, old)
+				}
+			}
+			future := autopilotNodeContribution(n, futureResidents, c.Workload)
+			useful := math.Min(math.Max(0, gap), future[m])
+			horizon := math.Min(300, cfg.MinDwell.Seconds())
+			benefit := useful * reference[m] * math.Max(0, horizon-fit.LoadSeconds)
+			// Actual quality contribution (not chip generation) ranks recipients.
+			// The cold load prior and destroyed resident cache impose a switch cost.
+			cost := fit.LoadSeconds + float64(len(victims))*cfg.MinBenefitSeconds
+			if !fit.Measured {
+				cost += cfg.MinBenefitSeconds
+			}
+			for _, old := range n.Residents {
+				cost += c.Contribution[n.ID][old] * reference[old] * fit.LoadSeconds
+			}
+			if floorShort {
+				benefit = math.Max(benefit, cost+cfg.MinBenefitSeconds+fit.Rate)
+			}
+			// Prefer to retain a scarce compatible device for an unmet restricted
+			// workload. Capability comes from the catalog/runtime gate, never M5 age.
+			if !fit.Restricted {
+				for restricted, rf := range n.Fits {
+					if rf.Restricted && rf.MeetsDeadline && c.Ready[restricted]+c.Future[restricted] < c.Need[restricted] {
+						cost += horizon
+					}
+				}
+			}
+			benefit -= cost
+			if benefit < cfg.MinBenefitSeconds {
+				continue
+			}
+			if best == nil || benefit > best.Benefit || (benefit == best.Benefit && n.ID < best.Node.ID) {
+				best = &autopilotAction{Node: n, Load: m, Unload: victims, Benefit: benefit, Future: future}
+			}
+		}
+	}
+	if best != nil || !cfg.AllowIdleUnload {
+		return best
+	}
+	for _, n := range f.Nodes {
+		if !n.Managed || !n.Idle || n.Pending || n.State == nil || !finiteAutopilotNonnegative(n.MemoryPressure) || n.MemoryPressure < .8 || !autopilotDonorsProtected(f, c, n) {
+			continue
+		}
+		var victims []string
+		for _, m := range n.State.ResidentModels {
+			d := f.Demand[m.ModelID]
+			if d.Rate > 0 || (!d.LastDemand.IsZero() && now.Sub(d.LastDemand) < cfg.IdleUnloadAfter) || slices.Contains(n.State.PinnedModels, m.ModelID) || m.ResidentSeconds < math.Max(cfg.MinDwell.Seconds(), float64(n.State.MinDwellSeconds)) || m.IdleSeconds < math.Max(cfg.IdleUnloadAfter.Seconds(), float64(n.State.MinDwellSeconds)) {
+				continue
+			}
+			victims = append(victims, m.ModelID)
+		}
+		if len(victims) > 0 {
+			var retained []string
+			for _, m := range n.Residents {
+				if !slices.Contains(victims, m) {
+					retained = append(retained, m)
+				}
+			}
+			return &autopilotAction{Node: n, Unload: victims, Future: autopilotNodeContribution(n, retained, c.Workload)}
+		}
+	}
+	return nil
+}
+
+// One fixed valuation per model prevents slow recipients from being rewarded
+// for taking longer to serve an identical request. Candidate-specific speed
+// enters Rate, never the value assigned to a recovered request.
+func autopilotReferenceService(f autopilotFleet, model string) float64 {
+	if s := f.Demand[model].ServiceSeconds; finiteAutopilotNonnegative(s) && s > 0 {
+		return s
+	}
+	var values []float64
+	for _, n := range f.Nodes {
+		if fit, ok := n.Fits[model]; ok && fit.MeetsDeadline && finiteAutopilotNonnegative(fit.ServiceSeconds) && fit.ServiceSeconds > 0 {
+			values = append(values, fit.ServiceSeconds)
+		}
+	}
+	if len(values) == 0 {
+		return 10
+	}
+	slices.Sort(values)
+	return values[len(values)/2]
+}

--- a/coordinator/registry/autopilot_planner_test.go
+++ b/coordinator/registry/autopilot_planner_test.go
@@ -1,0 +1,245 @@
+package registry
+
+import (
+	"math"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func autopilotPlannerFloat(v float64) *float64 { return &v }
+
+func autopilotPlannerFit(rate, service float64) autopilotModelFit {
+	return autopilotModelFit{Rate: rate, ServiceSeconds: service, LoadSeconds: 10, WeightsGiB: 8, Measured: true, MeetsDeadline: true}
+}
+
+func autopilotPlannerNode(id string, residents ...string) autopilotNode {
+	n := autopilotNode{
+		ID: id, Managed: true, Idle: true, Residents: append([]string(nil), residents...), Fits: map[string]autopilotModelFit{},
+		State: &protocol.ModelAutopilotState{
+			Protocol: protocol.ModelAutopilotProtocol, Enabled: true, CachedOnly: true,
+			MaxModelSlots: 3, FreeForLoadNoEvictGB: autopilotPlannerFloat(32),
+		},
+	}
+	for _, m := range residents {
+		n.Fits[m] = autopilotPlannerFit(1, 1)
+		n.State.ResidentModels = append(n.State.ResidentModels, protocol.ModelAutopilotResident{
+			ModelID: m, ResidentSeconds: 7200, IdleSeconds: 7200, WeightsGB: 100, ResidentGB: autopilotPlannerFloat(5),
+		})
+	}
+	return n
+}
+
+func TestAutopilotPlannerPrefersQualifiedFastRecipient(t *testing.T) {
+	slow, fast := autopilotPlannerNode("a-slow"), autopilotPlannerNode("z-fast")
+	slow.Fits["target"] = autopilotPlannerFit(.07, 10)
+	fast.Fits["target"] = autopilotPlannerFit(.7, 1)
+	for _, rate := range []float64{.2, 2} {
+		f := autopilotFleet{Nodes: []autopilotNode{slow, fast}, Demand: map[string]autopilotDemandView{
+			"target": {Rate: rate, Requests: 10, ServiceSeconds: 10},
+		}}
+		a := planAutopilotAction(f, DefaultAutopilotConfig(), autopilotDemandTestClock())
+		if a == nil || a.Node.ID != fast.ID || a.Load != "target" {
+			t.Fatalf("recipient-specific service cancelled speed advantage at rate %g: %+v", rate, a)
+		}
+		if a.Future["target"] != .7 {
+			t.Fatalf("wrong future service capacity: %+v", a)
+		}
+	}
+}
+
+func TestAutopilotPlannerUnqualifiedResidentCannotHideDeficit(t *testing.T) {
+	bad, good := autopilotPlannerNode("bad", "target"), autopilotPlannerNode("good")
+	badFit := autopilotPlannerFit(100, .01)
+	badFit.MeetsDeadline = false
+	bad.Fits["target"] = badFit
+	good.Fits["target"] = autopilotPlannerFit(.7, 1)
+	f := autopilotFleet{Nodes: []autopilotNode{bad, good}, Demand: map[string]autopilotDemandView{
+		"target": {Rate: 2, Requests: 20, ServiceSeconds: 10},
+	}, Floors: map[string]int{"target": 1}}
+	c := autopilotCoverage(f)
+	if c.Ready["target"] != 0 || c.Warm["target"] != 0 || len(bad.Residents) != 1 {
+		t.Fatalf("deadline-infeasible residency got useful credit or lost ownership: %+v", c)
+	}
+	a := planAutopilotAction(f, DefaultAutopilotConfig(), autopilotDemandTestClock())
+	if a == nil || a.Node.ID != good.ID {
+		t.Fatalf("bad residents hid a useful recipient: %+v", a)
+	}
+	// Even an existing deficit must not debit a contribution never credited.
+	if !autopilotDonorsProtected(f, c, bad) {
+		t.Fatal("uncounted resident caused a fictitious negative floor/capacity")
+	}
+}
+
+func TestAutopilotPlannerSharedGPUDoesNotSumIndependentThroughputs(t *testing.T) {
+	n := autopilotPlannerNode("shared", "a", "b")
+	n.Fits["a"], n.Fits["b"] = autopilotPlannerFit(2, 1), autopilotPlannerFit(4, .5)
+	d := map[string]autopilotDemandView{"a": {Rate: 1}, "b": {Rate: 1}}
+	contribution := autopilotNodeContribution(n, n.Residents, d)
+	if math.Abs(contribution["a"]-4.0/3) > 1e-12 || math.Abs(contribution["b"]-4.0/3) > 1e-12 {
+		t.Fatalf("wrong GPU time allocation: %+v", contribution)
+	}
+	if got := contribution["a"]/2 + contribution["b"]/4; math.Abs(got-1) > 1e-12 {
+		t.Fatalf("shared GPU credited %g machines", got)
+	}
+	bad := n.Fits["b"]
+	bad.MeetsDeadline = false
+	n.Fits["b"] = bad
+	contribution = autopilotNodeContribution(n, n.Residents, d)
+	if _, exists := contribution["b"]; exists || math.Abs(contribution["a"]-4.0/3) > 1e-12 {
+		t.Fatalf("unqualified work got useful credit or its contention vanished: %+v", contribution)
+	}
+}
+
+func TestAutopilotPlannerOccupancyIsMaximumAndIncludesNewModels(t *testing.T) {
+	n := autopilotPlannerNode("new-capacity")
+	n.Fits["new"] = autopilotPlannerFit(.7, 10)
+	f := autopilotFleet{Nodes: []autopilotNode{n}, Occupancy: map[string]int{"new": 20}}
+	c := autopilotCoverage(f)
+	if c.Need["new"] != 2 || c.Workload["new"].Rate != 2 {
+		t.Fatalf("unfinished requests disappeared before first terminal: %+v", c)
+	}
+	if a := planAutopilotAction(f, DefaultAutopilotConfig(), autopilotDemandTestClock()); a == nil || a.Load != "new" {
+		t.Fatalf("occupancy-only model was omitted from planning: %+v", a)
+	}
+	f.Demand = map[string]autopilotDemandView{"new": {Rate: 1, ServiceSeconds: 10}}
+	if got := autopilotCoverage(f).Need["new"]; got != 2 {
+		t.Fatalf("overlapping workload was added twice: %g", got)
+	}
+	f.Demand["new"] = autopilotDemandView{Rate: 3, ServiceSeconds: 10}
+	if got := autopilotCoverage(f).Need["new"]; got != 3 {
+		t.Fatalf("max lost the larger offered rate: %g", got)
+	}
+}
+
+func autopilotPlannerDonorFixture() (autopilotFleet, autopilotNode) {
+	donor := autopilotPlannerNode("donor", "a", "b")
+	donor.State.FreeForLoadNoEvictGB = autopilotPlannerFloat(0)
+	donor.State.MaxModelSlots = 2
+	donor.Fits["target"] = autopilotPlannerFit(1, 1)
+	peerA := autopilotPlannerNode("peer-a", "a")
+	peerA.Managed = false
+	f := autopilotFleet{Nodes: []autopilotNode{donor, peerA}, Demand: map[string]autopilotDemandView{
+		"a":      {Rate: .2, Requests: 10, ServiceSeconds: 1},
+		"b":      {Rate: .2, Requests: 10, ServiceSeconds: 1},
+		"target": {Rate: 2, Requests: 10, ServiceSeconds: 10},
+	}}
+	return f, donor
+}
+
+func TestAutopilotPlannerProtectsEveryDonorOnSharedDevice(t *testing.T) {
+	f, donor := autopilotPlannerDonorFixture()
+	if autopilotDonorsProtected(f, autopilotCoverage(f), donor) {
+		t.Fatal("first protected victim masked the second model's deficit")
+	}
+	if a := planAutopilotAction(f, DefaultAutopilotConfig(), autopilotDemandTestClock()); a != nil {
+		t.Fatalf("unsafe multi-victim plan: %+v", a)
+	}
+	peerB := autopilotPlannerNode("peer-b", "b")
+	peerB.Managed = false
+	f.Nodes = append(f.Nodes, peerB)
+	a := planAutopilotAction(f, DefaultAutopilotConfig(), autopilotDemandTestClock())
+	if a == nil || a.Node.ID != donor.ID || !reflect.DeepEqual(a.Unload, []string{"a", "b"}) {
+		t.Fatalf("protected feasible multi-victim move missing: %+v", a)
+	}
+}
+
+func TestAutopilotPlannerPendingCapacityCannotProtectDonors(t *testing.T) {
+	f, donor := autopilotPlannerDonorFixture()
+	pending := autopilotPlannerNode("pending-b", "b")
+	pending.Pending = true
+	pending.Future = map[string]float64{"b": 100}
+	f.Nodes = append(f.Nodes, pending)
+	c := autopilotCoverage(f)
+	if c.Future["b"] != 100 || c.Warm["b"] != 1 || c.Ready["b"] != .5 {
+		t.Fatalf("pending residency leaked ready credit: %+v", c)
+	}
+	if autopilotDonorsProtected(f, c, donor) {
+		t.Fatal("future load protected a currently needed donor")
+	}
+}
+
+func TestAutopilotPlannerVictimsRespectPinsDwellAndActualReclaim(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*autopilotNode)
+		want   bool
+	}{
+		{"actual reclaim", func(*autopilotNode) {}, true},
+		{"pinned", func(n *autopilotNode) { n.State.PinnedModels = []string{"a"} }, false},
+		{"young resident", func(n *autopilotNode) { n.State.ResidentModels[0].ResidentSeconds = 1 }, false},
+		{"recent work", func(n *autopilotNode) { n.State.ResidentModels[0].IdleSeconds = 1 }, false},
+		{"provider longer dwell", func(n *autopilotNode) { n.State.MinDwellSeconds = 8000 }, false},
+		{"padded weights are not reclaim", func(n *autopilotNode) {
+			for i := range n.State.ResidentModels {
+				n.State.ResidentModels[i].ResidentGB = nil
+			}
+		}, false},
+		{"negative reclaim", func(n *autopilotNode) { n.State.ResidentModels[0].ResidentGB = autopilotPlannerFloat(-10) }, false},
+		{"invalid free memory", func(n *autopilotNode) { n.State.FreeForLoadNoEvictGB = autopilotPlannerFloat(math.NaN()) }, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, n := autopilotPlannerDonorFixture()
+			tc.change(&n)
+			victims, ok := autopilotVictims(n, "target", DefaultAutopilotConfig())
+			if ok != tc.want || (ok && !reflect.DeepEqual(victims, []string{"a", "b"})) {
+				t.Fatalf("victims=%v allowed=%v, want %v", victims, ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestAutopilotPlannerNoEvictionWhenSlotAndMemoryAlreadyFit(t *testing.T) {
+	n := autopilotPlannerNode("room", "a")
+	n.State.PinnedModels = []string{"a"}
+	n.Fits["target"] = autopilotPlannerFit(1, 1)
+	victims, ok := autopilotVictims(n, "target", DefaultAutopilotConfig())
+	if !ok || len(victims) != 0 {
+		t.Fatalf("unnecessary eviction: %v allowed=%v", victims, ok)
+	}
+}
+
+func TestAutopilotPlannerStandaloneUnloadRequiresEveryGuard(t *testing.T) {
+	now := autopilotDemandTestClock()
+	for _, tc := range []struct {
+		name   string
+		change func(*autopilotFleet, *AutopilotConfig)
+		want   bool
+	}{
+		{"idle surplus under pressure", func(*autopilotFleet, *AutopilotConfig) {}, true},
+		{"default disabled", func(_ *autopilotFleet, c *AutopilotConfig) { c.AllowIdleUnload = false }, false},
+		{"not opted in", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].Managed = false }, false},
+		{"busy", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].Idle = false }, false},
+		{"pending", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].Pending = true }, false},
+		{"no memory pressure", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].MemoryPressure = .2 }, false},
+		{"unknown state", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].State = nil }, false},
+		{"pinned", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].State.PinnedModels = []string{"a"} }, false},
+		{"floor", func(f *autopilotFleet, _ *AutopilotConfig) { f.Floors = map[string]int{"a": 1} }, false},
+		{"recent arrival", func(f *autopilotFleet, _ *AutopilotConfig) {
+			f.Demand["a"] = autopilotDemandView{LastDemand: now.Add(-time.Minute)}
+		}, false},
+		{"young residency", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].State.ResidentModels[0].ResidentSeconds = 1 }, false},
+		{"recent device work", func(f *autopilotFleet, _ *AutopilotConfig) { f.Nodes[0].State.ResidentModels[0].IdleSeconds = 1 }, false},
+		{"provider longer idle dwell", func(f *autopilotFleet, _ *AutopilotConfig) {
+			f.Nodes[0].State.MinDwellSeconds = 7200
+			f.Nodes[0].State.ResidentModels[0].ResidentSeconds = 10800
+			f.Nodes[0].State.ResidentModels[0].IdleSeconds = 3600
+		}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n := autopilotPlannerNode("idle", "a")
+			n.MemoryPressure = .9
+			f := autopilotFleet{Nodes: []autopilotNode{n}, Demand: map[string]autopilotDemandView{}}
+			cfg := DefaultAutopilotConfig()
+			cfg.AllowIdleUnload = true
+			tc.change(&f, &cfg)
+			a := planAutopilotAction(f, cfg, now)
+			if (a != nil) != tc.want || (a != nil && (a.Load != "" || !slices.Equal(a.Unload, []string{"a"}))) {
+				t.Fatalf("standalone unload=%+v, want allowed=%v", a, tc.want)
+			}
+		})
+	}
+}

--- a/coordinator/registry/autopilot_provider_state.go
+++ b/coordinator/registry/autopilot_provider_state.go
@@ -1,0 +1,139 @@
+package registry
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func providerAutopilotManagedLocked(p *Provider) bool {
+	return p.ModelAutopilot != nil && p.ModelAutopilot.Enabled
+}
+func providerAutopilotTransitionLocked(p *Provider) bool {
+	return p.autopilotPending != nil || (p.ModelAutopilot != nil && p.ModelAutopilot.ActiveCommandID != "")
+}
+
+func cloneAutopilotState(in *protocol.ModelAutopilotState) *protocol.ModelAutopilotState {
+	if in == nil {
+		return nil
+	}
+	// Keep malformed opt-in/control ownership fail-closed without retaining an
+	// unbounded untrusted report. A later valid heartbeat can replace it.
+	if len(in.ResidentModels) > 32 || len(in.PinnedModels) > 256 || len(in.ActiveCommandID) > 64 || len(in.LastCommandID) > 64 {
+		return &protocol.ModelAutopilotState{Protocol: in.Protocol, Enabled: in.Enabled, ActiveCommandID: "invalid_report"}
+	}
+	for _, m := range in.ResidentModels {
+		if len(m.ModelID) > 256 {
+			return &protocol.ModelAutopilotState{Protocol: in.Protocol, Enabled: in.Enabled, ActiveCommandID: "invalid_report"}
+		}
+	}
+	for _, m := range in.PinnedModels {
+		if len(m) > 256 {
+			return &protocol.ModelAutopilotState{Protocol: in.Protocol, Enabled: in.Enabled, ActiveCommandID: "invalid_report"}
+		}
+	}
+	out := *in
+	out.PinnedModels = append([]string(nil), in.PinnedModels...)
+	out.ResidentModels = append([]protocol.ModelAutopilotResident(nil), in.ResidentModels...)
+	if in.FreeForLoadNoEvictGB != nil {
+		v := *in.FreeForLoadNoEvictGB
+		out.FreeForLoadNoEvictGB = &v
+	}
+	for i := range out.ResidentModels {
+		if in.ResidentModels[i].ResidentGB != nil {
+			v := *in.ResidentModels[i].ResidentGB
+			out.ResidentModels[i].ResidentGB = &v
+		}
+	}
+	return &out
+}
+
+func validAutopilotState(s *protocol.ModelAutopilotState) bool {
+	if s == nil || s.Protocol != protocol.ModelAutopilotProtocol || !s.Enabled || !s.CachedOnly || s.MaxModelSlots < 1 || s.MaxModelSlots > 32 || s.MinDwellSeconds < 0 || s.MinDwellSeconds > 86400 || len(s.ResidentModels) > 32 || len(s.PinnedModels) > 256 {
+		return false
+	}
+	if len(s.ActiveCommandID) > 64 || len(s.LastCommandID) > 64 {
+		return false
+	}
+	if s.FreeForLoadNoEvictGB == nil || !finiteAutopilotNonnegative(*s.FreeForLoadNoEvictGB) || *s.FreeForLoadNoEvictGB > 4096 {
+		return false
+	}
+	seen := make(map[string]bool)
+	for _, m := range s.ResidentModels {
+		if m.ModelID == "" || len(m.ModelID) > 256 || seen[m.ModelID] || !finiteAutopilotNonnegative(m.ResidentSeconds) || !finiteAutopilotNonnegative(m.IdleSeconds) || !finiteAutopilotNonnegative(m.WeightsGB) {
+			return false
+		}
+		if m.ResidentGB != nil && (!finiteAutopilotNonnegative(*m.ResidentGB) || *m.ResidentGB > 4096) {
+			return false
+		}
+		seen[m.ModelID] = true
+	}
+	return true
+}
+func finiteAutopilotNonnegative(v float64) bool { return v >= 0 && !math.IsNaN(v) && !math.IsInf(v, 0) }
+
+func autopilotResidentIDs(s *protocol.ModelAutopilotState) []string {
+	out := []string{}
+	if s != nil {
+		for _, m := range s.ResidentModels {
+			out = append(out, m.ModelID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func autopilotStateMatchesCapacity(p *Provider) bool {
+	if p.BackendCapacity == nil || p.capacitySeq == 0 || !validAutopilotState(p.ModelAutopilot) {
+		return false
+	}
+	residents := make(map[string]bool)
+	for _, m := range p.ModelAutopilot.ResidentModels {
+		residents[m.ModelID] = true
+	}
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.State == "running" || slot.State == "idle" {
+			if !residents[slot.Model] {
+				return false
+			}
+			delete(residents, slot.Model)
+		}
+	}
+	return len(residents) == 0
+}
+
+// Called only after the accepted capacity-sequence gate, under p.mu. Status
+// messages alone never clear reservations or manufacture warm slot capacity.
+func (r *Registry) reconcileAutopilotHeartbeatLocked(p *Provider, state *protocol.ModelAutopilotState, now time.Time) {
+	p.ModelAutopilot = cloneAutopilotState(state)
+	pending := p.autopilotPending
+	if pending == nil || state == nil || p.capacitySeq <= pending.CapacitySeq || state.ActiveCommandID != "" || state.LastCommandID != pending.Command.CommandID {
+		return
+	}
+	if state.LastCommandStatus != protocol.LoadModelStatusSucceeded && state.LastCommandStatus != protocol.LoadModelStatusFailed {
+		return
+	}
+	// A disabled report can acknowledge opt-out completion; its resident list
+	// must still exactly match the same accepted backend snapshot.
+	enabled := state.Enabled
+	if !enabled {
+		copy := cloneAutopilotState(state)
+		copy.Enabled = true
+		p.ModelAutopilot = copy
+	}
+	matches := autopilotStateMatchesCapacity(p)
+	p.ModelAutopilot = cloneAutopilotState(state)
+	if !matches {
+		return
+	}
+	if state.LastCommandStatus == protocol.LoadModelStatusFailed {
+		backoff := pending.FailureBackoff
+		if backoff <= 0 {
+			backoff = 2 * time.Minute
+		}
+		p.autopilotBackoffUntil = now.Add(backoff)
+	}
+	p.autopilotPending = nil
+}

--- a/coordinator/registry/autopilot_retries.go
+++ b/coordinator/registry/autopilot_retries.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+// Retry the exact same command, never a new destructive generation. If it was
+// lost, the provider rejects its expired acceptance deadline and publishes a
+// terminal snapshot; if active/completed, it returns the idempotent status.
+// This recovers lost sends/ACKs without inferring completion from TTL expiry.
+func (r *Registry) retryAutopilotCommands(now time.Time) {
+	type retry struct {
+		p       *Provider
+		command protocol.ModelAutopilotMessage
+	}
+	var retries []retry
+	r.mu.RLock()
+	for _, p := range r.providers {
+		p.mu.Lock()
+		pending := p.autopilotPending
+		if pending != nil && pending.Attempts < 3 && now.Sub(pending.LastSentAt) >= 30*time.Second {
+			pending.Attempts++
+			pending.LastSentAt = now
+			retries = append(retries, retry{p, pending.Command})
+		}
+		p.mu.Unlock()
+	}
+	r.mu.RUnlock()
+	for _, retry := range retries {
+		r.sendAutopilotCommand(retry.p, retry.command)
+	}
+}

--- a/coordinator/registry/autopilot_snapshot.go
+++ b/coordinator/registry/autopilot_snapshot.go
@@ -1,0 +1,187 @@
+package registry
+
+import (
+	"math"
+	"slices"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/modelpolicy"
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func (r *Registry) autopilotFleetSnapshot(c *modelAutopilotController, now time.Time) autopilotFleet {
+	demand := c.demand.snapshot(now, c.config.DemandWindow)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.autopilotFleetSnapshotLocked(c, demand, now)
+}
+
+// r.mu held; p.mu is acquired and released per provider. No IO or planning sort
+// runs under these locks. Reservation calls this with r.mu exclusive so donor
+// protection is recalculated against current, not stale proposed, placements.
+func (r *Registry) autopilotFleetSnapshotLocked(c *modelAutopilotController, demand map[string]autopilotDemandView, now time.Time) autopilotFleet {
+	f := autopilotFleet{Demand: demand, Floors: map[string]int{}, Occupancy: map[string]int{}, Excluded: map[string]int{}}
+	if r.warmPool != nil {
+		for m, n := range r.warmPool.config.MinWarmByModel {
+			f.Floors[m] = n
+		}
+	}
+	for key, deadline := range r.pendingModelLoads {
+		if now.Before(deadline) && !r.pendingModelLoadStarted[key].IsZero() {
+			f.LegacyPending++
+		}
+	}
+	for _, p := range r.providers {
+		p.mu.Lock()
+		n := autopilotNode{ID: p.ID, Session: p, Seq: p.capacitySeq, Managed: providerAutopilotManagedLocked(p), Pending: providerAutopilotTransitionLocked(p), MemoryPressure: p.SystemMetrics.MemoryPressure, Fits: map[string]autopilotModelFit{}}
+		n.Uncertain = p.autopilotPending != nil && p.autopilotPending.Uncertain
+		fresh := !p.capacitySamplesAt.IsZero() && now.Sub(p.capacitySamplesAt) <= c.config.MaxSnapshotAge && p.BackendCapacity != nil
+		if !fresh || p.PrivateOnly {
+			f.Excluded["stale_or_private"]++
+			p.mu.Unlock()
+			f.Nodes = append(f.Nodes, n)
+			continue
+		}
+		n.State = cloneAutopilotState(p.ModelAutopilot)
+		allIdle := p.pendingCount() == 0 && !warmPoolBackendSlotBusyLocked(p)
+		n.Idle = allIdle && !n.Pending && !now.Before(p.autopilotBackoffUntil) && !r.providerHasPendingLoad(p.ID) && p.SystemMetrics.ThermalState != "critical" && p.SystemMetrics.ThermalState != "serious" && p.SystemMetrics.CPUUsage < .9
+		if n.Managed && !autopilotStateMatchesCapacity(p) {
+			n.Idle = false
+			f.Excluded["unreconciled_state"]++
+		}
+		for _, slot := range p.BackendCapacity.Slots {
+			f.Occupancy[slot.Model] += max(0, slot.NumRunning) + max(0, slot.NumWaiting)
+		}
+		for _, model := range p.Models {
+			d := demand[model.ID]
+			if !r.providerPassesRoutingGatesLocked(p, model.ID, RequestTraits{HasTools: d.HasTools, RequiresToolConstraint: d.RequiresToolConstraint}, false, now) || (d.RequiresVision && !model.IsVision) {
+				continue
+			}
+			fit := r.autopilotModelFitLocked(p, model.ID, d, c.config)
+			if fit.Rate <= 0 {
+				f.Excluded["unknown_service"]++
+				continue
+			}
+			n.Fits[model.ID] = fit
+			for _, slot := range p.BackendCapacity.Slots {
+				if slot.Model == model.ID && (slot.State == "idle" || slot.State == "running") {
+					n.Residents = append(n.Residents, model.ID)
+					break
+				}
+			}
+		}
+		// Do not authorize a plan that ignores an off-catalog/local resident or
+		// resident rejected by current safety gates. Its owner retains control.
+		if n.Managed && !slices.Equal(sortedAutopilotStrings(n.Residents), autopilotResidentIDs(n.State)) {
+			n.Idle = false
+			f.Excluded["unmanaged_resident"]++
+		}
+		if pending := p.autopilotPending; pending != nil && n.Managed && !pending.Uncertain && pending.Status != protocol.LoadModelStatusFailed && now.Sub(pending.SentAt) <= c.config.CommandWatchdog {
+			futureResidents := []string{}
+			for _, model := range pending.Command.ExpectedResidentModels {
+				if !slices.Contains(pending.Command.UnloadModelIDs, model) {
+					futureResidents = append(futureResidents, model)
+				}
+			}
+			if pending.Command.LoadModelID != "" {
+				futureResidents = append(futureResidents, pending.Command.LoadModelID)
+			}
+			// Recompute against current catalog/runtime gates and workload. Stale
+			// or revoked capacity keeps its fence, never an optimistic credit.
+			n.FutureResidents = futureResidents
+		}
+		p.mu.Unlock()
+		f.Nodes = append(f.Nodes, n)
+	}
+	if r.queue != nil {
+		for _, m := range r.queue.QueuedModels() {
+			f.Occupancy[m] += r.queue.QueueSize(m)
+		}
+	}
+	// Stable traversal makes equal-score decisions reproducible.
+	slices.SortFunc(f.Nodes, func(a, b autopilotNode) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	return f
+}
+
+func sortedAutopilotStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	slices.Sort(out)
+	return out
+}
+
+func (r *Registry) autopilotModelFitLocked(p *Provider, model string, d autopilotDemandView, cfg AutopilotConfig) autopilotModelFit {
+	solo := r.resolvedSoloModelTPSLocked(p, model)
+	_, prefill := resolvedModelTPSLocked(p, model)
+	cap := r.effectiveMaxConcurrencyForModelRateLocked(p, model, solo)
+	floor := 15.0
+	if r.warmPool != nil {
+		floor = r.warmPool.config.DecodeFloorTPS
+	}
+	qc := min(cap, qualityConcurrency(solo.tps, floor, effectiveTPSLoadFactor, cap, 1))
+	if solo.tps <= 0 || prefill <= 0 || qc < 1 {
+		return autopilotModelFit{}
+	}
+	prompt, output := max(1, d.PromptTokens), max(1, d.OutputTokens)
+	if d.Requests == 0 {
+		prompt = 512
+		output = 256
+	}
+	decode := solo.tps / (1 + effectiveTPSLoadFactor*float64(qc))
+	service := math.Max(.1, float64(prompt)/prefill+float64(output)/decode)
+	// Smooth sparse job outcomes toward a modest prior; never mistake a new
+	// machine's zero jobs for a perfect measured success rate.
+	reliability := (float64(max(0, p.Reputation.SuccessfulJobs)) + 9) / (float64(max(0, p.Reputation.TotalJobs)) + 10)
+	reliability = math.Max(.1, math.Min(1, reliability))
+	resourceFactor := math.Max(.25, 1-.5*p.SystemMetrics.MemoryPressure-.25*p.SystemMetrics.CPUUsage)
+	if p.SystemMetrics.ThermalState == "fair" {
+		resourceFactor *= .85
+	}
+	if p.SystemMetrics.ThermalState == "serious" || p.SystemMetrics.ThermalState == "critical" {
+		resourceFactor *= .5
+	}
+	rate := float64(qc) / service * cfg.TargetUtilization * reliability * resourceFactor
+	load := cfg.LoadTimePrior.Seconds() // unmeasured prior, not an observed quantile
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == model && slot.ModelLoadTimeMS > 0 {
+			load = math.Max(1, float64(slot.ModelLoadTimeMS)/1000)
+			break
+		}
+	}
+	tail := max(prompt, d.TailPromptTokens)
+	deadline := modelpolicy.CoordinatorFirstContentDeadline(model, tail, 5*time.Second).Seconds()
+	first := float64(tail)/prefill + 1/solo.tps + math.Max(0, p.Reputation.AvgResponseTime.Seconds())
+	entry := r.modelCatalog[model]
+	weights := math.Max(r.catalogSizeGBLocked(model), advertisedModelSizeGBLocked(p, model)) * 1.2 * 1e9 / (1 << 30)
+	_, sampleCount := r.tpsRegistry.SoloMedian(model, chipClassKey(p.Hardware))
+	fit := autopilotModelFit{Rate: rate, ServiceSeconds: service, LoadSeconds: load, WeightsGiB: weights, Restricted: len(entry.RequiredProviderCapabilities) > 0, Measured: sampleCount >= qualityCapSoloMinSamples, MeetsDeadline: first <= deadline*.8}
+	if !modelFitsHardware(r.catalogMinRAMGbLocked(model), r.catalogSizeGBLocked(model), float64(p.Hardware.MemoryGB)) {
+		fit.MeetsDeadline = false
+	}
+	// Reuse the scheduler's version/model-specific structural KV arithmetic.
+	// It is only an upper-bound prefilter for cold models; a completed load
+	// must still report actual usable budgets before receiving capacity credit.
+	budget := coldTokenBudgetEstimate(float64(p.Hardware.MemoryGB), r.catalogSizeGBLocked(model), 0, p.Version, model)
+	for _, slot := range p.BackendCapacity.Slots {
+		if slot.Model == model && (slot.State == "running" || slot.State == "idle") {
+			budget = slot.ActiveTokenBudgetMax
+			break
+		}
+	}
+	maxOutput := d.RequestedMaxTokens
+	if maxOutput <= 0 {
+		maxOutput = 256
+	}
+	envelope := int64(tail) + int64(maxOutput)
+	if d.Requests > 0 && (budget <= 0 || envelope > budget) {
+		fit.MeetsDeadline = false
+	}
+	return fit
+}

--- a/coordinator/registry/autopilot_types.go
+++ b/coordinator/registry/autopilot_types.go
@@ -1,0 +1,91 @@
+package registry
+
+import (
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+type modelAutopilotController struct {
+	registry    *Registry
+	config      AutopilotConfig // immutable after construction
+	demand      autopilotDemandTracker
+	tickMu      sync.Mutex       // only ticks; never acquired by heartbeat or routing
+	lastSummary AutopilotSummary // guarded by registry.mu
+	running     bool             // guarded by registry.mu; prevents duplicate control goroutines
+}
+
+type autopilotPendingCommand struct {
+	Command        protocol.ModelAutopilotMessage
+	SentAt         time.Time
+	CapacitySeq    uint64
+	Status         string
+	Uncertain      bool
+	LastSentAt     time.Time
+	Attempts       int
+	FailureBackoff time.Duration
+}
+
+type autopilotModelFit struct {
+	Rate           float64 // sustainable request equivalents/sec for this workload
+	ServiceSeconds float64
+	LoadSeconds    float64
+	WeightsGiB     float64 // padded incoming transient
+	Restricted     bool
+	Measured       bool
+	MeetsDeadline  bool
+}
+type autopilotNode struct {
+	ID                     string
+	Session                *Provider
+	Seq                    uint64
+	Managed, Idle, Pending bool
+	MemoryPressure         float64
+	State                  *protocol.ModelAutopilotState
+	Residents              []string
+	Fits                   map[string]autopilotModelFit
+	Future                 map[string]float64
+	FutureResidents        []string
+	Uncertain              bool
+}
+type autopilotFleet struct {
+	Nodes         []autopilotNode
+	Demand        map[string]autopilotDemandView
+	Floors        map[string]int
+	Occupancy     map[string]int
+	LegacyPending int
+	Excluded      map[string]int
+}
+type autopilotAction struct {
+	Node    autopilotNode
+	Load    string
+	Unload  []string
+	Benefit float64
+	Future  map[string]float64
+}
+
+// Summaries expose bounded model-level diagnostic counts, never identities or
+// request content. The startup flags and these observations support shadow runs.
+type AutopilotModelSummary struct {
+	Model           string  `json:"model"`
+	LogicalRequests int     `json:"logical_requests"`
+	OfferedRPS      float64 `json:"offered_rps"`
+	CapacityRPS     float64 `json:"capacity_rps"`
+	PendingRPS      float64 `json:"pending_rps"`
+	ProtectedFloor  int     `json:"protected_floor"`
+	WarmProviders   int     `json:"warm_providers"`
+	EligibleIdle    int     `json:"eligible_idle"`
+	DeficitRPS      float64 `json:"deficit_rps"`
+}
+type AutopilotSummary struct {
+	At          time.Time               `json:"at"`
+	ObserveOnly bool                    `json:"observe_only"`
+	OptedIn     int                     `json:"opted_in"`
+	Pending     int                     `json:"pending"`
+	Proposed    int                     `json:"proposed"`
+	Issued      int                     `json:"issued"`
+	Uncertain   int                     `json:"uncertain"`
+	Excluded    map[string]int          `json:"excluded"`
+	Models      []AutopilotModelSummary `json:"models"`
+}

--- a/coordinator/registry/cold_dispatch.go
+++ b/coordinator/registry/cold_dispatch.go
@@ -88,6 +88,11 @@ func (r *Registry) ColdSpillProviders(model string, traits RequestTraits, requir
 func (r *Registry) coldSpillProviderEligibleLocked(p *Provider, model string, traits RequestTraits, requiresVision bool, now time.Time) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// Cold spill promises a legacy load_model. Managed inventory can be warmed
+	// only by an explicit placement command; never queue on this false promise.
+	if providerLegacyModelChangesBlockedLocked(p) {
+		return false
+	}
 
 	// Structural / trust / privacy / freshness / cooldown / trait gates.
 	if !r.providerPassesRoutingGatesLocked(p, model, traits, false, now) {

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	MinTrustLevel string
 	WarmPool      WarmPoolConfig
+	Autopilot     AutopilotConfig
 	CacheRouting  CacheRoutingConfig
 	QualityCap    QualityCapConfig
 }
@@ -146,6 +147,7 @@ func ReadConfig() Config {
 	artifacts, artifactsErr := readCacheRoutingArtifacts()
 	return Config{
 		MinTrustLevel: os.Getenv(env.EnvPrefix + "_MIN_TRUST"),
+		Autopilot:     autopilotConfigFromEnv(),
 		WarmPool: WarmPoolConfig{
 			Enabled:                   env.EnvBool(env.EnvPrefix+"_WARM_POOL_ENABLED", true),
 			ObserveOnly:               env.EnvBool(env.EnvPrefix+"_WARM_POOL_OBSERVE_ONLY", false),
@@ -230,6 +232,9 @@ func (c Config) Check() error {
 			c.MinTrustLevel, TrustNone, TrustSelfSigned, TrustHardware)
 	}
 	if err := c.WarmPool.Check(); err != nil {
+		return err
+	}
+	if err := c.Autopilot.Check(); err != nil {
 		return err
 	}
 	if err := c.CacheRouting.Check(); err != nil {

--- a/coordinator/registry/heartbeat.go
+++ b/coordinator/registry/heartbeat.go
@@ -305,6 +305,7 @@ func (r *Registry) Heartbeat(id string, msg *protocol.HeartbeatMessage) bool {
 	// Update backend capacity from heartbeat. A nil report clears prior live
 	// capacity so stale slot state cannot keep influencing routing.
 	p.BackendCapacity = backendCapacity
+	r.reconcileAutopilotHeartbeatLocked(p, msg.ModelAutopilot, now)
 	// Per-slot KV backend (v0.8.0 paged rollout). Recorded from the canonical
 	// report after unaccepted model identifiers have been removed,
 	// BEFORE the nil-clearing semantics above take effect for it: the record is

--- a/coordinator/registry/model_capacity.go
+++ b/coordinator/registry/model_capacity.go
@@ -108,7 +108,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			// path enforces, so the public capacity feed doesn't advertise a capped
 			// box (e.g. Gemma at 2) as routable up to the flat fallback (24) and lure
 			// upstream routers into sending requests this coordinator immediately 429s.
-			hasHeadroom := r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
+			hasHeadroom := !providerAutopilotRoutingBlockedLocked(p, m.ID) && r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
 			// activeRequests for multi-model providers.

--- a/coordinator/registry/model_commands.go
+++ b/coordinator/registry/model_commands.go
@@ -22,7 +22,7 @@ func (r *Registry) SendLoadModel(providerID, modelID string) error {
 		return fmt.Errorf("provider %q not found", providerID)
 	}
 	p.mu.Lock()
-	eligible := r.providerServesCatalogModelLocked(p, modelID)
+	eligible := !providerLegacyModelChangesBlockedLocked(p) && r.providerServesCatalogModelLocked(p, modelID)
 	p.mu.Unlock()
 	r.mu.RUnlock()
 	if !eligible {
@@ -75,7 +75,7 @@ func (r *Registry) SendPrefetchModel(providerID, modelID string, priority int) e
 		return fmt.Errorf("provider %q not found", providerID)
 	}
 	p.mu.Lock()
-	eligible := r.providerCanAcquireCatalogModelLocked(p, modelID)
+	eligible := !providerLegacyModelChangesBlockedLocked(p) && r.providerCanAcquireCatalogModelLocked(p, modelID)
 	p.mu.Unlock()
 	r.mu.RUnlock()
 	if !eligible {

--- a/coordinator/registry/model_loading.go
+++ b/coordinator/registry/model_loading.go
@@ -179,6 +179,9 @@ func (r *Registry) hasWarmProviderLocked(model string, now time.Time) bool {
 // with stale attestation or failed privacy checks should not suppress swap
 // planning. Caller must hold p.mu. Caller must hold r.mu (read or write).
 func (r *Registry) providerHasWarmModelLocked(p *Provider, model string, now time.Time) bool {
+	if providerAutopilotTransitionLocked(p) {
+		return false
+	}
 	// Liveness/trust/privacy core, with NO owner relaxation: private-only
 	// providers serve only their owner's self-route traffic, never the public
 	// fleet, and must not suppress public swap planning — otherwise a
@@ -256,6 +259,9 @@ func (r *Registry) bestModelLoadProviderLocked(model string, now time.Time, sele
 func (r *Registry) modelLoadCandidatePendingLocked(p *Provider, model string, now time.Time) (int, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if providerLegacyModelChangesBlockedLocked(p) {
+		return 0, false
+	}
 
 	// Liveness/trust/privacy core + catalog membership + dedicated-box
 	// isolation, with NO owner relaxation: this is a public load_model target
@@ -308,7 +314,7 @@ func (r *Registry) reservePendingModelLoads(actions []modelLoadAction, now time.
 	for _, action := range actions {
 		if p, ok := r.providers[action.providerID]; ok {
 			p.mu.Lock()
-			eligible := r.providerCanAcquireCatalogModelLocked(p, action.modelID)
+			eligible := !providerLegacyModelChangesBlockedLocked(p) && r.providerCanAcquireCatalogModelLocked(p, action.modelID)
 			p.mu.Unlock()
 			if !eligible {
 				continue

--- a/coordinator/registry/model_management_routing.go
+++ b/coordinator/registry/model_management_routing.go
@@ -1,0 +1,32 @@
+package registry
+
+// providerAutopilotRoutingBlockedLocked is a capacity gate, not a catalog or
+// trust gate. Managed providers retain their cached inventory for planning but
+// accept network inference only on confirmed warm models, outside transitions.
+// The provider applies the same rule, including owner requests over the network;
+// direct local inference retains its independent admission/ownership checks.
+// Caller holds r.mu and p.mu.
+func providerAutopilotRoutingBlockedLocked(p *Provider, model string) bool {
+	if providerAutopilotTransitionLocked(p) {
+		return true
+	}
+	if !providerAutopilotManagedLocked(p) {
+		return false
+	}
+	if p.BackendCapacity != nil {
+		for _, slot := range p.BackendCapacity.Slots {
+			if slot.Model == model {
+				return !slotStateModelLoaded(slot.State)
+			}
+		}
+	}
+	return true
+}
+
+// Consent fencing is independent of the controller's enabled/shadow mode: an
+// opted-in provider explicitly delegates cold residency changes to managed
+// commands and refuses legacy commands itself. A hypothetical plan never sets
+// either predicate; only actual provider consent or a real operation does.
+func providerLegacyModelChangesBlockedLocked(p *Provider) bool {
+	return providerAutopilotManagedLocked(p) || providerAutopilotTransitionLocked(p)
+}

--- a/coordinator/registry/model_management_routing_test.go
+++ b/coordinator/registry/model_management_routing_test.go
@@ -1,0 +1,168 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func managedProviderState(active string) *protocol.ModelAutopilotState {
+	return &protocol.ModelAutopilotState{Protocol: 1, Enabled: true, CachedOnly: true, ActiveCommandID: active, MaxModelSlots: 3}
+}
+
+func TestAutopilotRoutingFencePreservesWarmAndLegacyCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		managed bool
+		warm    bool
+		active  string
+		allowed bool
+	}{
+		{"legacy cold", false, false, "", true},
+		{"legacy warm", false, true, "", true},
+		{"managed cold", true, false, "", false},
+		{"managed warm", true, true, "", true},
+		{"managed transition warm", true, true, "operation", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			model := "managed-routing-model"
+			p := makeSchedulerProvider(t, reg, "provider", model, 80)
+			p.mu.Lock()
+			if !tc.warm {
+				p.BackendCapacity.Slots = nil
+			}
+			if tc.managed {
+				p.ModelAutopilot = managedProviderState(tc.active)
+			}
+			p.mu.Unlock()
+			candidates, capacity, tooLarge := reg.QuickCapacityCheck(model, 32, 64, RequestTraits{})
+			if tc.allowed && candidates != 1 {
+				t.Fatalf("warm/legacy capacity lost: candidates=%d capacity=%d tooLarge=%d", candidates, capacity, tooLarge)
+			}
+			if !tc.allowed && (candidates != 0 || capacity != 1 || tooLarge != 0) {
+				t.Fatalf("managed fence must be transient capacity: candidates=%d capacity=%d tooLarge=%d", candidates, capacity, tooLarge)
+			}
+			pr := &PendingRequest{RequestID: "logical-request", Model: model, EstimatedPromptTokens: 32, RequestedMaxTokens: 64}
+			winner, decision := reg.ReserveProviderEx(model, pr)
+			if (winner != nil) != tc.allowed {
+				t.Fatalf("reserve=%v allowed=%v decision=%+v", winner, tc.allowed, decision)
+			}
+			if !tc.allowed && decision.CapacityRejections != 1 {
+				t.Fatalf("normal dispatch lost capacity classification: %+v", decision)
+			}
+		})
+	}
+}
+
+func TestAutopilotRoutingFenceDoesNotBlockPlannerStructuralEligibility(t *testing.T) {
+	reg := New(testLogger())
+	model := "managed-planning-model"
+	p := makeWarmPoolColdProvider(t, reg, "provider", model, 80, 64, 0)
+	p.mu.Lock()
+	p.ModelAutopilot = managedProviderState("")
+	p.mu.Unlock()
+	reg.mu.RLock()
+	p.mu.Lock()
+	structural := reg.providerPassesRoutingGatesLocked(p, model, RequestTraits{}, false, time.Now())
+	admit := reg.providerCanAdmitLockedEx(p, model, RequestTraits{}, false, false, time.Now())
+	p.mu.Unlock()
+	reg.mu.RUnlock()
+	if !structural || admit {
+		t.Fatalf("planner must see managed cold inventory without admitting inference: structural=%v admit=%v", structural, admit)
+	}
+}
+
+func TestAutopilotCachedPlanRevalidatesManagedTransitionsAndColdResidency(t *testing.T) {
+	for _, active := range []bool{false, true} {
+		t.Run(map[bool]string{false: "became cold", true: "started transition"}[active], func(t *testing.T) {
+			reg := New(testLogger())
+			model := "managed-plan-model"
+			planTestProvider(t, reg, "primary", model, 0)
+			alternate := planTestProvider(t, reg, "alternate", model, 400)
+			pr := planTestRequest("primary-request", 32, 64)
+			pr.Model = model
+			winner, _, plan := reg.ReserveProviderWithPlan(model, pr)
+			if winner == nil || winner.ID != "primary" || plan == nil || plan.Len() != 1 {
+				t.Fatalf("fixture must retain warm alternate: winner=%v plan=%v", winner, plan)
+			}
+			alternate.mu.Lock()
+			alternate.ModelAutopilot = managedProviderState("")
+			if active {
+				alternate.ModelAutopilot.ActiveCommandID = "operation"
+			} else {
+				alternate.BackendCapacity.Slots = nil
+			}
+			alternate.mu.Unlock()
+			retry := planTestRequest("retry-request", 32, 64)
+			retry.Model = model
+			got, _, skips := reg.ReserveNextFromPlan(retry, plan, "primary")
+			if got != nil || len(skips) == 0 {
+				t.Fatalf("cached plan bypassed current management: provider=%v skips=%v", got, skips)
+			}
+			alternate.mu.Lock()
+			pending := alternate.pendingCount()
+			alternate.mu.Unlock()
+			if pending != 0 {
+				t.Fatalf("rejected cached plan reserved %d requests", pending)
+			}
+		})
+	}
+}
+
+func TestAutopilotManagedProviderCannotReceiveLegacyModelChanges(t *testing.T) {
+	reg := New(testLogger())
+	model := "managed-legacy-model"
+	p := makeWarmPoolColdProvider(t, reg, "managed", model, 80, 64, 0)
+	p.mu.Lock()
+	p.ModelAutopilot = managedProviderState("")
+	p.mu.Unlock()
+	sent := captureWarmPoolLoads(reg)
+	reg.ConfigureWarmPool(testWarmPoolConfig())
+	reg.RecordWarmPoolCapacityReject(model)
+	reg.warmPool.tick(time.Now())
+	if len(*sent) != 0 {
+		t.Fatalf("legacy warm pool sent managed load: %+v", *sent)
+	}
+	if actions := reg.planModelLoadActions([]string{model}, time.Now()); len(actions) != 0 {
+		t.Fatalf("queue swap planned managed provider: %+v", actions)
+	}
+	if actions := reg.reservePendingModelLoads([]modelLoadAction{{providerID: p.ID, modelID: model}}, time.Now()); len(actions) != 0 {
+		t.Fatalf("legacy reservation bypassed opt-in: %+v", actions)
+	}
+	if reg.ColdSpillProviders(model, RequestTraits{}, false) != 0 {
+		t.Fatal("cold spill promised a legacy managed load")
+	}
+	if err := reg.SendLoadModel(p.ID, model); err == nil {
+		t.Fatal("legacy load command bypassed explicit placement")
+	}
+	if err := reg.SendPrefetchModel(p.ID, model, 1); err == nil {
+		t.Fatal("legacy prefetch command bypassed cached-only consent")
+	}
+	var desired []protocol.DesiredModelEntry
+	reg.desiredModelsSender = func(_ string, entries []protocol.DesiredModelEntry) error {
+		desired = append([]protocol.DesiredModelEntry{}, entries...)
+		return nil
+	}
+	if err := reg.SendDesiredModels(p.ID, []protocol.DesiredModelEntry{{ModelName: "alias", DesiredBuild: model}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(desired) != 1 || desired[0].DesiredBuild != model {
+		t.Fatalf("catalog release updates must remain available under provider-serialized migration: %+v", desired)
+	}
+}
+
+func TestAutopilotTransitionCannotBypassWithOwnerNetworkRouting(t *testing.T) {
+	reg := New(testLogger())
+	model := "managed-owner-model"
+	p := makeSchedulerProvider(t, reg, "provider", model, 80)
+	p.mu.Lock()
+	p.AccountID = "owner"
+	p.ModelAutopilot = managedProviderState("operation")
+	p.mu.Unlock()
+	pr := &PendingRequest{RequestID: "owner-request", Model: model, EstimatedPromptTokens: 32, RequestedMaxTokens: 64, OwnerAccountID: "owner", SelfRouteOnly: true}
+	if winner, _ := reg.ReserveProviderEx(model, pr); winner != nil {
+		t.Fatal("owner network request bypassed an atomic placement transition")
+	}
+}

--- a/coordinator/registry/provider.go
+++ b/coordinator/registry/provider.go
@@ -167,7 +167,10 @@ type Provider struct {
 	IdleUnloadMins *int
 
 	// Live backend capacity from heartbeats (nil for providers without capacity reporting)
-	BackendCapacity *protocol.BackendCapacity
+	BackendCapacity       *protocol.BackendCapacity
+	ModelAutopilot        *protocol.ModelAutopilotState
+	autopilotPending      *autopilotPendingCommand
+	autopilotBackoffUntil time.Time
 
 	// capacitySamplesAt is the coordinator time of the last accepted slot
 	// sample reconciliation. Separate from LastHeartbeat: rejected capacity

--- a/coordinator/registry/provider_lifecycle.go
+++ b/coordinator/registry/provider_lifecycle.go
@@ -81,6 +81,7 @@ func (r *Registry) Register(id string, conn *websocket.Conn, msg *protocol.Regis
 	}
 
 	p := &Provider{
+		ModelAutopilot:              cloneAutopilotState(msg.ModelAutopilot),
 		ID:                          id,
 		stateRestorePending:         r.store != nil,
 		Hardware:                    msg.Hardware,

--- a/coordinator/registry/registry.go
+++ b/coordinator/registry/registry.go
@@ -219,6 +219,8 @@ type Registry struct {
 	cacheRoutingMaxDiscountMs    *float64
 	cacheRoutingMaxCostFraction  *float64
 	warmPool                     *warmPoolController
+	autopilot                    *modelAutopilotController
+	autopilotSender              func(providerID string, command protocol.ModelAutopilotMessage) error
 	// Provider-control sender seams let focused tests prove eligibility failures
 	// stop before any command invocation. Nil uses the provider WebSocket.
 	loadModelSender               func(providerID, modelID string) error

--- a/coordinator/registry/scheduler.go
+++ b/coordinator/registry/scheduler.go
@@ -173,6 +173,10 @@ type routingSnapshot struct {
 	// telemetry keep reading the provider-reported truth. Only set when the
 	// slot reports a token budget (activeTokenBudgetMax > 0).
 	budgetClamped bool
+	// A managed cold slot or a real placement transition cannot accept network
+	// work. Kept separate from structural eligibility so planners still see
+	// cached inventory and preflight reports temporary capacity, not absence.
+	autopilotBlocked bool
 	// kvBytesPerToken is the provider-reported per-token KV-cache cost (bytes)
 	// for THIS model's slot (BackendSlotCapacity.KVBytesPerToken). 0 = unreported
 	// (callers fall back to the kvCacheBytesPerToken default). Used by the
@@ -1724,6 +1728,7 @@ func (r *Registry) snapshotProviderIntoPLockedEx(dst *routingSnapshot, p *Provid
 		}
 	}
 	snap.modelLoaded = slotStateModelLoaded(snap.slotState)
+	snap.autopilotBlocked = providerAutopilotRoutingBlockedLocked(p, model)
 	snap.availableOnDisk = !snap.modelLoaded
 	snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 
@@ -1800,6 +1805,9 @@ func reportedFreeForLoadAdmits(catalogSizeGB float64, freeForLoadGB *float64) (a
 // Providers that report a token budget use budget-based admission;
 // legacy providers fall back to memory-based estimation.
 func freeMemoryAdmits(snap *routingSnapshot, reqPromptTokens, reqMaxTokens int) bool {
+	if snap.autopilotBlocked {
+		return false
+	}
 	// Gray-box budget clamp: a capacity-503 proved the provider's live gate
 	// rejects while the heartbeat budget below still advertises headroom
 	// (stale-optimistic). While the clamp holds, the slot is FULL — no
@@ -2568,6 +2576,9 @@ func providerModelIDs(p *Provider) []string {
 // The default wrapper (breaker honored) is unchanged for every other caller.
 // Caller holds r.mu and p.mu.
 func (r *Registry) providerCanAdmitLockedEx(p *Provider, model string, traits RequestTraits, selfRouteOwner bool, ignoreProviderBreaker bool, now time.Time) bool {
+	if providerAutopilotRoutingBlockedLocked(p, model) {
+		return false
+	}
 	if !r.providerPassesRoutingGatesLockedEx(p, model, traits, selfRouteOwner, now, ignoreProviderBreaker, false) {
 		return false
 	}
@@ -2799,6 +2810,7 @@ func (r *Registry) quickCapacityCheck(model string, estimatedPromptTokens, reque
 			}
 		}
 		snap.modelLoaded = slotStateModelLoaded(snap.slotState)
+		snap.autopilotBlocked = providerAutopilotRoutingBlockedLocked(p, model)
 		snap.availableOnDisk = !snap.modelLoaded
 		snap.fleetMedianTPS = r.tpsRegistry.Median(model, p.Hardware.ChipFamily)
 

--- a/coordinator/registry/warm_pool_controller.go
+++ b/coordinator/registry/warm_pool_controller.go
@@ -709,6 +709,7 @@ const (
 	warmColdTooLarge       warmColdReason = "model_too_large"
 	warmColdNoFreeForLoad  warmColdReason = "no_free_for_load"
 	warmColdStateRestoring warmColdReason = "state_restoring"
+	warmColdAutopilot      warmColdReason = "autopilot_managed"
 )
 
 // warmColdReasonStrings converts a reason tally to a string-keyed map for
@@ -744,6 +745,9 @@ func (r *Registry) warmPoolCandidateLocked(p *Provider, model string, now time.T
 // the boolean helpers here would change the reported reason mix — a behavior
 // change — so the checks are kept inline.
 func (r *Registry) warmPoolCandidateReasonLocked(p *Provider, model string, now time.Time) (warmPoolCandidate, warmColdReason) {
+	if providerLegacyModelChangesBlockedLocked(p) {
+		return warmPoolCandidate{}, warmColdAutopilot
+	}
 	if p.Status == StatusOffline || p.Status == StatusUntrusted || p.PrivateOnly {
 		return warmPoolCandidate{}, warmColdOfflineUntrust
 	}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,6 +1,6 @@
 # Architecture — how Darkbloom works
 
-> Last updated: 2026-09-03 · commit `5d400cf75`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Explanation pages: context, mechanism, invariants, failure modes, and a code
 map for each part of the system. The code in `coordinator/`,
@@ -43,6 +43,7 @@ how-to and runbook directories listed in [`../README.md`](../README.md).
 | Page | Concern |
 |---|---|
 | [routing.md](routing.md) | How a request becomes a provider choice: eligibility gates, cost model, selection, hedged dispatch, servability, breakers |
+| [model-autopilot.md](model-autopilot.md) | Opt-in cached model placement, useful shared-GPU capacity, explicit eviction ownership and recovery |
 | [scheduling.md](scheduling.md) | Per-model queue, slot states, token-budget admission, concurrency caps, model swaps, warm pool, heartbeat and eviction |
 | [cache-aware-routing.md](cache-aware-routing.md) | Provider-confirmed exact prefix-cache routing: proof, holders, cost discount, kill switch |
 | [prompt-contract-sidecar.md](prompt-contract-sidecar.md) | The Rust `promptsidecar`: token-boundary planning for cache routing, artifact identity, failure isolation |

--- a/docs/architecture/model-autopilot.md
+++ b/docs/architecture/model-autopilot.md
@@ -1,0 +1,234 @@
+# Opt-in model autopilot
+
+> Last updated: 2026-09-11 · commit `c7fda9228`
+
+Model autopilot manages GPU residency on explicitly enrolled providers, using
+cached models and measured network workload. It fills deficits in useful,
+deadline-qualified capacity and names every model it may unload. Configuration
+and consent are separate gates; the controller ships disabled and observation-only
+by default ([configuration](../reference/configuration.md#model-autopilot)).
+
+## Context
+
+The [48-hour evidence](../reports/2026-09-11-autopilot-capacity-evidence.md) found
+that exhausted first-content deadlines dominated 429s and that most sampled
+attempts selected already resident weights. A count of machines, resident models
+or retry attempts therefore does not measure capacity that can serve the offered
+work. Autopilot complements routing and provider admission; it does not promise
+a particular reduction in 429s.
+
+Provider `--all` and an empty enabled-model list describe advertised local
+inventory, not consent. `darkbloom autopilot enable` saves explicit consent for
+the next provider restart. Private-only providers do not enroll. Once enrolled,
+network requests use confirmed warm models and legacy cold-load commands are
+blocked, even when the coordinator controller is disabled or observing. The
+provider's ordinary idle-unload timer is paused. Shadow computation itself does
+not change residency; provider enrollment changes who owns residency decisions.
+
+Sources: `coordinator/registry/model_management_routing.go`
+(`providerAutopilotRoutingBlockedLocked`, `providerLegacyModelChangesBlockedLocked`);
+`provider-swift/Sources/darkbloom/AutopilotCommand.swift` (`Autopilot`);
+`provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift`
+(`startIdleMonitor`).
+
+## Mechanism
+
+```mermaid
+flowchart TD
+    A[Validated public logical request] --> B[Once-only terminal enrichment of arrival window]
+    B --> C[Mean work and tail prompt estimate]
+    D[Fresh fleet, occupancy, cached inventory and consent] --> E[Qualified shared GPU capacity]
+    C --> F[Compare offered demand and live occupancy]
+    E --> F
+    F --> G[Score feasible recipient and every donor]
+    G --> H{Observe only?}
+    H -->|Yes| I[Log hypothetical plan; no reservation]
+    H -->|No| J[Recheck live state and reserve whole device]
+    J --> K[Send immutable command ID and explicit victims]
+    K --> L[Provider rechecks local work, pins, memory and cached assistant]
+    L --> M[Unload named victims; load with implicit eviction disabled]
+    M --> N[Terminal status plus fresh paired capacity heartbeat]
+    N --> O[Reconcile actual residency and release reservation]
+    K --> P[Lost delivery or acknowledgement]
+    P --> Q[Bounded retransmission of the same command]
+    Q --> N
+    P --> R[Watchdog retains uncertain fence]
+```
+
+### Work and capacity
+
+`coordinator/api/autopilot_demand.go` gives each validated public logical request
+one terminal sample, independent of retries and speculative attempts. Scoped
+owner/serial traffic, account rejections and intrinsic invalid envelopes do not
+become public placement pressure. Honest short requests remain eligible samples.
+The registry groups samples by original `ReceivedAt`, handles out-of-order
+completion and expires old arrivals. It retains bounded model and time buckets,
+not identities or prompts (`coordinator/registry/autopilot_demand.go`).
+
+`PromptTokens` is mean offered prompt work; `TailPromptTokens` is a conservative
+p90 histogram bound used for deadline fit. Actual completed output and valid warm
+service duration have independent sample counts, so a completed cold request can
+teach output length without pretending to provide warm service timing. Terminal
+enrichment is delayed: the controller covers unfinished work using the maximum
+of offered work and live occupancy, never their sum.
+
+`coordinator/registry/autopilot_snapshot.go` (`autopilotModelFitLocked`) combines
+per-model/solo TPS, observed prefill, quality concurrency, reliability history,
+thermal state, CPU and memory pressure, and first-content policy. Catalog/runtime,
+trust, dedication, vision, tool-choice/grammar capabilities and memory gates still
+apply. M5/NAX requirements come from
+catalog capabilities, not a hardcoded generation ranking. Unknown load duration
+uses the configured prior; a reported slot load duration can replace that prior.
+
+`coordinator/registry/autopilot_planner.go` allocates at most one GPU's time across
+co-resident workloads. Deadline-infeasible residents retain ownership and can
+consume time, but earn no useful capacity credit. Pending operations are future
+capacity, never protection for a donor needed now. Each model uses one fixed
+reference value for recovered work; slower recipients cannot receive a higher
+benefit simply because they take longer to execute an identical request.
+
+### Placement and unloading
+
+A candidate must be enrolled, idle across the device, fresh and outside pending
+operations/backoff. The planner prefers a feasible placement with useful benefit
+after load and displacement costs, preserving scarce capabilities for unmet
+restricted models. It protects every affected donor, including retained
+co-residents fenced during the transition. Warm-pool operator floors remain
+inputs; a pending copy does not replace present donor coverage.
+
+A load that already fits needs no victim. Otherwise the planner selects explicit
+unpinned residents whose residence and idle dwell have elapsed. Incoming weight
+estimates include load padding; reclaim credit uses actual resident ownership,
+not scanner padding or an OS RSS measurement. The provider repeats total-victim
+feasibility before its
+first mutation, then calls `ensureModelLoaded` with `allowEviction: false`.
+Required enabled MTP assistants must also be verified locally before victims are
+removed. Autopilot commands neither download missing model/assistant artifacts
+nor delete cached disk files.
+
+Standalone idle unloading is separately disabled by default. When enabled, it
+requires sustained quiet, the configured idle/dwell limits, device memory
+pressure, zero live device work, no protected floor loss and no pinned victim.
+The exact defaults and fixed thresholds are in the
+[configuration reference](../reference/configuration.md#model-autopilot).
+
+Desired-build release policy remains independent. Its prefetch/reconciliation is
+deferred behind an active autopilot owner, then resumed. Explicitly superseded,
+no-longer-advertised residents have a separate cleanup path so pausing the idle
+timer does not retain obsolete builds forever. Cleanup preserves pins and live
+request/local/MTP ownership and does not infer retirement merely from a missing
+catalog entry (`provider-swift/Sources/ProviderCore/Autopilot/ProviderLoop+ReleaseCleanup.swift`,
+`cleanupAutopilotSupersededModels`).
+
+## Algorithm choice and advancement gates
+
+The implemented policy is a bounded workload-weighted greedy search with
+switching costs. This is a design choice under the measured telemetry limits,
+not a claim of global optimality or a queue-stability theorem.
+
+| Approach | Status | Fit for this network and next gate |
+|---|---|---|
+| Machine-count deficit | Baseline only | Simple to inspect, but treats unequal machines and shared resident slots as interchangeable. Retain as a replay control, not the production capacity objective. |
+| Workload-weighted greedy with switching costs | **Implemented** | Choose a feasible move using deadline-qualified service, cached artifacts, fixed per-model work value, load cost, donor coverage and scarce capabilities. Recheck every move against current reservations; no long-range forecast is required. |
+| Queue/backpressure or virtual deficit queues | Deferred | Could prioritize persistent unmet work and fairness across models. First establish unique logical backlog and starvation measurements; retry counts cannot be queue arrivals. [Neely's framework](https://link.springer.com/book/10.1007/978-3-031-79995-2) covers max-weight, virtual queues and cost/delay tradeoffs; its guarantees do not automatically apply to this controller. |
+| Rolling-horizon optimization | Deferred | Repeated constrained optimization could coordinate several placements using forecasts of demand, load time and future availability. [Receding-horizon control](https://web.stanford.edu/~boyd/papers/code_gen_rhc.html) provides that formulation; first validate these forecasts and strict solver-time/fallback bounds on our workload. The current one-step search is not MPC. |
+| Learned quality/load ranking | Deferred beyond current measured-rate estimates | Consider improving prediction calibration before learning a placement policy. Require timestamped exposure/outcome data, drift checks and held-out calibration; do not explore destructive placements on live providers to collect labels. |
+
+Cache locality and startup cost are supported design considerations in
+[ServerlessLLM](https://www.usenix.org/conference/osdi24/presentation/fu).
+Its system and published speedups are not performance claims for Darkbloom.
+Our first release keeps downloads outside autopilot and uses explicit load-time
+priors where completed-load measurements are missing.
+
+The retained hourly replay modestly favored its cost-aware simulator policy in aggregate
+while weakening restricted-model coverage; aggressive surplus release increased
+churn and reduced modeled coverage. Together with missing engine segments on
+timed-out requests and sparse cold-load samples, that supports conservative
+switching and explicit per-model gates, not tuning a more complex optimizer to
+an assumed causal model. See the [measurement limits](../reports/2026-09-11-autopilot-capacity-evidence.md).
+
+Advance a deferred method only after event-level, chronological replay preserves
+actual arrivals, departures, drains, failure outcomes and paired capacity;
+measured load distributions and prediction errors hold up on later windows;
+and a shadow comparison improves per-model completion/deadline quality without
+unacceptable churn, donor loss or restricted-hardware starvation. Promotion
+still requires bounded canary validation and the same ownership/safety gates.
+
+## Invariants
+
+1. **Consent is explicit.** Missing state grants no control; the provider setting
+   and operator active-controller setting are both required for new commands.
+   `autopilot_config.go` (`DefaultAutopilotConfig`),
+   `coordinator/registry/model_management_routing.go` and
+   `provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotSettings.swift` enforce their
+   respective sides.
+2. **Reservation owns the whole device.** Current session, capacity sequence,
+   resident set, donor coverage and operation limits are rechecked before
+   `autopilotPending` is installed. Network admission and competing legacy model
+   changes respect that ownership (`coordinator/registry/autopilot_commands.go`,
+   `reserveAutopilotAction`; `coordinator/registry/model_management_routing.go`).
+3. **Only named victims may be removed.** The provider validates all victims,
+   pins, dwell, leases, cache presence and total memory feasibility, then refuses
+   implicit eviction (`provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotPolicy.swift`,
+   `rejection`; `provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift`,
+   `runModelAutopilot`).
+4. **Acknowledgement is not capacity.** Only a later accepted capacity sequence
+   paired with the same terminal command ID and a matching resident set releases
+   the reservation. Stale/mismatched status cannot manufacture warm capacity
+   (`coordinator/registry/autopilot_provider_state.go`,
+   `reconcileAutopilotHeartbeatLocked`).
+5. **Retries preserve identity and expiry.** Bounded sends reuse the exact
+   command. An unseen expired command fails; an active/completed identical
+   command reports its known result. Watchdog expiry retains uncertainty rather
+   than assuming rollback (`coordinator/registry/autopilot_retries.go`,
+   `retryAutopilotCommands`; provider `handleModelAutopilot`).
+6. **Shared work is not multiplied.** Logical demand excludes retry
+   multiplication; occupancy overlaps offered work; co-resident capacities share
+   GPU time; useful floors count qualified contributions
+   (`coordinator/registry/autopilot_demand.go`, `autopilot_planner.go`).
+
+## Failure modes and estimation limits
+
+| Condition | Behavior and limit |
+|---|---|
+| Coordinator remains disabled/shadow after provider enrollment | No autopilot loads are issued; the enrolled provider still uses managed residency rules and warm-only network admission. Enrollment is not a no-op. |
+| State, capacity sequence or resident set changes | Replan/reject; provider rechecks after suspension and before mutation. |
+| Missing primary or required assistant cache | Reject before victim mutation; operator/release inventory preparation remains separate. |
+| Load fails after some victims were removed | Report failure and reconcile actual remaining capacity. The operation is not an atomic rollback to the old resident set; disk files remain available. |
+| Ambiguous write, lost status or watchdog expiry | Keep the fence; repeat only the bounded identical command. A first-send queue-full proof that nothing was enqueued is a distinct safe cleanup path. |
+| Sparse, stale or missing measurements | Fall back conservatively or exclude the candidate; service and load priors are estimates, not measured distributions. |
+| Deadline failures, invalid requests or external traffic changes | Additional residency may not help. Track logical completion, first-content failures and request shape separately from placements. |
+
+The model uses aggregate recent workload and a mean/p90 shape approximation,
+not a full queueing forecast or a simulation of every multimodal request. The
+[retained 14-day replay](../reports/2026-09-11-autopilot-capacity-evidence.md#conditional-machine-quality-and-loading-uncertainty)
+is a coarse counterfactual, not production uplift evidence.
+
+A local, uncontended 1,000-provider × 8-build benchmark of the implementation
+measured reservation around **3.2ms** (sample p95 around **3.6ms**) and a complete
+tick around **10.97ms** (sample p95 around **11.55ms**). The reservation benchmark
+includes snapshot/replanning under the registry write lock; the tick uses a fake
+sender. These are local development measurements, not production lock-tail or
+request-latency claims (`coordinator/registry/autopilot_controller_benchmark_test.go`,
+`BenchmarkAutopilotControllerFleet1000`).
+
+## Code map
+
+| Concern | Source / symbols |
+|---|---|
+| Startup, settings and tick summaries | `coordinator/registry/autopilot_config.go`, `autopilot_controller.go`; `StartAutopilotController`, `tick`, `AutopilotSnapshot` |
+| Logical request capture and observations | `coordinator/api/autopilot_demand.go`; `beginAutopilotDemand`, `finishAutopilotDemand`, `observeAutopilotCompletion` |
+| Arrival windows and independent sample counts | `coordinator/registry/autopilot_demand.go`; `record`, `snapshot` |
+| Fleet predicates and quality fit | `coordinator/registry/autopilot_snapshot.go`; `autopilotFleetSnapshotLocked`, `autopilotModelFitLocked` |
+| Useful coverage, victim selection and benefit | `coordinator/registry/autopilot_planner.go`; `autopilotCoverage`, `autopilotVictims`, `planAutopilotAction` |
+| Reservation, retries and heartbeat reconciliation | `coordinator/registry/autopilot_commands.go`, `autopilot_retries.go`, `autopilot_provider_state.go` |
+| Provider command ownership and release cleanup | `provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift`; `provider-swift/Sources/ProviderCore/Autopilot/ProviderLoop+ReleaseCleanup.swift` |
+| Consent and wire | `provider-swift/Sources/darkbloom/AutopilotCommand.swift`; `coordinator/protocol/model_autopilot.go`; `provider-swift/Sources/ProviderCore/Protocol/ModelAutopilot.swift` |
+
+## Related
+
+- [Operator rollout and rollback](../operations/model-autopilot.md)
+- [CLI consent and pins](../provider/cli-reference.md#darkbloom-autopilot)
+- [Wire contract](../reference/protocol-messages.md#model_autopilot)
+- [Configuration and timing defaults](../reference/configuration.md#model-autopilot)
+- [Measured capacity and 429 evidence](../reports/2026-09-11-autopilot-capacity-evidence.md)

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,6 @@
 # Operations runbooks
 
-> Last updated: 2026-09-08 · commit `ad9b7d2b1`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Procedures for deploying, migrating, and operating Darkbloom production
 infrastructure. Every runbook has the same shape — when to use, prerequisites,
@@ -17,6 +17,7 @@ shapes under [`../reference/README.md`](../reference/README.md).
 | [`provider-release.md`](provider-release.md) | Ship a provider CLI release: version bump, tag, signed and notarized bundle to R2, registration with the coordinator, rollback by deactivation |
 | [`dev-environment.md`](dev-environment.md) | Stand up, operate, and tear down the GCP dev environment |
 | [`release-policy-rollout.md`](release-policy-rollout.md) | Deploy the release-policy routing gate in shadow, then flip it to enforce |
+| [`model-autopilot.md`](model-autopilot.md) | Observe and activate a small consenting cohort; verify paired capacity, donor protection and rollback |
 | [`routing-v2-rollout.md`](routing-v2-rollout.md) | Kill switches and flag flips for the shipped routing-v2 behaviours (TTFT gate, queue-before-shed, cold dispatch, warm pool, budget clamp, anomaly detector) |
 | [`cache-routing-rollout.md`](cache-routing-rollout.md) | Turn exact prefix-cache routing on in production, widen the activation percent and plan-QPS bounds one at a time, verify with `GET /v1/cache/status`, roll back to `off` |
 | [`profiler-queries.md`](profiler-queries.md) | Read-only SQL recipes against the profiler tables (`request_profiles`, `fleet_snapshots`) for latency, fleet and outcome questions |

--- a/docs/operations/model-autopilot.md
+++ b/docs/operations/model-autopilot.md
@@ -1,0 +1,158 @@
+# Model autopilot rollout and rollback
+
+> Last updated: 2026-09-11 · commit `c7fda9228`
+
+Use this runbook to validate, observe and gradually activate model residency
+control on explicitly enrolled providers. It describes operator procedures;
+no production activation, provider enrollment or rollout is recorded as executed
+by this document.
+
+## When to use
+
+Use after the compatible coordinator and provider changes have passed their
+release checks. The [architecture](../architecture/model-autopilot.md) explains
+ownership and failure behavior; the [evidence report](../reports/2026-09-11-autopilot-capacity-evidence.md)
+explains why fewer 429s cannot be assumed from more resident copies alone.
+
+## Prerequisites
+
+- Review the exact coordinator/provider build identities and protocol support;
+  provider version alone does not establish autopilot consent.
+- Validate on the [dev environment](dev-environment.md) first. Production
+  deployments, configuration changes, traffic changes and fleet restarts require
+  explicit human approval for the specific operation under
+  [coordinator deployment](coordinator-deploy.md) and
+  [provider release](provider-release.md).
+- Use a small operator-owned or consenting provider set with known cached
+  primary builds and any configured MTP assistants. Record existing resident
+  models, local-work expectations, pins and current idle policy.
+- Preserve a timestamped logical-request baseline by model and prompt shape:
+  429 reasons, final-stream completion, first-content/decode quality, retry
+  amplification and current eligible capacity. Keep exact/broad short-input
+  cohorts separate from a claim that traffic is abusive.
+
+## Steps
+
+1. **Validate the code and failure paths locally.** Run the focused suites and
+   applicable provider tests described in the developer workflow:
+
+   ```bash
+   go test ./coordinator/registry ./coordinator/api ./coordinator/protocol -run Autopilot -count=1
+   go test -race ./coordinator/registry ./coordinator/api -run Autopilot -count=1
+   ```
+
+   Include opt-out parity, stale/paired heartbeats, duplicate/expired commands,
+   ambiguous delivery, whole-device busy guards, pins/dwell, assistant cache,
+   donor floors, tool-choice/grammar capability gates, partial load failure and
+   release-policy serialization. Passing
+   these checks does not authorize a production rollout.
+
+2. **Prepare a shadow coordinator configuration.** Through the approved
+   environment/deployment workflow, set:
+
+   ```dotenv
+   EIGENINFERENCE_AUTOPILOT_ENABLED=true
+   EIGENINFERENCE_AUTOPILOT_OBSERVE_ONLY=true
+   EIGENINFERENCE_AUTOPILOT_ALLOW_IDLE_UNLOAD=false
+   ```
+
+   Settings are read at startup, not hot-reloaded. Leave action limits and
+   conservative timing priors at the
+   [documented defaults](../reference/configuration.md#model-autopilot) initially.
+
+3. **Enroll only the chosen providers.** Inspect configured consent first:
+
+   ```bash
+   darkbloom autopilot status --json
+   darkbloom autopilot enable --min-dwell-seconds 1800 --pin MODEL_TO_RETAIN
+   darkbloom restart
+   darkbloom autopilot status
+   darkbloom status
+   ```
+
+   Substitute an actual model ID for `MODEL_TO_RETAIN`, or omit `--pin` when
+   none is required. The flag replaces the saved pin list when supplied;
+   [CLI reference](../provider/cli-reference.md#darkbloom-autopilot) describes
+   configuration and pin removal. `status` reports saved configuration, not
+   proof that the coordinator accepted a live heartbeat. Verify live consent
+   and the paired capacity/residency state in coordinator/provider logs.
+
+   Enrollment pauses the provider idle timer and delegates cold network loads
+   to autopilot even during shadow mode. With no active controller, only already
+   warm models receive network work. Preserve sufficient manual capacity while
+   observing the canary.
+
+4. **Inspect shadow plans over representative traffic.** Read coordinator
+   `model autopilot tick` logs: `observe_only`, `opted_in`, `pending`, `uncertain`,
+   `proposed`, `issued`, `excluded`, and per-model offered/ready/future capacity,
+   useful warm count, eligible idle candidates, protected floor and deficit.
+   `issued` must remain zero. Compare predicted victims and deficits with actual
+   cached inventory, live occupancy and hardware eligibility; do not count
+   hypothetical future placements as measured capacity.
+
+5. **Activate a bounded canary after review.** Apply the approved coordinator
+   change to `EIGENINFERENCE_AUTOPILOT_OBSERVE_ONLY=false` and restart through the
+   deployment runbook. Keep the enrolled set small and standalone idle unloading
+   disabled. Change one dimension at a time: enrollment, action limits and
+   surplus-unload policy should not widen together.
+
+6. **Expand only after complete command reconciliation.** Observe enough load
+   and unload cycles to cover genuine deficits, quiet periods and failures.
+   Require stable donor coverage and acceptable per-model completion/latency,
+   not just a better aggregate throughput number. Optional standalone unloading
+   requires a separate reviewed change to
+   `EIGENINFERENCE_AUTOPILOT_ALLOW_IDLE_UNLOAD=true`; first verify its quiet,
+   pressure, dwell, pin and floor conditions.
+
+## Verification
+
+| Check | Expected evidence |
+|---|---|
+| Consent boundary | Manual/private providers receive no autopilot command; advertising all models alone does not enroll them. |
+| Command lifecycle | A command ID names the complete expected resident set and explicit victims; its terminal acknowledgement is followed by a newer accepted capacity sequence carrying the same terminal ID and matching actual residents. |
+| Resource safety | No busy/pinned eviction, no implicit LRU victim, no unplanned primary/assistant download; donor capacity remains sufficient through the whole device transition. |
+| Recovery | Same-ID retransmission remains bounded; expired unseen commands fail safely; uncertain operations remain fenced rather than becoming optimistic capacity. |
+| Release independence | Desired-build reconciliation resumes after an autopilot owner; explicitly superseded residents clean up without dropping supported co-residents or violating local ownership. |
+| Network outcome | Compare model/shape-matched logical completions, first-content/decode quality, 429 reasons and attempts per request against the timestamped baseline; retain external traffic and cohort changes as confounders. |
+| Churn and overhead | Review load/unload count, failures, pending age, candidate exclusions, tick duration and registry/routing latency alongside any apparent capacity gain. |
+
+The coordinator emits `provider.model_autopilot_status` by status and
+`provider.model_autopilot_status_rejected` for rejected acknowledgements
+(`coordinator/api/provider.go`). These count messages, including retransmission
+responses; they are not unique successful placement counters. Use command IDs
+and paired heartbeat reconciliation for completed operations. `AutopilotSnapshot`
+is a registry accessor; this change does not add a public autopilot HTTP endpoint.
+
+Local synthetic 1,000-provider benchmarks are described in the
+[architecture](../architecture/model-autopilot.md#failure-modes-and-estimation-limits).
+They are not a production tail-latency gate. The historical website replay is
+also not proof of production 429 reduction.
+
+## Rollback
+
+1. **Stop new scheduling through the approved deployment workflow.** Set
+   `EIGENINFERENCE_AUTOPILOT_OBSERVE_ONLY=true`, or disable
+   `EIGENINFERENCE_AUTOPILOT_ENABLED`, and apply with the required coordinator
+   restart. This stops future controller issuance; it is not a cancellation of
+   a command already accepted by a provider.
+2. **Reconcile operations already in progress.** Inspect provider command state
+   and fresh actual capacity. Do not clear an uncertain fence merely because
+   the acceptance deadline or watchdog elapsed. Retries preserve the original
+   ID; a partial failure does not promise automatic restoration of all victims.
+   If operator recovery requires a provider restart, authorize that specific
+   action, preserve logs and verify the new session/resident snapshot.
+3. **Revoke the selected provider's configured consent when appropriate.**
+
+   ```bash
+   darkbloom autopilot disable
+   darkbloom restart
+   darkbloom autopilot status
+   darkbloom status
+   ```
+
+   This takes effect on restart, restores ordinary idle-policy ownership and
+   leaves model files on disk. A disabled coordinator alone does not revoke
+   provider consent or restore legacy cold-load behavior on enrolled providers.
+4. **Verify baseline behavior and capacity.** Check live consent, no new command
+   issuance, actual warm/idle slots, donor coverage and logical request outcomes.
+   Roll back binaries separately only under the release/deployment procedures.

--- a/docs/provider/cli-reference.md
+++ b/docs/provider/cli-reference.md
@@ -1,6 +1,6 @@
 # Provider CLI reference
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Reference for the `darkbloom` command-line tool: every subcommand and flag, the
 files and identifiers it creates, the `provider.toml` keys it reads with their
@@ -26,7 +26,7 @@ set to any value skips it. Logging goes to stderr so launchd captures it in
 
 ## Subcommands
 
-Declaration order of `Darkbloom.configuration.subcommands` (21):
+Declaration order of `Darkbloom.configuration.subcommands` (23):
 
 | Command | Purpose | `--config` | Source (`provider-swift/Sources/darkbloom/…`) |
 |---|---|---|---|
@@ -48,6 +48,8 @@ Declaration order of `Darkbloom.configuration.subcommands` (21):
 | `report` | Upload recent unified logs to the coordinator | ✓ | `ReportCommand.swift` (`Report`) |
 | `autoupdate` | Toggle `provider.auto_update` | ✓ | `AutoUpdateCommand.swift` (`AutoUpdate`) |
 | `beta` | `list`, `status`, `enable`, `disable` beta features | ✓ | `BetaCommand.swift` (`Beta`) |
+| `idle` | Configure the saved idle-memory policy | ✓ | `IdleCommand.swift` (`Idle`) |
+| `autopilot` | Explicit consent, dwell and pins for cached model residency | ✓ | `AutopilotCommand.swift` (`Autopilot`) |
 | `fan` | Experimental fan control (`status`, `diagnose`, `enable`, `configure`, `disable`, `uninstall`) | | `Fan/FanCommand.swift` (`Fan`) |
 | `watchdog` | Internal, hidden: crash-recovery watchdog process | ✓ | `WatchdogCommand.swift` (`Watchdog`) |
 | `runtime-smoke` | Internal, hidden: load packaged Metal runtime and exit | | `RuntimeSmokeCommand.swift` (`RuntimeSmoke`) |
@@ -264,7 +266,36 @@ Examples:
 
 Writes `provider.auto_update` to the config file.
 
-### `darkbloom beta`
+### `darkbloom autopilot`
+
+Explicit consent for coordinator-managed residency of cached advertised models.
+Source: `provider-swift/Sources/darkbloom/AutopilotCommand.swift` (`Autopilot`,
+`setModelAutopilot`). Every subcommand accepts `--config`; changes apply after
+`darkbloom restart`, not to an already-running daemon.
+
+| Command / option | Default | Effect |
+|---|---|---|
+| `darkbloom autopilot` or `status` | read-only | Print saved consent, cached-only scope, dwell, pins and config path; this is not confirmation of coordinator acknowledgement |
+| `status --json` | `false` | Emit the saved `ModelAutopilotSettings` object |
+| `enable` | disabled until explicitly enabled | Persist `enabled = true`; the coordinator also needs an active controller to issue commands |
+| `enable --min-dwell-seconds <n>` | preserve saved value | Set minimum residence and idle time before replacement; accepted range `60...86400` seconds |
+| `enable --pin <id>...` | preserve saved pins when omitted | Replace the saved pin list with these deduplicated model IDs; the configured `[backend] model` is also pinned at runtime |
+| `disable` | — | Persist `enabled = false`; restart restores ordinary idle-policy ownership |
+
+`--all` and `[backend] enabled_models = []` are inventory selection, not opt-in.
+Private-only providers do not enroll. Enrollment pauses automatic idle unloading
+and makes network inference warm-only outside explicit managed transitions;
+this remains true while the coordinator is disabled or observation-only. The
+stored idle timeout is preserved. Direct local inference and desired-build
+release policy retain their own guarded lifecycle.
+
+Autopilot commands require local primary and configured assistant artifacts,
+name every allowed victim and retain disk files. To clear explicit pins, set
+`[backend.model_autopilot] pinned_models = []` in the config and restart; omitting
+`--pin` preserves them. See [autopilot architecture](../architecture/model-autopilot.md)
+and [operator rollout](../operations/model-autopilot.md).
+
+## `darkbloom beta`
 
 | Subcommand | Flag / positional | Type | Default | Effect |
 |---|---|---|---|---|
@@ -758,11 +789,14 @@ override `provider.toml` for one process, are in
 | `[provider] auto_restart` | `true` | Arm the watchdog LaunchAgent |
 | `[provider] update_jitter_seconds` | `300` | Max random delay before an automatic install or a network provider drains a model for a prepared MTP replacement; serving continues during the delay. `0` disables jitter; capped at `3600`. Standalone MTP upgrades skip this delay. Random staggering provides no fleet availability guarantee (`provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift`, `updateJitterSeconds`; `provider-swift/Sources/ProviderCore/Update/UpdateJitter.swift`, `delay`; `provider-swift/Sources/ProviderCore/ProviderLoop+MTPDrain.swift`, `waitBeforeMTPUpgradeDrain`) |
 | `[backend] enabled_models` | `[]` | Advertise only these ids; empty = all serveable |
-| `[backend] idle_timeout_mins` | `60` | Unload a model idle this long; `0` disables |
+| `[backend] idle_timeout_mins` | `60` | Unload a model idle this long; `0` disables; paused while model autopilot is enabled |
 | `[backend] max_model_slots` | `3` | Resident models |
 | `[backend] engine_v2_max_concurrent` | `4` (clamped to `[1, 8]`) | Concurrent requests per engine |
 | `[backend] engine_v2_kv_backend` | `"auto"` | `auto` / `paged` / `contiguous`; per-model table `engine_v2_kv_backend_by_model` takes precedence. Candidate `auto` tries paged only for the [exact qualified-artifact allowlist](../architecture/prefix-cache.md#kv-layouts), with contiguous fallback; all other IDs remain contiguous (`EngineV2KVBackendPolicy.parseSelection`, `preferredBackend`) |
 | `[backend] mtp_mode` | `auto` | Written by `darkbloom beta enable|disable mtp` |
+| `[backend.model_autopilot] enabled` | `false` | Explicit cached-residency consent; applies after restart, separate from `--all` (`provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotSettings.swift`) |
+| `[backend.model_autopilot] min_dwell_seconds` | `1800` | Minimum residence and idle time before autopilot replacement; runtime clamps to `60...86400` (`ModelAutopilotSettings.effectiveMinDwellSeconds`) |
+| `[backend.model_autopilot] pinned_models` | `[]` | Models autopilot must retain; configured `[backend] model` is additionally pinned (`provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift`, `autopilotPinnedModels`) |
 | `[backend] startup_preload` | `true` | Load advertised models at start |
 | `[coordinator] url` | `"wss://api.darkbloom.dev/ws/provider"` | |
 | `[coordinator] heartbeat_interval_secs` | `5` | Heartbeat; state file refresh is half of it |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -256,6 +256,46 @@ Throughput anomaly detector:
 | `EIGENINFERENCE_THROUGHPUT_ANOMALY_RATIO` | float > 0 | `0.35` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Observed/expected ratio below which a bucket is anomalous. |
 | `EIGENINFERENCE_THROUGHPUT_ANOMALY_MIN_SAMPLES` | integer > 0 | `3` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Providers required in a bucket before it is judged. |
 | `EIGENINFERENCE_THROUGHPUT_ANOMALY_EFFICIENCY` | float > 0 | `0.80` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Expected decode efficiency relative to the chip's theoretical rate. |
+
+### Model autopilot
+
+All coordinator variables below are startup-only and read by
+`coordinator/registry/autopilot_config.go` (`autopilotConfigFromEnv`, `Check`).
+Provider consent is separate persistent TOML, documented in
+[CLI configuration](../provider/cli-reference.md#providertoml-keys-read-by-the-cli).
+See [architecture](../architecture/model-autopilot.md) and
+[rollout](../operations/model-autopilot.md).
+
+| Variable | Values / type | Default | Effect / source |
+|---|---|---|---|
+| `EIGENINFERENCE_AUTOPILOT_ENABLED` | bool | `false` | Enable demand collection and controller ticks (`autopilotConfigFromEnv`) |
+| `EIGENINFERENCE_AUTOPILOT_OBSERVE_ONLY` | bool | `true` | Compute/log hypothetical plans without reserving, fencing or sending commands (`autopilotConfigFromEnv`; `autopilot_controller.go`, `tick`) |
+| `EIGENINFERENCE_AUTOPILOT_INTERVAL` | Go duration, `1s...1m` | `10s` | Tick cadence (`autopilotConfigFromEnv`, `Check`) |
+| `EIGENINFERENCE_AUTOPILOT_DEMAND_WINDOW` | Go duration, `1m...30m` | `5m` | Arrival-window workload aggregation (`autopilotConfigFromEnv`, `Check`) |
+| `EIGENINFERENCE_AUTOPILOT_MIN_DWELL`, `EIGENINFERENCE_AUTOPILOT_IDLE_UNLOAD_AFTER` | Go durations, dwell `1m...24h`; idle ≥ dwell and ≤ `24h` | `30m`, `1h` | Replacement residence/idle protection and optional standalone quiet window; provider's longer dwell also binds (`autopilotConfigFromEnv`, `Check`) |
+| `EIGENINFERENCE_AUTOPILOT_LOAD_TIME_PRIOR` | Go duration, `1s...5m` | `30s` | Conservative unmeasured load cost; valid slot observations may replace it (`autopilotConfigFromEnv`; `autopilot_snapshot.go`, `autopilotModelFitLocked`) |
+| `EIGENINFERENCE_AUTOPILOT_MAX_ACTIONS_PER_TICK`, `EIGENINFERENCE_AUTOPILOT_MAX_CONCURRENT_OPERATIONS` | ints, `1...32`, `1...64` | `2`, `4` | Per-tick proposals/commands and managed-operation start budget, accounting for currently observed legacy pending loads; legacy controllers retain separate limits (`autopilotConfigFromEnv`; `autopilot_controller.go`, `tick`) |
+| `EIGENINFERENCE_AUTOPILOT_TARGET_UTILIZATION` | float, `0.1...0.9` | `0.7` | Quality-capacity utilization factor (`autopilotConfigFromEnv`; `autopilot_snapshot.go`, `autopilotModelFitLocked`) |
+| `EIGENINFERENCE_AUTOPILOT_ALLOW_IDLE_UNLOAD` | bool | `false` | Allow standalone surplus unloading after quiet/dwell, pins, floors, whole-device-idle and pressure gates (`autopilotConfigFromEnv`; `autopilot_planner.go`, `planAutopilotAction`) |
+
+These implementation defaults have **no environment-variable override** in this
+change; programmatic configuration fields are validated by `AutopilotConfig.Check`.
+
+| Field / rule | Default or bound | Source |
+|---|---|---|
+| `MaxSnapshotAge` | `30s` | `coordinator/registry/autopilot_config.go`, `DefaultAutopilotConfig` |
+| `CommandAcceptTimeout` | `20s`; acceptance/first mutation, not total operation duration | `DefaultAutopilotConfig`; `provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift`, `checkAutopilotLoadOwnership` |
+| `CommandWatchdog` | `5m`; retain uncertain ownership rather than assume completion | `DefaultAutopilotConfig`; `coordinator/registry/autopilot_commands.go`, `markAutopilotWatchdogs` |
+| `FailureBackoff` | `2m` | `DefaultAutopilotConfig`; `coordinator/registry/autopilot_provider_state.go`, `reconcileAutopilotHeartbeatLocked` |
+| `MinBenefitSeconds` | `30` | `DefaultAutopilotConfig`; `coordinator/registry/autopilot_planner.go`, `planAutopilotAction` |
+| Same-command sends | At most `3` total, separated by at least `30s`; immutable ID/payload/expiry | `coordinator/registry/autopilot_retries.go`, `retryAutopilotCommands` |
+| Standalone unload memory-pressure threshold | `0.8`; additional quiet, dwell, work and floor guards apply | `coordinator/registry/autopilot_planner.go`, `planAutopilotAction` |
+| Demand retention | `10s` buckets, at most `256` models; partial boundary bucket retains < `10s` | `coordinator/registry/autopilot_demand.go`, `record`, `snapshot` |
+
+Enrolling a provider changes its local residency rules independently of the
+coordinator flags: legacy cold loads are blocked and the local idle timer is
+paused. Observation mode does not itself mutate provider state, but it also does
+not undo that explicit enrollment.
 
 ### Billing, Stripe and base rewards
 

--- a/docs/reference/protocol-messages.md
+++ b/docs/reference/protocol-messages.md
@@ -1,12 +1,12 @@
 # Provider ↔ coordinator protocol messages
 
-> Last updated: 2026-09-09 · commit `af7a74126`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Every JSON frame on the provider WebSocket (`GET /ws/provider`), with the Go
 type, the Swift type, and the presence rule for each field. Go is the canon
-(`coordinator/protocol/messages.go`, `capacity.go`, `profile.go`); Swift mirrors
+(`coordinator/protocol/messages.go`, `capacity.go`, `profile.go`, `model_autopilot.go`); Swift mirrors
 it (`provider-swift/Sources/ProviderCore/Protocol/Messages.swift`, `Types.swift`,
-`InferenceProfile.swift`). There are 16 provider→coordinator and 10
+`InferenceProfile.swift`, `ModelAutopilot.swift`). There are 17 provider→coordinator and 11
 coordinator→provider message types; nothing else is accepted.
 
 Conventions: **req** = always present; **opt** = Go `omitempty`, Swift
@@ -41,6 +41,7 @@ This does not add a message type or change the public error code.
 | provider → coordinator | `inference_error` | `InferenceErrorMessage` | `.inferenceError` |
 | provider → coordinator | `attestation_response` | `AttestationResponseMessage` | `.attestationResponse` |
 | provider → coordinator | `code_attestation_response` | `CodeAttestationResponseMessage` | `.codeAttestationResponse` |
+| provider → coordinator | `model_autopilot_status` | `ModelAutopilotStatusMessage` (`model_autopilot.go`) | `.modelAutopilotStatus` |
 | provider → coordinator | `load_model_status` | `LoadModelStatusMessage` | `.loadModelStatus` |
 | provider → coordinator | `prefetch_model_status` | `PrefetchModelStatusMessage` | `.prefetchModelStatus` |
 | provider → coordinator | `models_update` | `ModelsUpdateMessage` | `.modelsUpdate` |
@@ -54,14 +55,16 @@ This does not add a message type or change the public error code.
 | coordinator → provider | `attestation_challenge` | `AttestationChallengeMessage` | `.attestationChallenge` |
 | coordinator → provider | `code_attestation_resume_challenge` | `CodeAttestationResumeChallenge` | `.codeAttestationResumeChallenge` |
 | coordinator → provider | `runtime_status` | `RuntimeStatusMessage` | `.runtimeStatus` |
+| coordinator → provider | `model_autopilot` | `ModelAutopilotMessage` (`model_autopilot.go`) | `.modelAutopilot` |
 | coordinator → provider | `load_model` | `LoadModelMessage` | `.loadModel` |
 | coordinator → provider | `prefetch_model` | `PrefetchModelMessage` | `.prefetchModel` |
 | coordinator → provider | `desired_models` | `DesiredModelsMessage` | `.desiredModels` |
 | coordinator → provider | `trust_status` | `TrustStatusMessage` | `.trustStatus` |
 | coordinator → provider | `capacity_probe` | `CapacityProbeMessage` (`capacity.go`) | `.capacityProbe` |
 
-There is no `unload` or `unload_model` message; see
-[Model unloading](#model-unloading-no-message).
+There is no standalone `unload` or `unload_model` message. Explicit opted-in
+unloading uses [`model_autopilot`](#model_autopilot); see
+[Model unloading](#model-unloading).
 
 ## Provider → coordinator
 
@@ -75,6 +78,7 @@ connection, first.
 | `hardware` | `Hardware` | `HardwareInfo` | req | [`hardware`](#hardware) |
 | `models` | `[]ModelInfo` | `[ModelInfo]` | req | [`models[]`](#models) |
 | `backend` | `string` | `String` | req | e.g. `"mlx-swift"`; the coordinator sends `load_model`, `prefetch_model` and `desired_models` only to `backend == "mlx-swift"` |
+| `model_autopilot` | `*ModelAutopilotState` | `ModelAutopilotSnapshot?` | opt | Explicit consent and resident ownership; [state object](#model_autopilot-state). Missing state does not grant consent; scheduling/reconciliation requires a fresh paired backend-capacity snapshot |
 | `runtime_capabilities` | `[]string` | `[ProviderRuntimeCapability]` | opt | connection-scoped runtime capabilities; Swift omits when empty |
 | `version` | `string` | `String?` | opt | provider binary version, e.g. `"0.2.31"` |
 | `public_key` | `string` | `String?` | opt | base64 X25519 public key `K` for E2E encryption |
@@ -171,6 +175,7 @@ the sinks of each field are in [`telemetry-inventory.md`](telemetry-inventory.md
 | `stats` | `HeartbeatStats` | `ProviderStats` | req | [`stats`](#stats) |
 | `warm_models` | `[]string` | `[String]` | opt | resident models; Swift omits when empty |
 | `system_metrics` | `SystemMetrics` | `SystemMetrics` | req | `memory_pressure` (`float64`, 0–1), `cpu_usage` (`float64`, 0–1), `thermal_state` ∈ {`nominal`, `fair`, `serious`, `critical`} |
+| `model_autopilot` | `*ModelAutopilotState` | `ModelAutopilotSnapshot?` | opt | Explicit consent and resident ownership; [state object](#model_autopilot-state). Missing state does not grant consent; scheduling/reconciliation requires a fresh paired backend-capacity snapshot |
 | `backend_capacity` | `*BackendCapacity` | `BackendCapacity?` | opt | nil on old providers; [`backend_capacity`](#backend_capacity) |
 | `prefix_cache_protocol` | `int` | `Int?` | opt | Swift omits nil/0 |
 | `prefix_cache_v2_models` | `*[]PrefixCacheV2Capability` | `[…]?` | ptr | omitted (old provider) vs authoritative `[]` (v2 provider clearing its live set) |
@@ -451,6 +456,26 @@ Go `CodeAttestationResponseMessage` · Swift `CodeAttestationResponse`. `nonce`
 nonce bytes), both required. Verified against the SE key bound at registration,
 never a key carried in this message.
 
+### `model_autopilot_status`
+
+Go `ModelAutopilotStatusMessage` (`coordinator/protocol/model_autopilot.go`) ·
+Swift `ModelAutopilotStatus`
+(`provider-swift/Sources/ProviderCore/Protocol/ModelAutopilot.swift`).
+
+| JSON key | Go / Swift | Presence | Meaning |
+|---|---|---|---|
+| `command_id` | `string` / `String` | req | Identifies the immutable command on this provider session |
+| `status` | `string` / `State` | req | `started`, `succeeded`, `failed` |
+| `error` | `string` / `String?` | opt | Diagnostic failure text; not an authorization or capacity signal |
+| `model_autopilot` | `*ModelAutopilotState` / `ModelAutopilotSnapshot` | opt in Go; current Swift includes it | Provider command/residency state; status alone never changes scheduler capacity |
+
+`Registry.HandleAutopilotStatus` accepts only the matching current session and
+pending command. Completion requires a later accepted capacity sequence paired
+with the same terminal command ID and matching actual residents
+(`coordinator/registry/autopilot_provider_state.go`,
+`reconcileAutopilotHeartbeatLocked`). Repeated status messages are acknowledgements,
+not additional completed operations.
+
 ### `load_model_status`
 
 Go `LoadModelStatusMessage` · Swift `LoadModelStatus`. `model_id` (req);
@@ -614,10 +639,39 @@ encoded by Swift as `[RuntimeMismatch]`). For a `template:<name>` component
 [runtime manifest](../architecture/security/attestation.md#runtime-manifest)
 accepts for that name.
 
+### `model_autopilot`
+
+Go `ModelAutopilotMessage` (`coordinator/protocol/model_autopilot.go`) · Swift
+`ModelAutopilotCommand` (`provider-swift/Sources/ProviderCore/Protocol/ModelAutopilot.swift`).
+Sent only for explicit, compatible provider consent after whole-device reservation.
+
+| JSON key | Go / Swift | Presence | Meaning |
+|---|---|---|---|
+| `command_id` | `string` / `String` | req | Nonempty, at most64 bytes; exact payload/ID reused for bounded retries |
+| `load_model_id` | `string` / `String?` | opt | One advertised local cached build; omitted for unload-only commands |
+| `unload_model_ids` | `[]string` / `[String]` | req | Explicit permitted victims, unique and at most32; `[]` means no eviction |
+| `expected_resident_models` | `[]string` / `[String]` | req | Complete unique resident set expected before mutation, at most32 |
+| `expires_at_ms` | `int64` / `Int64` | req | Unix milliseconds; must be in the future and no more than300s ahead at first acceptance; coordinator's configured default window is in [configuration](configuration.md#model-autopilot) |
+| `lease_seconds` | `int` / `Int` | req | `0...86400`; minimum hold lease on a newly loaded target, separate from provider residence/idle dwell |
+
+The provider rejects a changed resident set, busy device, pinned/young victim,
+active lease, unsupported hardware, missing local primary/assistant or infeasible
+total victim memory. A command must load a model or name at least one victim;
+the target cannot also be a victim. It calls `ensureModelLoaded` with
+`allowEviction: false` and retains disk files. Expiry bounds acceptance and first
+mutation, not completion after a transition already began.
+
+The provider caches a bounded command history. An identical active/completed
+command returns its existing status; reused IDs with altered payload are
+rejected. Same-ID recovery never extends the original expiration. See
+[autopilot ownership](../architecture/model-autopilot.md#invariants).
+
 ### `load_model`
 
 Go `LoadModelMessage` · Swift `LoadModel`. `model_id` (req). Sent only to
 `backend == "mlx-swift"`; the provider replies with `load_model_status`.
+Opted-in autopilot providers block this legacy residency path and use explicit
+`model_autopilot` commands instead.
 
 ### `prefetch_model`
 
@@ -658,6 +712,41 @@ set is pinned by `TestCapacityProbeShapeClosed` (`coordinator/protocol/capacity_
 
 ## Shared objects
 
+### `model_autopilot` state
+
+Go `ModelAutopilotState` · Swift `ModelAutopilotSnapshot`, declared in the
+`model_autopilot.go` / `ModelAutopilot.swift` files cited above. It appears on
+registration and heartbeat, and in command status. The negotiated `protocol`
+value, rather than a provider version string or advertised inventory, identifies
+support.
+
+| JSON key | Go / Swift | Presence | Meaning |
+|---|---|---|---|
+| `protocol` | `int` / `Int` | req | `1` for this cached-only protocol |
+| `enabled`, `cached_only` | `bool` / `Bool` | req | Explicit consent and cached-only scope; both must be true for planning |
+| `min_dwell_seconds` | `int` / `Int` | req | Provider minimum residence and idle duration before replacement |
+| `pinned_models` | `[]string` / `[String]` | req | Up to256 protected model IDs |
+| `max_model_slots` | `int` / `Int` | req | Valid planning range `1...32` |
+| `resident_models` | `[]ModelAutopilotResident` / `[ModelAutopilotResident]` | req | Unique resident inventory, at most32; must match the paired capacity snapshot |
+| `free_for_load_no_evict_gb` | `*float64` / `Double?` | opt | Weight-only incoming headroom in GiB with all residents retained; absent is unknown and cannot authorize a load |
+| `active_command_id`, `last_command_id` | `string` / `String?` | opt | Current owner and most recent terminal command ID |
+| `last_command_status` | `string` / `State?` | opt | Most recent terminal `succeeded` or `failed` state for reconciliation |
+
+Resident entries:
+
+| JSON key | Go / Swift | Presence | Meaning |
+|---|---|---|---|
+| `model_id` | `string` / `String` | req | Concrete build ID |
+| `resident_seconds`, `idle_seconds` | `float64` / `Int` | req | Nonnegative durations; current Swift emits whole seconds |
+| `weights_gb` | `float64` / `Double` | req | Scanner-padded load estimate, not reclaimable free memory |
+| `resident_gb` | `*float64` / `Double?` | opt | Actual slot-owned weight bytes expressed in GiB; the only victim reclaim credit, not OS RSS |
+
+State validation and malformed-report fencing are in
+`coordinator/registry/autopilot_provider_state.go` (`validAutopilotState`,
+`cloneAutopilotState`, `autopilotStateMatchesCapacity`). A status frame cannot
+replace the paired heartbeat, clear an uncertain operation by age alone or
+make unconfirmed slots routable.
+
 ### `EncryptedPayload`
 
 Go `EncryptedPayload` · Swift `EncryptedPayload`. `ephemeral_public_key`
@@ -676,23 +765,27 @@ Go `UsageInfo` · Swift `UsageInfo`.
 | `cached_tokens`, `prefill_tokens_saved` | `int` | `UInt64?` | opt |
 | `cache_stage_ms` | `float64` | `Double?` | opt — the one provider-side duration outside `profile` |
 
-## Model unloading (no message)
+## Model unloading
 
-The coordinator never tells a provider to unload. Residency changes reach a
-provider only as a `desired_models` reconciliation (prefetch → hard-swap →
-`models_update`) and through the provider's own idle timeout
-(`provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift`;
-`idle_timeout_mins` in `provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift`;
-default in [`../provider/cli-reference.md#providertoml-keys-read-by-the-cli`](../provider/cli-reference.md#providertoml-keys-read-by-the-cli),
-`0` disables). The coordinator observes the result on the next heartbeat
-(`warm_models`, `slots[]`); its assumption about that idle-unload cycle is a
-comment in `coordinator/registry/capacity_cooldown.go`.
+Opted-in providers accept explicit victim lists through `model_autopilot`.
+There is no separate generic unload command. The provider's ordinary idle timer
+is paused while enrolled, and commands cannot fall through to implicit LRU
+victims. Default standalone autopilot unloading is off; load-driven replacement
+still requires all dwell, memory, pin and donor protections.
+
+Non-enrolled providers keep their existing idle and legacy model lifecycle.
+`desired_models` release reconciliation remains independent, is deferred behind
+an active autopilot owner and resumes afterward. Explicitly superseded models
+have a guarded cleanup path so the paused idle timer does not retain retired
+builds. The coordinator observes actual results through the paired resident and
+backend-capacity heartbeat. See [autopilot architecture](../architecture/model-autopilot.md).
 
 ## Tests that pin the wire
 
 | Layer | Files |
 |---|---|
 | Go shape and envelope | `coordinator/protocol/messages_register_heartbeat_test.go`, `messages_backend_capacity_test.go`, `messages_inference_test.go`, `messages_terminal_cause_test.go`, `messages_attestation_test.go`, `messages_model_lifecycle_test.go`, `messages_envelope_test.go`, `prefix_cache_v2_test.go`, `prefix_cache_telemetry_test.go`, `capacity_test.go`, `inference_failure_test.go`, `tool_constraints_test.go`, `type_scan_test.go` |
+| Autopilot command/state | `coordinator/protocol/model_autopilot_test.go`; `provider-swift/Tests/ProviderCoreTests/ModelAutopilotTests.swift` |
 | Go ↔ Swift key pinning | `coordinator/api/provider_wire_test.go`; `provider-swift/Tests/ProviderCoreTests/ProtocolTests.swift`, `CapacityQuoteProtocolTests.swift` |
 | `profile` fixture | `coordinator/protocol/testdata/profiler_wire_fixture.json` — written by Go, loaded by Swift |
 

--- a/docs/reports/2026-09-11-autopilot-capacity-evidence.md
+++ b/docs/reports/2026-09-11-autopilot-capacity-evidence.md
@@ -1,0 +1,274 @@
+# Autopilot capacity and 429 evidence
+
+> Last updated: 2026-09-11 · commit `7c394fa2b`
+
+This frozen measurement supports opt-in model loading and unloading. Most recent
+429s were exhausted first-content deadlines on already resident models; the
+controller therefore needs useful service capacity, request shape and hardware
+eligibility, rather than machine counts or retry volume alone. No production
+configuration, provider state or traffic was changed during this investigation.
+
+## Window and provenance
+
+| Evidence | Scope and provenance |
+|---|---|
+| Datadog | **2026-09-09 23:00:00Z ≤ t < 2026-09-11 23:00:00Z**, all 48 hourly buckets; `env:production,service:d-inference-coordinator` |
+| Rejection ledger | Same 48 hours, eight six-hour aggregate queries; primary database through the existing coordinator connection |
+| Fleet history | First fleet snapshot of each hour, all 48 hours; point samples, not hourly occupancy averages |
+| Current inventory | 2026-09-11 23:33Z; snapshot time **23:33:04.907774Z** |
+| Routing samples | Sep 10 **16:00–16:05Z**, the peak 429 hour, and Sep 11 **22:00–22:05Z** |
+| Provider profiles | Sep 11 **22:00–22:01Z**; the attempted five-minute query exceeded its deadline and was narrowed |
+| Billed token shapes | Sep 10 **16:00–17:00Z** and Sep 11 **22:00–23:00Z** |
+| Live coordinator | Separately fetched health: version **0.9.2**, commit `ef7b5a9aa69e62374c83d8f2baddb2957e38c9a8`, 1,159 providers |
+| Retained context | Previous **336h**, Aug26 23:00Z–Sep 9 23:00Z, 55,175,428 billed records; detailed historical fleet only 146h |
+
+Database queries used `BEGIN READ ONLY`, `default_transaction_read_only=on`,
+a 15-second statement timeout, one-second lock timeout and no parallel query
+workers. Schema inspection confirmed `replica:false`; these were bounded reads
+on the primary, not a replica. A first query's SQL alias syntax error was
+corrected before collection. The successful routing aggregate preceding the
+profile timeout was retained separately.
+
+Raw aggregate JSON, exact SQL and Datadog query strings, collection scripts,
+`evidence-summary.json` and file hashes are retained outside the PR at
+`reports/2026-09-11-autopilot-evidence` in the operator checkout. They contain no prompt content,
+provider/account/request identifiers, key hashes or credentials. Source semantics
+were checked against the stamp commit; this is distinct from the live commit.
+
+## Logical 429s and repeated attempts
+
+Datadog recorded **10,655,401 logical request outcome events**, including
+**748,867 rate_limited events (7.03%)**. The independent asynchronous rejection
+ledger recorded **749,762 HTTP 429 rows**. These best-effort sources differ in
+terminal timing, sink/delivery behavior and window boundaries; their denominators
+must not be silently forced to match.
+
+| Persisted reason | 429 rows | Share |
+|---|---:|---:|
+| `first_chunk_timeout` | 662,170 | 88.32% |
+| `deadline_unreachable` | 51,717 | 6.90% |
+| `oversized_request` | 18,598 | 2.48% |
+| `queue_full` | 13,290 | 1.77% |
+| `context_exceeded` | 2,712 | 0.36% |
+| `queue_timeout` | 602 | 0.08% |
+| `routing_saturated` | 457 | 0.06% |
+| `unservable_token_budget` | 149 | 0.02% |
+| `no_provider` | 67 | 0.01% |
+
+**733,091 (97.78%)** were recorded at dispatch stage, 13,892 at queue stage and
+2,779 at preflight. Dispatch does not establish useful engine execution: a
+provider may refuse the remaining deadline without generating.
+
+| Model | Logical outcomes | Rate limited | Rate |
+|---|---:|---:|---:|
+| Gemma QAT | 6,959,797 | 279,897 | 4.02% |
+| GPT-OSS 20B | 2,694,644 | 315,564 | 11.71% |
+| Qwen3.5 35B | 445,559 | 90,786 | 20.38% |
+| Qwen3.6 35B VL MTP | 338,443 | 29,227 | 8.64% |
+| Qwen3.8 27B MTP | 133,496 | 26,049 | 19.51% |
+| Qwen3.5 9B | 79,274 | 5,457 | 6.88% |
+| Nemotron 3.5 Lightning | 3,617 | 1,886 | 52.14% |
+
+Nemotron's small, recently observed cohort is not a stable long-run estimate.
+Qwen3.6 had **18,094 oversized-request 429s**, exceeding its 11,058 first-content
+timeouts. Additional copies cannot fix a model-context overflow or a request
+that cannot fit any eligible node; larger compatible nodes may help only the
+latter when such nodes exist.
+
+Attempt counters were much larger: Qwen3.5 35B had **4,501,368 deadline refusals**
+and 354,574 success attempts; Gemma 14,446,290 and 6,674,322; GPT 6,760,793 and
+2,377,861. Peak five-minute Gemma routing contained **133,736 rows**, only
+**22,668 attempt-0 rows**, and 111,044 deadline refusals. These are not independent
+arrivals. An attempt-fed capacity target would amplify retries into new demand.
+
+`coordinator/api/attempt_outcome_metrics.go` (`emitAttemptOutcomeMetric`,
+`recordRequestOutcomeORView`) separates dispatched attempts, undispatched queue
+exits and logical outcomes. Legacy `request_outcome.success` records response
+commitment, not complete streams; the separate final-stream view includes timeout
+and mid-stream failures. `ratelimit.rejections` recorded another 29,512 events
+without useful reason labels; it must not be added to the logical 429 count.
+
+## Timeout shape and what remains unknown
+
+| Model | First-content timeouts | Estimated prompt >4,096 | Mean estimated prompt | Mean requested max output |
+|---|---:|---:|---:|---:|
+| GPT-OSS | 281,362 | 79.53% | 12,954 | 25,910 |
+| Gemma QAT | 260,353 | 71.48% | 9,114 | 6,533 |
+| Qwen3.5 35B | 81,464 | 33.13% | 5,480 | 15,749 |
+| Qwen3.8 27B | 23,497 | 77.81% | 12,169 | 16,780 |
+| Qwen3.6 35B | 11,058 | 45.62% | 11,567 | 16,927 |
+
+Requested maximum output is a reservation input, **not measured output work**.
+Successful completion lengths inform service demand, while output limits still
+constrain KV admission separately. Failed calls have no observed counterfactual
+completion length.
+
+At the peak, **133,637/133,736 Gemma attempts (99.93%) selected resident
+idle/running model slots**. In the recent five-minute sample, GPT's 682
+first-content timeout attempts selected 506 idle resident slots, 142 running
+resident slots and 34 unknown states. Gemma's 89 selected 80 idle and 9 running
+resident slots. Missing weights alone do not explain these failures.
+
+An idle model slot is not an idle GPU: another model, pending reservations,
+subsequent arrivals or stale heartbeats may consume resources. The one-minute
+profile sample contained 21,443 rows and 11,566 valid provider profiles, but
+**none of its 170 first-content timeout rows had engine segments**. A precise
+causal split between intrinsic prefill, engine queueing, batch contention and
+co-resident GPU work is therefore unavailable.
+
+Observable late-attempt GPT timeout cohorts averaged roughly **10–27 total
+attempts**, **1.7–8.1s remaining dispatch budget**, and **26–47s predicted TTFT**.
+[INFERENCE] Remaining-deadline fit and repeated refusal are material planning and
+routing diagnostics; loading more copies alone cannot be assumed to recover
+these requests. The prediction is not ground truth, and this observational
+sample does not measure the gain from changing it.
+
+`coordinator/api/rejection_telemetry.go` (`recordRejection`) computes
+`could_have_served` from an asynchronous candidate count, not a completed-request
+counterfactual or remaining-deadline guarantee. `warm_provider_existed` is not
+populated by that path. Engine profile stamps are offsets from enqueue, not
+additive durations (`coordinator/protocol/profile.go`, `EngineProfile`). Success
+profiles are sampled while failures bypass sampling
+(`coordinator/api/profiler.go`, `sampled`); profile proportions are not request
+success rates.
+
+## Short-input traffic
+
+Only **1,471** persisted 429s had a positive estimated prompt ≤32 tokens and
+**7** had exactly 27. Most 429s were not themselves short-input requests; indirect
+contention from short traffic remains possible but is not causally identified.
+
+In the peak billed Gemma hour, 52,725/209,421 records (25.18%) had ≤32 input
+tokens: 50,527 had exactly 25, only 53 exactly 27, and 52,272 had ≤32 input and ≤8
+output. In the later hour, only 678/120,565 (0.56%) were ≤32; exactly 25 fell to 20
+and exactly 27 to zero. Short-shape traffic subsided while 429s persisted.
+
+The retained Sep 9 export had 8,326,514 Gemma records with 25 billed input tokens,
+commonly estimated 18–20 at routing. Token length is not proof of abuse; literal 27
+filtering misses that cohort. Preserve raw and filtered analysis, and estimate
+work rather than treating a tiny completion like a long generation. All current
+traffic is OpenRouter according to the operator; historical caller attribution
+was not independently complete in these records.
+
+## Eligible cached machines and useful capacity
+
+The current inventory had **1,159 machines, 952 broadly eligible, 721 broadly
+eligible idle, 359 with multiple resident models**, and 100 advertising at least
+five catalog builds. Broad eligibility means at least one snapshot row was
+`eligible`, `no_headroom` or `free_memory`; it does not establish target-model
+load admission, opt-in or dedication compatibility.
+
+| Model | Advertised local inventory | Broad eligible idle, cached but nonresident | Public cold count |
+|---|---:|---:|---:|
+| GPT-OSS | 538 | 147 | 148 |
+| Gemma QAT | 528 | 71 | 108 |
+| Qwen3.5 35B | 263 | 60 | 116 |
+| Qwen3.6 35B | 671 | 181 | 218 |
+| Qwen3.8 27B | 80 | **5** | 9 |
+| Qwen3.5 9B | 89 | 13 | 14 |
+| Nemotron | 44 | **1** | 3 |
+
+These are different predicates at separate instants, not additive capacity.
+`coordinator/registry/model_capacity.go` counts warm/cold before immediate
+concurrency/token-headroom accounting; its generic 500-token TTFT estimate is not
+a promise for a long actual request. Cold counts may contain non-idle nodes.
+
+There were 180 M5 machines, 107 broadly eligible idle, but only 80 advertisements
+of `EigenLabs/Qwen3.8-27B-4bit-mtp`. Its exact catalog rule was still **RAM ≥36 GiB
+plus both `apple_m5` and `mlx_nax`**, with 71 broadly eligible advertisements and
+only 5 idle cached/nonresident candidates. An M5 label alone is insufficient.
+[INFERENCE] Compatible hardware has opportunity cost when assigned a general
+model; already-advertised inventory must not be treated as permission for new
+autopilot control.
+
+Hourly samples contained 717–972 entirely idle machines. At peak 16:00Z, Gemma had
+378 resident copies,313 eligibility=`eligible` slots and158 running/75 waiting
+requests. At recent 22:00Z, Qwen3.6 had341 resident copies but only 107
+eligibility=`eligible` slots. Resident copies, model queues and independent GPU
+service are distinct measures.
+
+## Conditional machine quality and loading uncertainty
+
+`warm-quality.json` contains 71 model/chip/prompt-bin cohorts and 8,259 successes:
+Sep 11 22:00–22:05Z, successful attempt 0, idle selected model slot, no running work
+on that slot, text-only, billed prompt>32 and output≥32. These are selected live
+successes, not isolated benchmarks; shape mix, co-resident activity, network time
+and survivor bias remain. Small cohorts require conservative priors.
+
+Examples for estimated prompts 513–4096:
+
+| Model/chip | n | TTFT p90 | Service p90 | Recorded decode p10 / median |
+|---|---:|---:|---:|---:|
+| Gemma/M1 | 386 | 5.46s | 6.77s | 6 / 9 TPS |
+| Gemma/M3 | 763 | 3.70s | 7.03s | 6 / 16 TPS |
+| Gemma/M4 | 1,298 | 4.92s | 7.89s | 6 / 12 TPS |
+| Gemma/M5 | 691 | 2.85s | 6.41s | 9 / 22 TPS |
+| GPT/M3 | 447 | 4.53s | 20.22s | 20 / 45 TPS |
+| GPT/M4 | 674 | 5.23s | 18.75s | 18 / 39.5 TPS |
+| GPT/M5 | 29 | 4.50s | 29.44s | 11.8 / 24 TPS |
+| Qwen3.8/M5 | 33 | 3.43s | 27.42s | 20 / 33 TPS |
+| Qwen3.6/M5 | 81 | 2.74s | 22.00s | 39 / 71 TPS |
+
+These observations do not support a universal chip-generation ranking. Use exact
+model, chip class/GPU cores, fresh per-slot and validated solo observations,
+current contention, memory, thermal state and reliability. Do not install these
+five-minute success quantiles as permanent model constants.
+
+The profile sample had only two reported cold loads: one successful GPT/M3 load
+wait of 2.411s and one failed Qwen3.6/M5 wait of 0.170s. It cannot establish a p90
+load-time distribution. Unknown load cost remains a configurable conservative
+prior until completed-load telemetry supports a per-model estimate.
+
+The earlier website's coarse 14-day replay estimated 96.04% capacity coverage for
+pressure-only allocation versus 94.80% with proactive surplus release. It used
+hourly workloads, synthetic opt-in, current inventory for historical replay and
+assumed loading/service behavior. It was not an event replay, production success
+measurement or validated causal uplift. It supports cautious unloading as an
+initial hypothesis, not an optimal dwell constant.
+
+## Requirements supported by this evidence
+
+1. **Unique workload demand:** record validated public logical arrivals once;
+   separate attempts, retries and account/invalid-request failures. Keep arrival
+   time distinct from terminal time. Use actual completed output/service data
+   with explicit missing-data priors; keep requested output limits for admission.
+2. **Useful hardware capacity:** reuse exact catalog, capability, attestation,
+   dedicated-family, request-trait and memory gates. Account for all models'
+   GPU/KV work and pending reservations; preserve scarce compatibility. A large
+   free-memory number or model-slot count is not a service guarantee.
+3. **Bounded opt-in placement:** explicit provider consent, no implicit eviction,
+   cache-aware choices and a shared operation/memory reservation mechanism.
+   Keep manual providers and pinned residency outside controller ownership;
+   reconcile actual state on completion, failure and reconnect; a timeout must
+   not silently restore capacity while an operation may still be running.
+4. **Measured quality and deadline fit:** prefer recent per-model/per-machine
+   service observations with conservative fallback and freshness checks. Track
+   future load readiness separately from immediate request admission. Repeated
+   deadline refusal must not multiply the placement target.
+5. **Conservative unloading:** drain first; initially require no active, queued
+   or pending device work, sustained surplus, dwell and retained per-model
+   useful-capacity floors. An eviction must have a feasible replacement and
+   enough expected benefit to cover switching cost. Retain disk bytes and
+   explicitly account for every victim of a multi-model change.
+6. **Observable validation:** compare per-model completion/TTFT/decode quality,
+   deadlines, candidate gate reasons, pending loads and predicted benefit with
+   load/unload outcomes, bytes downloaded and churn. Shadow results, passing
+   tests, opt-in activation and production gains are separate evidence gates.
+
+## OpenRouter traffic-growth interpretation
+
+The retained 14-day exploratory analysis used network logical-outcome volume as
+an offered-traffic proxy; current OpenRouter attribution was operator-confirmed,
+not independently complete across history. For GPT-OSS, rejection share had an
+adjusted correlation of **−0.257** with next-hour log-volume growth (334 hourly
+transitions; day-block interval **[−0.342, −0.130]**), controlling for current/prior
+volume, time of day and trend. Adding that feature reduced final-four-day
+absolute log-growth prediction error by about **24%** against the specified
+baseline (239 training / 95 later observations). This was one of 144 explored
+associations, not prospective validation or evidence that OpenRouter explicitly
+rewards a particular capacity change. Offered traffic can change because of
+upstream demand, request mix, provider selection or our observed service quality;
+these data do not identify those causes separately. Neither that association
+nor the new 48-hour rejection analysis establishes that an autopilot placement
+will cause OpenRouter to send more traffic. The frozen network-lab
+`signals.py` and `network.json` association record retain the calculation.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,6 +1,6 @@
 # Reports — dated records
 
-> Last updated: 2026-09-11 · commit `6938e8547`
+> Last updated: 2026-09-11 · commit `c7fda9228`
 
 Frozen records: incident analyses, measurements, experiment results, and
 migration records. Each file describes the code **as it was on its date**; none
@@ -11,6 +11,7 @@ what was decided and whether it shipped read [`../design/README.md`](../design/R
 File names start with the date of the work (`YYYY-MM-DD-slug.md`). Each file's
 freshness stamp carries its own date, not the current one.
 
+- [Autopilot capacity and 429 evidence](2026-09-11-autopilot-capacity-evidence.md) — 48-hour logical rejection and retry measurements, cached hardware availability, conditional service quality and conservative opt-in loading/unloading requirements.
 - [GPT-OSS 20B default SSD prefix-cache qualification](2026-09-11-gptoss-default-prefix-cache.md) — authenticated reconstruction, mixed suffixes and B1/B2/B4 task checks pass; 86–91% median warm-hit TTFT reductions, with standalone transport and ephemeral-key limits retained.
 - [0.9.2 provider-only rollout review](2026-09-10-provider-092-rollout-review.md) — verified 0.9.1 coordinator compatibility, shared inference interactions and remaining fleet-release gates.
 - [Final cache routing checks](2026-09-07-final-cache-routing.md) — twenty cache-off/SSD cases pass with two isolated providers, including holder selection, tenant isolation, cancellation and cold fallback.

--- a/provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotPolicy.swift
+++ b/provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotPolicy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Pure, fail-closed validation before the runtime reserves the transition.
+/// Runtime repeats this against live state after its memory-sampling await.
+public enum ModelAutopilotPolicy {
+    public static func rejection(command: ModelAutopilotCommand, snapshot: ModelAutopilotSnapshot,
+                                 busy: Bool, nowMs: Int64) -> String? {
+        guard snapshot.enabled, snapshot.protocolVersion == 1, snapshot.cachedOnly else { return "not_opted_in" }
+        guard !command.commandId.isEmpty, command.commandId.utf8.count <= 64,
+              command.unloadModelIds.count <= 32,
+              command.expectedResidentModels.count <= 32,
+              Set(command.unloadModelIds).count == command.unloadModelIds.count,
+              Set(command.expectedResidentModels).count == command.expectedResidentModels.count,
+              command.loadModelId?.isEmpty != true,
+              command.loadModelId != nil || !command.unloadModelIds.isEmpty,
+              command.leaseSeconds >= 0, command.leaseSeconds <= 86_400,
+              !command.unloadModelIds.contains(where: { $0.isEmpty }),
+              !(command.loadModelId.map { command.unloadModelIds.contains($0) } ?? false)
+        else { return "invalid_command" }
+        guard command.expiresAtMs > nowMs,
+              command.expiresAtMs <= nowMs.addingReportingOverflow(300_000).partialValue
+        else { return "expired_command" }
+        guard !busy else { return "provider_busy" }
+        let residents = Set(snapshot.residentModels.map(\.modelId))
+        guard residents == Set(command.expectedResidentModels),
+              Set(command.unloadModelIds).isSubset(of: residents)
+        else { return "residency_changed" }
+        guard Set(snapshot.pinnedModels).isDisjoint(with: command.unloadModelIds) else { return "pinned_model" }
+        for victim in snapshot.residentModels where command.unloadModelIds.contains(victim.modelId) {
+            guard victim.residentSeconds >= snapshot.minDwellSeconds,
+                  victim.idleSeconds >= snapshot.minDwellSeconds else { return "minimum_dwell" }
+        }
+        let added = command.loadModelId.map { residents.contains($0) ? 0 : 1 } ?? 0
+        guard residents.count - command.unloadModelIds.count + added <= snapshot.maxModelSlots else { return "slot_capacity" }
+        return nil
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotSettings.swift
+++ b/provider-swift/Sources/ProviderCore/Autopilot/ModelAutopilotSettings.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Opt-in grants control over GPU residency of advertised, already cached builds.
+/// It never grants permission to download new weights or remove disk files.
+public struct ModelAutopilotSettings: Codable, Sendable, Equatable {
+    public var enabled: Bool
+    public var minDwellSeconds: UInt64
+    public var pinnedModels: [String]
+
+    public init(enabled: Bool = false, minDwellSeconds: UInt64 = 1_800, pinnedModels: [String] = []) {
+        self.enabled = enabled
+        self.minDwellSeconds = minDwellSeconds
+        self.pinnedModels = pinnedModels
+    }
+
+    /// Bounds timer conversions even for a hand-edited configuration.
+    public var effectiveMinDwellSeconds: Int {
+        Int(min(86_400, max(60, minDwellSeconds)))
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case minDwellSeconds = "min_dwell_seconds"
+        case pinnedModels = "pinned_models"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        minDwellSeconds = try c.decodeIfPresent(UInt64.self, forKey: .minDwellSeconds) ?? 1_800
+        pinnedModels = try c.decodeIfPresent([String].self, forKey: .pinnedModels) ?? []
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Autopilot/ProviderLoop+ReleaseCleanup.swift
+++ b/provider-swift/Sources/ProviderCore/Autopilot/ProviderLoop+ReleaseCleanup.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+extension ProviderLoop {
+    /// Desired-build releases already retire the old advertisement. Pausing the
+    /// ordinary idle timer must not strand those known-obsolete GPU residents.
+    /// This path cannot infer retirement from an absent catalog entry and never
+    /// takes a still-supported co-resident out of service.
+    internal func cleanupAutopilotSupersededModels() async {
+        guard modelAutopilotEnabled, autopilotCommand == nil, !isShuttingDown,
+              !isDrainingForUpdate, !isLoadingAny, !isReslicing,
+              engineV2RecoveryInProgress.isEmpty else { return }
+        var attempts = 0
+        for model in autopilotSupersededModels.sorted() {
+            guard autopilotCommand == nil, !isShuttingDown, !isDrainingForUpdate,
+                  !isLoadingAny, !isReslicing else { return }
+            // Advertisement returned (rollback/new release choice), or the
+            // slot is already gone: the earlier release no longer owns it.
+            guard advertisedModels[model] == nil, modelSlots[model] != nil else {
+                autopilotSupersededModels.remove(model)
+                continue
+            }
+            guard !autopilotPinnedModels.contains(model), !requestToModel.values.contains(model),
+                  !hasLocalReservation(model), !modelsUnloading.contains(model),
+                  !modelsLoading.contains(model), !isMTPUpgradeTargetRetained(model),
+                  !engineV2RecoveryInProgress.contains(model) else { continue }
+            guard attempts < 4 else { return }
+            attempts += 1
+            // unloadModel repeats request/local/MTP/command-owner checks after
+            // its own suspension and publishes actual final capacity.
+            if await unloadModel(model, forEviction: true) {
+                autopilotSupersededModels.remove(model)
+            }
+        }
+    }
+}

--- a/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
+++ b/provider-swift/Sources/ProviderCore/Config/ProviderConfig.swift
@@ -149,6 +149,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
     /// coordinator-driven preloads so advertised model count cannot become a
     /// memory-unbounded slot cap.
     public var maxModelSlots: UInt64
+    /// Explicit network residency control; advertising all cached models is not consent.
+    public var modelAutopilot: ModelAutopilotSettings
     /// Box-wide concurrent-request cap per v2 engine slot
     /// (`engine_v2_max_concurrent` under `[backend]`). Default
     /// ``defaultEngineV2MaxConcurrent`` — 4 as of v0.8.1, reverting v0.8.0's
@@ -297,7 +299,8 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         mtp: Bool? = nil,
         mtpMode: MTPMode = .auto,
         prefillDeadlineMode: PrefillDeadlineMode? = nil,
-        mtpDrafterPath: String? = nil
+        mtpDrafterPath: String? = nil,
+        modelAutopilot: ModelAutopilotSettings = .init()
     ) {
         self.port = port
         self.model = model
@@ -316,6 +319,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.mtpMode = mtp.map { $0 ? .on : .off } ?? mtpMode
         self.prefillDeadlineMode = prefillDeadlineMode
         self.mtpDrafterPath = mtpDrafterPath
+        self.modelAutopilot = modelAutopilot
     }
 
     enum CodingKeys: String, CodingKey {
@@ -324,6 +328,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         case enabledModels = "enabled_models"
         case idleTimeoutMins = "idle_timeout_mins"
         case maxModelSlots = "max_model_slots"
+        case modelAutopilot = "model_autopilot"
         case engineV2MaxConcurrent = "engine_v2_max_concurrent"
         case engineV2MaxConcurrentByModel = "engine_v2_max_concurrent_by_model"
         case engineV2KVBackend = "engine_v2_kv_backend"
@@ -358,6 +363,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         self.enabledModels = try container.decodeIfPresent([String].self, forKey: .enabledModels) ?? []
         self.idleTimeoutMins = try container.decodeIfPresent(UInt64.self, forKey: .idleTimeoutMins) ?? 60
         self.maxModelSlots = try container.decodeIfPresent(UInt64.self, forKey: .maxModelSlots) ?? 3
+        self.modelAutopilot = try container.decodeIfPresent(ModelAutopilotSettings.self, forKey: .modelAutopilot) ?? .init()
         self.engineV2MaxConcurrent =
             try container.decodeIfPresent(UInt64.self, forKey: .engineV2MaxConcurrent)
             ?? Self.defaultEngineV2MaxConcurrent
@@ -403,6 +409,7 @@ public struct BackendSettings: Sendable, Equatable, Codable {
         try container.encode(enabledModels, forKey: .enabledModels)
         try container.encode(idleTimeoutMins, forKey: .idleTimeoutMins)
         try container.encode(maxModelSlots, forKey: .maxModelSlots)
+        try container.encode(modelAutopilot, forKey: .modelAutopilot)
         try container.encode(engineV2MaxConcurrent, forKey: .engineV2MaxConcurrent)
         try container.encode(engineV2MaxConcurrentByModel, forKey: .engineV2MaxConcurrentByModel)
         try container.encode(engineV2KVBackend, forKey: .engineV2KVBackend)

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Inbound.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Inbound.swift
@@ -159,6 +159,9 @@ extension CoordinatorClient {
                 eventContinuation?.yield(.runtimeOutdated(mismatches: status.mismatches))
             }
 
+        case .modelAutopilot(let command):
+            eventContinuation?.yield(.modelAutopilot(command))
+
         case .loadModel(let load):
             logger.info("Received coordinator-driven preload for: \(load.modelId)")
             eventContinuation?.yield(.loadModel(modelId: load.modelId))

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClient+Registration.swift
@@ -37,7 +37,8 @@ extension CoordinatorClient {
             prefixCacheMemoryModels: prefixCache.protocolVersion == 2
                 ? prefixCache.memoryModels : nil,
             prefixCacheStatuses: prefixCache.statuses,
-            prefixCacheDonationOutcomes: prefixCache.donationOutcomes
+            prefixCacheDonationOutcomes: prefixCache.donationOutcomes,
+            modelAutopilot: state.modelAutopilot
         )
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
             throw CoordinatorError.encodingFailed
@@ -76,7 +77,7 @@ extension CoordinatorClient {
         // EVERY heartbeat build flows through here — the 5s baseline and the
         // event-triggered sends — so seq is dense, monotonic, and the
         // published snapshot is exactly what the coordinator last saw.
-        let capacity = state.stampAndPublishHeartbeatCapacity(state.backendCapacity)
+        let (capacity, modelAutopilot) = state.modelAutopilotHeartbeat()
         let prefixCache = state.prefixCacheV2Advertisement()
         let metrics = SystemMetricsCollector.collect(cpuCores: config.hardware.cpuCores.total)
 
@@ -122,7 +123,8 @@ extension CoordinatorClient {
                 ? prefixCache.memoryModels : nil,
             prefixCacheStatuses: prefixCache.statuses,
             prefixCacheDonationOutcomes: prefixCache.donationOutcomes,
-            idleUnloadMins: config.idleUnloadMins
+            idleUnloadMins: config.idleUnloadMins,
+            modelAutopilot: modelAutopilot
         )
 
         do {

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientCodec.swift
@@ -15,7 +15,8 @@ public enum CoordinatorClientCodec {
         prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
         prefixCacheMemoryModels: [PrefixCacheV2Capability]? = nil,
         prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
-        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
+        modelAutopilot: ModelAutopilotSnapshot? = nil
     ) -> ProviderMessage {
         // A token that arrived after the config was built (APNs slow at startup)
         // overrides the config value so a reconnect re-registers WITH it.
@@ -66,7 +67,8 @@ public enum CoordinatorClientCodec {
             prefixCacheStatuses: prefixCacheStatuses,
             prefixCacheDonationOutcomes: prefixCacheDonationOutcomes,
             toolConstraintProtocol: constrainedModels.isEmpty ? nil : 1,
-            toolConstraintModels: constrainedModels.isEmpty ? nil : constrainedModels
+            toolConstraintModels: constrainedModels.isEmpty ? nil : constrainedModels,
+            modelAutopilot: modelAutopilot
         ))
     }
 
@@ -81,7 +83,8 @@ public enum CoordinatorClientCodec {
         prefixCacheV2Models: [PrefixCacheV2Capability]? = nil,
         prefixCacheMemoryModels: [PrefixCacheV2Capability]? = nil,
         prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
-        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil
+        prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
+        modelAutopilot: ModelAutopilotSnapshot? = nil
     ) throws -> Data {
         try ProviderProtocolCodec.encodeProviderMessage(
             registrationMessage(
@@ -95,7 +98,8 @@ public enum CoordinatorClientCodec {
                 prefixCacheV2Models: prefixCacheV2Models,
                 prefixCacheMemoryModels: prefixCacheMemoryModels,
                 prefixCacheStatuses: prefixCacheStatuses,
-                prefixCacheDonationOutcomes: prefixCacheDonationOutcomes
+                prefixCacheDonationOutcomes: prefixCacheDonationOutcomes,
+                modelAutopilot: modelAutopilot
             )
         )
     }
@@ -114,7 +118,8 @@ public enum CoordinatorClientCodec {
         prefixCacheMemoryModels: [PrefixCacheV2Capability]? = nil,
         prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
         prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
-        idleUnloadMins: UInt64? = nil
+        idleUnloadMins: UInt64? = nil,
+        modelAutopilot: ModelAutopilotSnapshot? = nil
     ) -> ProviderMessage {
         .heartbeat(ProviderMessage.Heartbeat(
             status: status,
@@ -130,7 +135,8 @@ public enum CoordinatorClientCodec {
             prefixCacheMemoryModels: prefixCacheMemoryModels,
             prefixCacheStatuses: prefixCacheStatuses,
             prefixCacheDonationOutcomes: prefixCacheDonationOutcomes,
-            idleUnloadMins: idleUnloadMins
+            idleUnloadMins: idleUnloadMins,
+            modelAutopilot: modelAutopilot
         ))
     }
 
@@ -195,6 +201,9 @@ public enum CoordinatorClientCodec {
                 nonce: nonce,
                 signature: signature
             ))
+
+        case .modelAutopilotStatus(let status):
+            return .modelAutopilotStatus(status)
 
         case .loadModelStatus(let modelId, let status, let error):
             return .loadModelStatus(ProviderMessage.LoadModelStatus(

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientState.swift
@@ -185,6 +185,8 @@ public final class ProviderState: @unchecked Sendable {
     private var _warmModels: [String] = []
     private var _currentModelHash: String? = nil
     private var _backendCapacity: BackendCapacity? = nil
+    private var _modelAutopilot: ModelAutopilotSnapshot? = nil
+    private var _capacityModelAutopilot: ModelAutopilotSnapshot? = nil
     private var _prefixCacheV2Sources: [String: any DurablePrefixCacheEvidenceSource] = [:]
     private var _prefixCacheMemorySources: [String: ResidentPrefixCacheEvidence] = [:]
     private var _prefixCacheStatuses: [PrefixCacheModelStatus] = []
@@ -223,9 +225,36 @@ public final class ProviderState: @unchecked Sendable {
         set { lock.withLock { _currentModelHash = newValue } }
     }
 
+    public var modelAutopilot: ModelAutopilotSnapshot? {
+        get { lock.withLock { _modelAutopilot } }
+        set { lock.withLock { _modelAutopilot = newValue } }
+    }
+
     public var backendCapacity: BackendCapacity? {
         get { lock.withLock { _backendCapacity } }
         set { lock.withLock { _backendCapacity = newValue } }
+    }
+
+    /// Publish the matching residency/capacity pair. A terminal command must
+    /// never ride an older capacity payload merely because a heartbeat races
+    /// the asynchronous rebuild.
+    public func setModelAutopilotCapacity(_ capacity: BackendCapacity, snapshot: ModelAutopilotSnapshot?) {
+        lock.withLock {
+            _backendCapacity = capacity
+            _capacityModelAutopilot = snapshot
+        }
+    }
+
+    public func modelAutopilotHeartbeat() -> (BackendCapacity?, ModelAutopilotSnapshot?) {
+        lock.withLock {
+            let snapshot = _modelAutopilot?.activeCommandId != nil ? _modelAutopilot : _capacityModelAutopilot
+            var capacity = _backendCapacity
+            if snapshot?.activeCommandId != nil, var fenced = capacity {
+                for index in fenced.slots.indices { fenced.slots[index].state = "reloading" }
+                capacity = fenced
+            }
+            return (stampHeartbeatCapacityLocked(capacity), snapshot)
+        }
     }
 
     /// Mirror of the ProviderLoop's "refuse new work" windows (update drain,
@@ -285,24 +314,26 @@ public final class ProviderState: @unchecked Sendable {
     public func stampAndPublishHeartbeatCapacity(
         _ capacity: BackendCapacity?
     ) -> BackendCapacity? {
-        guard var capacity else { return nil }
-        return lock.withLock {
-            // The caller may have read this payload before a model drain
-            // began. Project the live fence under the publication lock so
-            // that old snapshot cannot advertise the target as routable.
-            for index in capacity.slots.indices
-                where _modelAdmissionDrains.contains(capacity.slots[index].model)
-            {
-                capacity.slots[index].state = "reloading"
-            }
-            _capacitySeq &+= 1
-            capacity.capacitySeq = _capacitySeq
-            let agedProcessMemory = capacity.telemetry?.processMemory?
-                .agedForHeartbeat(now: DispatchTime.now().uptimeNanoseconds)
-            capacity.telemetry?.processMemory = agedProcessMemory
-            _publishedCapacity = capacity
-            return capacity
+        lock.withLock { stampHeartbeatCapacityLocked(capacity) }
+    }
+
+    private func stampHeartbeatCapacityLocked(_ candidate: BackendCapacity?) -> BackendCapacity? {
+        guard var capacity = candidate else { return nil }
+        // The caller may have read this payload before a model drain
+        // began. Project the live fence under the publication lock so
+        // that old snapshot cannot advertise the target as routable.
+        for index in capacity.slots.indices
+            where _modelAdmissionDrains.contains(capacity.slots[index].model)
+        {
+            capacity.slots[index].state = "reloading"
         }
+        _capacitySeq &+= 1
+        capacity.capacitySeq = _capacitySeq
+        let agedProcessMemory = capacity.telemetry?.processMemory?
+            .agedForHeartbeat(now: DispatchTime.now().uptimeNanoseconds)
+        capacity.telemetry?.processMemory = agedProcessMemory
+        _publishedCapacity = capacity
+        return capacity
     }
 
     /// Reset the capacity-seq session on a fresh coordinator connection: the

--- a/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
+++ b/provider-swift/Sources/ProviderCore/Coordinator/CoordinatorClientTypes.swift
@@ -119,6 +119,7 @@ public enum CoordinatorEvent: Sendable {
     /// (off-thread) and reply with a `loadModelStatus` outbound message
     /// when the load completes or fails.
     case loadModel(modelId: String)
+    case modelAutopilot(ModelAutopilotCommand)
     /// Coordinator-driven background prefetch. Provider should download +
     /// verify the build on disk (off-thread, no GPU load) and reply with
     /// `prefetchModelStatus` outbound messages. `priority` orders concurrent
@@ -251,6 +252,7 @@ public enum OutboundMessage: Sendable {
     case attestationResponse(AttestationResponsePayload)
     case codeAttestationResponse(nonce: String, signature: String)
     case loadModelStatus(modelId: String, status: ProviderMessage.LoadModelStatus.Status, error: String?)
+    case modelAutopilotStatus(ModelAutopilotStatus)
     case prefetchModelStatus(
         modelId: String,
         status: ProviderMessage.PrefetchModelStatus.Status,

--- a/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/Messages.swift
@@ -179,6 +179,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case attestationResponse(AttestationResponse)
     case codeAttestationResponse(CodeAttestationResponse)
     case loadModelStatus(LoadModelStatus)
+    case modelAutopilotStatus(ModelAutopilotStatus)
     case prefetchModelStatus(PrefetchModelStatus)
     case modelsUpdate(ModelsUpdate)
     case prefixCacheLookup(PrefixCacheLookup)
@@ -188,6 +189,7 @@ public enum ProviderMessage: Sendable, Equatable {
     case capacityQuote(CapacityQuote)
 
     public struct Register: Sendable, Equatable {
+        public var modelAutopilot: ModelAutopilotSnapshot?
         public var hardware: HardwareInfo
         public var models: [ModelInfo]
         public var backend: String
@@ -250,8 +252,10 @@ public enum ProviderMessage: Sendable, Equatable {
             prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
             prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
             toolConstraintProtocol: Int? = nil,
-            toolConstraintModels: [String]? = nil
+            toolConstraintModels: [String]? = nil,
+            modelAutopilot: ModelAutopilotSnapshot? = nil
         ) {
+            self.modelAutopilot = modelAutopilot
             self.hardware = hardware
             self.models = models
             self.backend = backend
@@ -282,6 +286,7 @@ public enum ProviderMessage: Sendable, Equatable {
     }
 
     public struct Heartbeat: Sendable, Equatable {
+        public var modelAutopilot: ModelAutopilotSnapshot?
         public var status: ProviderStatus
         public var activeModel: String?
         public var warmModels: [String]
@@ -323,7 +328,8 @@ public enum ProviderMessage: Sendable, Equatable {
             prefixCacheMemoryModels: [PrefixCacheV2Capability]? = nil,
             prefixCacheStatuses: [PrefixCacheModelStatus]? = nil,
             prefixCacheDonationOutcomes: [PrefixCacheDonationOutcomeCount]? = nil,
-            idleUnloadMins: UInt64? = nil
+            idleUnloadMins: UInt64? = nil,
+            modelAutopilot: ModelAutopilotSnapshot? = nil
         ) {
             self.status = status
             self.activeModel = activeModel
@@ -339,6 +345,7 @@ public enum ProviderMessage: Sendable, Equatable {
             self.prefixCacheStatuses = prefixCacheStatuses
             self.prefixCacheDonationOutcomes = prefixCacheDonationOutcomes
             self.idleUnloadMins = idleUnloadMins
+            self.modelAutopilot = modelAutopilot
         }
     }
 
@@ -851,6 +858,7 @@ extension ProviderMessage: Codable {
         case attestationResponse = "attestation_response"
         case codeAttestationResponse = "code_attestation_response"
         case loadModelStatus = "load_model_status"
+        case modelAutopilotStatus = "model_autopilot_status"
         case prefetchModelStatus = "prefetch_model_status"
         case modelsUpdate = "models_update"
         case prefixCacheLookup = "prefix_cache_lookup"
@@ -886,6 +894,7 @@ extension ProviderMessage: Codable {
         case prefixCacheDonationOutcomes = "prefix_cache_donation_outcomes"
         case toolConstraintProtocol = "tool_constraint_protocol"
         case toolConstraintModels = "tool_constraint_models"
+        case modelAutopilot = "model_autopilot"
         // Heartbeat
         case status
         case activeModel = "active_model"
@@ -961,8 +970,13 @@ extension ProviderMessage: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {
+        case .modelAutopilotStatus(let status):
+            try status.encode(to: encoder)
+            try container.encode(TypeValue.modelAutopilotStatus, forKey: .type)
+
         case .register(let r):
             try container.encode(TypeValue.register, forKey: .type)
+            try container.encodeIfPresent(r.modelAutopilot, forKey: .modelAutopilot)
             try container.encode(r.hardware, forKey: .hardware)
             try container.encode(r.models, forKey: .models)
             try container.encode(r.backend, forKey: .backend)
@@ -1006,6 +1020,7 @@ extension ProviderMessage: Codable {
 
         case .heartbeat(let h):
             try container.encode(TypeValue.heartbeat, forKey: .type)
+            try container.encodeIfPresent(h.modelAutopilot, forKey: .modelAutopilot)
             try container.encode(h.status, forKey: .status)
             try container.encodeIfPresent(h.activeModel, forKey: .activeModel)
             if !h.warmModels.isEmpty {
@@ -1215,6 +1230,9 @@ extension ProviderMessage: Codable {
         let type = try container.decode(TypeValue.self, forKey: .type)
 
         switch type {
+        case .modelAutopilotStatus:
+            self = .modelAutopilotStatus(try ModelAutopilotStatus(from: decoder))
+
         case .register:
             self = .register(Register(
                 hardware: try container.decode(HardwareInfo.self, forKey: .hardware),
@@ -1250,7 +1268,8 @@ extension ProviderMessage: Codable {
                 toolConstraintProtocol: try container.decodeIfPresent(
                     Int.self, forKey: .toolConstraintProtocol),
                 toolConstraintModels: try container.decodeIfPresent(
-                    [String].self, forKey: .toolConstraintModels)
+                    [String].self, forKey: .toolConstraintModels),
+                modelAutopilot: try container.decodeIfPresent(ModelAutopilotSnapshot.self, forKey: .modelAutopilot)
             ))
 
         case .heartbeat:
@@ -1274,7 +1293,8 @@ extension ProviderMessage: Codable {
                 prefixCacheDonationOutcomes: try container.decodeIfPresent(
                     [PrefixCacheDonationOutcomeCount].self,
                     forKey: .prefixCacheDonationOutcomes),
-                idleUnloadMins: try container.decodeIfPresent(UInt64.self, forKey: .idleUnloadMins)
+                idleUnloadMins: try container.decodeIfPresent(UInt64.self, forKey: .idleUnloadMins),
+                modelAutopilot: try container.decodeIfPresent(ModelAutopilotSnapshot.self, forKey: .modelAutopilot)
             ))
 
         case .inferenceAccepted:
@@ -1488,6 +1508,7 @@ public enum CoordinatorMessage: Sendable, Equatable {
     case codeAttestationResumeChallenge(CodeAttestationResumeChallenge)
     case runtimeStatus(RuntimeStatus)
     case loadModel(LoadModel)
+    case modelAutopilot(ModelAutopilotCommand)
     case prefetchModel(PrefetchModel)
     case desiredModels(DesiredModels)
     case trustStatus(TrustStatus)
@@ -1678,6 +1699,7 @@ extension CoordinatorMessage: Codable {
         case codeAttestationResumeChallenge = "code_attestation_resume_challenge"
         case runtimeStatus = "runtime_status"
         case loadModel = "load_model"
+        case modelAutopilot = "model_autopilot"
         case prefetchModel = "prefetch_model"
         case desiredModels = "desired_models"
         case trustStatus = "trust_status"
@@ -1753,6 +1775,10 @@ extension CoordinatorMessage: Codable {
             if !s.mismatches.isEmpty {
                 try container.encode(s.mismatches, forKey: .mismatches)
             }
+
+        case .modelAutopilot(let command):
+            try command.encode(to: encoder)
+            try container.encode(TypeValue.modelAutopilot, forKey: .type)
 
         case .loadModel(let l):
             try container.encode(TypeValue.loadModel, forKey: .type)
@@ -1857,6 +1883,9 @@ extension CoordinatorMessage: Codable {
                 verified: try container.decode(Bool.self, forKey: .verified),
                 mismatches: try container.decodeIfPresent([RuntimeMismatch].self, forKey: .mismatches) ?? []
             ))
+
+        case .modelAutopilot:
+            self = .modelAutopilot(try ModelAutopilotCommand(from: decoder))
 
         case .loadModel:
             self = .loadModel(LoadModel(

--- a/provider-swift/Sources/ProviderCore/Protocol/ModelAutopilot.swift
+++ b/provider-swift/Sources/ProviderCore/Protocol/ModelAutopilot.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Protocol 1 is cached-only. Absent snapshot means no consent; neither an empty
+/// enabled_models allowlist nor an advertised build implies opt-in.
+public struct ModelAutopilotSnapshot: Codable, Sendable, Equatable {
+    public var protocolVersion: Int = 1
+    public var enabled: Bool
+    public var cachedOnly: Bool = true
+    public var minDwellSeconds: Int
+    public var pinnedModels: [String]
+    public var maxModelSlots: Int
+    public var residentModels: [ModelAutopilotResident]
+    /// Weight-only headroom while retaining ALL residents, from the load gate.
+    public var freeForLoadNoEvictGb: Double?
+    public var activeCommandId: String?
+    public var lastCommandId: String?
+    public var lastCommandStatus: ModelAutopilotStatus.State?
+
+    public init(enabled: Bool, minDwellSeconds: Int = 1_800, pinnedModels: [String] = [],
+                maxModelSlots: Int = 1, residentModels: [ModelAutopilotResident] = [],
+                freeForLoadNoEvictGb: Double? = nil, activeCommandId: String? = nil,
+                lastCommandId: String? = nil, lastCommandStatus: ModelAutopilotStatus.State? = nil) {
+        self.enabled = enabled
+        self.minDwellSeconds = minDwellSeconds
+        self.pinnedModels = pinnedModels
+        self.maxModelSlots = maxModelSlots
+        self.residentModels = residentModels
+        self.freeForLoadNoEvictGb = freeForLoadNoEvictGb
+        self.activeCommandId = activeCommandId
+        self.lastCommandId = lastCommandId
+        self.lastCommandStatus = lastCommandStatus
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion = "protocol", enabled
+        case cachedOnly = "cached_only", minDwellSeconds = "min_dwell_seconds"
+        case pinnedModels = "pinned_models", maxModelSlots = "max_model_slots"
+        case residentModels = "resident_models", freeForLoadNoEvictGb = "free_for_load_no_evict_gb"
+        case activeCommandId = "active_command_id", lastCommandId = "last_command_id"
+        case lastCommandStatus = "last_command_status"
+    }
+}
+
+public struct ModelAutopilotResident: Codable, Sendable, Equatable {
+    public var modelId: String
+    public var residentSeconds: Int
+    public var idleSeconds: Int
+    /// Scanner-padded load estimate; NOT extra free memory or throughput.
+    public var weightsGb: Double
+    /// Actual slot weight ownership in GiB, the only victim reclaim credit.
+    public var residentGb: Double?
+    public init(modelId: String, residentSeconds: Int, idleSeconds: Int, weightsGb: Double,
+                residentGb: Double? = nil) {
+        self.modelId = modelId
+        self.residentSeconds = residentSeconds
+        self.idleSeconds = idleSeconds
+        self.weightsGb = weightsGb
+        self.residentGb = residentGb
+    }
+    enum CodingKeys: String, CodingKey {
+        case modelId = "model_id", residentSeconds = "resident_seconds"
+        case idleSeconds = "idle_seconds", weightsGb = "weights_gb"
+        case residentGb = "resident_gb"
+    }
+}
+
+public struct ModelAutopilotCommand: Codable, Sendable, Equatable {
+    public var commandId: String
+    public var loadModelId: String?
+    public var unloadModelIds: [String]
+    public var expectedResidentModels: [String]
+    public var expiresAtMs: Int64
+    public var leaseSeconds: Int
+
+    public init(commandId: String, loadModelId: String? = nil, unloadModelIds: [String] = [],
+                expectedResidentModels: [String] = [], expiresAtMs: Int64, leaseSeconds: Int = 1_800) {
+        self.commandId = commandId
+        self.loadModelId = loadModelId
+        self.unloadModelIds = unloadModelIds
+        self.expectedResidentModels = expectedResidentModels
+        self.expiresAtMs = expiresAtMs
+        self.leaseSeconds = leaseSeconds
+    }
+    enum CodingKeys: String, CodingKey {
+        case commandId = "command_id", loadModelId = "load_model_id"
+        case unloadModelIds = "unload_model_ids", expectedResidentModels = "expected_resident_models"
+        case expiresAtMs = "expires_at_ms", leaseSeconds = "lease_seconds"
+    }
+}
+
+public struct ModelAutopilotStatus: Codable, Sendable, Equatable {
+    public enum State: String, Codable, Sendable { case started, succeeded, failed }
+    public var commandId: String
+    public var status: State
+    public var error: String?
+    public var modelAutopilot: ModelAutopilotSnapshot
+    public init(commandId: String, status: State, error: String? = nil, modelAutopilot: ModelAutopilotSnapshot) {
+        self.commandId = commandId
+        self.status = status
+        self.error = error
+        self.modelAutopilot = modelAutopilot
+    }
+    enum CodingKeys: String, CodingKey {
+        case commandId = "command_id", status, error
+        case modelAutopilot = "model_autopilot"
+    }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+AutoUpdate.swift
@@ -187,7 +187,7 @@ extension ProviderLoop {
     internal func resumeServingAfterUpdate() async {
         updatePhase = .idle
         // Quote path mirror (routing v2): quotes may admit again.
-        state.refusingNewWork = isReconnectingAfterRetirement || isShuttingDown
+        state.refusingNewWork = isReconnectingAfterRetirement || isShuttingDown || autopilotCommand != nil
         // Announce the un-drain NOW: the coordinator ages its drain mark on a
         // TTL, so a prompt `serving`/`idle` heartbeat ends the routing
         // blackout instead of leaving it to the next 5 s baseline tick.

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Autopilot.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+extension ProviderLoop {
+    var modelAutopilotEnabled: Bool {
+        loopConfig.config.backend.modelAutopilot.enabled && !loopConfig.config.coordinator.privateOnly
+    }
+
+    var autopilotPinnedModels: Set<String> {
+        var pins = Set(loopConfig.config.backend.modelAutopilot.pinnedModels)
+        if let model = loopConfig.config.backend.model, !model.isEmpty { pins.insert(model) }
+        return pins
+    }
+
+    func publishModelAutopilotSnapshot() {
+        let now = ContinuousClock.now
+        autopilotResidentSince = autopilotResidentSince.filter { modelSlots[$0.key] != nil }
+        autopilotLeaseUntil = autopilotLeaseUntil.filter { modelSlots[$0.key] != nil }
+        for id in modelSlots.keys where autopilotResidentSince[id] == nil {
+            autopilotResidentSince[id] = now
+        }
+        state.modelAutopilot = ModelAutopilotSnapshot(
+            enabled: modelAutopilotEnabled,
+            minDwellSeconds: loopConfig.config.backend.modelAutopilot.effectiveMinDwellSeconds,
+            pinnedModels: autopilotPinnedModels.sorted(), maxModelSlots: maxModelSlots,
+            residentModels: modelSlots.keys.sorted().map { id in
+                ModelAutopilotResident(modelId: id,
+                    residentSeconds: Self.autopilotSeconds(now - (autopilotResidentSince[id] ?? now)),
+                    idleSeconds: Self.autopilotSeconds(now - (modelSlots[id]?.lastInferenceAt ?? now)),
+                    weightsGb: advertisedModels[id]?.estimatedMemoryGb
+                        ?? Double(modelSlots[id]?.sizing.weightsBytes ?? 0) / 1_073_741_824,
+                    residentGb: modelSlots[id].map { Double(max(0, $0.sizing.weightsBytes)) / 1_073_741_824 })
+            },
+            freeForLoadNoEvictGb: autopilotCommand == nil ? autopilotFreeNoEvictGb : nil,
+            activeCommandId: autopilotCommand?.commandId,
+            lastCommandId: autopilotLastCommandId, lastCommandStatus: autopilotLastCommandStatus)
+    }
+
+    private static func autopilotSeconds(_ duration: Duration) -> Int {
+        Int(max(0, min(31_536_000, duration.components.seconds)))
+    }
+
+    func checkAutopilotLoadOwnership(_ commandId: String?) throws {
+        if let command = autopilotCommand {
+            guard !isShuttingDown, !isDrainingForUpdate else {
+                throw InferenceError.modelLoadFailed("provider_draining")
+            }
+            guard commandId == command.commandId else {
+                throw InferenceError.modelLoadFailed("model autopilot placement in progress")
+            }
+            guard autopilotMutationStarted || Self.autopilotNowMs < command.expiresAtMs else {
+                throw InferenceError.modelLoadFailed("expired_command")
+            }
+        } else if commandId != nil {
+            throw InferenceError.modelLoadFailed("model autopilot command ownership lost")
+        }
+    }
+
+    private static var autopilotNowMs: Int64 { Int64(Date().timeIntervalSince1970 * 1_000) }
+
+    func handleModelAutopilot(_ command: ModelAutopilotCommand, send: SendHandle) {
+        publishModelAutopilotSnapshot()
+        if let previous = autopilotHistory[command.commandId] {
+            let matches = previous.0 == command
+            emitModelAutopilotStatus(command, status: matches ? previous.1 : .failed,
+                error: matches ? previous.2 : "command_id_reused", send: send)
+            return
+        }
+        if let active = autopilotCommand {
+            emitModelAutopilotStatus(command,
+                status: active == command ? .started : .failed,
+                error: active == command ? nil : "provider_busy", send: send)
+            return
+        }
+        if let rejection = autopilotRejection(command) {
+            finishModelAutopilot(command, status: .failed, error: rejection, send: send)
+            return
+        }
+        // No suspension between the all-idle validation and this reservation.
+        // Admission, load, idle and MTP paths all consult this same owner.
+        logger.info("Model autopilot starting command=\(command.commandId) load=\(command.loadModelId ?? "none") victims=\(command.unloadModelIds.count)")
+        autopilotGeneration &+= 1
+        autopilotCommand = command
+        autopilotMutationStarted = false
+        state.refusingNewWork = true
+        publishModelAutopilotSnapshot()
+        emitModelAutopilotStatus(command, status: .started, send: send)
+        autopilotTask = Task { [weak self] in
+            guard let self else { return }
+            await self.runModelAutopilot(command, send: send)
+        }
+    }
+
+    private func autopilotRejection(_ command: ModelAutopilotCommand) -> String? {
+        publishModelAutopilotSnapshot()
+        guard let snapshot = state.modelAutopilot else { return "not_opted_in" }
+        let busy = isShuttingDown || isDrainingForUpdate || isReconnectingAfterRetirement || hasInflightWork || isLoadingAny || isReslicing
+            || !modelsLoading.isEmpty || !modelsUnloading.isEmpty || !retiringModels.isEmpty
+            || startupPreloadTask != nil || !preloadTasks.isEmpty
+            || !pendingAdvertise.isEmpty || mtpStagingReservations.hasRetainedTargets
+            || !mtpUpgradeTransitions.isEmpty || !engineV2RecoveryInProgress.isEmpty
+        if let error = ModelAutopilotPolicy.rejection(command: command, snapshot: snapshot,
+            busy: busy, nowMs: Self.autopilotNowMs) { return error }
+        if command.unloadModelIds.contains(where: {
+            autopilotLeaseUntil[$0].map { ContinuousClock.now < $0 } ?? false
+        }) { return "active_lease" }
+        if let target = command.loadModelId {
+            guard advertisedModels[target] != nil,
+                  ModelScanner.resolveLocalPath(modelID: target) != nil else { return "model_not_cached" }
+            guard ModelRuntimeRequirements.isEligible(modelID: target,
+                available: loopConfig.runtimeCapabilities) else { return "hardware_ineligible" }
+        }
+        return nil
+    }
+
+    func validateAutopilotAssistant(_ preparation: SpecDecPreparation) throws {
+        guard preparation.status.configured, preparation.artifact == nil else { return }
+        switch preparation.status.reason {
+        case .configDisabled, .killSwitchDisabled, .targetUnsupported: return
+        default: throw AutopilotFailure("assistant_not_cached_or_invalid")
+        }
+    }
+
+    private func runModelAutopilot(_ command: ModelAutopilotCommand, send: SendHandle) async {
+        do {
+            await updateAggregateCapacity()
+            // Resolve only VERIFIED LOCAL assistant artifacts before victims.
+            // Optional MTP must not add unplanned downloads or memory costs.
+            var assistantBytes: UInt64 = 0
+            if let target = command.loadModelId, modelSlots[target] == nil,
+               let info = advertisedModels[target], let path = ModelScanner.resolveLocalPath(modelID: target) {
+                let preparation = await specDecPreparation(modelId: target, modelInfo: info,
+                    modelDirectory: path, allowDownload: false)
+                try validateAutopilotAssistant(preparation)
+                assistantBytes = preparation.artifact?.additionalWeightBytes ?? 0
+            }
+            let available = await availableMemoryGb()
+            if let error = autopilotRejection(command) { throw AutopilotFailure(error) }
+            // Validate TOTAL victim feasibility before removing even one model.
+            // Use actual resident weights here, never the padded load estimate
+            // as reclaim credit. The subsequent load re-samples OS memory.
+            if let target = command.loadModelId, modelSlots[target] == nil {
+                guard let info = advertisedModels[target], info.estimatedMemoryGb.isFinite,
+                      info.estimatedMemoryGb > 0 else { throw AutopilotFailure("unknown_model_size") }
+                let reclaimable = command.unloadModelIds.reduce(0.0) {
+                    $0 + Double(max(0, modelSlots[$1]?.sizing.weightsBytes ?? 0)) / 1_073_741_824
+                }
+                guard ModelLoadAdmission.evictionCanReach(availableGb: available,
+                    reclaimableGb: reclaimable,
+                    requiredGb: ModelLoadAdmission.requiredToLoadGb(
+                        weightsGb: info.estimatedMemoryGb + Double(assistantBytes) / 1_073_741_824,
+                        headroomGb: loadHeadroomGb))
+                else { throw AutopilotFailure("insufficient_memory_without_other_victims") }
+            }
+            // expires_at_ms bounds acceptance / first mutation, not completion.
+            // Never abandon ownership halfway through a multi-victim change.
+            try checkAutopilotLoadOwnership(command.commandId)
+            autopilotMutationStarted = true
+            for victim in command.unloadModelIds {
+                try Task.checkCancellation()
+                try checkAutopilotLoadOwnership(command.commandId)
+                guard !isShuttingDown, !isDrainingForUpdate,
+                      await unloadModel(victim, forEviction: true, autopilotCommandId: command.commandId) else {
+                    throw AutopilotFailure("victim_became_busy")
+                }
+            }
+            if let target = command.loadModelId {
+                try Task.checkCancellation()
+                try await ensureModelLoaded(modelId: target, allowEviction: false,
+                    autopilotCommandId: command.commandId)
+                guard modelSlots[target] != nil, !modelsUnloading.contains(target),
+                      advertisedModels[target] != nil else { throw AutopilotFailure("load_did_not_settle") }
+                autopilotLeaseUntil[target] = .now.advanced(by: .seconds(command.leaseSeconds))
+            }
+            finishModelAutopilot(command, status: .succeeded, send: send)
+        } catch {
+            finishModelAutopilot(command, status: .failed, error: error.localizedDescription, send: send)
+        }
+        // Terminal snapshot is rebuilt WITH backend capacity before the forced
+        // heartbeat; coordinator must reconcile the pair, not trust status alone.
+        await updateAggregateCapacity()
+        await coordinatorClient?.sendEventHeartbeat()
+        await resumeAutopilotDeferredModelChanges(send: send)
+        await retryReserveDeferredPrefetches()
+    }
+
+    private func finishModelAutopilot(_ command: ModelAutopilotCommand,
+        status: ModelAutopilotStatus.State, error: String? = nil, send: SendHandle) {
+        if autopilotCommand?.commandId == command.commandId {
+            autopilotCommand = nil
+            autopilotMutationStarted = false
+            autopilotTask = nil
+            state.refusingNewWork = isShuttingDown || isDrainingForUpdate || isReconnectingAfterRetirement
+        }
+        autopilotHistory[command.commandId] = (command, status, error)
+        autopilotHistoryOrder.append(command.commandId)
+        if autopilotHistoryOrder.count > 64 {
+            autopilotHistory.removeValue(forKey: autopilotHistoryOrder.removeFirst())
+        }
+        logger.info("Model autopilot command=\(command.commandId) status=\(status.rawValue) error=\(error ?? "none")")
+        autopilotGeneration &+= 1
+        autopilotLastCommandId = command.commandId
+        autopilotLastCommandStatus = status
+        publishModelAutopilotSnapshot()
+        emitModelAutopilotStatus(command, status: status, error: error, send: send)
+    }
+
+    private func emitModelAutopilotStatus(_ command: ModelAutopilotCommand,
+        status: ModelAutopilotStatus.State, error: String? = nil, send: SendHandle) {
+        guard let snapshot = state.modelAutopilot else { return }
+        send.send(.modelAutopilotStatus(ModelAutopilotStatus(commandId: command.commandId,
+            status: status, error: error, modelAutopilot: snapshot)))
+    }
+}
+
+private struct AutopilotFailure: LocalizedError {
+    let message: String
+    init(_ message: String) { self.message = message }
+    var errorDescription: String? { message }
+}

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Cancellation.swift
@@ -151,10 +151,10 @@ extension ProviderLoop {
     }
 
     internal func waitForInflightDrain(timeout: Duration, reason: String = "shutdown") async -> Bool {
-        guard hasInflightWork else { return true }
+        guard hasInflightWork || autopilotCommand != nil else { return true }
         logger.info("Waiting up to \(timeout.components.seconds)s for active inference to finish before \(reason)")
         let started = ContinuousClock.now
-        while hasInflightWork {
+        while hasInflightWork || autopilotCommand != nil {
             if Task.isCancelled { return false }
             if ContinuousClock.now - started >= timeout {
                 return false

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Capacity.swift
@@ -64,6 +64,7 @@ extension ProviderLoop {
         kvBudget.proactiveReclaimSweep()
         await updateAggregateCapacity()
         await recoverWedgedEngineV2Slots()
+        await cleanupAutopilotSupersededModels()
         writeDaemonState()
     }
 
@@ -80,6 +81,7 @@ extension ProviderLoop {
         // may publish one epoch behind rather than wait until the next tick.
         // Staging and model-drain changes invalidate the old snapshot; their mutation
         // paths explicitly publish a replacement.
+        let autopilotGenerationAtEntry = autopilotGeneration
         let reserveEpochAtEntry = activationReserveEpoch
         let stagingGenerationAtEntry = mtpStagingReservations.generation
         let drainGenerationAtEntry = mtpAdmissionDrains.generation
@@ -162,6 +164,13 @@ extension ProviderLoop {
             // coordinator's cold-load routing desyncs from it.
             headroomGb: loadHeadroomGb,
             outstandingReservationBytes: unmaterializedCommitments)
+        // Same coherent process sample and reserve as load admission, without
+        // credit for any resident model. This is weight-only headroom.
+        let freeForLoadNoEvictGb = max(0, ModelLoadAdmission.freeForLoadGb(
+            totalBytes: totalMem, systemAvailableBytes: processMemory.systemAvailableBytes,
+            gpuActiveBytes: mlxActiveBytes, gpuCacheBytes: mlxCacheBytes,
+            reserveBytes: loadReserve, outstandingReservationBytes: unmaterializedCommitments)
+            - loadHeadroomGb)
         let reclaimer = kvBudget.cacheReclaimerTelemetrySnapshot()
         let reclaimerTelemetry = MLXCacheReclaimerTelemetry(
             cacheLimitBytes: UInt64(max(
@@ -178,10 +187,14 @@ extension ProviderLoop {
         // enforces. Recompute over the current state instead of publishing
         // them; bounded so a push storm cannot starve the publish.
         // A newer staging/drain refresh owns the replacement snapshot. Never let
-        // the bounded reserve retry publish obsolete staging or admission capacity.
-        if (mtpStagingReservations.generation != stagingGenerationAtEntry
+        // the bounded reserve retry publish obsolete staging, admission or
+        // command-terminal state. An old refresh must not pair pre-command
+        // engine slots with a new terminal command acknowledgement.
+        if (autopilotGeneration != autopilotGenerationAtEntry
+            || mtpStagingReservations.generation != stagingGenerationAtEntry
             || mtpAdmissionDrains.generation != drainGenerationAtEntry) && attempt >= 2 { return }
-        guard (activationReserveEpoch == reserveEpochAtEntry
+        guard (autopilotGeneration == autopilotGenerationAtEntry
+            && activationReserveEpoch == reserveEpochAtEntry
             && mtpStagingReservations.generation == stagingGenerationAtEntry
             && mtpAdmissionDrains.generation == drainGenerationAtEntry) || attempt >= 2 else {
             logger.info(
@@ -207,10 +220,10 @@ extension ProviderLoop {
 
         // Existing coordinators reject reloading per model; an unknown new
         // state would remain routable. Keep other slots and provider status live.
-        for index in allSlots.indices where mtpAdmissionDrains.contains(allSlots[index].model) {
+        for index in allSlots.indices where autopilotCommand != nil || mtpAdmissionDrains.contains(allSlots[index].model) {
             allSlots[index].state = "reloading"
         }
-        state.backendCapacity = BackendCapacity(
+        let capacity = BackendCapacity(
             slots: allSlots,
             gpuMemoryActiveGb: Double(mlxActiveBytes) / gbDivisor,
             gpuMemoryPeakGb: Double(mlxPeakBytes) / gbDivisor,
@@ -221,6 +234,9 @@ extension ProviderLoop {
             telemetry: capacityTelemetry,
             prefixCacheMaintenance: PrefixCacheMaintenanceTelemetry(SSDWholeRootMaintainer.shared.statsSnapshot())
         )
+        autopilotFreeNoEvictGb = freeForLoadNoEvictGb
+        publishModelAutopilotSnapshot()
+        state.setModelAutopilotCapacity(capacity, snapshot: state.modelAutopilot)
         state.inferenceActive = totalActive > 0
         let loadedSlots = modelSlots.compactMap { modelId, slot
             -> (String, EngineV2Bridge)? in

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+DrainState.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+DrainState.swift
@@ -3,7 +3,7 @@ extension ProviderLoop {
     /// retirement reconnect barrier, including the late in-flight drain.
     internal func setRetirementReconnectBarrier(_ active: Bool) {
         isReconnectingAfterRetirement = active
-        state.refusingNewWork = active || isDrainingForUpdate || isShuttingDown
+        state.refusingNewWork = active || isDrainingForUpdate || isShuttingDown || autopilotCommand != nil
         if let client = coordinatorClient {
             Task { await client.sendEventHeartbeat() }
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+EngineV2Liveness.swift
@@ -78,6 +78,7 @@ extension ProviderLoop {
     /// capacity-refresh tick; `now` is injectable so tests can drive the
     /// 120s thresholds without waiting.
     internal func recoverWedgedEngineV2Slots(now: ContinuousClock.Instant = .now) async {
+        guard autopilotCommand == nil else { return }
         guard hasEngineV2Slots, !isShuttingDown else { return }
         for modelId in modelSlots.keys.sorted() {
             await recoverEngineV2SlotIfWedged(modelId: modelId, now: now)
@@ -89,7 +90,7 @@ extension ProviderLoop {
     internal func recoverEngineV2SlotIfWedged(
         modelId: String, now: ContinuousClock.Instant
     ) async {
-        guard let slot = modelSlots[modelId],
+        guard autopilotCommand == nil, !engineV2RecoveryInProgress.contains(modelId), let slot = modelSlots[modelId],
             !modelsUnloading.contains(modelId),
             !modelsLoading.contains(modelId)
         else { return }
@@ -98,11 +99,14 @@ extension ProviderLoop {
         guard await bridge.confirmedWedgeForRecovery(now: now) else { return }
         // Re-validate after the verdict's suspension: an unload/reload may
         // have swapped the slot while we awaited the bridge actor.
-        guard modelSlots[modelId]?.engineV2 === bridge,
+        guard autopilotCommand == nil, !engineV2RecoveryInProgress.contains(modelId), modelSlots[modelId]?.engineV2 === bridge,
             !modelsUnloading.contains(modelId),
             !modelsLoading.contains(modelId),
             !isShuttingDown
         else { return }
+
+        engineV2RecoveryInProgress.insert(modelId)
+        defer { engineV2RecoveryInProgress.remove(modelId) }
 
         // Cooldown: a second confirmed wedge within 120s of the last
         // recovery ATTEMPT means the rebuild did not stick — stop
@@ -111,6 +115,11 @@ extension ProviderLoop {
         // load path until a later lazy reload gets a fresh chance).
         if let last = engineV2LastRecoveryAt[modelId],
             now - last < Self.engineV2RecoveryCooldown {
+            // Own this emergency unload before telemetry suspends, so a new
+            // autopilot plan cannot mistake the slot for an idle resident.
+            let recoveryPin = Self.engineV2RecoveryPinPrefix + modelId
+            requestToModel[recoveryPin] = modelId
+            defer { requestToModel.removeValue(forKey: recoveryPin) }
             logger.error(
                 "engine_v2 liveness: \(modelId) wedged again inside the recovery cooldown — unloading (fail loud)")
             await bridge.emitSelfRestartTelemetry(

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+IdleTimeout.swift
@@ -27,6 +27,15 @@ extension ProviderLoop {
     /// resident forever).
     internal func startIdleMonitor() {
         idleMonitorTask?.cancel()
+        idleMonitorTask = nil
+        // Explicit autopilot enrollment transfers idle-residency decisions to
+        // the controller. Keeping the old timer as a second authority would
+        // unload its warm floor each hour, followed by an immediate reload.
+        // The configured idle policy resumes unchanged after opting out.
+        guard !modelAutopilotEnabled else {
+            logger.info("Idle residency is managed by model autopilot; local idle timer paused")
+            return
+        }
         let timeoutMinutes = loopConfig.config.backend.idleTimeoutMins
         guard timeoutMinutes > 0 else {
             logger.info("Idle-timeout disabled (idle_timeout_mins=0)")
@@ -51,7 +60,7 @@ extension ProviderLoop {
     /// Re-validates each candidate before unloading since `await unloadModel`
     /// is a suspension point that could allow new requests to arrive.
     private func tickIdleMonitor(timeout: Duration) async {
-        guard !modelSlots.isEmpty else { return }
+        guard !modelSlots.isEmpty, !modelAutopilotEnabled, autopilotCommand == nil else { return }
 
         let now = ContinuousClock.now
 
@@ -74,7 +83,8 @@ extension ProviderLoop {
         for modelId in candidates {
             guard !isMTPUpgradeTargetRetained(modelId) else { continue }
             let currentInflight = Set(requestToModel.values)
-            guard !currentInflight.contains(modelId),
+            guard autopilotCommand == nil, !modelAutopilotEnabled,
+                  !currentInflight.contains(modelId),
                   !hasLocalReservation(modelId),
                   !modelsUnloading.contains(modelId),
                   let slot = modelSlots[modelId] else { continue }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+InferenceHandler.swift
@@ -126,6 +126,9 @@ extension ProviderLoop {
     /// could keep reservations non-empty and hold `run()` open for the full
     /// shutdown drain timeout, then have its models unloaded mid-stream.
     internal func throwIfRefusingNewLocalWork(modelId: String? = nil) throws {
+        if autopilotCommand != nil {
+            throw MultiModelBatchSchedulerEngineError.queueFull("model autopilot placement in progress")
+        }
         if isShuttingDown {
             throw MultiModelBatchSchedulerEngineError.queueFull("provider shutting down")
         }
@@ -460,6 +463,17 @@ extension ProviderLoop {
         // and requestToModel registration, so the drain sees every old owner.
         if rejectIfDrainingForMTP(modelId: modelId, requestId: requestId, send: send,
             lookupReceiptFinalizer: lookupReceiptFinalizer) { return }
+
+        // Authoritative autopilot check after all admission suspensions and
+        // before request ownership is registered. Managed network work may use
+        // warm models only; owner-local work retains its own load path.
+        if autopilotCommand != nil || (modelAutopilotEnabled && modelSlots[modelId] == nil) {
+            lookupReceiptFinalizer.sendTerminal(
+                .inferenceError(requestId: requestId,
+                    failure: InferenceFailure(code: .capacity, statusCode: 503), profile: profile),
+                fallbackFailure: .capacity, send: send)
+            return
+        }
 
         // 5. Send inference_accepted
         send.send(.inferenceAccepted(requestId: requestId))

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+MTPUpgrade.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+MTPUpgrade.swift
@@ -74,7 +74,7 @@ extension ProviderLoop {
     }
 
     func pendingMTPUpgradeModels() -> [String] {
-        guard !isShuttingDown, !state.refusingNewWork,
+        guard autopilotCommand == nil, !isShuttingDown, !state.refusingNewWork,
             SpecDecArtifactFunnel.killSwitchEnabled(environment: ProcessInfo.processInfo.environment)
         else { return [] }
         return modelSlots.compactMap { modelID, slot in

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+ModelLoading.swift
@@ -195,9 +195,10 @@ extension ProviderLoop {
     /// the assistant before admission. The target remains independently
     /// loadable: assistant headroom failure selects target-only decode.
     internal func ensureModelLoaded(
-        modelId: String, allowEviction: Bool = true
+        modelId: String, allowEviction: Bool = true, autopilotCommandId: String? = nil
     ) async throws {
         await waitForMTPUpgrade(modelId)
+        try checkAutopilotLoadOwnership(autopilotCommandId)
         try ModelRuntimeRequirements.requireEligible(
             modelID: modelId, available: loopConfig.runtimeCapabilities)
         if isShuttingDown {
@@ -205,6 +206,7 @@ extension ProviderLoop {
         }
 
         try throwIfRetiring(modelId)
+        try checkAutopilotLoadOwnership(autopilotCommandId)
 
         while modelsUnloading.contains(modelId) {
             await waitForModelUnload(modelId)
@@ -215,6 +217,7 @@ extension ProviderLoop {
         // parked when the tombstone landed. Re-check before every
         // resident-slot return.
         try throwIfRetiring(modelId)
+        try checkAutopilotLoadOwnership(autopilotCommandId)
 
         if modelSlots[modelId] != nil {
             return
@@ -234,9 +237,10 @@ extension ProviderLoop {
             // on may have FAILED its self-test and begun retiring while we
             // were parked.
             try throwIfRetiring(modelId)
+            try checkAutopilotLoadOwnership(autopilotCommandId)
             if modelSlots[modelId] != nil { return }
             try await ensureModelLoaded(
-                modelId: modelId, allowEviction: allowEviction)
+                modelId: modelId, allowEviction: allowEviction, autopilotCommandId: autopilotCommandId)
             return
         }
 
@@ -252,7 +256,9 @@ extension ProviderLoop {
             )
         }
         var mtpPreparation = await specDecPreparation(
-            modelId: modelId, modelInfo: modelInfo, modelDirectory: modelPath)
+            modelId: modelId, modelInfo: modelInfo, modelDirectory: modelPath,
+            allowDownload: autopilotCommandId == nil)
+        if autopilotCommandId != nil { try validateAutopilotAssistant(mtpPreparation) }
 
         // Re-check residency and in-flight loads after the preparation await:
         // a concurrent request for the same cold model can pass the checks
@@ -269,10 +275,11 @@ extension ProviderLoop {
         // begun retiring this model meanwhile; the resident return below
         // must not hand the request to the failed build.
         try throwIfRetiring(modelId)
+        try checkAutopilotLoadOwnership(autopilotCommandId)
         if modelSlots[modelId] != nil { return }
         if modelsLoading.contains(modelId) {
             try await ensureModelLoaded(
-                modelId: modelId, allowEviction: allowEviction)
+                modelId: modelId, allowEviction: allowEviction, autopilotCommandId: autopilotCommandId)
             return
         }
 
@@ -291,8 +298,10 @@ extension ProviderLoop {
             }
             // Same rule at the load-gate wait's resident return.
             try throwIfRetiring(modelId)
+            try checkAutopilotLoadOwnership(autopilotCommandId)
             if modelSlots[modelId] != nil { return }
         }
+        try checkAutopilotLoadOwnership(autopilotCommandId)
         isLoadingAny = true
 
         // Re-check slot cap after gate (another load may have consumed a slot)
@@ -439,6 +448,9 @@ extension ProviderLoop {
             // weights BEFORE survivor grants are restored/regrown. Never
             // bind `borrow()` to a long-lived local — that would keep the
             // weights alive past `release()`.
+            // Recheck command ownership/draining after hashing and memory
+            // waits. Acceptance expiry never abandons a started replacement.
+            try checkAutopilotLoadOwnership(autopilotCommandId)
             let newcomer = EngineV2NewcomerBox(try await loadModelContainer(from: modelPath))
             try Task.checkCancellation()
             if isShuttingDown { throw CancellationError() }
@@ -831,8 +843,13 @@ extension ProviderLoop {
     }
 
     @discardableResult
-    internal func unloadModel(_ modelId: String, forEviction: Bool = false) async -> Bool {
+    internal func unloadModel(_ modelId: String, forEviction: Bool = false, autopilotCommandId: String? = nil) async -> Bool {
         await waitForMTPUpgrade(modelId)
+        // An idle/eviction candidate may have been captured before the
+        // autopilot transaction reserved this box. Only its explicit victims
+        // may be removed until the transaction settles.
+        if forEviction, let command = autopilotCommand,
+           command.commandId != autopilotCommandId { return false }
         // Recheck after the transition wait: staging or new work can begin
         // after the LRU/idle snapshot. Explicit retirement still may unload;
         // its retained target stays charged until preparation/discard ends.
@@ -902,6 +919,7 @@ extension ProviderLoop {
     }
 
     internal func syncWarmModelState() {
+        publishModelAutopilotSnapshot()
         let loaded = modelSlots.keys.filter { !modelsUnloading.contains($0) }.sorted()
         state.warmModels = loaded
         let activeSlots = modelSlots.filter { !modelsUnloading.contains($0.key) }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Prefetch.swift
@@ -289,6 +289,10 @@ extension ProviderLoop {
     }
 
     func applyVerifiedPrefetch(modelId: String) async {
+        if autopilotCommand != nil {
+            reserveDeferredPrefetches.insert(modelId)
+            return
+        }
         guard ModelRuntimeRequirements.isEligible(
             modelID: modelId, available: loopConfig.runtimeCapabilities)
         else {
@@ -318,6 +322,10 @@ extension ProviderLoop {
             return (withHash, hash)
         }.value
 
+        if autopilotCommand != nil {
+            reserveDeferredPrefetches.insert(modelId)
+            return
+        }
         // A verified prefetch whose snapshot we can't scan must NOT be
         // advertised: a synthetic zero-size ModelInfo would be routed with
         // estimatedMemoryGb == 0, bypassing memory sizing/admission until the
@@ -399,7 +407,7 @@ extension ProviderLoop {
         // can act — the pending-load reservation fences competing KV
         // grants, not this. Defer through the desired-build backoff; the
         // load's install clears the marker well within the retry budget.
-        guard modelsLoading.isEmpty else {
+        guard modelsLoading.isEmpty, autopilotCommand == nil else {
             logger.info(
                 "Prefetch verified \(modelId) while a load is in flight (\(modelsLoading.sorted())); "
                     + "deferring the advertisement")
@@ -438,7 +446,7 @@ extension ProviderLoop {
         // bridge's grant): a load admitted during those hops passed its gate
         // against the pre-raise floor and is not in `modelSlots` yet, so the
         // preflight neither counted its weights nor covered its transient.
-        guard modelsLoading.isEmpty else {
+        guard modelsLoading.isEmpty, autopilotCommand == nil else {
             releaseResliceGate()
             logger.info(
                 "Prefetch verified \(modelId) but a load entered during the preflight; "
@@ -557,9 +565,16 @@ extension ProviderLoop {
 
     /// Locally retire a superseded build: stop advertising it (so no new requests
     /// route to it and the next register won't re-announce it) and forget its hash.
-    /// The GPU slot, if resident, is left to the idle monitor — a lazy drop.
+    /// The GPU slot, if resident, drains lazily. Legacy providers use their
+    /// idle timer; autopilot providers track this explicit release retirement
+    /// for bounded cleanup once the old build is inactive and unpinned.
     private func dropAdvertisedBuild(_ buildID: String) async {
+        if autopilotCommand != nil {
+            autopilotDeferredDrops.insert(buildID)
+            return
+        }
         guard advertisedModels[buildID] != nil else { return }
+        if modelAutopilotEnabled { autopilotSupersededModels.insert(buildID) }
         advertisedModels.removeValue(forKey: buildID)
         modelHashes.removeValue(forKey: buildID)
         await coordinatorClient?.unadvertiseModel(buildID)
@@ -580,6 +595,10 @@ extension ProviderLoop {
     /// build is dropped; missing → background-prefetch it (applyVerifiedPrefetch
     /// advertises it + drops the previous build once verified).
     internal func reconcileDesiredModels(_ entries: [CoordinatorMessage.DesiredModelEntry], send: SendHandle) async {
+        if autopilotCommand != nil {
+            autopilotDeferredDesiredModels = entries
+            return
+        }
         let requestedDesired = Set(entries.map(\.desiredBuild).filter { !$0.isEmpty })
         let currentDesired = Set(requestedDesired.filter {
             ModelRuntimeRequirements.isEligible(
@@ -643,4 +662,18 @@ extension ProviderLoop {
         return ModelScanner.parseModelInfo(snapshotDir: snapshot, modelName: modelId)
     }
 
+}
+
+
+extension ProviderLoop {
+    internal func resumeAutopilotDeferredModelChanges(send: SendHandle) async {
+        guard autopilotCommand == nil, !isShuttingDown else { return }
+        let drops = autopilotDeferredDrops
+        autopilotDeferredDrops.removeAll()
+        for model in drops.sorted() { await dropAdvertisedBuild(model) }
+        if let desired = autopilotDeferredDesiredModels {
+            autopilotDeferredDesiredModels = nil
+            await reconcileDesiredModels(desired, send: send)
+        }
+    }
 }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Preload.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Preload.swift
@@ -27,6 +27,11 @@ extension ProviderLoop {
     /// `succeeded` -- the coordinator can use this as an idempotent
     /// "ensure warm" call.
     internal func handleLoadModelRequest(modelId: String, send: SendHandle) {
+        if modelAutopilotEnabled {
+            send.send(.loadModelStatus(modelId: modelId, status: .failed,
+                error: "model_autopilot_requires_explicit_command"))
+            return
+        }
         let eligibility = ModelRuntimeRequirements.evaluate(
             modelID: modelId, available: loopConfig.runtimeCapabilities)
         guard eligibility.isEligible else {

--- a/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop+Serve.swift
@@ -162,6 +162,7 @@ extension ProviderLoop {
         )
 
         // 4. Create coordinator client and start connection
+        publishModelAutopilotSnapshot()
         let coordinator = CoordinatorClient(
             config: coordinatorConfig,
             stats: stats,
@@ -285,6 +286,9 @@ extension ProviderLoop {
                         logger.warning("  \(m.component): expected=\(m.expected), got=\(m.got)")
                     }
 
+                case .modelAutopilot(let command):
+                    handleModelAutopilot(command, send: send)
+
                 case .loadModel(let modelId):
                     handleLoadModelRequest(modelId: modelId, send: send)
 
@@ -351,6 +355,7 @@ extension ProviderLoop {
         // any still-running startup preload driver (it outlives the readiness
         // gate when the timeout passed).
         var preloads = Array(preloadTasks.values)
+        if let autopilotTask { preloads.append(autopilotTask) }
         if let startupTask = startupPreloadTask {
             preloads.append(startupTask)
         }

--- a/provider-swift/Sources/ProviderCore/ProviderLoop.swift
+++ b/provider-swift/Sources/ProviderCore/ProviderLoop.swift
@@ -239,6 +239,26 @@ public actor ProviderLoop {
     /// model out from under a local stream. See `LocalReservationCounter`.
     internal var localReservations = LocalReservationCounter()
 
+    // Residency operations outlive WebSocket reconnects; never clear uncertain
+    // ownership on a transport timeout. Fresh heartbeats reconcile completion.
+    internal var autopilotCommand: ModelAutopilotCommand?
+    internal var autopilotTask: Task<Void, Never>?
+    internal var autopilotMutationStarted = false
+    internal var autopilotGeneration: UInt64 = 0
+    internal var autopilotHistory: [String: (ModelAutopilotCommand, ModelAutopilotStatus.State, String?)] = [:]
+    internal var autopilotHistoryOrder: [String] = []
+    internal var autopilotLastCommandId: String?
+    internal var autopilotLastCommandStatus: ModelAutopilotStatus.State?
+    internal var autopilotResidentSince: [String: ContinuousClock.Instant] = [:]
+    internal var autopilotLeaseUntil: [String: ContinuousClock.Instant] = [:]
+    internal var autopilotFreeNoEvictGb: Double?
+    internal var autopilotDeferredDesiredModels: [CoordinatorMessage.DesiredModelEntry]?
+    internal var autopilotDeferredDrops: Set<String> = []
+    /// Explicit desired-build retirements, never inferred from missing catalog
+    /// entries. Release cleanup is distinct from network placement authority.
+    internal var autopilotSupersededModels: Set<String> = []
+
+
     /// The running local OpenAI HTTP server task (unified mode), if any.
     internal var localServerTask: Task<Void, Never>?
 
@@ -374,6 +394,8 @@ public actor ProviderLoop {
     /// inside `engineV2RecoveryCooldown` unloads the slot instead of
     /// thrashing rebuilds).
     internal var engineV2LastRecoveryAt: [String: ContinuousClock.Instant] = [:]
+    /// Unlike network request pins, maintenance ownership survives disconnect.
+    internal var engineV2RecoveryInProgress: Set<String> = []
 
     /// Tracks in-flight inference tasks by request ID so they can be cancelled.
     internal var inflightTasks: [String: Task<Void, Never>] = [:]
@@ -563,7 +585,7 @@ public actor ProviderLoop {
 
     /// Background task that periodically checks idle state and unloads
     /// the model when the timeout has elapsed. nil when disabled
-    /// (`idleTimeoutMins == 0`) or before `run()` starts it.
+    /// (`idleTimeoutMins == 0` or model autopilot) or before `run()` starts it.
     internal var idleMonitorTask: Task<Void, Never>?
 
     /// Periodically refreshes provider-reported backend capacity so heartbeats

--- a/provider-swift/Sources/darkbloom/AutopilotCommand.swift
+++ b/provider-swift/Sources/darkbloom/AutopilotCommand.swift
@@ -1,0 +1,78 @@
+import ArgumentParser
+import Foundation
+import ProviderCore
+
+/// Provider consent is local configuration and takes effect on restart. Default
+/// off; `--all` is deliberately unrelated to this explicit enrollment.
+struct Autopilot: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "autopilot",
+        abstract: "Opt in to network-managed loading and unloading of cached models.",
+        discussion: "Autopilot preserves active requests and pinned models, uses only cached advertised builds, and keeps model files on disk. While enabled, autopilot replaces the automatic idle-unload timer; the stored idle policy resumes when disabled. Changes apply after darkbloom restart. The coordinator must also enable its autopilot controller.",
+        subcommands: [Status.self, Enable.self, Disable.self], defaultSubcommand: Status.self)
+
+    struct Status: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Show configured autopilot consent and limits.")
+        @OptionGroup var configOptions: ConfigOptions
+        @Flag(help: "Emit JSON.") var json = false
+        mutating func run() async throws {
+            let runtime = try loadRuntimeSnapshot(configOptions: configOptions)
+            let settings = runtime.config.backend.modelAutopilot
+            if json { try printJSON(settings); return }
+            print("Model autopilot: \(settings.enabled ? "enabled" : "disabled") (configured; applies after restart)")
+            print("  Scope: advertised models already cached on this Mac; no new base-model downloads")
+            if settings.enabled { print("  Idle memory: controlled by autopilot; the configured idle timer is paused") }
+            print("  Minimum residence and idle time before replacement: \(settings.effectiveMinDwellSeconds) seconds")
+            print("  Pinned models: \(settings.pinnedModels.isEmpty ? "none" : settings.pinnedModels.joined(separator: ", "))")
+            if runtime.config.coordinator.privateOnly { print("  Private-only mode prevents network autopilot.") }
+            print("  Config: \(runtime.configPath.path)")
+        }
+    }
+
+    struct Enable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Allow the coordinator to manage cached model residency.",
+            discussion: "Pauses the configured idle-unload timer while enabled. Active requests and pinned models remain protected. Requires a coordinator with autopilot enabled; otherwise only already-warm models serve network requests. Applies after darkbloom restart.")
+        @OptionGroup var configOptions: ConfigOptions
+        @Option(help: "Minimum residence and idle time before replacement, 60–86400 seconds.")
+        var minDwellSeconds: UInt64?
+        @Option(parsing: .upToNextOption, help: "Model IDs to protect from autopilot unloading; replaces the configured pin list.")
+        var pin: [String] = []
+        mutating func run() async throws {
+            if let seconds = minDwellSeconds, !(60...86_400).contains(seconds) {
+                throw ValidationError("min-dwell-seconds must be between 60 and 86400")
+            }
+            let path = try setModelAutopilot(enabled: true, dwell: minDwellSeconds,
+                pins: pin.isEmpty ? nil : pin, configPath: configOptions.config)
+            print("Model autopilot enabled for cached models; automatic idle unloading is now controller-managed. Apply with `darkbloom restart`.\nSaved to \(path.path)")
+        }
+    }
+
+    struct Disable: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(abstract: "Revoke coordinator control of model residency after restart.")
+        @OptionGroup var configOptions: ConfigOptions
+        mutating func run() async throws {
+            let path = try setModelAutopilot(enabled: false, configPath: configOptions.config)
+            print("Model autopilot disabled. Apply with `darkbloom restart`.\nSaved to \(path.path)")
+        }
+    }
+}
+
+@discardableResult
+func setModelAutopilot(enabled: Bool, dwell: UInt64? = nil, pins: [String]? = nil,
+                       configPath: String?) throws -> URL {
+    if let dwell, !(60...86_400).contains(dwell) {
+        throw ValidationError("min-dwell-seconds must be between 60 and 86400")
+    }
+    let snapshot = try loadRuntimeSnapshot(configPath: configPath)
+    let path = try configPath == nil ? ConfigManager.defaultConfigPath() : snapshot.configPath
+    return try withExclusiveConfigLock(at: path) {
+        var config = FileManager.default.fileExists(atPath: path.path)
+            ? try ConfigManager.load(from: path) : snapshot.config
+        config.backend.modelAutopilot.enabled = enabled
+        if let dwell { config.backend.modelAutopilot.minDwellSeconds = dwell }
+        if let pins { config.backend.modelAutopilot.pinnedModels = Array(Set(pins)).sorted() }
+        try ConfigManager.save(config, to: path)
+        return path
+    }
+}

--- a/provider-swift/Sources/darkbloom/Darkbloom.swift
+++ b/provider-swift/Sources/darkbloom/Darkbloom.swift
@@ -46,6 +46,7 @@ struct Darkbloom: AsyncParsableCommand {
             AutoUpdate.self,
             Beta.self,
             Idle.self,
+            Autopilot.self,
             Fan.self,
             Watchdog.self,
             RuntimeSmoke.self,

--- a/provider-swift/Sources/darkbloom/StatusCommand.swift
+++ b/provider-swift/Sources/darkbloom/StatusCommand.swift
@@ -24,7 +24,12 @@ struct Status: AsyncParsableCommand {
         print("Coordinator: \(config.coordinator.url)")
         print("Backend port: \(config.backend.port)")
         print("Configured model: \(config.backend.model ?? "auto-select")")
-        print("Memory when idle: \(IdleUnloadPolicy.describe(minutes: config.backend.idleTimeoutMins)) (manage with `darkbloom idle`)")
+        if config.backend.modelAutopilot.enabled && !config.coordinator.privateOnly {
+            print("Memory when idle: managed by model autopilot (configured; applies after restart)")
+            print("  Stored idle policy resumes after opt-out: \(IdleUnloadPolicy.describe(minutes: config.backend.idleTimeoutMins))")
+        } else {
+            print("Memory when idle: \(IdleUnloadPolicy.describe(minutes: config.backend.idleTimeoutMins)) (manage with `darkbloom idle`)")
+        }
         print("Beta features: \(betaFeaturesStatus(config)) (manage with `darkbloom beta`)")
         print("Auto-restart: \(autoRestartStatus(config: config))")
 

--- a/provider-swift/Tests/DarkbloomCLITests/AutopilotCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/AutopilotCommandTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import darkbloom
+import ProviderCore
+
+@Suite("ModelAutopilot CLI")
+struct AutopilotCommandTests {
+    @Test func enrollmentPersistsWithoutChangingLegacyModelOrIdlePolicy() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("provider.toml")
+        var config = ProviderConfig(provider: ProviderSettings(name: "autopilot-test"))
+        config.backend.enabledModels = ["a", "b"]
+        config.backend.idleTimeoutMins = 17
+        try ConfigManager.save(config, to: path)
+        try setModelAutopilot(enabled: true, dwell: 600, pins: ["b", "b"], configPath: path.path)
+        let enabled = try ConfigManager.load(from: path)
+        #expect(enabled.backend.modelAutopilot.enabled)
+        #expect(enabled.backend.modelAutopilot.minDwellSeconds == 600)
+        #expect(enabled.backend.modelAutopilot.pinnedModels == ["b"])
+        #expect(enabled.backend.enabledModels == ["a", "b"])
+        #expect(enabled.backend.idleTimeoutMins == 17)
+        try setModelAutopilot(enabled: false, configPath: path.path)
+        let disabled = try ConfigManager.load(from: path)
+        #expect(!disabled.backend.modelAutopilot.enabled)
+        #expect(disabled.backend.modelAutopilot.pinnedModels == ["b"])
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
+++ b/provider-swift/Tests/ProviderCoreTests/Helpers/MockCoordinator.swift
@@ -607,6 +607,7 @@ public final class MockCoordinator: @unchecked Sendable {
             case .inferenceResponseChunk(let c): captured.inferenceChunks.append(c)
             case .inferenceComplete(let c):   captured.inferenceComplete.append(c)
             case .inferenceError(let e):      captured.inferenceErrors.append(e)
+            case .modelAutopilotStatus: break // Observable through providerMessage event stream.
             case .loadModelStatus(let s):    captured.loadModelStatuses.append(s)
             case .prefetchModelStatus(let s): captured.prefetchModelStatuses.append(s)
             case .modelsUpdate(let u):       captured.modelsUpdates.append(u)

--- a/provider-swift/Tests/ProviderCoreTests/ModelAutopilotTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelAutopilotTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+@testable import ProviderCore
+
+@Suite("ModelAutopilot")
+struct ModelAutopilotTests {
+    private let now: Int64 = 1_000_000
+    private func snapshot() -> ModelAutopilotSnapshot {
+        .init(enabled: true, minDwellSeconds: 1_800, maxModelSlots: 2,
+              residentModels: [
+                .init(modelId: "donor", residentSeconds: 3_600, idleSeconds: 2_000, weightsGb: 12, residentGb: 10),
+                .init(modelId: "keep", residentSeconds: 3_600, idleSeconds: 2_000, weightsGb: 10)])
+    }
+    private func command() -> ModelAutopilotCommand {
+        .init(commandId: "one", loadModelId: "new", unloadModelIds: ["donor"],
+              expectedResidentModels: ["keep", "donor"], expiresAtMs: now + 60_000)
+    }
+    private func reject(_ command: ModelAutopilotCommand, _ snapshot: ModelAutopilotSnapshot,
+                        busy: Bool = false) -> String? {
+        ModelAutopilotPolicy.rejection(command: command, snapshot: snapshot, busy: busy, nowMs: now)
+    }
+
+    @Test func defaultOffAndPartialConfigRemainDefaultOff() throws {
+        #expect(BackendSettings().modelAutopilot.enabled == false)
+        let settings = try JSONDecoder().decode(ModelAutopilotSettings.self, from: Data("{}".utf8))
+        #expect(settings == ModelAutopilotSettings())
+        let backend = try JSONDecoder().decode(BackendSettings.self, from: Data("{}".utf8))
+        #expect(backend.modelAutopilot == settings)
+        #expect(ModelAutopilotSettings(minDwellSeconds: .max).effectiveMinDwellSeconds == 86_400)
+    }
+
+    @Test func consentBusyExpiryAndSnapshotAreMandatory() {
+        let c = command()
+        let s = snapshot()
+        #expect(reject(c, s) == nil)
+        var oversized = c; oversized.commandId = String(repeating: "x", count: 65)
+        #expect(reject(oversized, s) == "invalid_command")
+        var disabled = s; disabled.enabled = false
+        #expect(reject(c, disabled) == "not_opted_in")
+        #expect(reject(c, s, busy: true) == "provider_busy")
+        var stale = c; stale.expiresAtMs = now
+        #expect(reject(stale, s) == "expired_command")
+        stale.expiresAtMs = now + 300_001
+        #expect(reject(stale, s) == "expired_command")
+        stale = c; stale.expectedResidentModels = ["donor"]
+        #expect(reject(stale, s) == "residency_changed")
+    }
+
+    @Test func allVictimsMustBeIdleOldAndUnpinnedAndFitSlots() {
+        let c = command()
+        var s = snapshot(); s.pinnedModels = ["donor"]
+        #expect(reject(c, s) == "pinned_model")
+        s = snapshot(); s.residentModels[0].idleSeconds = 1_799
+        #expect(reject(c, s) == "minimum_dwell")
+        s = snapshot(); s.residentModels[0].residentSeconds = 1_799
+        #expect(reject(c, s) == "minimum_dwell")
+        var noVictim = c; noVictim.unloadModelIds = []
+        #expect(reject(noVictim, snapshot()) == "slot_capacity")
+        var duplicate = c; duplicate.unloadModelIds = ["donor", "donor"]
+        #expect(reject(duplicate, snapshot()) == "invalid_command")
+        var twoVictims = c; twoVictims.unloadModelIds = ["donor", "keep"]
+        s = snapshot(); s.residentModels[1].idleSeconds = 0
+        #expect(reject(twoVictims, s) == "minimum_dwell")
+    }
+
+    @Test func unloadAndLeaseRenewalAreExplicit() {
+        var c = command(); c.loadModelId = nil
+        #expect(reject(c, snapshot()) == nil)
+        c.unloadModelIds = []
+        #expect(reject(c, snapshot()) == "invalid_command")
+        c.loadModelId = "keep"
+        #expect(reject(c, snapshot()) == nil)
+        c.unloadModelIds = ["keep"]
+        #expect(reject(c, snapshot()) == "invalid_command")
+    }
+
+    @Test func commandAndStatusHaveSymmetricFlatWireFields() throws {
+        let encoder = JSONEncoder(), decoder = JSONDecoder()
+        let commandMessage = CoordinatorMessage.modelAutopilot(command())
+        let wire = try encoder.encode(commandMessage)
+        let object = try #require(JSONSerialization.jsonObject(with: wire) as? [String: Any])
+        #expect(object["type"] as? String == "model_autopilot")
+        #expect(object["command_id"] as? String == "one")
+        #expect(object["unload_model_ids"] as? [String] == ["donor"])
+        #expect(try decoder.decode(CoordinatorMessage.self, from: wire) == commandMessage)
+        let status = ModelAutopilotStatus(commandId: "one", status: .failed,
+                                         error: "minimum_dwell", modelAutopilot: snapshot())
+        let reply = ProviderMessage.modelAutopilotStatus(status)
+        let replyData = try encoder.encode(reply)
+        #expect(try decoder.decode(ProviderMessage.self, from: replyData) == reply)
+        let encoded = try #require(JSONSerialization.jsonObject(with: replyData) as? [String: Any])
+        let snapshotObject = try #require(encoded["model_autopilot"] as? [String: Any])
+        #expect(snapshotObject["protocol"] as? Int == 1)
+        #expect(snapshotObject["cached_only"] as? Bool == true)
+        let residents = try #require(snapshotObject["resident_models"] as? [[String: Any]])
+        #expect(residents.first?["weights_gb"] as? Double == 12)
+        #expect(residents.first?["resident_gb"] as? Double == 10)
+    }
+
+    @Test func terminalHeartbeatCannotCombineWithEarlierCapacity() {
+        let state = ProviderState()
+        var running = snapshot(); running.activeCommandId = "one"
+        state.modelAutopilot = running
+        let old = BackendCapacity(slots: [], gpuMemoryActiveGb: 0, gpuMemoryPeakGb: 0, gpuMemoryCacheGb: 0, totalMemoryGb: 128)
+        state.setModelAutopilotCapacity(old, snapshot: running)
+        var terminal = snapshot(); terminal.lastCommandId = "one"; terminal.lastCommandStatus = .succeeded
+        state.modelAutopilot = terminal
+        let beforeRebuild = state.modelAutopilotHeartbeat()
+        #expect(beforeRebuild.1?.activeCommandId == "one")
+        #expect(beforeRebuild.1?.lastCommandId == nil)
+        state.setModelAutopilotCapacity(BackendCapacity(slots: [], gpuMemoryActiveGb: 0, gpuMemoryPeakGb: 0, gpuMemoryCacheGb: 0, totalMemoryGb: 128), snapshot: terminal)
+        let afterRebuild = state.modelAutopilotHeartbeat()
+        #expect(afterRebuild.1?.activeCommandId == nil)
+        #expect(afterRebuild.1?.lastCommandId == "one")
+        #expect(afterRebuild.0?.capacitySeq == 2)
+    }
+}
+
+private final class AutopilotRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [OutboundMessage] = []
+    func append(_ message: OutboundMessage) { lock.withLock { messages.append(message) } }
+    var statuses: [ModelAutopilotStatus] {
+        lock.withLock { messages.compactMap { if case .modelAutopilotStatus(let status) = $0 { return status }; return nil } }
+    }
+    var legacyFailures: Int {
+        lock.withLock { messages.filter { if case .loadModelStatus(_, .failed, _) = $0 { return true }; return false }.count }
+    }
+}
+
+private func autopilotTestLoop(enabled: Bool) throws -> ProviderLoop {
+    try ProviderLoop(config: ProviderLoopConfig(
+        coordinatorURL: "ws://127.0.0.1:0/unused",
+        hardware: HardwareInfo(machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+            memoryGb: 128, memoryAvailableGb: 124, cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+            gpuCores: 40, memoryBandwidthGbs: 546),
+        models: [], config: ProviderConfig(provider: ProviderSettings(name: "autopilot-test"), backend: BackendSettings(modelAutopilot: .init(enabled: enabled)))),
+        purgeLegacyFiles: false, attestationSigner: nil)
+}
+
+@Suite("ModelAutopilot runtime")
+struct ModelAutopilotRuntimeTests {
+    @Test func unconsentedCommandsNeverStartAndDuplicateIsIdempotent() async throws {
+        let loop = try autopilotTestLoop(enabled: false), recorder = AutopilotRecorder()
+        let command = ModelAutopilotCommand(commandId: "denied", loadModelId: "uncached",
+            expiresAtMs: Int64(Date().timeIntervalSince1970 * 1_000) + 60_000)
+        await loop.handleModelAutopilot(command, send: SendHandle(recorder.append))
+        await loop.handleModelAutopilot(command, send: SendHandle(recorder.append))
+        #expect(recorder.statuses.count == 2)
+        #expect(recorder.statuses.allSatisfy { $0.status == .failed && $0.error == "not_opted_in" })
+        #expect(await loop.autopilotCommand == nil)
+        #expect(await loop.autopilotHistory.count == 1)
+    }
+
+    @Test func enrolledProviderHasOneIdleResidencyAuthority() async throws {
+        let managed = try autopilotTestLoop(enabled: true)
+        await managed.startIdleMonitor()
+        #expect(await managed.idleMonitorTask == nil)
+        let legacy = try autopilotTestLoop(enabled: false)
+        await legacy.startIdleMonitor()
+        let timer = await legacy.idleMonitorTask
+        #expect(timer != nil)
+        timer?.cancel()
+    }
+
+    @Test func managedProviderRefusesLegacyLoadsAndUncachedCommands() async throws {
+        let loop = try autopilotTestLoop(enabled: true), recorder = AutopilotRecorder()
+        let send = SendHandle(recorder.append)
+        await loop.handleLoadModelRequest(modelId: "uncached", send: send)
+        #expect(recorder.legacyFailures == 1)
+        let command = ModelAutopilotCommand(commandId: "cold", loadModelId: "uncached",
+            expiresAtMs: Int64(Date().timeIntervalSince1970 * 1_000) + 60_000)
+        await loop.handleModelAutopilot(command, send: send)
+        #expect(recorder.statuses.last?.error == "model_not_cached")
+        #expect(await loop.autopilotTask == nil)
+        #expect(await loop.preloadTasks.isEmpty)
+    }
+}
+
+private extension ProviderLoop {
+    func startAutopilotMutationForTest() { autopilotMutationStarted = true }
+    func installAutopilotTransitionForTest(_ command: ModelAutopilotCommand?) {
+        autopilotCommand = command
+        autopilotMutationStarted = false
+        publishModelAutopilotSnapshot()
+    }
+}
+
+extension ModelAutopilotRuntimeTests {
+    @Test func acceptanceExpiryDoesNotAbandonStartedMutation() async throws {
+        let loop = try autopilotTestLoop(enabled: true)
+        let expired = ModelAutopilotCommand(commandId: "in-progress", loadModelId: "target", expiresAtMs: 1)
+        await loop.installAutopilotTransitionForTest(expired)
+        do {
+            try await loop.checkAutopilotLoadOwnership(expired.commandId)
+            Issue.record("expired command entered first mutation")
+        } catch let InferenceError.modelLoadFailed(message) { #expect(message == "expired_command") }
+        await loop.startAutopilotMutationForTest()
+        try await loop.checkAutopilotLoadOwnership(expired.commandId)
+        await loop.installAutopilotTransitionForTest(nil)
+    }
+
+    @Test func missingConfiguredAssistantIsRejectedBeforePlacement() async throws {
+        let loop = try autopilotTestLoop(enabled: true)
+        do {
+            try await loop.validateAutopilotAssistant(.init(artifact: nil,
+                status: .disabled(.artifactNotCached, configured: true)))
+            Issue.record("missing configured assistant accepted by cached-only command")
+        } catch {
+            #expect(error.localizedDescription == "assistant_not_cached_or_invalid")
+        }
+        try await loop.validateAutopilotAssistant(.init(artifact: nil,
+            status: .disabled(.configDisabled, configured: false)))
+        try await loop.validateAutopilotAssistant(.init(artifact: nil,
+            status: .disabled(.killSwitchDisabled, configured: true)))
+    }
+
+    @Test func transitionExcludesLocalAndCompetingLoadsAndParticipatesInDrain() async throws {
+        let loop = try autopilotTestLoop(enabled: true)
+        let command = ModelAutopilotCommand(commandId: "owned", loadModelId: "target",
+            expiresAtMs: Int64(Date().timeIntervalSince1970 * 1_000) + 60_000)
+        await loop.installAutopilotTransitionForTest(command)
+        do {
+            try await loop.throwIfRefusingNewLocalWork()
+            Issue.record("local reservation entered an active residency transition")
+        } catch {
+            #expect(error.localizedDescription.contains("placement in progress"))
+        }
+        do {
+            try await loop.ensureModelLoaded(modelId: "other")
+            Issue.record("competing load entered an active residency transition")
+        } catch let InferenceError.modelLoadFailed(message) {
+            #expect(message.contains("placement in progress"))
+        } catch { Issue.record("Unexpected competing-load error: \(error)") }
+        let drained = await loop.waitForInflightDrain(timeout: .milliseconds(1), reason: "test")
+        #expect(!drained)
+        let recorder = AutopilotRecorder()
+        var competing = command; competing.commandId = "different"
+        await loop.handleModelAutopilot(competing, send: SendHandle(recorder.append))
+        #expect(recorder.statuses.last?.error == "provider_busy")
+        #expect(await loop.autopilotCommand?.commandId == "owned")
+        #expect(await loop.autopilotHistory.isEmpty)
+        await loop.installAutopilotTransitionForTest(nil)
+        #expect(await loop.waitForInflightDrain(timeout: .milliseconds(1)))
+    }
+}

--- a/provider-swift/Tests/ProviderCoreTests/ModelAutopilotUnloadTests.swift
+++ b/provider-swift/Tests/ProviderCoreTests/ModelAutopilotUnloadTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MLXLMCommon
+import MLXNN
+import Testing
+@testable import ProviderCore
+
+private final class AutopilotEmptyModel: Module, LanguageModel {
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult { .tokens(input.text) }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+}
+private struct AutopilotEmptyProcessor: UserInputProcessor {
+    struct Unused: Error {}
+    func prepare(input: UserInput) async throws -> LMInput { throw Unused() }
+}
+private func autopilotEmptyContainer() -> ModelContainer {
+    .init(context: ModelContext(configuration: ModelConfiguration(id: "test/autopilot"),
+        model: AutopilotEmptyModel(), processor: AutopilotEmptyProcessor(), tokenizer: StubBridgeTokenizer()))
+}
+private extension ProviderLoop {
+    func markAutopilotResidentOld(_ model: String, local: Bool = false, superseded: Bool = false) {
+        autopilotResidentSince[model] = .now.advanced(by: .seconds(-3_600))
+        modelSlots[model]?.lastInferenceAt = .now.advanced(by: .seconds(-3_600))
+        if local { localReservations.reserve(model) }
+        if superseded { autopilotSupersededModels.insert(model); advertisedModels.removeValue(forKey: model) }
+        publishModelAutopilotSnapshot()
+    }
+    func autopilotLoadedIDs() -> [String] { modelSlots.keys.sorted() }
+    func unadvertiseWithoutReleaseForTest(_ model: String) { advertisedModels.removeValue(forKey: model) }
+}
+private final class AutopilotUnloadRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [ModelAutopilotStatus] = []
+    func send(_ message: OutboundMessage) {
+        if case .modelAutopilotStatus(let status) = message { lock.withLock { states.append(status) } }
+    }
+    var last: ModelAutopilotStatus? { lock.withLock { states.last } }
+}
+
+@Suite("ModelAutopilot actual unload lifecycle", .serialized)
+struct ModelAutopilotUnloadTests {
+    private func fixture(pins: [String] = []) async throws -> (ProviderLoop, [String: InertStubEngine]) {
+        let ids = ["old", "keep", "local"]
+        let loop = try ProviderLoop(config: ProviderLoopConfig(
+            coordinatorURL: "ws://127.0.0.1:0/unused",
+            hardware: HardwareInfo(machineModel: "Mac16,5", chipName: "Apple M4 Max", chipFamily: .m4, chipTier: .max,
+                memoryGb: 128, memoryAvailableGb: 124, cpuCores: CpuCores(total: 16, performance: 12, efficiency: 4),
+                gpuCores: 40, memoryBandwidthGbs: 546),
+            models: ids.map { ModelInfo(id: $0, modelType: "gemma4", sizeBytes: 1024, estimatedMemoryGb: 0.001) },
+            config: ProviderConfig(provider: ProviderSettings(name: "autopilot-unload-test"),
+                backend: BackendSettings(modelAutopilot: .init(enabled: true, pinnedModels: pins)))),
+            purgeLegacyFiles: false, attestationSigner: nil)
+        await loop.setLoadedModelsPersistenceEnabledForTesting(false)
+        let runtime = EngineV2Runtime()
+        await loop.setEngineV2RuntimeForTesting(runtime)
+        var engines: [String: InertStubEngine] = [:]
+        for model in ids {
+            let (bridge, engine) = makeInertStubBridge(modelId: model)
+            engines[model] = engine
+            await runtime.register(modelId: model, bridge: bridge)
+            await loop.installModelSlotForTesting(modelId: model, container: autopilotEmptyContainer(),
+                tokenizer: TokenizerHandle(StubBridgeTokenizer()), engineV2: bridge)
+            await loop.markAutopilotResidentOld(model)
+        }
+        return (loop, engines)
+    }
+
+    @Test func explicitUnloadTouchesOnlyDeclaredVictim() async throws {
+        let (loop, engines) = try await fixture()
+        let recorder = AutopilotUnloadRecorder()
+        await loop.handleModelAutopilot(.init(commandId: "unload", unloadModelIds: ["old"],
+            expectedResidentModels: ["old", "keep", "local"],
+            expiresAtMs: Int64(Date().timeIntervalSince1970 * 1_000) + 60_000), send: SendHandle(recorder.send))
+        let task = await loop.autopilotTask
+        await task?.value
+        #expect(recorder.last?.status == .succeeded)
+        #expect(engines["old"]?.shutdownCalls == 1)
+        #expect(engines["keep"]?.shutdownCalls == 0)
+        #expect(engines["local"]?.shutdownCalls == 0)
+        #expect(await loop.autopilotLoadedIDs() == ["keep", "local"])
+    }
+
+    @Test func releaseCleanupPreservesArbitraryUnadvertisedAndSupportedResidents() async throws {
+        let (loop, engines) = try await fixture()
+        await loop.markAutopilotResidentOld("old", superseded: true)
+        await loop.unadvertiseWithoutReleaseForTest("keep")
+        await loop.cleanupAutopilotSupersededModels()
+        #expect(engines["old"]?.shutdownCalls == 1)
+        #expect(engines["keep"]?.shutdownCalls == 0)
+        #expect(engines["local"]?.shutdownCalls == 0)
+        #expect(await loop.autopilotLoadedIDs() == ["keep", "local"])
+    }
+
+    @Test func releaseCleanupOnlyRetiresExplicitInactiveUnpinnedBuilds() async throws {
+        let (loop, engines) = try await fixture(pins: ["keep"])
+        await loop.markAutopilotResidentOld("old", superseded: true)
+        await loop.markAutopilotResidentOld("keep", superseded: true)
+        await loop.markAutopilotResidentOld("local", local: true, superseded: true)
+        await loop.cleanupAutopilotSupersededModels()
+        #expect(engines["old"]?.shutdownCalls == 1)
+        #expect(engines["keep"]?.shutdownCalls == 0)
+        #expect(engines["local"]?.shutdownCalls == 0)
+        #expect(await loop.autopilotLoadedIDs() == ["keep", "local"])
+        await loop.releaseLocalReservation("local")
+        await loop.cleanupAutopilotSupersededModels()
+        #expect(engines["local"]?.shutdownCalls == 1)
+        #expect(engines["keep"]?.shutdownCalls == 0)
+    }
+}


### PR DESCRIPTION
## Summary

An advertised model is not necessarily resident or useful for a request's deadline, and several models on one Mac share the same GPU. Add an explicitly opt-in residency controller that fills workload deficits with compatible cached models and removes only named, idle, unpinned models when the expected benefit justifies the replacement. The coordinator ships disabled and observe-only; providers must separately enroll with `darkbloom autopilot enable` and restart.

The investigation combines the retained 14-day dataset with fresh, read-only Datadog, database and fleet evidence for Sep 9–11. Of 749,762 persisted 429s in the new 48-hour window, **88.32% were first-chunk timeouts**. In the peak five-minute Gemma routing sample, **99.93% of attempts selected resident slots**. This is why the controller scores qualified service capacity, prompt/output work, deadline fit and shared-device contention rather than just counting machines or retry attempts. The evidence does not establish a causal 429 improvement from this implementation.

### Before

```mermaid
flowchart TD
    A[Public inference request] --> B[Admission and dispatch attempts]
    B --> C[ReserveProviderEx and cold spill]
    B --> D[Queue pressure and TriggerModelSwaps]
    E[Warm-pool targets] --> F[Warm-pool load commands]
    C --> G[Provider ensureModelLoaded]
    D --> G
    F --> G
    G --> H[Provider-local loading and possible LRU eviction]
    H --> I[Resident model serves request or deadline expires]
    J[Provider idle monitor] --> K[Independent idle unloading]
    L[Advertised local inventory] --> C
```

### After

```mermaid
flowchart TD
    A[Validated public logical request] --> B[beginAutopilotDemand and finishAutopilotDemand]
    B --> C[Bounded arrival and work observations]
    D[Explicit consent plus fresh capacity and inventory] --> E[autopilotFleetSnapshotLocked]
    C --> F[planAutopilotAction: shared GPU capacity and donor floors]
    E --> F
    F --> G{Observe only?}
    G -->|Yes| H[Log hypothetical plan without reservation]
    G -->|No| I[reserveAutopilotAction: recheck and fence whole device]
    I --> J[runModelAutopilot: cache, work, pins, dwell and memory guards]
    J --> K[Unload explicit victims and load without implicit eviction]
    K --> L[Terminal command status plus paired fresh capacity]
    L --> M[reconcileAutopilotHeartbeatLocked: actual residency becomes routable]
    I --> N[Bounded identical retries; uncertain operations stay fenced]
    N --> L
    O[Managed provider admission] --> P[Confirmed warm models only; legacy cold changes fenced]
    Q[No provider consent] --> R[Existing routing and residency behavior]
```

## Implementation and interface

- Once-only public logical demand separates attempts, account/invalid-request failures and final-stream completion. Short inputs remain workload samples; token count alone is not treated as abuse.
- Reuses catalog/runtime/attestation/dedication/vision/tool-constraint gates, model/chip quality observations, token-budget checks, memory and thermal pressure, and live occupancy. Co-resident models share device capacity. Scarce capability matters: the observed Qwen3.8 build requires M5, verified NAX and 36 GiB, not an M5 label alone.
- New optional `model_autopilot` registration/heartbeat state, matching Go/Swift command and status messages, immutable command identity, exact resident-set preconditions, named victims and no-eviction memory reporting. Missing consent grants no new control. No schema migration or public HTTP endpoint.
- Provider rechecks local and network work, slot/memory feasibility, pins and dwell, including cached MTP assistants. No implicit eviction, primary/assistant downloading, or disk-cache deletion. Release-policy cleanup remains serialized and bounded to explicitly superseded inactive builds.
- Acknowledgements alone never create warm capacity. Accepted sequenced heartbeats reconcile the actual final serving set; ambiguous delivery retains a fence. Same-ID retries are bounded and never extend expiry. Partial load failure reports actual residency rather than promising rollback.
- Pressure-driven replacement is the default policy. Standalone idle unloading is a separate disabled option. Managed operation starts account for existing legacy pending loads; future legacy operations retain their own limits.

Provider enrollment itself delegates residency and pauses ordinary idle unloading, even if the coordinator remains disabled/shadow. Enrolled providers use warm-only network admission until the controller is active. This is documented in the rollout and rollback procedures.

## Test plan

- [x] `go test ./coordinator/...`, `go vet ./coordinator/...`, and CI-pinned `golangci-lint` v2.1.6: **0 lint issues**.
- [x] Race tests for autopilot, dispatch planning, warm-pool interactions, pending loads, cold spill, capacity checks and request outcome capture in API/registry packages; focused controller/planner race tests repeated after the final dead-state cleanup.
- [x] Linux/amd64 coordinator build with `CGO_ENABLED=0`.
- [x] `swift test --package-path provider-swift --no-parallel`: **2,864 Swift Testing tests across 328 suites plus 98 XCTest tests passed**, using the exact pinned MLX submodules and native Metal library. Earlier parallel runs exposed shared-state/timing failures; the complete serial run passed without changing unrelated tests.
- [x] Compiled `darkbloom autopilot enable --help`.
- [x] Documentation lint over all 281 pages and `git diff --check`.
- [x] Independent review of the Go/Swift command, ownership, expiry, retry and reconciliation contract; no remaining must-fix findings.

## Components touched

- [x] coordinator (Go)
- [x] provider-swift (Swift CLI)
- [x] docs
- [x] Protocol/interface changes described above; matching Go and Swift sides updated.

## Notes for reviewers

Read `docs/reports/2026-09-11-autopilot-capacity-evidence.md`, then `docs/architecture/model-autopilot.md` and `docs/operations/model-autopilot.md`. The architecture covers the algorithm choice, estimates and safety invariants; the runbook describes dev validation, shadow observation, canary activation and rollback.

Load-time defaults and coarse historical replay remain estimates. The current data cannot separate intrinsic prefill from engine/shared-GPU queueing for timeout requests: all 170 sampled timeout profiles lacked engine segments. Local synthetic fleet benchmarks are overhead checks, not production tail-latency measurements. Model/shape-matched completion, TTFT, retry amplification and churn must determine whether a canary is helping.

GitHub CI: Docs Lint and Release Integrity passed. [Threat Model Review](https://github.com/Layr-Labs/d-inference/actions/runs/34661128390/job/103463679008) failed before producing a review because the configured Anthropic credential returned HTTP 401 (`API key is invalid`). This is a CI credential blocker; the check has not passed. Other GitHub checks were still running when this note was added.

No production configuration, provider enrollment, deployment or traffic was changed. This PR does not bump a release version or enable the controller.
