### PR TITLE
refactor(benchmarks): preserve source evidence and simplify model reports

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `e56edbb69`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -470,6 +470,13 @@ ls -l provider-swift/.build/debug/darkbloom provider-swift/.build/debug/mlx.meta
 ./provider-swift/.build/debug/darkbloom --version    # prints ProviderCore.version, e.g. 0.8.16
 ls console-ui/.next
 ```
+
+### Model benchmark wrapper fixtures
+
+The Gemma and GPT-OSS report tooling has CPU-only Python checks that need no
+provider build, model snapshot or Metal runtime. Run both package suites from
+[the wrapper verification procedure](test.md#model-benchmark-wrapper-contracts)
+before running a native benchmark with either launcher.
 
 ## Troubleshooting
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `e56edbb69`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -1171,6 +1171,37 @@ token IDs are accepted.
   step prints a non-zero executed count (the tripwire in `run-nested-suite.sh`).
 - The e2e run logs `postgres started`, one `using configured provider binary`
   or provider build line per provider, and finishes with `ok  github.com/eigeninference/d-inference/e2e`.
+
+### Model benchmark wrapper contracts
+
+From the repository root, with Python 3.10 or later:
+
+```bash
+PYTHONPATH=scripts:. python3 -m unittest discover -s scripts/gemma_contbatch/tests -t scripts
+PYTHONPATH=scripts:. python3 -m unittest discover -s scripts/gptoss_profile/tests -t scripts
+```
+
+These fixtures use synthetic reports, mocked benchmark launches and host
+observations, temporary Git repositories, and owned Python children. They do not
+execute Swift, load a model, or measure a GPU.
+
+`scripts/gemma_contbatch/results.py` (`compare`) keeps the existing ordered
+phase/metric schema and rejects missing or duplicate comparison rows before
+computing deltas. `scripts/gemma_contbatch/process.py` (`source_fingerprint`)
+uses NUL-separated Git filename bytes so quoted or non-ASCII untracked kernel
+names still contribute their actual contents to the Metal source identity.
+
+`scripts/gptoss_profile/config.py` (`instrumentation_controls`) shares the
+existing diagnostic-knob policy between CLI measurement and ABBA designs.
+`scripts/gptoss_profile/summary.py` (`decode_intervals`) computes each
+repetition's common-window bounds once and retains only intervals wholly inside
+that window for its common-window percentiles; ordinary percentiles still
+include every row interval. `scripts/gptoss_profile/validation.py` (`positive`)
+rejects JSON booleans as measured positive numbers.
+
+These checks preserve benchmark schemas, backend controls, raw-output retention,
+power requirements and timing definitions. They do not establish model speed,
+output quality, live artifact provenance, or thermal equivalence.
 
 ## Troubleshooting
 

--- a/scripts/gemma_contbatch/backend.py
+++ b/scripts/gemma_contbatch/backend.py
@@ -1,30 +1,11 @@
-"""The KV backend a run ACTUALLY measured, and the pin that gates a diff.
+"""Record every phase's measured KV backend and pin baseline comparisons.
 
-A decode curve is only comparable to another decode curve if both were
-produced by the same KV backend. Nothing else in this harness can establish
-that: `--kv-backend auto` is a *selection* and resolves contiguous as of
-v0.8.1 (see the provider's `EngineV2Factory.prepareProductionBackend`). The
-wrapper requests `paged` explicitly; that selection refuses when paged cannot
-be built, while the fleet kill switch can deliberately degrade it to
-contiguous. A run that
-did not build the backend it names measures the fallback while every other
-check in this wrapper stays green, and a percentage delta against a baseline
-recorded on the other backend is a backend change wearing a performance
-change's clothes.
-
-So the resolved backend is extracted per decode cell, recorded in the report,
-and pinned before any delta is computed.
-
-Vocabulary is the resolved *kind* -- "paged" or "contiguous" -- matching
-`EngineV2KVBackendKind.rawValue` and the `kv_backend` field the coordinator
-records per slot. The engine's verbatim descriptor carries a
-"(fallback: <reason>)" tail on a degrade, and that reason is extracted into
-`degrades`: a slot that meant to serve paged and quietly served
-contiguous is the failure that matters, and only the reason separates a
-machine that cannot serve paged from one that simply was not PACKAGED for
-it -- the kernel preflight resolves its SwiftPM resource bundle relative to
-the executable, so a bare `cp` of the binary without the `.bundle` beside it
-disables paged on a box that is perfectly capable of running it.
+Selection is an input; the engine's resolved descriptor is the evidence. An
+explicit selection that resolves another backend, a mixed population, or a
+fallback reason remains visible in the report and fails its posture check.
+Fallback reasons are retained verbatim so packaging failures are distinguishable
+from capacity or kernel failures. A baseline comparison pins both phase and
+batch-size populations before computing any deltas.
 """
 
 from __future__ import annotations

--- a/scripts/gemma_contbatch/config.py
+++ b/scripts/gemma_contbatch/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
 
 
 # Schema of the *wrapper* report (distinct from the per-benchmark payload
@@ -32,17 +31,9 @@ SCHEMA_VERSION = 6
 
 
 DEFAULT_MODEL = "mlx-community/gemma-4-26B-A4B-it-qat-4bit"
-# The canonical posture this release is measured under. Both defaults are
-# load-bearing:
-#
-#   contiguous — `auto` resolves contiguous as of v0.8.1, but naming the
-#                backend keeps every phase's release posture explicit and
-#                prevents a future default flip from changing the benchmark.
-#   1,2,4,8    — the current production concurrency default is B=4 under the
-#                contiguous `auto` posture, while B=8 remains a supported
-#                stress point. The list is sparse on
-#                purpose: a dense 1..8 ladder doubles wall time for cells no
-#                gate reads.
+# Fixed benchmark controls, independent of per-model serving defaults. Naming
+# the backend keeps every phase comparable across future automatic-policy
+# changes. The sparse batch ladder includes B=8 without timing every 1..8 cell.
 DEFAULT_KV_BACKEND = "contiguous"
 DEFAULT_BATCH_SIZES = [1, 2, 4, 8]
 KV_BACKENDS = ("auto", "contiguous", "paged")

--- a/scripts/gemma_contbatch/process.py
+++ b/scripts/gemma_contbatch/process.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -103,12 +104,15 @@ def source_fingerprint(path: Path) -> tuple[list[str], str]:
             stdout=subprocess.PIPE,
         ).stdout
         digest.update(tracked_diff)
-        untracked = capture(
-            ["git", "ls-files", "--others", "--exclude-standard"], path
-        ).splitlines()
-        for relative in sorted(untracked):
-            source = path / relative
-            digest.update(relative.encode())
+        # NUL separates raw filenames; line output C-quotes tabs, newlines,
+        # quotes and non-ASCII bytes, which are not paths that can be opened.
+        untracked = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+            cwd=path, check=True, stdout=subprocess.PIPE,
+        ).stdout.split(b"\0")
+        for relative in sorted(name for name in untracked if name):
+            source = path / os.fsdecode(relative)
+            digest.update(relative)
             if source.is_file():
                 with source.open("rb") as handle:
                     for chunk in iter(lambda: handle.read(1024 * 1024), b""):

--- a/scripts/gemma_contbatch/results.py
+++ b/scripts/gemma_contbatch/results.py
@@ -1,4 +1,4 @@
-"""Baseline comparison of a summary against the committed baseline."""
+"""Baseline comparison against an explicitly supplied, validated report."""
 
 from __future__ import annotations
 
@@ -57,83 +57,36 @@ def compare(current: dict, baseline: dict) -> dict:
     baseline_summary = baseline["summary"]
     comparisons: dict[str, object] = {"baselineName": baseline.get("name", "baseline")}
 
-    base_prefill = index_against_baseline(
-        "prefill", current["prefill"], baseline_summary["prefill"], "promptTokens"
-    )
-    comparisons["prefill"] = [
-        {
-            "promptTokens": item["promptTokens"],
-            "tokensPerSecondPercent": percent_delta(
-                item["medianTokensPerSecond"],
-                base_prefill[item["promptTokens"]]["medianTokensPerSecond"],
-            ),
-            "elapsedMsPercent": percent_delta(
-                item["medianElapsedMs"],
-                base_prefill[item["promptTokens"]]["medianElapsedMs"],
-            ),
-        }
-        for item in current["prefill"]
-    ]
-
-    base_ttft = index_against_baseline(
-        "schedulerTTFT",
-        current["schedulerTTFT"],
-        baseline_summary["schedulerTTFT"],
-        "promptTokens",
-    )
-    comparisons["schedulerTTFT"] = [
-        {
-            "promptTokens": item["promptTokens"],
-            "ttftMsPercent": percent_delta(
-                item["medianTTFTMs"],
-                base_ttft[item["promptTokens"]]["medianTTFTMs"],
-            ),
-        }
-        for item in current["schedulerTTFT"]
-    ]
-
-    base_decode = index_against_baseline(
-        "decode", current["decode"], baseline_summary["decode"], "batchSize"
-    )
-    comparisons["decode"] = [
-        {
-            "batchSize": item["batchSize"],
-            "perRequestPercent": percent_delta(
-                item["perRequestTokensPerSecond"],
-                base_decode[item["batchSize"]]["perRequestTokensPerSecond"],
-            ),
-            "aggregatePercent": percent_delta(
-                item["aggregateTokensPerSecond"],
-                base_decode[item["batchSize"]]["aggregateTokensPerSecond"],
-            ),
-        }
-        for item in current["decode"]
-    ]
-
-    base_arrival = index_against_baseline(
-        "arrival", current["arrival"], baseline_summary["arrival"], "name"
-    )
-    comparisons["arrival"] = [
-        {
-            "name": item["name"],
-            "ttftMsPercent": percent_delta(
-                item["medianTTFTMs"], base_arrival[item["name"]]["medianTTFTMs"]
-            ),
-            "aggregateDecodePercent": percent_delta(
-                item["medianAggregateDecodeTokensPerSecond"],
-                base_arrival[item["name"]][
-                    "medianAggregateDecodeTokensPerSecond"
-                ],
-            ),
-            "endToEndPercent": percent_delta(
-                item["medianEndToEndTokensPerSecond"],
-                base_arrival[item["name"]]["medianEndToEndTokensPerSecond"],
-            ),
-            "makespanPercent": percent_delta(
-                item["medianMakespanMs"],
-                base_arrival[item["name"]]["medianMakespanMs"],
-            ),
-        }
-        for item in current["arrival"]
-    ]
+    # Each section names its row identity and its output-to-source metric map.
+    # Keep this order: a malformed earlier section must still fail first.
+    for section, key, metrics in (
+        ("prefill", "promptTokens", {
+            "tokensPerSecondPercent": "medianTokensPerSecond",
+            "elapsedMsPercent": "medianElapsedMs",
+        }),
+        ("schedulerTTFT", "promptTokens", {"ttftMsPercent": "medianTTFTMs"}),
+        ("decode", "batchSize", {
+            "perRequestPercent": "perRequestTokensPerSecond",
+            "aggregatePercent": "aggregateTokensPerSecond",
+        }),
+        ("arrival", "name", {
+            "ttftMsPercent": "medianTTFTMs",
+            "aggregateDecodePercent": "medianAggregateDecodeTokensPerSecond",
+            "endToEndPercent": "medianEndToEndTokensPerSecond",
+            "makespanPercent": "medianMakespanMs",
+        }),
+    ):
+        reference = index_against_baseline(
+            section, current[section], baseline_summary[section], key
+        )
+        comparisons[section] = [
+            {
+                key: item[key],
+                **{
+                    output: percent_delta(item[source], reference[item[key]][source])
+                    for output, source in metrics.items()
+                },
+            }
+            for item in current[section]
+        ]
     return comparisons

--- a/scripts/gemma_contbatch/runner.py
+++ b/scripts/gemma_contbatch/runner.py
@@ -105,15 +105,7 @@ def persist_failed_report(failure: BenchmarkCommandFailure, output_dir: Path) ->
 
 
 def sweep_argv(benchmark: list[str], args: argparse.Namespace) -> list[str]:
-    """The full `darkbloom benchmark --sweep` argv this wrapper runs.
-
-    Pure, so the two controls that make a run attributable can be asserted
-    without a GPU: before #583 was wired through here, the wrapper measured
-    whatever `--kv-backend auto` happened to resolve, on a `B=1..--max-batch`
-    ladder that stopped below the paged/contiguous crossover at ~B=5. A green
-    run could therefore neither name its backend nor reach the batch sizes
-    the release is claimed on.
-    """
+    """Build the repeated prefill/decode matrix with explicit backend and batch sizes."""
     repeated_lengths = ",".join(
         str(length)
         for length in args.prefill_lengths
@@ -137,15 +129,7 @@ def sweep_argv(benchmark: list[str], args: argparse.Namespace) -> list[str]:
 
 
 def scheduler_argv(benchmark: list[str], args: argparse.Namespace) -> list[str]:
-    """The full `darkbloom benchmark --scheduler-prefill` argv.
-
-    Carries `--kv-backend` for the same reason the sweep does. This phase
-    builds a FRESH production engine per measurement, so without the
-    selection every TTFT number came off `.auto` -- CONTIGUOUS -- while the
-    sweep beside it measured paged, and the report attributed both to one
-    backend. There is no batch-size curve to forward: each cold prefill is a
-    single request, `maxConcurrentRequests: 1` by construction.
-    """
+    """Pin the backend for each fresh single-request scheduler-prefill engine."""
     return benchmark + [
         "--scheduler-prefill",
         "--prefill-lengths",
@@ -158,14 +142,7 @@ def scheduler_argv(benchmark: list[str], args: argparse.Namespace) -> list[str]:
 
 
 def arrival_argv(benchmark: list[str], args: argparse.Namespace) -> list[str]:
-    """The full `darkbloom benchmark --arrival-invariance` argv.
-
-    Same pin, one engine: every arrival topology is measured on a single warm
-    engine, so this phase resolves exactly one backend and an unpinned run
-    resolved `.auto`'s. No batch-size curve here either -- the concurrency is
-    the widest arrival pattern (burst, 4 rows), fixed by the topologies the
-    benchmark defines rather than by a flag.
-    """
+    """Pin the shared warm engine used by every fixed four-row arrival pattern."""
     return benchmark + [
         "--arrival-invariance",
         "--kv-backend",
@@ -312,9 +289,8 @@ def main() -> int:
             comparison_axis=args.comparison_axis,
             metadata=metadata,
         )
-        # Keep the release's contiguous posture fixed across comparisons. A
-        # paged-versus-contiguous difference would otherwise read as a code or
-        # Gemma-optimization delta with no trace of its cause in the summary.
+        # Compare only the same measured backend population, whether the
+        # operator selected the contiguous control or an explicit alternative.
         validate_kv_backend_pin(baseline, kv_backend)
         report["comparison"] = compare(summary, baseline)
 

--- a/scripts/gemma_contbatch/tests/test_comparison.py
+++ b/scripts/gemma_contbatch/tests/test_comparison.py
@@ -1,0 +1,71 @@
+"""Comparison schema, row identity, and refusal order without a benchmark."""
+
+import copy
+import unittest
+
+from ..results import compare
+
+
+def comparison_fixture():
+    # Distinct changes make crossing a column or phase observable.
+    current = {
+        "prefill": [{"promptTokens": 128, "medianTokensPerSecond": 120, "medianElapsedMs": 40}],
+        "schedulerTTFT": [{"promptTokens": 128, "medianTTFTMs": 75}],
+        "decode": [{"batchSize": 4, "perRequestTokensPerSecond": 24, "aggregateTokensPerSecond": 96}],
+        "arrival": [{"name": "burst", "medianTTFTMs": 90,
+                     "medianAggregateDecodeTokensPerSecond": 150,
+                     "medianEndToEndTokensPerSecond": 40, "medianMakespanMs": 600}],
+    }
+    baseline = {"name": "reference", "summary": {
+        "prefill": [{"promptTokens": 128, "medianTokensPerSecond": 100, "medianElapsedMs": 50}],
+        "schedulerTTFT": [{"promptTokens": 128, "medianTTFTMs": 100}],
+        "decode": [{"batchSize": 4, "perRequestTokensPerSecond": 16, "aggregateTokensPerSecond": 120}],
+        "arrival": [{"name": "burst", "medianTTFTMs": 60,
+                     "medianAggregateDecodeTokensPerSecond": 100,
+                     "medianEndToEndTokensPerSecond": 0, "medianMakespanMs": 800}],
+    }}
+    return current, baseline
+
+
+class ComparisonTests(unittest.TestCase):
+    def test_every_metric_preserves_schema_and_zero_baseline(self):
+        current, baseline = comparison_fixture()
+        original = copy.deepcopy((current, baseline))
+        actual = compare(current, baseline)
+        expected = {
+            "baselineName": "reference",
+            "prefill": [{"promptTokens": 128, "tokensPerSecondPercent": 20, "elapsedMsPercent": -20}],
+            "schedulerTTFT": [{"promptTokens": 128, "ttftMsPercent": -25}],
+            "decode": [{"batchSize": 4, "perRequestPercent": 50, "aggregatePercent": -20}],
+            "arrival": [{"name": "burst", "ttftMsPercent": 50, "aggregateDecodePercent": 50,
+                         "endToEndPercent": None, "makespanPercent": -25}],
+        }
+        self.assertEqual(list(actual), list(expected))
+        self.assertEqual(actual.pop("baselineName"), expected.pop("baselineName"))
+        for section in expected:
+            self.assertEqual(len(actual[section]), 1)
+            self.assertEqual(list(actual[section][0]), list(expected[section][0]))
+            for key, value in expected[section][0].items():
+                if isinstance(value, (float, int)):
+                    self.assertAlmostEqual(actual[section][0][key], value)
+                else:
+                    self.assertEqual(actual[section][0][key], value)
+        self.assertEqual((current, baseline), original)
+
+    def test_duplicate_and_missing_rows_refuse_every_phase(self):
+        for section in ("prefill", "schedulerTTFT", "decode", "arrival"):
+            for side in ("current", "baseline"):
+                for mutation in ("duplicate", "missing"):
+                    with self.subTest(section=section, side=side, mutation=mutation):
+                        current, baseline = comparison_fixture()
+                        target = current if side == "current" else baseline["summary"]
+                        target[section] = target[section] * 2 if mutation == "duplicate" else []
+                        with self.assertRaisesRegex(RuntimeError, f"baseline {section} shape"):
+                            compare(current, baseline)
+
+    def test_first_invalid_phase_still_fails_first(self):
+        current, baseline = comparison_fixture()
+        baseline["summary"]["prefill"] = []
+        baseline["summary"]["decode"] = []
+        with self.assertRaisesRegex(RuntimeError, "baseline prefill shape"):
+            compare(current, baseline)

--- a/scripts/gemma_contbatch/tests/test_source_fingerprint.py
+++ b/scripts/gemma_contbatch/tests/test_source_fingerprint.py
@@ -1,0 +1,31 @@
+"""Dirty source identity uses filename bytes, including Git-quoted names."""
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+from ..process import source_fingerprint
+
+
+class SourceFingerprintTests(unittest.TestCase):
+    def test_untracked_kernel_content_changes_fingerprint_for_quoted_names(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q", str(root)], check=True)
+            subprocess.run(["git", "-C", str(root), "-c", "core.hooksPath=/dev/null",
+                            "-c", "commit.gpgsign=false", "-c", "user.name=Fixture",
+                            "-c", "user.email=fixture@example.invalid",
+                            "commit", "-q", "--allow-empty", "-m", "fixture"], check=True)
+            for name in ('plain.metal', 'kernel"variant.metal', 'café.metal', 'line\nbreak.metal', 'tab\tname.metal'):
+                with self.subTest(name=name):
+                    source = root / name
+                    source.write_bytes(b"before")
+                    status, before = source_fingerprint(root)
+                    self.assertTrue(status)
+                    source.write_bytes(b"after!")
+                    after_status, after = source_fingerprint(root)
+                    self.assertEqual(status, after_status)
+                    self.assertNotEqual(before, after)
+                    self.assertEqual(after, source_fingerprint(root)[1])
+                    source.unlink()

--- a/scripts/gptoss_profile/config.py
+++ b/scripts/gptoss_profile/config.py
@@ -69,3 +69,10 @@ def environment(inherited, overrides=()):
     result.update(explicit)
     result.update(FIXED_CONTROLS)
     return result, {k: result[k] for k in sorted(set(explicit) | set(FIXED_CONTROLS))}
+
+
+def instrumentation_controls(controls):
+    """Enabled diagnostic knobs are not valid measurement controls."""
+    return [key for key, value in controls.items()
+            if any(word in key for word in ("PROFILE", "TRACE", "TIMING", "CAPTURE", "DEBUG"))
+            and value.lower() not in {"0", "false", "no", "off", ""}]

--- a/scripts/gptoss_profile/control_design.py
+++ b/scripts/gptoss_profile/control_design.py
@@ -3,7 +3,7 @@
 import json
 from pathlib import Path
 
-from .config import Cell, environment
+from .config import Cell, environment, instrumentation_controls
 
 
 def load_design(path):
@@ -64,9 +64,7 @@ def load_design(path):
         if not isinstance(overrides, dict) or any(not isinstance(k, str) or not isinstance(v, str) for k, v in overrides.items()):
             raise ValueError("Arm environment must map string keys to string values")
         _, explicit = environment({}, [f"{key}={value}" for key, value in overrides.items()])
-        instrumentation = [key for key, value in explicit.items()
-                           if any(word in key for word in ("PROFILE", "TRACE", "TIMING", "CAPTURE", "DEBUG"))
-                           and value.lower() not in {"0", "false", "no", "off", ""}]
+        instrumentation = instrumentation_controls(explicit)
         if instrumentation:
             raise ValueError(f"ABBA timing controls require instrumentation disabled: {instrumentation}")
         arm["environment"] = explicit

--- a/scripts/gptoss_profile/runner.py
+++ b/scripts/gptoss_profile/runner.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from .config import cells, command, environment
+from .config import cells, command, environment, instrumentation_controls
 from .process import run
 from .power import power_failure
 from .provenance import assert_artifacts_unchanged, digest, file_pin, fingerprint, host_snapshot, model_pin, now, source_pin, write_json
@@ -63,9 +63,7 @@ def execute(args):
     if not binary.is_file() or not os.access(binary, os.X_OK):
         raise ValueError("--binary must name an existing executable; this runner does not build")
     child_env, controls = environment(os.environ, args.env)
-    instrumentation = [key for key, value in controls.items()
-                       if any(word in key for word in ("PROFILE", "TRACE", "TIMING", "CAPTURE", "DEBUG"))
-                       and value.lower() not in {"0", "false", "no", "off", ""}]
+    instrumentation = instrumentation_controls(controls)
     if args.mode == "measurement" and instrumentation:
         raise ValueError(f"Instrumentation controls require --mode diagnostic: {instrumentation}")
     print("Hashing binary, Metal libraries, and model snapshot for run provenance…", flush=True)

--- a/scripts/gptoss_profile/summary.py
+++ b/scripts/gptoss_profile/summary.py
@@ -27,6 +27,23 @@ def dispersion(values):
             "coefficientOfVariation": stdev(values) / mean(values) if len(values) > 1 and mean(values) else None}
 
 
+def decode_intervals(timings):
+    """All row intervals and those wholly inside each repetition's overlap."""
+    intervals, common = [], []
+    for timing in timings:
+        rows = timing["rows"]
+        start = max(row["tokenArrivalMs"][0] for row in rows)
+        end = min(row["tokenArrivalMs"][-1] for row in rows)
+        for row in rows:
+            times = row["tokenArrivalMs"]
+            for first, last in zip(times, times[1:]):
+                interval = last - first
+                intervals.append(interval)
+                if first >= start and last <= end:
+                    common.append(interval)
+    return intervals, common
+
+
 def summarize_cell(report, spec):
     cell = spec["cell"]
     result = {**cell, "iterations": spec["iterations"],
@@ -34,12 +51,7 @@ def summarize_cell(report, spec):
     if cell["phase"] == "decode":
         timings = [s["decodeTiming"] for s in report["decode"]]
         aggregates = [t["overlapAggregateTokensPerSecond"] for t in timings]
-        intervals = [b - a for t in timings for row in t["rows"]
-                     for a, b in zip(row["tokenArrivalMs"], row["tokenArrivalMs"][1:])]
-        common_intervals = [b - a for t in timings for row in t["rows"]
-                            for a, b in zip(row["tokenArrivalMs"], row["tokenArrivalMs"][1:])
-                            if a >= max(r["tokenArrivalMs"][0] for r in t["rows"])
-                            and b <= min(r["tokenArrivalMs"][-1] for r in t["rows"])]
+        intervals, common_intervals = decode_intervals(timings)
         result.update({"aggregateDecodeTPS": median(aggregates),
                        "aggregateDecodeDistribution": dispersion(aggregates),
                        "perRequestDecodeTPS": median(aggregates) / cell["batch"],

--- a/scripts/gptoss_profile/tests/test_measurement_policy.py
+++ b/scripts/gptoss_profile/tests/test_measurement_policy.py
@@ -1,0 +1,46 @@
+"""CPU-only measurement policy and common-window interval contracts."""
+
+import unittest
+
+from gptoss_profile.config import instrumentation_controls
+from gptoss_profile.summary import decode_intervals
+from gptoss_profile.validation import positive, validate
+
+
+class MeasurementPolicyTests(unittest.TestCase):
+    def test_diagnostic_control_names_and_values_preserve_exact_policy(self):
+        names = [f"MLX_{kind}_ENABLED" for kind in ("PROFILE", "TRACE", "TIMING", "CAPTURE", "DEBUG")]
+        for disabled in ("0", "false", "no", "off", "", "FaLsE", "OFF"):
+            self.assertEqual(instrumentation_controls(dict.fromkeys(names, disabled)), [])
+        for enabled in ("1", "true", "arbitrary", " off "):
+            self.assertEqual(instrumentation_controls(dict.fromkeys(names, enabled)), names)
+        self.assertEqual(instrumentation_controls({"MLX_NORMAL": "1", "MLX_trace": "1"}), [])
+
+    def test_scalar_metrics_require_real_positive_finite_numbers(self):
+        for value in (True, False, None, "1", 0, -1, float("nan"), float("inf")):
+            with self.subTest(value=value):
+                self.assertFalse(positive(value))
+        for value in (1, 1.0, .25):
+            self.assertTrue(positive(value))
+
+    def test_boolean_ttft_cannot_validate_as_a_measurement(self):
+        spec = {"cell": {"phase": "prefill", "context": 512}, "iterations": 1,
+                "decodeTokens": 64, "backend": "contiguous", "provenanceID": "fixture"}
+        manifest = {"modelID": "fixture", "model": {"path": "/tmp/fixture"}, "provenanceID": "fixture"}
+        report = {"schemaVersion": 4, "modelID": "fixture", "modelPath": "/tmp/fixture",
+                  "kvBackend": {"selection": "contiguous", "resolved": ["contiguous"]},
+                  "promptLengths": [512], "samples": [{"promptTokens": 512, "ttftMs": True,
+                                                       "resolvedKVBackend": "contiguous"}]}
+        with self.assertRaisesRegex(ValueError, "Invalid prefill sample"):
+            validate(report, spec, manifest)
+        report["samples"][0]["ttftMs"] = 1
+        validate(report, spec, manifest)
+
+    def test_intervals_keep_row_order_and_inclusive_overlap_boundaries(self):
+        timings = [
+            {"rows": [{"tokenArrivalMs": [0, 10, 20, 30]}, {"tokenArrivalMs": [10, 15, 25]}]},
+            {"rows": [{"tokenArrivalMs": [100, 105, 120]}]},
+        ]
+        all_intervals, common = decode_intervals(timings)
+        self.assertEqual(all_intervals, [10, 10, 10, 5, 10, 5, 15])
+        self.assertEqual(common, [10, 5, 10, 5, 15])

--- a/scripts/gptoss_profile/validation.py
+++ b/scripts/gptoss_profile/validation.py
@@ -10,7 +10,7 @@ def require(condition, message):
 
 
 def positive(value):
-    return isinstance(value, (int, float)) and math.isfinite(value) and value > 0
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) and value > 0
 
 
 def validate(report, spec, manifest):


### PR DESCRIPTION
The Gemma wrapper could assign the same Metal source fingerprint to different untracked kernel contents when Git quoted the filename. Read NUL-separated filename bytes so quotes, Unicode, tabs and newlines resolve to the actual file before hashing. A real temporary-Git regression reproduced four failures on the original source. GPT-OSS also accepted JSON `true` as a positive measured TTFT; reject booleans while preserving real positive numbers.

Simplify report operations across both wrappers: an explicit ordered Gemma comparison table replaces four duplicate indexing/projection paths; GPT-OSS shares its existing diagnostic-control policy between CLI and ABBA designs, and computes common-window interval boundaries once per repetition. Clarify that Gemma's fixed contiguous benchmark control is separate from model-specific serving defaults. Remove 80 net production-source lines, including obsolete historical commentary.

Before:
```mermaid
flowchart LR
  G[Git line output] --> Q[Quoted filename treated as path]
  Q --> F[Kernel contents can be absent from fingerprint]
  C[Four Gemma comparison branches] --> R[Percentage report]
  P[CLI and ABBA duplicate diagnostic policy] --> M[Measured or diagnostic mode]
  T[Each token interval] --> B[Recompute row extrema]
  B --> S[GPT-OSS summary]
  V[Boolean TTFT] --> Y[Accepted as positive measurement]
```

After:
```mermaid
flowchart LR
  G[Git NUL-separated filename bytes] --> F[Hash actual untracked kernel contents]
  C[Ordered Gemma phase and metric table] --> I[Same row-shape refusal]
  I --> R[Same percentage report fields and order]
  P[Shared instrumentation_controls] --> M[Same CLI and ABBA mode policy]
  T[One common window per repetition] --> B[Classify every row interval]
  B --> S[Same GPT-OSS percentiles]
  V[Boolean TTFT] --> N[Invalid measurement]
```

Validation: 69 Gemma and 37 GPT-OSS CPU tests pass on Python 3.12, including existing failed-command report retention, same-provenance resume, power refusal, token parity, and trace completeness fixtures. New tests cover all nine comparison metric mappings, missing/duplicate rows and refusal order, exact diagnostic knob values, interval boundaries, boolean TTFT rejection, and five real Git filename forms. Baseline suites passed 65/33 tests before changes.

A seeded differential check compared 1,000 Gemma output/error cases and 1,000 complete synthetic GPT-OSS decode summaries against the original source: exact match, including JSON key order. Docs lint passes all 278 documents; signed commits and diff checks pass.

No benchmark, Swift, model, Metal, or real-host execution. Model/runtime defaults, report schemas, tolerances, comparison refusal policies, process ownership, and raw artifact retention remain unchanged apart from rejecting boolean scalar measurements and correctly fingerprinting quoted filenames. These CPU checks make no model throughput or TTFT claim.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764959&installation_model_id=21733&pr_number=941&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F941&signature=681f195c2100be929ea44ecb30f8d618ddb2ece76567dd39cc81926a49758dc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->