### PR TITLE
fix(coordinator): make key and account token admission atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — concurrent token quota enforcement
+
+- Prevent simultaneous inference requests from exceeding account or API-key token quotas through separate availability checks and charges. Extra output-token reconciliation shares the admission lock, and retry-hint checks no longer consume quota.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/api/server.go
+++ b/coordinator/api/server.go
@@ -205,6 +205,7 @@ type Server struct {
 	baseRewards                   *baserewards.Engine
 	logger                        *slog.Logger
 	mux                           *http.ServeMux
+	tokenAdmissionMu              [64]sync.Mutex  // account-wide key/tier admission and output reconciliation
 	modelAliasMutationMu          sync.Mutex      // serializes cross-endpoint alias validation + persistence
 	challengeInterval             time.Duration   // 0 means use DefaultChallengeInterval
 	skipChallenge                 bool            // if true, skip attestation challenges entirely (testing only)
@@ -612,39 +613,27 @@ func (s *Server) applyTokenRateLimitWithAdmission(w http.ResponseWriter, r *http
 		}
 	}
 
-	keyID, inRPS, inBurst, outRPS, outBurst, keyEnforced := s.keyTokenParams(r)
+	keyLimits := s.keyTokenLimits(r)
 	admission.AccountOutputLimited = tl != nil && tl.HasOutputLimit()
-	admission.KeyOutputLimited = keyEnforced && outRPS > 0 && outBurst > 0
-	admission.KeyOutputRPS = outRPS
-	admission.KeyOutputBurst = outBurst
+	if keyLimits != nil {
+		admission.KeyOutputLimited = keyLimits.outputRPS > 0 && keyLimits.outputBurst > 0
+		admission.KeyOutputRPS = keyLimits.outputRPS
+		admission.KeyOutputBurst = keyLimits.outputBurst
+	}
 	if admission.TracksOutput() {
 		s.ddHistogram("ratelimit.output_admission.estimated_tokens", float64(admission.AdmittedOutputTokens), outputAdmissionTags(tier, admission.EstimatedOutput))
 	}
 
-	// Peek BOTH the per-key override and the account-level limiter before
-	// consuming either. Only commit when both have capacity, so a rejection in
-	// one limiter never debits the other (a per-key request that the account
-	// bucket rejects must not drain the key's quota, and vice-versa).
-	if keyEnforced {
-		if ok, dim, retry := s.keyTokenLimiter.Peek(keyID, inputTokens, admission.AdmittedOutputTokens, inRPS, inBurst, outRPS, outBurst); !ok {
-			s.writeTokenRateLimited(w, "key", dim, retry)
-			return admission, false
-		}
-	}
-	if tl != nil {
-		if ok, dim, retry := tl.Peek(accountID, inputTokens, admission.AdmittedOutputTokens); !ok {
+	deniedTier, dimension, retry := s.admitTokenBuckets(accountID, tl, keyLimits, inputTokens, admission.AdmittedOutputTokens)
+	if dimension != "" {
+		if deniedTier == "account" {
+			deniedTier = tier
 			setTokenRateLimitHeaders(w, tl, accountID)
-			s.writeTokenRateLimited(w, tier, dim, retry)
-			return admission, false
 		}
-	}
-
-	// Both dimensions have capacity — commit to each.
-	if keyEnforced {
-		s.keyTokenLimiter.Commit(keyID, inputTokens, admission.AdmittedOutputTokens, inRPS, inBurst, outRPS, outBurst)
+		s.writeTokenRateLimited(w, deniedTier, dimension, retry)
+		return admission, false
 	}
 	if tl != nil {
-		tl.Commit(accountID, inputTokens, admission.AdmittedOutputTokens)
 		setTokenRateLimitHeaders(w, tl, accountID)
 	}
 	return admission, true
@@ -679,21 +668,7 @@ func (s *Server) reconcileOutputAdmission(pr *registry.PendingRequest, actualOut
 	if delta == 0 {
 		return
 	}
-	if admission.AccountOutputLimited {
-		var tl *ratelimit.TokenLimiter
-		switch admission.AccountTier {
-		case "service":
-			tl = s.serviceTokenLimiter
-		default:
-			tl = s.consumerTokenLimiter
-		}
-		if tl != nil {
-			tl.DebitOutput(pr.ConsumerKey, delta)
-		}
-	}
-	if admission.KeyOutputLimited && s.keyTokenLimiter != nil {
-		s.keyTokenLimiter.DebitOutput(pr.KeyID, delta, admission.KeyOutputRPS, admission.KeyOutputBurst)
-	}
+	s.debitAdmissionOutput(pr, delta)
 	s.ddCount("ratelimit.output_admission.delta_tokens_total", int64(delta), tags)
 }
 
@@ -760,31 +735,6 @@ func (s *Server) applyKeyRPMLimit(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	return true
-}
-
-// keyTokenParams resolves the per-key ITPM/OTPM override for the calling key.
-// enforced is false when no per-key token limit applies (no key, no limiter, or
-// no override set), in which case the other return values are zero.
-func (s *Server) keyTokenParams(r *http.Request) (keyID string, inRPS float64, inBurst int, outRPS float64, outBurst int, enforced bool) {
-	if s.keyTokenLimiter == nil {
-		return "", 0, 0, 0, 0, false
-	}
-	k := apiKeyFromContext(r.Context())
-	if k == nil || k.ID == "" {
-		return "", 0, 0, 0, 0, false
-	}
-	if k.ITPMLimit != nil && *k.ITPMLimit > 0 {
-		inRPS = float64(*k.ITPMLimit) / 60.0
-		inBurst = int(*k.ITPMLimit)
-	}
-	if k.OTPMLimit != nil && *k.OTPMLimit > 0 {
-		outRPS = float64(*k.OTPMLimit) / 60.0
-		outBurst = int(*k.OTPMLimit)
-	}
-	if inRPS <= 0 && outRPS <= 0 {
-		return "", 0, 0, 0, 0, false
-	}
-	return k.ID, inRPS, inBurst, outRPS, outBurst, true
 }
 
 // setRequestRateLimitHeaders emits the standard request-dimension rate-limit

--- a/coordinator/api/token_admission.go
+++ b/coordinator/api/token_admission.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"hash/fnv"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/ratelimit"
+	"github.com/eigeninference/d-inference/coordinator/registry"
+)
+
+type keyTokenLimits struct {
+	id                      string
+	inputRPS, outputRPS     float64
+	inputBurst, outputBurst int
+}
+
+func (s *Server) keyTokenLimits(r *http.Request) *keyTokenLimits {
+	if s.keyTokenLimiter == nil {
+		return nil
+	}
+	key := apiKeyFromContext(r.Context())
+	if key == nil || key.ID == "" {
+		return nil
+	}
+	limits := &keyTokenLimits{id: key.ID}
+	if key.ITPMLimit != nil && *key.ITPMLimit > 0 {
+		limits.inputRPS, limits.inputBurst = float64(*key.ITPMLimit)/60, int(*key.ITPMLimit)
+	}
+	if key.OTPMLimit != nil && *key.OTPMLimit > 0 {
+		limits.outputRPS, limits.outputBurst = float64(*key.OTPMLimit)/60, int(*key.OTPMLimit)
+	}
+	if limits.inputRPS <= 0 && limits.outputRPS <= 0 {
+		return nil
+	}
+	return limits
+}
+
+// Every key belongs to one account. Serialize that account's whole admission
+// transaction, including reconciliation debt, across both key and tier buckets.
+// The fixed shard table bounds memory; HTTP writes happen after unlocking.
+func (s *Server) tokenAdmissionLock(accountID string) *sync.Mutex {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(accountID))
+	return &s.tokenAdmissionMu[h.Sum32()%uint32(len(s.tokenAdmissionMu))]
+}
+
+func (s *Server) admitTokenBuckets(accountID string, account *ratelimit.TokenLimiter, key *keyTokenLimits, input, output int) (string, string, time.Duration) {
+	lock := s.tokenAdmissionLock(accountID)
+	lock.Lock()
+	defer lock.Unlock()
+	if key != nil {
+		if ok, dimension, retry := s.keyTokenLimiter.Peek(key.id, input, output, key.inputRPS, key.inputBurst, key.outputRPS, key.outputBurst); !ok {
+			return "key", dimension, retry
+		}
+	}
+	if account != nil {
+		if ok, dimension, retry := account.Peek(accountID, input, output); !ok {
+			return "account", dimension, retry
+		}
+	}
+	if key != nil {
+		s.keyTokenLimiter.Commit(key.id, input, output, key.inputRPS, key.inputBurst, key.outputRPS, key.outputBurst)
+	}
+	if account != nil {
+		account.Commit(accountID, input, output)
+	}
+	return "", "", 0
+}
+
+func (s *Server) debitAdmissionOutput(pr *registry.PendingRequest, delta int) {
+	lock := s.tokenAdmissionLock(pr.ConsumerKey)
+	lock.Lock()
+	defer lock.Unlock()
+	admission := pr.TokenAdmission
+	if admission.AccountOutputLimited {
+		var tl *ratelimit.TokenLimiter
+		switch admission.AccountTier {
+		case "service":
+			tl = s.serviceTokenLimiter
+		default:
+			tl = s.consumerTokenLimiter
+		}
+		if tl != nil {
+			tl.DebitOutput(pr.ConsumerKey, delta)
+		}
+	}
+	if admission.KeyOutputLimited && s.keyTokenLimiter != nil {
+		s.keyTokenLimiter.DebitOutput(pr.KeyID, delta, admission.KeyOutputRPS, admission.KeyOutputBurst)
+	}
+}

--- a/coordinator/api/token_admission_concurrency_test.go
+++ b/coordinator/api/token_admission_concurrency_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/ratelimit"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+func TestConcurrentTokenAdmissionRespectsAccountBurst(t *testing.T) {
+	for _, mode := range []string{"account", "key", "both", "separate keys"} {
+		t.Run(mode, func(t *testing.T) {
+			for attempt := 0; attempt < 100; attempt++ {
+				s := &Server{}
+				if mode != "key" {
+					s.consumerTokenLimiter = ratelimit.NewTokenLimiter(0.000001, 1, 0.000001, 1)
+				}
+				if mode != "account" {
+					s.keyTokenLimiter = ratelimit.NewKeyTokenLimiter()
+				}
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+				var admitted atomic.Int32
+				for i := 0; i < 16; i++ {
+					wg.Add(1)
+					go func(index int) {
+						defer wg.Done()
+						var req *http.Request
+						if mode == "account" {
+							req = tokenReq("same-account", "")
+						} else {
+							keyID := "shared-key"
+							if mode == "separate keys" {
+								keyID = fmt.Sprintf("key-%d", index)
+							}
+							limit := int64(1)
+							req = tokenReqWithKey("same-account", "", &store.APIKey{ID: keyID, ITPMLimit: &limit, OTPMLimit: &limit})
+						}
+						<-start
+						if s.applyTokenRateLimit(httptest.NewRecorder(), req, 1, 1) {
+							admitted.Add(1)
+						}
+					}(i)
+				}
+				close(start)
+				wg.Wait()
+				if admitted.Load() != 1 {
+					t.Fatalf("round %d admitted %d requests from a one-token burst", attempt, admitted.Load())
+				}
+			}
+		})
+	}
+}

--- a/coordinator/ratelimit/bucket_check.go
+++ b/coordinator/ratelimit/bucket_check.go
@@ -1,0 +1,42 @@
+package ratelimit
+
+import (
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// CheckN returns availability and a retry hint without consuming tokens.
+// Callers coordinating several buckets must hold their transaction lock across
+// all checks and the subsequent charges.
+func (l *Limiter) CheckN(accountID string, n int) (bool, time.Duration) {
+	if accountID == "" || n <= 0 {
+		return true, 0
+	}
+	now := time.Now()
+	return checkBucket(l.bucketFor(accountID, now).limiter, now, n, l.cfg.RPS, l.cfg.Burst)
+}
+
+// CheckNWithRate is the per-key counterpart, with the same unlimited and
+// oversized-charge rules as AllowNWithRate.
+func (l *Limiter) CheckNWithRate(key string, n int, rps float64, burst int) (bool, time.Duration) {
+	if key == "" || n <= 0 || rps <= 0 || burst <= 0 {
+		return true, 0
+	}
+	n = min(n, burst)
+	now := time.Now()
+	return checkBucket(l.bucketForWithRate(key, rps, burst, now).limiter, now, n, rps, burst)
+}
+
+func checkBucket(bucket *rate.Limiter, now time.Time, n int, rps float64, burst int) (bool, time.Duration) {
+	available := bucket.TokensAt(now)
+	if n <= burst && available >= float64(n) {
+		return true, 0
+	}
+	deficit := max(float64(n)-available, 0)
+	retry := time.Duration(deficit / rps * float64(time.Second))
+	if retry < time.Millisecond {
+		retry = DefaultRetryAfter
+	}
+	return false, min(retry, maxRetryAfter)
+}

--- a/coordinator/ratelimit/bucket_check_test.go
+++ b/coordinator/ratelimit/bucket_check_test.go
@@ -1,0 +1,65 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func TestBucketCheckRefillDoesNotConsume(t *testing.T) {
+	now := time.Now()
+	bucket := rate.NewLimiter(1, 1)
+	if !bucket.AllowN(now, 1) {
+		t.Fatal("initial token unavailable")
+	}
+	for _, elapsed := range []time.Duration{0, time.Second / 2, time.Second, 2 * time.Second} {
+		at := now.Add(elapsed)
+		before := bucket.TokensAt(at)
+		allowed, retry := checkBucket(bucket, at, 1, 1, 1)
+		if allowed != (elapsed >= time.Second) {
+			t.Fatalf("at %s allowed=%v", elapsed, allowed)
+		}
+		if !allowed && retry <= 0 {
+			t.Fatal("rejected check lost retry hint")
+		}
+		if after := bucket.TokensAt(at); after != before {
+			t.Fatalf("check consumed capacity: before=%f after=%f", before, after)
+		}
+	}
+	if !bucket.AllowN(now.Add(time.Second), 1) {
+		t.Fatal("successful refill checks consumed the token")
+	}
+}
+
+func TestBucketChecksKeepLimitAndClampRules(t *testing.T) {
+	fixed := New(Config{RPS: 0.000001, Burst: 2})
+	if ok, _ := fixed.CheckN("acct", 3); ok {
+		t.Fatal("fixed check accepted more than burst")
+	}
+	if ok, _ := fixed.CheckN("acct", 2); !ok {
+		t.Fatal("rejection consumed fixed quota")
+	}
+	if ok, _ := fixed.AllowN("acct", 2); !ok {
+		t.Fatal("successful check consumed fixed quota")
+	}
+	if ok, retry := fixed.CheckN("acct", 1); ok || retry != maxRetryAfter {
+		t.Fatalf("drained fixed check=%v retry=%s", ok, retry)
+	}
+	variable := New(Config{})
+	if ok, _ := variable.CheckNWithRate("key", 100, 0.000001, 2); !ok {
+		t.Fatal("per-key oversized charge must clamp to burst")
+	}
+	if ok, _ := variable.AllowNWithRate("key", 2, 0.000001, 2); !ok {
+		t.Fatal("successful check consumed variable quota")
+	}
+	if ok, _ := variable.CheckNWithRate("key", 1, 0.000001, 2); ok {
+		t.Fatal("drained variable bucket admitted")
+	}
+	if ok, _ := variable.CheckNWithRate("key", 100, 0, 2); !ok {
+		t.Fatal("zero rate must remain unlimited")
+	}
+	if ok, _ := variable.CheckNWithRate("key", 100, 1, 0); !ok {
+		t.Fatal("zero burst must remain unlimited")
+	}
+}

--- a/coordinator/ratelimit/key_token_limiter.go
+++ b/coordinator/ratelimit/key_token_limiter.go
@@ -66,14 +66,12 @@ func (t *KeyTokenLimiter) Allow(key string, inputTokens, outputTokens int,
 	defer lock.Unlock()
 
 	if inputEnforced {
-		if !t.input.CanNWithRate(key, inputTokens, inRPS, inBurst) {
-			_, retry := t.input.AllowNWithRate(key, inputTokens, inRPS, inBurst)
+		if ok, retry := t.input.CheckNWithRate(key, inputTokens, inRPS, inBurst); !ok {
 			return false, "input_tokens", retry
 		}
 	}
 	if outputEnforced {
-		if !t.output.CanNWithRate(key, outputTokens, outRPS, outBurst) {
-			_, retry := t.output.AllowNWithRate(key, outputTokens, outRPS, outBurst)
+		if ok, retry := t.output.CheckNWithRate(key, outputTokens, outRPS, outBurst); !ok {
 			return false, "output_tokens", retry
 		}
 	}
@@ -104,13 +102,15 @@ func (t *KeyTokenLimiter) Peek(key string, inputTokens, outputTokens int,
 	lock.Lock()
 	defer lock.Unlock()
 
-	if inputEnforced && !t.input.CanNWithRate(key, inputTokens, inRPS, inBurst) {
-		_, retry := t.input.AllowNWithRate(key, inputTokens, inRPS, inBurst)
-		return false, "input_tokens", retry
+	if inputEnforced {
+		if ok, retry := t.input.CheckNWithRate(key, inputTokens, inRPS, inBurst); !ok {
+			return false, "input_tokens", retry
+		}
 	}
-	if outputEnforced && !t.output.CanNWithRate(key, outputTokens, outRPS, outBurst) {
-		_, retry := t.output.AllowNWithRate(key, outputTokens, outRPS, outBurst)
-		return false, "output_tokens", retry
+	if outputEnforced {
+		if ok, retry := t.output.CheckNWithRate(key, outputTokens, outRPS, outBurst); !ok {
+			return false, "output_tokens", retry
+		}
 	}
 	return true, "", 0
 }

--- a/coordinator/ratelimit/token_limiter.go
+++ b/coordinator/ratelimit/token_limiter.go
@@ -75,15 +75,13 @@ func (t *TokenLimiter) Allow(accountID string, inputTokens, outputTokens int) (a
 	var in, out int
 	if t.input != nil {
 		in = clampCharge(inputTokens, t.input.Burst())
-		if !t.input.CanN(accountID, in) {
-			_, retry := t.input.AllowN(accountID, in) // fails atomically, no debit; yields Retry-After
+		if ok, retry := t.input.CheckN(accountID, in); !ok {
 			return false, "input_tokens", retry
 		}
 	}
 	if t.output != nil {
 		out = clampCharge(outputTokens, t.output.Burst())
-		if !t.output.CanN(accountID, out) {
-			_, retry := t.output.AllowN(accountID, out)
+		if ok, retry := t.output.CheckN(accountID, out); !ok {
 			return false, "output_tokens", retry
 		}
 	}
@@ -111,15 +109,13 @@ func (t *TokenLimiter) Peek(accountID string, inputTokens, outputTokens int) (ok
 
 	if t.input != nil {
 		in := clampCharge(inputTokens, t.input.Burst())
-		if !t.input.CanN(accountID, in) {
-			_, retry := t.input.AllowN(accountID, in) // fails atomically, no debit; yields Retry-After
+		if ok, retry := t.input.CheckN(accountID, in); !ok {
 			return false, "input_tokens", retry
 		}
 	}
 	if t.output != nil {
 		out := clampCharge(outputTokens, t.output.Burst())
-		if !t.output.CanN(accountID, out) {
-			_, retry := t.output.AllowN(accountID, out)
+		if ok, retry := t.output.CheckN(accountID, out); !ok {
 			return false, "output_tokens", retry
 		}
 	}

--- a/docs/architecture/components/consumer.md
+++ b/docs/architecture/components/consumer.md
@@ -1,6 +1,6 @@
 # Consumer surface
 
-> Last updated: 2026-09-04 · commit `7ae06021f`
+> Last updated: 2026-09-11 · commit `720e3b7a1`
 
 The consumer surface is the coordinator's OpenAI- and Anthropic-compatible request pipeline: it speaks OpenAI Chat Completions, OpenAI Responses, Anthropic Messages and legacy Completions to clients and turns each request into one provider job through a single pipeline in `handleChatCompletions` (`coordinator/api/consumer.go`), with an endpoint-specific lowering step before it and a re-shaping step after it. This page is for engineers changing or debugging that pipeline: it explains what "compatible" means concretely, walks the stages, and lists the invariants and failure modes that follow. The exact routes, headers, and JSON shapes are in [`../../reference/api-contracts.md`](../../reference/api-contracts.md).
 
@@ -34,7 +34,7 @@ Stages in the order `handleChatCompletions` runs them. Each stage either advance
 | 5 | Model resolve: alias → build under the request's constraints; unresolvable → unavailable | `resolveRequestedModel` → `registry.ResolveModelConstrainedWithTraits` | 503 `model_unavailable` |
 | 6 | Vision/tool fail-fast and remote-media gate | `visionToolsFailFast`, `gateRemoteMediaPreDispatch` | 400, 503 `model_unavailable` |
 | 7 | Bounds and deadline: clamp `max_tokens`, compute the first-content deadline, shed if the model is rejecting | `ensureMaxTokensBound`, `FirstContentDeadline`, `shedIfModelRejected` | 429 with `Retry-After` |
-| 8 | Token-rate admission (input/output tokens per minute) | `applyTokenRateLimitWithAdmission` (`coordinator/api/server.go`) | 429 with `Retry-After` |
+| 8 | Token-rate admission (input/output tokens per minute) | `applyTokenRateLimitWithAdmission` (`coordinator/api/server.go`) → `admitTokenBuckets` (`coordinator/api/token_admission.go`) | 429 with `Retry-After` |
 | 9 | Reserve balance for the worst-case cost | `reserveInferenceBalance` (`coordinator/api/inference_admission.go`) | 402 (`error.type` and `code` per [`billing.md`](../billing.md#payment-required-responses)) |
 | 10 | Fetch remote media (billed as media, after the reservation) | `resolveRemoteMedia` | 400 |
 | 11 | Capacity admission: can any eligible provider take this prompt now? | `runInferenceAdmission` | 429, 503, 413 `payload_too_large` |
@@ -54,6 +54,8 @@ Provider-side execution between stages 13 and 14 — the WebSocket `inference_re
 5. **No keepalives.** Silence on a stream means no token has been produced; the first-content deadline bounds it before commit (a miss is a 429 with `Retry-After`) and [`inferenceTimeout`](../../reference/api-contracts.md#timeouts-and-constants) between chunks after (a terminal `error` event).
 6. **Providers never see the caller.** They receive an encrypted job carrying the build id and the prompt, not the API key or account.
 7. **A departed client cancels the job.** Client disconnect before commit is recorded as 499 and sends `cancel` to the provider (`emitClientGone`, `sendProviderCancel`).
+
+8. **Concurrent token admissions share one account transaction.** `admitTokenBuckets` checks the key and account input/output buckets before charging any of them, under a bounded account-sharded lock. `debitAdmissionOutput` uses the same lock for extra output-token debt. `CheckN` and `CheckNWithRate` calculate availability and retry hints without consuming tokens; HTTP errors and headers are written after releasing the transaction lock (`coordinator/api/token_admission.go`, `coordinator/ratelimit/bucket_check.go`).
 
 ## Failure modes
 

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,6 +1,6 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `720e3b7a1`
 
 The complete public HTTP surface of the coordinator, derived from the 108 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
@@ -40,6 +40,12 @@ responses and error codes are unchanged.
 | `fin` | Financial tier: the stricter limiter installed by `SetFinancialRateLimiter`, applied to every account regardless of role; same 429 shape | `rateLimitFinancial` |
 
 Both tiers set `x-ratelimit-limit-requests`, `x-ratelimit-remaining-requests`, `x-ratelimit-reset-requests` on allowed *and* rejected responses (`setRequestRateLimitHeaders`). Limiter `Retry-After` values are clamped to `[DefaultRetryAfter, maxRetryAfter]` ([Timeouts and constants](#timeouts-and-constants)).
+
+Inference token-quota checks and charges are serialized per account across
+key and account buckets by `admitTokenBuckets`
+(`coordinator/api/token_admission.go`). A rejected charge consumes no tokens;
+429 responses keep their existing tier, dimension and `Retry-After` fields.
+The mechanism is described in the [consumer invariants](../architecture/components/consumer.md#invariants).
 
 ## Routes
 


### PR DESCRIPTION
Concurrent inference requests can both pass token-quota peeks before either charges the buckets. The later `Commit` ignores a failed charge, so two requests can proceed against a one-token account burst. The regression reproduces that outcome in the API admission helper.

The key and account checks/charges now run under one bounded account-sharded lock in `admitTokenBuckets`; extra output-token reconciliation uses the same lock. HTTP headers and error writes stay outside it. A private key-limit record replaces the six-value parameter tuple, and `server.go` retains tier selection and response handling.

Both token limiters now obtain availability and a retry hint through a non-consuming bucket check. A refill between the old `CanN` and consuming `AllowN` hint call can no longer debit a rejected request. Unlimited dimensions, oversized-charge clamps, service/admin behavior, output estimates and header/error shapes retain their existing rules.

```mermaid
flowchart LR
  subgraph Before
    A[Concurrent requests] --> B[Separate key and account Peek]
    B --> C[Locks released before Commit]
    C --> D[Failed charge ignored: quota exceeded]
    E[Failed CanN] --> F[Consuming AllowN for retry hint]
  end
  subgraph After
    G[Concurrent requests] --> H[admitTokenBuckets account lock]
    H --> I[Non-consuming checks for key and account]
    I -->|All fit| J[Charge both before unlock]
    I -->|Rejected| K[Unlock then existing 429]
    L[Additional output debt] --> H
  end
```

Validation:
- API concurrency regression failed on master: two admissions from a one-token burst in round 3.
- 100 contention rounds each for account-only, key-only, combined limits and different keys sharing an account pass after the fix (400 rounds total).
- Fixed-time refill tests verify rejected and successful checks never consume quota. Fixed/per-key tests preserve caps, oversized-charge behavior and unlimited dimensions.
- Focused API race tests passed (1.897s); limiter check tests passed (1.256s). The preceding broader token-related race run also passed (API 4.507s, limiter 1.325s), including existing header/rejection/estimation cases.
- Docs lint passed (278 pages). No current Markdown references the removed `keyTokenParams` helper.
- Full coordinator `GOTOOLCHAIN=go1.25.0 go test ./...` passed (API 195.247s); CI also validates the published branch.

The locks coordinate one coordinator process. They do not introduce distributed quota storage or change the existing per-process limiter model.
