### PR TITLE
fix(e2e): require observed latency and consolidate assertion reports

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-12 · commit `bbe228bad`
+> Last updated: 2026-09-12 · commit `9a1fab617`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -471,6 +471,13 @@ ls -l provider-swift/.build/debug/darkbloom provider-swift/.build/debug/mlx.meta
 ls console-ui/.next
 ```
 
+### Harness assertion checks
+
+The latency and accounting report helpers compile and run with Go alone:
+`go test -race ./e2e/testbed/assert -count=1`. These CPU fixtures use synthetic
+latency samples and stub query rows; they do not build a provider or require a
+Postgres server. See [test.md](test.md#harness-assertion-contracts) for their scope.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -494,10 +501,3 @@ Candidate native prefix-cache benchmarks must build ProviderCore and
 prompt SPI carries production sampling parameters into each engine request.
 See [native benchmark validation](test.md#resident-prefix-benchmark-validation)
 for sampling scope, regression filters and diagnostic restrictions.
-
-## Harness assertion checks
-
-The latency and accounting report helpers compile and run with Go alone:
-`go test -race ./e2e/testbed/assert -count=1`. These CPU fixtures use synthetic
-latency samples and stub query rows; they do not build a provider or require a
-Postgres server. See [test.md](test.md#harness-assertion-contracts) for their scope.

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `bbe228bad`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -494,3 +494,10 @@ Candidate native prefix-cache benchmarks must build ProviderCore and
 prompt SPI carries production sampling parameters into each engine request.
 See [native benchmark validation](test.md#resident-prefix-benchmark-validation)
 for sampling scope, regression filters and diagnostic restrictions.
+
+## Harness assertion checks
+
+The latency and accounting report helpers compile and run with Go alone:
+`go test -race ./e2e/testbed/assert -count=1`. These CPU fixtures use synthetic
+latency samples and stub query rows; they do not build a provider or require a
+Postgres server. See [test.md](test.md#harness-assertion-contracts) for their scope.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-12 · commit `bbe228bad`
+> Last updated: 2026-09-12 · commit `9a1fab617`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1172,6 +1172,25 @@ token IDs are accepted.
 - The e2e run logs `postgres started`, one `using configured provider binary`
   or provider build line per provider, and finishes with `ok  github.com/eigeninference/d-inference/e2e`.
 
+### Harness assertion contracts
+
+Run `go test -race ./e2e/testbed/assert -count=1` to check latency evidence and
+accounting report handling without a model, provider process or database.
+`e2e/testbed/assert/assert.go` (`Asserter.Evaluate`) requires a non-nil sample
+with a positive count for every configured segment; missing or empty evidence
+fails the segment's presence assertion. A real sample with zero duration remains
+valid. Enabled mean, p95, p99 and median bounds keep their order, inclusive
+comparison and existing report labels.
+
+`e2e/testbed/assert/accounting_test.go` (`TestAccountingSQLResultContracts`) checks query-row scan failures, zero and
+nonzero results, report ordering and sticky failure. It does not execute SQL or
+prove ledger integrity. The existing `payment_earnings_parity_sql` and
+`earnings_matches_payments_sql` results are informational fee-account counts and
+net-charge sums: successful queries pass regardless of the returned number.
+The other four SQL assertions require zero violations. Live database checks
+still use `PostgresAccountingAsserter.EvaluateAll` in
+`e2e/testbed/assert/accounting.go`.
+
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
@@ -1495,22 +1514,3 @@ with the original fixture (`e2e/connected_cache_http_test.go`,
 production-attestation or persistent-key restart claim. The original measured
 fixture rejects `correctness_only: true`; preserve its schema-2 evidence and use
 a separately reviewed schema-3 comparator for this seven-case pair.
-
-## Harness assertion contracts
-
-Run `go test -race ./e2e/testbed/assert -count=1` to check latency evidence and
-accounting report handling without a model, provider process or database.
-`e2e/testbed/assert/assert.go` (`Asserter.Evaluate`) requires a non-nil sample
-with a positive count for every configured segment; missing or empty evidence
-fails the segment's presence assertion. A real sample with zero duration remains
-valid. Enabled mean, p95, p99 and median bounds keep their order, inclusive
-comparison and existing report labels.
-
-`e2e/testbed/assert/accounting_test.go` checks query-row scan failures, zero and
-nonzero results, report ordering and sticky failure. It does not execute SQL or
-prove ledger integrity. The existing `payment_earnings_parity_sql` and
-`earnings_matches_payments_sql` results are informational fee-account counts and
-net-charge sums: successful queries pass regardless of the returned number.
-The other four SQL assertions require zero violations. Live database checks
-still use `PostgresAccountingAsserter.EvaluateAll` in
-`e2e/testbed/assert/accounting.go`.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `bbe228bad`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1495,3 +1495,22 @@ with the original fixture (`e2e/connected_cache_http_test.go`,
 production-attestation or persistent-key restart claim. The original measured
 fixture rejects `correctness_only: true`; preserve its schema-2 evidence and use
 a separately reviewed schema-3 comparator for this seven-case pair.
+
+## Harness assertion contracts
+
+Run `go test -race ./e2e/testbed/assert -count=1` to check latency evidence and
+accounting report handling without a model, provider process or database.
+`e2e/testbed/assert/assert.go` (`Asserter.Evaluate`) requires a non-nil sample
+with a positive count for every configured segment; missing or empty evidence
+fails the segment's presence assertion. A real sample with zero duration remains
+valid. Enabled mean, p95, p99 and median bounds keep their order, inclusive
+comparison and existing report labels.
+
+`e2e/testbed/assert/accounting_test.go` checks query-row scan failures, zero and
+nonzero results, report ordering and sticky failure. It does not execute SQL or
+prove ledger integrity. The existing `payment_earnings_parity_sql` and
+`earnings_matches_payments_sql` results are informational fee-account counts and
+net-charge sums: successful queries pass regardless of the returned number.
+The other four SQL assertions require zero violations. Live database checks
+still use `PostgresAccountingAsserter.EvaluateAll` in
+`e2e/testbed/assert/accounting.go`.

--- a/e2e/testbed/assert/accounting.go
+++ b/e2e/testbed/assert/accounting.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/eigeninference/d-inference/coordinator/store"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -114,82 +115,43 @@ func (pa *PostgresAccountingAsserter) EvaluateAll(ctx context.Context) *Assertio
 		return report
 	}
 
-	pa.assertBalanceIntegritySQL(ctx, report)
-	pa.assertNoNegativeBalancesSQL(ctx, report)
-	pa.assertLedgerContinuitySQL(ctx, report)
-	pa.assertPaymentEarningsParitySQL(ctx, report)
-	pa.assertEarningsMatchesPaymentsSQL(ctx, report)
-	pa.assertBillingSessionConsistencySQL(ctx, report)
+	for _, check := range accountingSQLChecks() {
+		check.evaluate(report, pa.pool.QueryRow(ctx, check.query))
+	}
 
 	return report
 }
 
-func (pa *PostgresAccountingAsserter) assertBalanceIntegritySQL(ctx context.Context, report *AssertionReport) {
-	name := "balance_integrity_sql"
+// observation preserves the two existing informational accounting results: their
+// counts are reported, but they do not establish payment/earnings equality.
+type accountingSQLCheck struct {
+	name, query, message string
+	observation          bool
+}
 
-	row := pa.pool.QueryRow(ctx, `
+func accountingSQLChecks() []accountingSQLCheck {
+	return []accountingSQLCheck{
+		{
+			name: "balance_integrity_sql",
+			query: `
 		SELECT COUNT(*) FROM balances b
 		WHERE b.balance_micro_usd != COALESCE((
 			SELECT SUM(amount_micro_usd) FROM ledger_entries
 			WHERE account_id = b.account_id
 		), 0)
-	`)
-
-	var driftCount int
-	if err := row.Scan(&driftCount); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
-	}
-
-	passed := driftCount == 0
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  passed,
-		Message: fmt.Sprintf("%d accounts with balance drift", driftCount),
-	})
-	if !passed {
-		report.Passed = false
-	}
-}
-
-func (pa *PostgresAccountingAsserter) assertNoNegativeBalancesSQL(ctx context.Context, report *AssertionReport) {
-	name := "no_negative_balances_sql"
-
-	row := pa.pool.QueryRow(ctx, `
+	`,
+			message: "%d accounts with balance drift",
+		},
+		{
+			name: "no_negative_balances_sql",
+			query: `
 		SELECT COUNT(*) FROM balances WHERE balance_micro_usd < 0
-	`)
-
-	var negCount int
-	if err := row.Scan(&negCount); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
-	}
-
-	passed := negCount == 0
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  passed,
-		Message: fmt.Sprintf("%d accounts with negative balance", negCount),
-	})
-	if !passed {
-		report.Passed = false
-	}
-}
-
-func (pa *PostgresAccountingAsserter) assertLedgerContinuitySQL(ctx context.Context, report *AssertionReport) {
-	name := "ledger_continuity_sql"
-
-	row := pa.pool.QueryRow(ctx, `
+	`,
+			message: "%d accounts with negative balance",
+		},
+		{
+			name: "ledger_continuity_sql",
+			query: `
 		SELECT COUNT(*) FROM (
 			SELECT le.id,
 			       le.account_id,
@@ -200,113 +162,54 @@ func (pa *PostgresAccountingAsserter) assertLedgerContinuitySQL(ctx context.Cont
 		) sub
 		WHERE prev_balance_after IS NOT NULL
 		  AND prev_balance_after + amount_micro_usd != balance_after
-	`)
-
-	var gapCount int
-	if err := row.Scan(&gapCount); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
-	}
-
-	passed := gapCount == 0
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  passed,
-		Message: fmt.Sprintf("%d ledger continuity gaps found", gapCount),
-	})
-	if !passed {
-		report.Passed = false
-	}
-}
-
-func (pa *PostgresAccountingAsserter) assertPaymentEarningsParitySQL(ctx context.Context, report *AssertionReport) {
-	name := "payment_earnings_parity_sql"
-
-	row := pa.pool.QueryRow(ctx, `
+	`,
+			message: "%d ledger continuity gaps found",
+		},
+		{
+			name: "payment_earnings_parity_sql",
+			query: `
 		SELECT COUNT(*) FROM (
 			SELECT le.account_id
 			FROM ledger_entries le
 			WHERE le.entry_type = 'platform_fee'
 			GROUP BY le.account_id
 		) sub
-	`)
-
-	var feeAccountCount int
-	if err := row.Scan(&feeAccountCount); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
-	}
-
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  true,
-		Message: fmt.Sprintf("%d accounts with platform fee entries recorded", feeAccountCount),
-	})
-}
-
-func (pa *PostgresAccountingAsserter) assertEarningsMatchesPaymentsSQL(ctx context.Context, report *AssertionReport) {
-	name := "earnings_matches_payments_sql"
-
-	row := pa.pool.QueryRow(ctx, `
+	`,
+			message:     "%d accounts with platform fee entries recorded",
+			observation: true,
+		},
+		{
+			name: "earnings_matches_payments_sql",
+			query: `
 		SELECT COALESCE(SUM(le.amount_micro_usd), 0)
 		FROM ledger_entries le
 		WHERE le.entry_type IN ('charge', 'refund')
-	`)
-
-	var totalCharges int
-	if err := row.Scan(&totalCharges); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
-	}
-
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  true,
-		Message: fmt.Sprintf("net charges across all accounts: %d micro-USD", totalCharges),
-	})
-}
-
-func (pa *PostgresAccountingAsserter) assertBillingSessionConsistencySQL(ctx context.Context, report *AssertionReport) {
-	name := "billing_session_consistency_sql"
-
-	row := pa.pool.QueryRow(ctx, `
+	`,
+			message:     "net charges across all accounts: %d micro-USD",
+			observation: true,
+		},
+		{
+			name: "billing_session_consistency_sql",
+			query: `
 		SELECT COUNT(*) FROM billing_sessions
 		WHERE completed_at IS NOT NULL AND status != 'completed'
-	`)
-
-	var inconsistent int
-	if err := row.Scan(&inconsistent); err != nil {
-		report.Results = append(report.Results, AssertionResult{
-			Name:    name,
-			Passed:  false,
-			Message: fmt.Sprintf("query failed: %v", err),
-		})
-		report.Passed = false
-		return
+	`,
+			message: "%d billing sessions with completed_at set but status != 'completed'",
+		},
 	}
+}
 
-	passed := inconsistent == 0
-	report.Results = append(report.Results, AssertionResult{
-		Name:    name,
-		Passed:  passed,
-		Message: fmt.Sprintf("%d billing sessions with completed_at set but status != 'completed'", inconsistent),
-	})
-	if !passed {
+func (check accountingSQLCheck) evaluate(report *AssertionReport, row pgx.Row) {
+	var count int
+	result := AssertionResult{Name: check.name}
+	if err := row.Scan(&count); err != nil {
+		result.Message = fmt.Sprintf("query failed: %v", err)
+	} else {
+		result.Passed = check.observation || count == 0
+		result.Message = fmt.Sprintf(check.message, count)
+	}
+	report.Results = append(report.Results, result)
+	if !result.Passed {
 		report.Passed = false
 	}
 }

--- a/e2e/testbed/assert/accounting_test.go
+++ b/e2e/testbed/assert/accounting_test.go
@@ -1,0 +1,73 @@
+package assert
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type accountingRow struct {
+	count int
+	err   error
+}
+
+func (row accountingRow) Scan(dest ...any) error {
+	if row.err != nil {
+		return row.err
+	}
+	if len(dest) != 1 {
+		return fmt.Errorf("expected one destination, got %d", len(dest))
+	}
+	count, ok := dest[0].(*int)
+	if !ok {
+		return fmt.Errorf("expected *int destination, got %T", dest[0])
+	}
+	*count = row.count
+	return nil
+}
+
+func TestAccountingSQLResultContracts(t *testing.T) {
+	// These report names and ordering are consumed by existing E2E reports.
+	checks := accountingSQLChecks()
+	require.Len(t, checks, 6)
+	wantNames := []string{
+		"balance_integrity_sql", "no_negative_balances_sql", "ledger_continuity_sql",
+		"payment_earnings_parity_sql", "earnings_matches_payments_sql", "billing_session_consistency_sql",
+	}
+	wantMessages := []string{
+		"%d accounts with balance drift", "%d accounts with negative balance", "%d ledger continuity gaps found",
+		"%d accounts with platform fee entries recorded", "net charges across all accounts: %d micro-USD",
+		"%d billing sessions with completed_at set but status != 'completed'",
+	}
+	for i, check := range checks {
+		t.Run(wantNames[i], func(t *testing.T) {
+			require.Equal(t, wantNames[i], check.name)
+			for _, count := range []int{0, 2, -3} {
+				report := &AssertionReport{Passed: true}
+				check.evaluate(report, accountingRow{count: count})
+				// The fee-count and net-charge observations are intentionally
+				// informational, including nonzero and negative net charges.
+				passed := count == 0 || i == 3 || i == 4
+				require.Equal(t, passed, report.Passed)
+				require.Equal(t, []AssertionResult{{Name: wantNames[i], Passed: passed, Message: fmt.Sprintf(wantMessages[i], count)}}, report.Results)
+			}
+			report := &AssertionReport{Passed: true}
+			check.evaluate(report, accountingRow{err: errors.New("scan failed")})
+			require.False(t, report.Passed)
+			require.Equal(t, []AssertionResult{{Name: wantNames[i], Message: "query failed: scan failed"}}, report.Results)
+			check.evaluate(report, accountingRow{})
+			require.False(t, report.Passed, "later passing results cannot clear an earlier failure")
+			require.Len(t, report.Results, 2)
+		})
+	}
+}
+
+func TestPostgresAccountingRequiresConnection(t *testing.T) {
+	report := NewPostgresAccountingAsserter(nil).EvaluateAll(context.Background())
+	require.False(t, report.Passed)
+	require.False(t, report.Timestamp.IsZero())
+	require.Equal(t, []AssertionResult{{Name: "postgres_connection", Message: "no pgxpool.Pool connection provided"}}, report.Results)
+}

--- a/e2e/testbed/assert/assert.go
+++ b/e2e/testbed/assert/assert.go
@@ -62,7 +62,7 @@ func (a *Asserter) Evaluate(stats map[testbed.Segment]*SegmentStatsView) *Assert
 
 	for _, t := range a.thresholds {
 		s, ok := stats[t.Segment]
-		if !ok {
+		if !ok || s == nil || s.Count <= 0 {
 			report.Results = append(report.Results, AssertionResult{
 				Name:    fmt.Sprintf("%s:present", t.Segment),
 				Passed:  false,
@@ -72,48 +72,23 @@ func (a *Asserter) Evaluate(stats map[testbed.Segment]*SegmentStatsView) *Assert
 			continue
 		}
 
-		if t.MaxMean > 0 {
-			passed := s.Mean <= t.MaxMean
-			report.Results = append(report.Results, AssertionResult{
-				Name:    fmt.Sprintf("%s:mean<=%s", t.Segment, t.MaxMean),
-				Passed:  passed,
-				Message: fmt.Sprintf("mean=%s (threshold=%s)", s.Mean, t.MaxMean),
-			})
-			if !passed {
-				report.Passed = false
+		for _, check := range []struct {
+			name       string
+			value, max time.Duration
+		}{
+			{"mean", s.Mean, t.MaxMean},
+			{"p95", s.P95, t.MaxP95},
+			{"p99", s.P99, t.MaxP99},
+			{"median", s.Median, t.MaxMedian},
+		} {
+			if check.max <= 0 {
+				continue
 			}
-		}
-
-		if t.MaxP95 > 0 {
-			passed := s.P95 <= t.MaxP95
+			passed := check.value <= check.max
 			report.Results = append(report.Results, AssertionResult{
-				Name:    fmt.Sprintf("%s:p95<=%s", t.Segment, t.MaxP95),
+				Name:    fmt.Sprintf("%s:%s<=%s", t.Segment, check.name, check.max),
 				Passed:  passed,
-				Message: fmt.Sprintf("p95=%s (threshold=%s)", s.P95, t.MaxP95),
-			})
-			if !passed {
-				report.Passed = false
-			}
-		}
-
-		if t.MaxP99 > 0 {
-			passed := s.P99 <= t.MaxP99
-			report.Results = append(report.Results, AssertionResult{
-				Name:    fmt.Sprintf("%s:p99<=%s", t.Segment, t.MaxP99),
-				Passed:  passed,
-				Message: fmt.Sprintf("p99=%s (threshold=%s)", s.P99, t.MaxP99),
-			})
-			if !passed {
-				report.Passed = false
-			}
-		}
-
-		if t.MaxMedian > 0 {
-			passed := s.Median <= t.MaxMedian
-			report.Results = append(report.Results, AssertionResult{
-				Name:    fmt.Sprintf("%s:median<=%s", t.Segment, t.MaxMedian),
-				Passed:  passed,
-				Message: fmt.Sprintf("median=%s (threshold=%s)", s.Median, t.MaxMedian),
+				Message: fmt.Sprintf("%s=%s (threshold=%s)", check.name, check.value, check.max),
 			})
 			if !passed {
 				report.Passed = false

--- a/e2e/testbed/assert/assert_test.go
+++ b/e2e/testbed/assert/assert_test.go
@@ -90,3 +90,30 @@ func TestAssertionReportSummaryTable(t *testing.T) {
 
 	assert.NotEmpty(t, report.SummaryTable())
 }
+
+func TestAsserterRequiresObservedSamples(t *testing.T) {
+	a := NewAsserter([]Threshold{{Segment: testbed.SegmentTTFT, MaxMean: time.Second}})
+	for name, stats := range map[string]*SegmentStatsView{"nil": nil, "empty": {}, "invalid count": {Count: -1}} {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				report := a.Evaluate(map[testbed.Segment]*SegmentStatsView{testbed.SegmentTTFT: stats})
+				require.False(t, report.Passed)
+				require.Len(t, report.Results, 1)
+				require.Equal(t, "ttft:present", report.Results[0].Name)
+			})
+		})
+	}
+	require.True(t, a.Evaluate(map[testbed.Segment]*SegmentStatsView{testbed.SegmentTTFT: {Count: 1}}).Passed, "one observed zero-duration sample is valid")
+}
+
+func TestAsserterPreservesThresholdOrderBoundaryAndDetails(t *testing.T) {
+	a := NewAsserter([]Threshold{{Segment: testbed.SegmentTTFT, MaxMean: 2 * time.Second, MaxP95: 2 * time.Second, MaxP99: 2 * time.Second, MaxMedian: 500 * time.Millisecond}})
+	report := a.Evaluate(map[testbed.Segment]*SegmentStatsView{testbed.SegmentTTFT: {Count: 10, Mean: 2 * time.Second, P95: 3 * time.Second, P99: time.Second, Median: time.Second}})
+	require.False(t, report.Passed)
+	require.Equal(t, []AssertionResult{
+		{Name: "ttft:mean<=2s", Passed: true, Message: "mean=2s (threshold=2s)"},
+		{Name: "ttft:p95<=2s", Passed: false, Message: "p95=3s (threshold=2s)"},
+		{Name: "ttft:p99<=2s", Passed: true, Message: "p99=1s (threshold=2s)"},
+		{Name: "ttft:median<=500ms", Passed: false, Message: "median=1s (threshold=500ms)"},
+	}, report.Results)
+}


### PR DESCRIPTION
A configured latency segment could pass without any observations when its stats existed with `Count == 0`, and nil stats panicked. Require a positive sample count before evaluating bounds; real zero-duration observations remain valid. An ordered threshold table replaces four repeated branches while preserving inclusive limits, labels, messages and order.

Consolidate PostgreSQL assertion scan/report handling into ordered checks. All six SQL strings and their execution order remain byte-identical, and query failures remain sticky. The two existing fee-count/net-charge observations still report numbers rather than enforce equality; the other four checks still require zero violations. No production billing or query policy changes.

Before:
```mermaid
flowchart LR
  S[Latency stats] --> P[Map entry present]
  P --> Z[Empty sample can pass; nil panics]
  P --> T[Four repeated threshold branches]
  T --> R[Assertion report]
  DB[Six SQL methods] --> D[Repeated scan and append handling]
  D --> R
```

After:
```mermaid
flowchart LR
  S[Latency stats] --> P[Present, nonnil, positive count]
  P -->|missing evidence| F[Failed presence result]
  P -->|observed| T[Ordered threshold checks]
  T --> R[Same labels, bounds and order]
  F --> R
  DB[Six unchanged ordered queries] --> D[Shared scan and result handling]
  D -->|scan or invariant failure| E[Sticky failed report]
  D -->|success| R
```

Validation: `go test -race ./e2e/testbed/assert -count=1` passes 9 functions / 18 including subtests in 1.485s. The nil/zero/negative-count cases failed on the original source before the fix. Boundary, order and report strings are pinned; stub rows cover every SQL result policy, scan errors, and later success after failure. A static comparison verified exact SQL bytes/order. Docs lint passes all 278 documents; signed commits and `git diff --check` pass.

These are CPU tests with synthetic samples and stub query rows. They do not execute PostgreSQL, a provider, Swift, or a model, and do not qualify model speed or live ledger integrity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764525&installation_model_id=21733&pr_number=939&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F939&signature=3237ebe4ff36c829932ebfb56dea2afce89ad3c2f33e404698ecf2a335b9775a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->