### PR TITLE
Reject overflowing occupancy before recording solo throughput

### DIFF
--- a/coordinator/registry/solo_tps.go
+++ b/coordinator/registry/solo_tps.go
@@ -129,11 +129,15 @@ func soloSampleEligible(bc *protocol.BackendCapacity) bool {
 	}
 	load := 0
 	for _, slot := range bc.Slots {
-		if n := slot.NumRunning + slot.NumWaiting; n > 0 {
-			load += n
-		}
-		if load > 1 {
-			return false
+		for _, n := range [...]int{slot.NumRunning, slot.NumWaiting} {
+			// Compare before adding untrusted counts: load stays in [0, 1],
+			// so an overflowing busy report cannot appear uncontended.
+			if n > 1-load {
+				return false
+			}
+			if n > 0 {
+				load += n
+			}
 		}
 	}
 	return true

--- a/coordinator/registry/solo_tps_overflow_test.go
+++ b/coordinator/registry/solo_tps_overflow_test.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"math"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/protocol"
+)
+
+func TestHeartbeatRejectsOverflowingSoloOccupancy(t *testing.T) {
+	for _, counts := range [][2]int{{math.MaxInt, 1}, {1, math.MaxInt}, {math.MaxInt, math.MaxInt}} {
+		reg := New(testLogger())
+		registration := testRegisterMessage()
+		provider := reg.Register("busy", nil, registration)
+		model := registration.Models[0].ID
+		if !reg.Heartbeat(provider.ID, &protocol.HeartbeatMessage{
+			BackendCapacity: &protocol.BackendCapacity{Slots: []protocol.BackendSlotCapacity{{
+				Model: model, State: "running", NumRunning: counts[0], NumWaiting: counts[1],
+				ObservedDecodeTPS: 40,
+			}}},
+		}) {
+			t.Fatal("otherwise valid heartbeat was rejected")
+		}
+		// Load-inclusive service estimates still accept the reading; a busy
+		// box cannot donate the same reading as an uncontended quality rate.
+		if got := reg.tpsRegistry.Median(model, registration.Hardware.ChipFamily); got != 40 {
+			t.Fatalf("load-inclusive sample was lost: %v", got)
+		}
+		if rate, samples := reg.tpsRegistry.SoloMedian(model, chipClassKey(registration.Hardware)); rate != 0 || samples != 0 {
+			t.Errorf("running/waiting %v produced solo rate %v from %d samples", counts, rate, samples)
+		}
+	}
+}
+
+func TestSoloSampleEligibilityCountsWithoutOverflow(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		slots []protocol.BackendSlotCapacity
+		want  bool
+	}{
+		{"idle", nil, true},
+		{"single decode", []protocol.BackendSlotCapacity{{NumRunning: 1}}, true},
+		{"single waiting", []protocol.BackendSlotCapacity{{NumWaiting: 1}}, true},
+		{"peers across slots", []protocol.BackendSlotCapacity{{NumRunning: 1}, {NumWaiting: 1}}, false},
+		{"negative report ignored", []protocol.BackendSlotCapacity{{NumRunning: -1}, {NumRunning: 1}}, true},
+		{"negative cannot hide peers", []protocol.BackendSlotCapacity{{NumRunning: -1, NumWaiting: 2}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := soloSampleEligible(&protocol.BackendCapacity{Slots: tc.slots}); got != tc.want {
+				t.Fatalf("solo eligible = %v, want %v", got, tc.want)
+			}
+		})
+	}
+	if soloSampleEligible(nil) {
+		t.Fatal("missing capacity is not a solo sample")
+	}
+}

--- a/docs/architecture/scheduling.md
+++ b/docs/architecture/scheduling.md
@@ -1,6 +1,6 @@
 # Scheduling: queues, slots, capacity and the warm pool
 
-> Last updated: 2026-09-10 · commit `213b8c2b6`
+> Last updated: 2026-09-11 · commit `f8503600f`
 
 Scheduling is the coordinator's model of *how much work the fleet can take
 and where the weights are*: the per-model request queue, the per-slot state
@@ -236,6 +236,13 @@ from `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL`; the solo
 decode rate is the provider's median solo sample (at least
 `defaultQualityCapSoloMinSamples`, the default of
 `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES`), or a seeded/benchmark rate.
+
+Solo samples require at most one running or waiting request across the whole
+provider and a running decode in the sampled slot (`coordinator/registry/solo_tps.go`,
+`soloSampleEligible`; `coordinator/registry/heartbeat.go`). Each occupancy count
+is compared against the remaining allowance before addition, so an overflowing
+busy report cannot enter the solo sample pool. The separate load-inclusive TPS
+store still receives valid observed rates from busy providers.
 
 ### Model slots, pending loads and swaps
 


### PR DESCRIPTION
A provider can report running/waiting counts whose sum overflows an integer. `soloSampleEligible` previously interpreted the wrapped total as an uncontended box and admitted its observed decode rate into the solo sample pool used by quality-cap estimates.

Compare each count with the remaining one-request allowance before addition. The accumulator stays bounded to zero or one, busy samples cannot wrap into eligibility, and ordinary idle/single-request behavior is preserved. Heartbeat still records valid load-inclusive rates and requires a running decode in the slot before donating a solo sample.

Before:
```mermaid
flowchart LR
  H[Heartbeat capacity] --> N[Clamp negative slot counts]
  N --> S[soloSampleEligible adds running plus waiting]
  S --> O[Large positive counts overflow]
  O --> E[Busy box appears uncontended]
  E --> R[RecordSolo contaminates quality sample pool]
  H --> L[Record load-inclusive observed rate]
```

After:
```mermaid
flowchart LR
  H[Heartbeat capacity] --> N[Same negative count clamp]
  N --> S[soloSampleEligible compares each count with remaining allowance]
  S --> B[More than one request rejects solo donation]
  S --> E[At most one request remains eligible]
  E --> D[Running sampled slot required]
  D --> R[RecordSolo retains uncontended sample policy]
  H --> L[Same load-inclusive observed rate]
```

The broader operation review covered all nine request/attempt profiling, trait gating, TTFT calibration/shadow and TPS-cache source files. Their ownership, sample acceptance, numeric policies, bounds and routing defaults remain unchanged; this PR only fixes the proven occupancy overflow. This adds four production lines rather than claiming a line-count reduction.

Validation:

- New real-heartbeat tests reproduce three overflowing count combinations on unchanged master; a direct negative-plus-busy case also exposes the prior addition problem.
- `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry -count=1` passes (24.089s).
- Existing request/attempt, trait, calibration, shadow, median-cache and solo resolver/seed test assertions were reviewed. Checked-in deployment values are read by existing tests; this PR changes no deployment configuration.
- Independent source/test review found no blocker. Documentation lint passes for all 278 pages.
- No model, live coordinator, deployment, numerical tuning or performance benchmark execution.
