### PR TITLE
Align contributor and dependency entry points with the current repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Environment
       description: |
-        Include `darkbloom --version`, macOS version, Mac model + RAM, and browser for web bugs. For a source build, include the commit and toolchain versions.
+        Include the affected component's version and environment: `darkbloom --version`, macOS version and Mac model + RAM for provider bugs; browser for web bugs; server, container or CI details when relevant. For a source build, include the commit and toolchain versions.
       placeholder: |
         - provider: output of `darkbloom --version`
         - macOS: output of `sw_vers -productVersion`

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,9 +65,9 @@ body:
       description: |
         Include the affected component's version and environment: `darkbloom --version`, macOS version and Mac model + RAM for provider bugs; browser for web bugs; server, container or CI details when relevant. For a source build, include the commit and toolchain versions.
       placeholder: |
-        - provider: output of `darkbloom --version`
-        - macOS: output of `sw_vers -productVersion`
-        - hardware: MacBook Pro M3 Pro, 36 GB
+        - component version or source commit:
+        - OS, runtime, browser or container (as applicable):
+        - provider only: `darkbloom --version`, macOS version, Mac model and RAM
     validations:
       required: true
 
@@ -75,7 +75,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Include relevant output from `darkbloom logs --last 10m`, or `darkbloom logs --file --lines 50` for file logs. See [the provider CLI reference](https://github.com/Layr-Labs/d-inference/blob/master/docs/provider/cli-reference.md#darkbloom-logs) for options. Redact sensitive data.
+      description: Include logs for the affected component, such as server or container output, browser console errors, or CI logs. For provider bugs, use `darkbloom logs --last 10m` or `darkbloom logs --file --lines 50`; see [the provider CLI reference](https://github.com/Layr-Labs/d-inference/blob/master/docs/provider/cli-reference.md#darkbloom-logs) for options. Redact sensitive data.
       render: shell
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a defect in d-inference (coordinator, provider, console UI, app, image bridge, etc.)
+description: Report a defect in the coordinator, provider, web apps, or tooling
 title: "[bug] "
 labels: ["bug"]
 body:
@@ -17,10 +17,11 @@ body:
       description: Which part of the system is affected?
       options:
         - coordinator (Go)
-        - provider (Rust, legacy)
-        - provider-swift (Swift CLI)
+        - prompt sidecar (Rust)
+        - provider-swift (Swift CLI, app, and helpers)
         - console-ui (Next.js)
-        - enclave (Swift Secure Enclave helper)
+        - admin-ui (Next.js)
+        - landing
         - infra / deploy / CI
         - docs
         - not sure
@@ -32,7 +33,7 @@ body:
     attributes:
       label: What happened?
       description: A clear description of the bug, including any error messages or unexpected output.
-      placeholder: e.g. provider crashed with X after running `eigeninference-provider serve` on a fresh M2 Air
+      placeholder: e.g. provider crashed with X after running `darkbloom start`
     validations:
       required: true
 
@@ -50,8 +51,8 @@ body:
       label: Steps to reproduce
       description: Minimal steps that reliably trigger the bug.
       placeholder: |
-        1. Install v0.3.5 via the install.sh one-liner
-        2. Run `eigeninference-provider serve --model llama-3.1-8b-instruct`
+        1. Install a provider release (include its version below)
+        2. Run `darkbloom start` (include relevant config and model ID)
         3. Send a chat completion from the console UI
         4. Observe the failure
     validations:
@@ -62,10 +63,10 @@ body:
     attributes:
       label: Environment
       description: |
-        Anything relevant to reproducing this — provider version (`eigeninference-provider --version`), macOS version, Mac model + RAM, browser (for console UI bugs), etc.
+        Include `darkbloom --version`, macOS version, Mac model + RAM, and browser for web bugs. For a source build, include the commit and toolchain versions.
       placeholder: |
-        - provider: v0.3.5
-        - macOS: 15.4 (Sequoia)
+        - provider: output of `darkbloom --version`
+        - macOS: output of `sw_vers -productVersion`
         - hardware: MacBook Pro M3 Pro, 36 GB
     validations:
       required: true
@@ -74,7 +75,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Relevant log output. For provider crashes, include the last ~50 lines of `~/Library/Logs/eigeninference-provider/*.log`. Use code fences and redact anything sensitive.
+      description: Include relevant output from `darkbloom logs --last 10m`, or `darkbloom logs --file --lines 50` for file logs. See [the provider CLI reference](https://github.com/Layr-Labs/d-inference/blob/master/docs/provider/cli-reference.md#darkbloom-logs) for options. Redact sensitive data.
       render: shell
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,10 +15,11 @@ body:
       description: Which part of the system would this affect?
       options:
         - coordinator (Go)
-        - provider (Rust, legacy)
-        - provider-swift (Swift CLI)
+        - prompt sidecar (Rust)
+        - provider-swift (Swift CLI, app, and helpers)
         - console-ui (Next.js)
-        - enclave (Swift Secure Enclave helper)
+        - admin-ui (Next.js)
+        - landing
         - infra / deploy / CI
         - docs
         - cross-cutting / not sure
@@ -30,7 +31,7 @@ body:
     attributes:
       label: Problem / motivation
       description: What problem are you trying to solve? Who is this for? Why does it matter now?
-      placeholder: e.g. "Providers running on 8GB Macs can't serve any catalog model and there's no way to opt them into STT-only mode."
+      placeholder: e.g. "I need to compare provider earnings across dates, but the current view only shows totals."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -15,10 +15,11 @@ body:
       label: Component
       options:
         - coordinator (Go)
-        - provider (Rust, legacy)
-        - provider-swift (Swift CLI)
+        - prompt sidecar (Rust)
+        - provider-swift (Swift CLI, app, and helpers)
         - console-ui (Next.js)
-        - enclave (Swift Secure Enclave helper)
+        - admin-ui (Next.js)
+        - landing
         - infra / deploy / CI
         - docs
     validations:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
 
   - package-ecosystem: "gomod"
-    directory: "/coordinator"
+    directory: "/"
     schedule:
       interval: "daily"
       time: "08:00"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Thanks for contributing to d-inference. A few quick notes:
 
 - Link an issue with `Closes #123` so the issue auto-closes on merge.
-- Set the milestone (e.g. `v0.3.6`) so we know which release this targets.
+- Set a milestone if the change targets a specific release.
 - Add `area:*` labels for the components you touched.
 - Don't include external IPs, internal hostnames, or secrets in code, comments, or screenshots.
 -->
@@ -14,6 +14,20 @@ Thanks for contributing to d-inference. A few quick notes:
 ## Linked issue
 
 Closes #
+
+## Before and after
+
+<!-- Replace these placeholders with the behavior and code paths changed by this PR. -->
+
+```mermaid
+flowchart LR
+  subgraph Before
+    A[Trigger] --> B[Current function or component] --> C[Current outcome]
+  end
+  subgraph After
+    D[Same trigger] --> E[Changed function or component] --> F[New outcome]
+  end
+```
 
 ## Test plan
 
@@ -30,10 +44,12 @@ For UI changes, include a screenshot or short video.
 <!-- Tick all that apply so reviewers know what to look at. -->
 
 - [ ] coordinator (Go)
-- [ ] provider (Rust, legacy)
-- [ ] provider-swift (Swift CLI)
+- [ ] prompt sidecar (Rust)
+- [ ] provider-swift (Swift CLI, app, and helpers)
 - [ ] console-ui (Next.js)
-- [ ] enclave (Swift)
+- [ ] admin-ui (Next.js)
+- [ ] landing
+- [ ] e2e harness
 - [ ] infra / CI / release
 - [ ] docs
 
@@ -41,7 +57,7 @@ For UI changes, include a screenshot or short video.
 
 <!--
 If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
-- Did you update the matching side? (provider/src/protocol.rs ↔ coordinator/internal/protocol/messages.go)
+- Did you update the matching side? (provider-swift/Sources/ProviderCore/Protocol/Messages.swift ↔ coordinator/protocol/messages.go)
 - Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
 - Does this need a version bump or a migration note?
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,7 +57,7 @@ For UI changes, include a screenshot or short video.
 
 <!--
 If you changed a WebSocket message, an HTTP endpoint, a config key, or a CLI flag:
-- Did you update the matching side? (provider-swift/Sources/ProviderCore/Protocol/Messages.swift ↔ coordinator/protocol/messages.go)
+- Did you update the matching side? (provider-swift/Sources/ProviderCore/Protocol/ ↔ coordinator/protocol/messages.go)
 - Are release artifacts (`release-swift.yml`, `scripts/install.sh`, `LatestProviderVersion`) still consistent?
 - Does this need a version bump or a migration note?
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Contributor guidance** — Issue forms and the PR template reference the current components, provider commands and review requirements. Go dependency update checks use the repository's root module.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-11 · commit `fd1fd7969`
+> Last updated: 2026-09-11 · commit `6d775977d`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-11 · commit `6d775977d`
+> Last updated: 2026-09-11 · commit `cdb7bf231`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `fd1fd7969`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -51,6 +51,9 @@ Go/Swift fixture and focused checks are described in [test.md](test.md) and
 | `admin-ui/` | Next.js 16 / React 19 | `npm`; dev/start on port `4001`. |
 | `landing/` | static HTML/JS | No build step; `earn-calculator-core.test.js` runs with `node --test`. |
 | `Makefile` | — | Every target below; `make help` lists them. |
+
+Dependency update checks in [`.github/dependabot.yml`](../../.github/dependabot.yml)
+use the root Go module and the console UI's package directory.
 
 ## Steps
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `fd1fd7969`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -9,6 +9,12 @@ the docs lint locally; CI runs a subset per pull request (see the CI workflow
 map: the console UI job lints and builds but does not run vitest, and the
 benchmark-wrapper tests run only locally). The e2e suite needs an Apple Silicon
 Mac with the test checkpoints cached.
+
+Record the checks you ran in the
+[pull request template](../../.github/pull_request_template.md), along with a
+before-and-after diagram of the changed behavior and code paths. The
+[bug report form](../../.github/ISSUE_TEMPLATE/bug_report.yml) lists the version,
+environment and provider log details needed to reproduce a failure.
 
 The Nemotron coordinator-serving path uses typed SDK events. `OpenAIServiceTests`
 and `ToolCallParserIntegrationTests` in `libs/mlx-swift-lm/Tests/MLXLMServerTests`

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `fd1fd7969`
+> Last updated: 2026-09-11 · commit `6d775977d`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -9,12 +9,6 @@ the docs lint locally; CI runs a subset per pull request (see the CI workflow
 map: the console UI job lints and builds but does not run vitest, and the
 benchmark-wrapper tests run only locally). The e2e suite needs an Apple Silicon
 Mac with the test checkpoints cached.
-
-Record the checks you ran in the
-[pull request template](../../.github/pull_request_template.md), along with a
-before-and-after diagram of the changed behavior and code paths. The
-[bug report form](../../.github/ISSUE_TEMPLATE/bug_report.yml) lists the version,
-environment and provider log details needed to reproduce a failure.
 
 The Nemotron coordinator-serving path uses typed SDK events. `OpenAIServiceTests`
 and `ToolCallParserIntegrationTests` in `libs/mlx-swift-lm/Tests/MLXLMServerTests`
@@ -928,6 +922,10 @@ node --test landing/earn-calculator-core.test.js
 ```
 
 ### 6. Scripts and release integrity
+
+For changes to [dependency update configuration](../../.github/dependabot.yml),
+confirm that each update directory contains its ecosystem’s manifest, then run
+the relevant component checks in this guide.
 
 ```bash
 make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contbatch/tests -t .   (in scripts/)

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `6d775977d`
+> Last updated: 2026-09-11 · commit `cdb7bf231`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs


### PR DESCRIPTION
Go dependency updates pointed at `/coordinator`, but the only Go module is at the repository root. Point Dependabot at `/` so it can find `go.mod`. Its schedule, grouping and update policy remain the same.

Issue forms now reference the current Swift provider, Rust prompt sidecar, web apps and supported provider log commands. The PR template includes the required before-and-after diagram and correct Swift/Go protocol paths, removing obsolete release and legacy-provider examples.

```mermaid
flowchart LR
  subgraph Before
    A[Go dependency check] --> B[dependabot.yml selects coordinator directory]
    B --> C[No go.mod at that path]
    D[Contributor opens form or PR] --> E[Legacy commands and protocol paths]
    E --> F[Incomplete reproduction or review context]
  end
  subgraph After
    A2[Go dependency check] --> B2[dependabot.yml selects repository root]
    B2 --> C2[Existing Go module found]
    D2[Contributor opens form or PR] --> E2[Current components and log commands]
    E2 --> F2[Versioned reproduction and behavior/code diagram]
  end
```

Validation: all four edited YAML files parse; each configured Dependabot directory contains its expected manifest. Provider log examples match the CLI reference and source, protocol paths exist, and docs lint passes for 278 pages. This is a static configuration/documentation change; no new runtime tests or dependency updates are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791765129&installation_model_id=21733&pr_number=942&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F942&signature=e4e75df8ee705fd6811e697bf5a389572d1682edea4f9827c9bafaeef2eb9633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->