### PR TITLE
Harden capacity readiness, quote expiry and request sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Coordinator capacity and admission** — Model readiness honors public routing gates while retaining inventory and the fleet-wide health-breaker fallback. Expired capacity probes settle as timeouts; oversized prompt/output sums are rejected without integer wrapping.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/registry/capacity_quotes.go
+++ b/coordinator/registry/capacity_quotes.go
@@ -56,11 +56,12 @@ type QuoteOutcome struct {
 }
 
 // quoteDelivery is the tracker→collector handoff for one settled probe.
-// quote == nil means transport failure (send error or disconnect).
+// timeout marks an expiry sweep; otherwise quote == nil means transport failure.
 type quoteDelivery struct {
 	quoteID    string
 	providerID string
 	quote      *protocol.CapacityQuoteMessage
+	timeout    bool
 }
 
 // pendingQuote is one outstanding probe: the provider binding the quote must
@@ -100,10 +101,10 @@ type quoteTracker struct {
 	sweeps    int
 }
 
-// add registers an outstanding probe. The opportunistic sweep (same idiom as
-// the sibling cooldown maps) drops expired entries whose collector died
-// before its window sweep — a leak only a panicked collector can create,
-// since a live one takes back every silent entry at expiry. The >1024 size
+// add registers an outstanding probe. The opportunistic sweep settles expired
+// entries, including when its collector has not yet processed the timer. Every
+// removal must deliver an outcome: collectors treat a missing entry as a claim
+// whose delivery is in flight. The >1024 size
 // trigger merely makes a sweep WORTH considering; the time gate
 // (quoteTrackerSweepInterval) decides whether one actually runs.
 func (t *quoteTracker) add(quoteID string, pq *pendingQuote) {
@@ -120,6 +121,9 @@ func (t *quoteTracker) add(quoteID string, pq *pendingQuote) {
 			for id, e := range t.pending {
 				if now.After(e.expiresAt) {
 					delete(t.pending, id)
+					if e.deliver != nil {
+						e.deliver <- quoteDelivery{quoteID: id, providerID: e.providerID, timeout: true}
+					}
 				}
 			}
 		}
@@ -345,7 +349,7 @@ func (r *Registry) ProbePlanCandidates(plan *DispatchPlan, shape CapacityProbeSh
 func applyQuoteDelivery(plan *DispatchPlan, d quoteDelivery) QuoteOutcome {
 	if d.quote == nil {
 		plan.DemoteEntry(d.providerID)
-		return QuoteOutcome{ProviderID: d.providerID, SendFailed: true}
+		return QuoteOutcome{ProviderID: d.providerID, Timeout: d.timeout, SendFailed: !d.timeout}
 	}
 	if d.quote.AdmissibleNow {
 		plan.ConfirmEntry(d.providerID, d.quote)

--- a/coordinator/registry/capacity_quotes_expiry_test.go
+++ b/coordinator/registry/capacity_quotes_expiry_test.go
@@ -1,0 +1,58 @@
+package registry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestQuoteTrackerSweepSettlesLiveCollector(t *testing.T) {
+	reg := New(testLogger())
+	const model = "swept-quote-model"
+	planTestProvider(t, reg, "primary", model, 0)
+	alternate := planTestProvider(t, reg, "alternate", model, 400)
+	request := planTestRequest("swept-quote", 100, 64)
+	request.Model = model
+	_, _, plan := reg.ReserveProviderWithPlan(model, request)
+	setQuoteCapable(alternate)
+	conn := attachTestWriter(t, alternate)
+	out := reg.ProbePlanCandidates(plan, CapacityProbeShape{Model: model}, time.Hour)
+	probe := readProbeFrame(t, conn)
+
+	// Advance just this quote's expiry, then force the opportunistic sweep
+	// before its collector's timer runs. No scheduler timing race is needed.
+	tracker := &reg.capacityQuotes
+	tracker.mu.Lock()
+	pending := tracker.pending[probe.QuoteID]
+	pending.expiresAt = time.Now().Add(-time.Second)
+	for i := range 1025 {
+		tracker.pending[fmt.Sprintf("unexpired-%d", i)] = &pendingQuote{expiresAt: time.Now().Add(time.Hour)}
+	}
+	tracker.lastSweep = time.Time{}
+	tracker.mu.Unlock()
+	tracker.add("trigger", &pendingQuote{expiresAt: time.Now().Add(time.Hour)})
+
+	select {
+	case result := <-out:
+		if !result.Timeout || result.SendFailed || result.Quote != nil || result.ProviderID != alternate.ID {
+			t.Fatalf("swept outcome = %+v, want timeout for %s", result, alternate.ID)
+		}
+		if !plan.entries[0].view.Demoted {
+			t.Fatal("timeout was published before demoting the plan entry")
+		}
+	case <-time.After(time.Second):
+		// Release the collector on the regressed implementation too, so the
+		// characterization failure does not leave its hour-long goroutine.
+		pending.deliver <- quoteDelivery{quoteID: probe.QuoteID, providerID: alternate.ID}
+		collectOutcomes(t, out)
+		t.Fatal("expiry sweep removed the probe without settling its live collector")
+	}
+	select {
+	case _, open := <-out:
+		if open {
+			t.Fatal("swept probe produced more than one outcome")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("settled collector did not close its output")
+	}
+}

--- a/coordinator/registry/dedicated_models.go
+++ b/coordinator/registry/dedicated_models.go
@@ -16,8 +16,12 @@ import "strings"
 // the coordinator entrypoint to read EIGENINFERENCE_DEDICATED_MODELS. An empty
 // or all-blank input yields a nil slice (feature disabled).
 func ParseDedicatedModels(csv string) []string {
+	return normalizeDedicatedModels(strings.Split(csv, ","))
+}
+
+func normalizeDedicatedModels(patterns []string) []string {
 	var out []string
-	for _, p := range strings.Split(csv, ",") {
+	for _, p := range patterns {
 		p = strings.ToLower(strings.TrimSpace(p))
 		if p == "" {
 			continue
@@ -32,20 +36,9 @@ func ParseDedicatedModels(csv string) []string {
 // empty (or all-blank) list disables the feature. Called once at startup before
 // the coordinator begins serving.
 func (r *Registry) SetDedicatedModels(patterns []string) {
-	normalized := make([]string, 0, len(patterns))
-	for _, p := range patterns {
-		p = strings.ToLower(strings.TrimSpace(p))
-		if p == "" {
-			continue
-		}
-		normalized = append(normalized, p)
-	}
+	normalized := normalizeDedicatedModels(patterns)
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if len(normalized) == 0 {
-		r.dedicatedModels = nil
-		return
-	}
 	r.dedicatedModels = normalized
 }
 

--- a/coordinator/registry/model_capacity.go
+++ b/coordinator/registry/model_capacity.go
@@ -25,6 +25,7 @@ type ModelCapacity struct {
 // providerCapSnap is a per-provider snapshot collected under the registry
 // lock, then aggregated into ModelCapacity outside the lock.
 type providerCapSnap struct {
+	providerID            string
 	model                 string
 	warm                  bool
 	running               bool
@@ -68,6 +69,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 
 	// Phase 1: collect per-provider snapshots under the lock.
 	var snaps []providerCapSnap
+	breakerModels := make(map[string]struct{})
 
 	r.mu.RLock()
 	for _, p := range r.providers {
@@ -108,8 +110,11 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			// path enforces, so the public capacity feed doesn't advertise a capped
 			// box (e.g. Gemma at 2) as routable up to the flat fallback (24) and lure
 			// upstream routers into sending requests this coordinator immediately 429s.
-			hasHeadroom := r.providerPassesRoutingGatesLocked(p, m.ID, RequestTraits{}, false, now) &&
-				r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
+			passesGates, reason := r.providerRoutingGateReasonLockedEx(p, m.ID, RequestTraits{}, false, now, false, false)
+			if reason == GateBreaker || reason == GateEjection {
+				breakerModels[m.ID] = struct{}{}
+			}
+			hasHeadroom := passesGates && r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
 			// activeRequests for multi-model providers.
@@ -136,6 +141,7 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			)
 
 			snap := providerCapSnap{
+				providerID:            p.ID,
 				model:                 m.ID,
 				hasHeadroom:           hasHeadroom,
 				effectiveTPS:          decodeTPS,
@@ -180,6 +186,17 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			snaps = append(snaps, snap)
 		}
 		p.mu.Unlock()
+	}
+	// A strict per-provider gate cannot decide the fleet-wide breaker valve.
+	// Only affected models need the shared dispatch scan; inventory stays intact.
+	for model := range breakerModels {
+		if fallback := r.modelCapacityBreakerFallbackLocked(model); fallback != nil {
+			for i := range snaps {
+				if snaps[i].model == model {
+					snaps[i].hasHeadroom = fallback[snaps[i].providerID]
+				}
+			}
+		}
 	}
 	r.mu.RUnlock()
 
@@ -305,4 +322,27 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 		})
 	}
 	return result
+}
+
+// modelCapacityBreakerFallbackLocked returns the fleet's last-resort cohort only
+// when dispatch would bypass health breakers. Capacity has no request shape, so
+// test the smallest positive text reservation (one output token, no deadline).
+// Healthy-but-busy peers suppress the fallback through the shared scan tallies;
+// structural, thermal, memory and cooldown gates still apply on its second pass.
+// Caller holds r.mu and no provider lock. No reservation is committed.
+func (r *Registry) modelCapacityBreakerFallbackLocked(model string) map[string]bool {
+	request := &PendingRequest{Model: model, RequestedMaxTokens: 1}
+	scan := r.scanCandidatesLocked(model, request, false)
+	if len(scan.pool) > 0 || !shouldBypassBreakerFailOpen(nil, scan.breakerRejected, scan.capacityRejections, scan.ttftRejections) {
+		return nil
+	}
+	scan = r.scanCandidatesLocked(model, request, true)
+	if len(scan.pool) == 0 {
+		return nil
+	}
+	providers := make(map[string]bool, len(scan.pool))
+	for _, candidate := range scan.pool {
+		providers[candidate.provider.ID] = true
+	}
+	return providers
 }

--- a/coordinator/registry/model_capacity.go
+++ b/coordinator/registry/model_capacity.go
@@ -28,7 +28,7 @@ type providerCapSnap struct {
 	model                 string
 	warm                  bool
 	running               bool
-	hasHeadroom           bool // pending < maxConcurrency
+	hasHeadroom           bool // public model gates and concurrency both pass
 	effectiveTPS          float64
 	prefillTPS            float64
 	activeRequests        int // numRunning + numWaiting from backend slot, or pendingCount
@@ -108,7 +108,8 @@ func (r *Registry) ModelCapacitySnapshot() []ModelCapacity {
 			// path enforces, so the public capacity feed doesn't advertise a capped
 			// box (e.g. Gemma at 2) as routable up to the flat fallback (24) and lure
 			// upstream routers into sending requests this coordinator immediately 429s.
-			hasHeadroom := r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
+			hasHeadroom := r.providerPassesRoutingGatesLocked(p, m.ID, RequestTraits{}, false, now) &&
+				r.hasConcurrencyHeadroomForModelCapResolvedLocked(p, m.ID)
 			// Count only pending requests for this specific model, not the
 			// total across all models. Using the total inflates
 			// activeRequests for multi-model providers.

--- a/coordinator/registry/model_capacity_gates_test.go
+++ b/coordinator/registry/model_capacity_gates_test.go
@@ -1,0 +1,50 @@
+package registry
+
+import "testing"
+
+func TestModelCapacityDoesNotAdvertiseStructurallyExcludedPairs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		exclude func(*Registry, *Provider)
+	}{
+		{"broken template", func(_ *Registry, p *Provider) {
+			p.mu.Lock()
+			p.Models[0].TemplateRenderOK = boolPtr(false)
+			p.mu.Unlock()
+		}},
+		{"mixed dedicated family", func(r *Registry, p *Provider) {
+			r.SetDedicatedModels([]string{"gemma-4"})
+			addAdvertisedModel(p, qwenBuild)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := New(testLogger())
+			p := makeSchedulerProvider(t, reg, "excluded", gemmaBuild, 100)
+			initial := reg.ModelCapacitySnapshot()
+			if len(initial) != 1 || !initial[0].Ready || initial[0].RoutableProviders != 1 {
+				t.Fatalf("healthy pair must initially be ready: %+v", initial)
+			}
+			tc.exclude(reg, p)
+			request := &PendingRequest{RequestID: "excluded", Model: gemmaBuild, RequestedMaxTokens: 64}
+			if selected, _ := reg.ReserveProviderEx(gemmaBuild, request); selected != nil {
+				t.Fatal("precondition: routing must exclude this provider/model pair")
+			}
+			found := false
+			for _, capacity := range reg.ModelCapacitySnapshot() {
+				if capacity.ModelID != gemmaBuild {
+					continue
+				}
+				found = true
+				if capacity.Ready || capacity.CanAccept || capacity.RoutableProviders != 0 {
+					t.Fatalf("unroutable pair advertised ready: %+v", capacity)
+				}
+				if capacity.WarmProviders != 1 {
+					t.Fatalf("excluded pair lost its resident inventory: %+v", capacity)
+				}
+			}
+			if !found {
+				t.Fatal("excluded pair disappeared from model inventory")
+			}
+		})
+	}
+}

--- a/coordinator/registry/model_capacity_gates_test.go
+++ b/coordinator/registry/model_capacity_gates_test.go
@@ -1,6 +1,10 @@
 package registry
 
-import "testing"
+import (
+	"fmt"
+	"github.com/eigeninference/d-inference/coordinator/attestation"
+	"testing"
+)
 
 func TestModelCapacityDoesNotAdvertiseStructurallyExcludedPairs(t *testing.T) {
 	for _, tc := range []struct {
@@ -46,5 +50,58 @@ func TestModelCapacityDoesNotAdvertiseStructurallyExcludedPairs(t *testing.T) {
 				t.Fatal("excluded pair disappeared from model inventory")
 			}
 		})
+	}
+}
+
+func TestModelCapacityPreservesFleetBreakerFallback(t *testing.T) {
+	for _, health := range []bool{false, true} {
+		for _, peer := range []string{"none", "healthy", "busy", "thermal", "broken template"} {
+			t.Run(fmt.Sprintf("ejection=%v/peer=%s", health, peer), func(t *testing.T) {
+				reg := New(testLogger())
+				model := "capacity-breaker"
+				bad := makeSchedulerProvider(t, reg, "bad", model, 100)
+				if health {
+					bad.AttestationResult = &attestation.VerificationResult{Valid: true, SerialNumber: "CAPACITY-BAD"}
+					for range healthEjectionConsecTrip {
+						reg.RecordProviderServeOutcome("serial:CAPACITY-BAD", false, 500, "boom")
+					}
+					if !reg.HealthEjectionOpen("serial:CAPACITY-BAD") {
+						t.Fatal("ejection did not open")
+					}
+				} else {
+					for range providerBreakerConsecTrip {
+						reg.RecordProviderOutcome(bad.ID, false, 500, "boom")
+					}
+					if !reg.ProviderBreakerOpen(bad.ID) {
+						t.Fatal("breaker did not open")
+					}
+				}
+				if peer != "none" {
+					p := makeSchedulerProvider(t, reg, "peer", model, 50)
+					switch peer {
+					case "busy":
+						p.BackendCapacity.Slots[0].MaxConcurrency = 1
+						p.AddPending(&PendingRequest{RequestID: "busy", Model: model})
+					case "thermal":
+						p.SystemMetrics.ThermalState = "critical"
+					case "broken template":
+						p.Models[0].TemplateRenderOK = boolPtr(false)
+					}
+				}
+				capacity := reg.ModelCapacitySnapshot()
+				request := &PendingRequest{RequestID: "probe", Model: model, RequestedMaxTokens: 1}
+				selected, decision := reg.ReserveProviderEx(model, request)
+				want := 1
+				if peer == "busy" {
+					want = 0
+				}
+				if (selected != nil) != (want > 0) || decision.CandidateCount != want {
+					t.Fatalf("dispatch precondition: selected=%v decision=%+v", selected != nil, decision)
+				}
+				if len(capacity) != 1 || capacity[0].RoutableProviders != want || capacity[0].Ready != (want > 0) {
+					t.Fatalf("capacity disagrees with dispatch cohort: %+v; want %d", capacity, want)
+				}
+			})
+		}
 	}
 }

--- a/coordinator/registry/servability.go
+++ b/coordinator/registry/servability.go
@@ -1,6 +1,9 @@
 package registry
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // Servability prediction.
 //
@@ -395,15 +398,18 @@ func providerBudgetFits(snap *routingSnapshot, reqPromptTokens, reqMaxTokens int
 	if !known {
 		return true, false
 	}
-	prompt := reqPromptTokens
-	if prompt < 0 {
-		prompt = 0
+	return budget >= 0 && servableRequestTokens(reqPromptTokens, reqMaxTokens) <= uint64(budget), true
+}
+
+// servableRequestTokens shares the request-size normalization used by live
+// provider fit and structural fleet prediction. Two nonnegative int values fit
+// in uint64 even when their sum cannot be represented by int, so an enormous
+// request cannot wrap below a known budget or context ceiling.
+func servableRequestTokens(prompt, output int) uint64 {
+	if output <= 0 {
+		output = defaultRequestedMaxTokens
 	}
-	maxTok := reqMaxTokens
-	if maxTok <= 0 {
-		maxTok = defaultRequestedMaxTokens
-	}
-	return int64(prompt)+int64(maxTok) <= budget, true
+	return uint64(max(prompt, 0)) + uint64(output)
 }
 
 // PredictServable reports whether the fleet can structurally serve a request of
@@ -422,34 +428,22 @@ func providerBudgetFits(snap *routingSnapshot, reqPromptTokens, reqMaxTokens int
 // contextPromptTokens == estimatedPromptTokens; a value below the raw estimate is
 // floored to it (calibration only scales up).
 func (r *Registry) PredictServable(model string, estimatedPromptTokens, contextPromptTokens, requestedMaxTokens, contextLimit int, traits RequestTraits, requiresVision bool, allowedSerials ...string) ServabilityVerdict {
-	reqPrompt := estimatedPromptTokens
-	if reqPrompt < 0 {
-		reqPrompt = 0
-	}
-	reqContextPrompt := contextPromptTokens
-	if reqContextPrompt < reqPrompt {
-		reqContextPrompt = reqPrompt
-	}
-	reqMax := requestedMaxTokens
-	if reqMax <= 0 {
-		reqMax = defaultRequestedMaxTokens
-	}
-	budgetRequestTokens := reqPrompt + reqMax
-	contextRequestTokens := reqContextPrompt + reqMax
+	budgetRequestTokens := servableRequestTokens(estimatedPromptTokens, requestedMaxTokens)
+	contextRequestTokens := servableRequestTokens(max(contextPromptTokens, estimatedPromptTokens), requestedMaxTokens)
 
 	verdict := ServabilityVerdict{
 		Servable:      true,
-		RequestTokens: budgetRequestTokens,
+		RequestTokens: int(min(budgetRequestTokens, uint64(math.MaxInt))),
 		ContextLimit:  contextLimit,
 	}
 
 	// Tier 1: context window. Model-level and provider-agnostic. Exceeding the
 	// model's context is a guaranteed failure on every provider. Uses the
 	// (possibly calibrated) context-prompt count.
-	if contextLimit > 0 && contextRequestTokens > contextLimit {
+	if contextLimit > 0 && contextRequestTokens > uint64(contextLimit) {
 		verdict.Servable = false
 		verdict.Reason = ServabilityContextExceeded
-		verdict.RequestTokens = contextRequestTokens
+		verdict.RequestTokens = int(min(contextRequestTokens, uint64(math.MaxInt)))
 		return verdict
 	}
 
@@ -518,7 +512,7 @@ func (r *Registry) PredictServable(model string, estimatedPromptTokens, contextP
 	// all-zero-budget fleet would fail open and dispatch into a guaranteed
 	// provider-side token/KV rejection. Any unknown budget, or zero eligible
 	// providers (a different rejection path owns that), still fails open.
-	if providerCount > 0 && !sawUnknown && int64(budgetRequestTokens) > fleetMax {
+	if providerCount > 0 && !sawUnknown && budgetRequestTokens > uint64(fleetMax) {
 		verdict.Servable = false
 		verdict.Reason = ServabilityPromptTooLong
 		return verdict

--- a/coordinator/registry/servability_overflow_test.go
+++ b/coordinator/registry/servability_overflow_test.go
@@ -1,0 +1,33 @@
+package registry
+
+import (
+	"math"
+	"testing"
+)
+
+func TestServabilityRejectsOverflowingRequestSize(t *testing.T) {
+	reg := New(testLogger())
+	const model = "overflowing-request"
+	makeTokenBudgetProvider(t, reg, "resident", model, 100, 0, 100_000, 80)
+	for _, contextLimit := range []int{0, math.MaxInt} {
+		verdict := reg.PredictServable(model, math.MaxInt, math.MaxInt, 1, contextLimit, RequestTraits{}, false)
+		if verdict.Servable || verdict.RequestTokens != math.MaxInt {
+			t.Errorf("overflowing request context=%d produced %+v", contextLimit, verdict)
+		}
+		want := ServabilityPromptTooLong
+		if contextLimit > 0 {
+			want = ServabilityContextExceeded
+		}
+		if verdict.Reason != want {
+			t.Errorf("context=%d reason=%q, want %q", contextLimit, verdict.Reason, want)
+		}
+	}
+	known := routingSnapshot{modelLoaded: true, activeTokenBudgetMax: math.MaxInt}
+	if fits, reported := providerBudgetFits(&known, math.MaxInt, math.MaxInt); fits || !reported {
+		t.Fatalf("overflowing request fit known budget: fits=%v known=%v", fits, reported)
+	}
+	unknown := routingSnapshot{modelLoaded: true}
+	if fits, reported := providerBudgetFits(&unknown, math.MaxInt, math.MaxInt); !fits || reported {
+		t.Fatalf("missing budget must retain fail-open semantics: fits=%v known=%v", fits, reported)
+	}
+}

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-11 · commit `fd31a0570`
+> Last updated: 2026-09-11 · commit `6716a2cff`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -276,6 +276,15 @@ Useful reuse subtracts a bounded credit; excess restore cost increases
 `ThisReqMs`. Queue, load, decode and admission costs remain intact. The rules
 and their flag are the subject of
 [`cache-aware-routing.md`](cache-aware-routing.md).
+
+Capacity readiness preserves the same fleet-wide health-breaker fallback. If a
+model has an observed breaker/ejection rejection, `modelCapacityBreakerFallbackLocked`
+in `coordinator/registry/model_capacity.go` uses the shared candidate scan and
+`shouldBypassBreakerFailOpen` before admitting last-resort providers. A healthy
+but busy peer suppresses that fallback. The read-only probe represents the
+smallest positive text reservation (one output token, no TTFT ceiling); it does
+not commit a reservation. Structural, thermal, memory and cooldown gates remain
+in force, and inventory totals stay separate from readiness.
 
 ### Selection paths
 

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-08 · commit `0c162cdae`
+> Last updated: 2026-09-11 · commit `fd31a0570`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -313,12 +313,26 @@ still contain the retired `cache_tiebreak` string. The
 runner-up (the lowest-cost candidate other than the winner) is recorded for telemetry
 and as the first alternate in the dispatch plan.
 
+The public capacity snapshot (`coordinator/registry/model_capacity.go`,
+`ModelCapacitySnapshot`) applies the same model routing gates before counting a
+provider as ready, together with the existing concurrency and token headroom
+checks. A broken template, mixed dedicated-family catalog or active routing
+cooldown therefore cannot advertise immediate readiness. Warm/cold inventory
+counts still describe the advertised models independently of readiness.
+
 ### Hedged (speculative) dispatch
 
 A request that has not produced first content by its **speculative point**
 launches a backup and races the two. The mechanics live in
 `coordinator/api/dispatch.go` (`runSpeculative`, `runRace`) with timing in
 `coordinator/api/hedge_schedule.go` and `coordinator/api/first_token_clock.go`.
+
+Capacity probes settle exactly once through `quoteTracker` in
+`coordinator/registry/capacity_quotes.go`. A quote, send failure, disconnect or
+expiry claims the pending entry. Opportunistic expiry sweeps deliver a timeout
+to the owning collector as well as removing the entry; otherwise a collector
+could wait indefinitely for a delivery that no longer has an owner. The
+collector demotes an expired alternate before publishing its timeout outcome.
 
 **Launch offset.** The initial speculative point is
 `deadline × speculativeTimerRatio`, `speculativeTimerRatio = 0.5`
@@ -376,6 +390,12 @@ reasons:
   budget and `estimatedPromptTokens + max_tokens` exceeds the largest
   (`FleetMaxBudget`). If any eligible provider's budget is unknown the
   verdict stays servable.
+
+`servableRequestTokens` shares negative-prompt normalization and the default
+output allowance with the live provider-fit check. It adds the two counts in
+`uint64`, so a request larger than the signed integer range still exceeds known
+context or budget limits. Only the displayed `ServabilityVerdict.RequestTokens`
+is capped to the largest `int`; unknown budgets retain their fail-open policy.
 
 A provider's structural budget (`snapshotStructuralBudget`) is its reported
 `ActiveTokenBudgetMax` when the slot reports one; for a provider that is not


### PR DESCRIPTION
Capacity operations had three discrepancies: expiry cleanup could strand a live quote collector; public readiness could advertise a provider/model pair that routing rejects; and prompt-plus-output arithmetic could overflow below a known token limit. Fix those paths using the existing delivery and routing policies, and share request-size and dedicated-pattern normalization.

Before:
```mermaid
flowchart LR
  S[quoteTracker expiry sweep] --> D[Delete entry without delivery]
  D --> W[Collector waits indefinitely]
  C[ModelCapacitySnapshot] --> H[Concurrency and token headroom]
  H --> R[Broken template or mixed dedicated box can appear ready]
  Q[Prompt and output counts] --> A[Repeated signed addition]
  A --> O[Overflow can pass known limits]
  P[CSV parser and startup setter] --> N[Separate pattern normalization loops]
```

After:
```mermaid
flowchart LR
  S[quoteTracker expiry sweep] --> D[Claim and buffer timeout delivery]
  D --> W[Collector demotes plan, publishes outcome, closes]
  C[ModelCapacitySnapshot] --> G[Existing public model routing gates]
  G --> F[Shared fleet fallback when breakers alone remove all routes]
  F --> H[Same concurrency and token headroom]
  H --> R[Readiness matches gates; model inventory remains]
  Q[Prompt and output counts] --> A[Shared normalized uint64 sum]
  A --> O[Known context and budget checks cannot wrap]
  P[CSV parser and startup setter] --> N[One dedicated-pattern normalizer]
```

The request-size helper preserves negative-prompt normalization and the default output allowance. Two nonnegative `int` counts fit in `uint64`; only the displayed `RequestTokens` field saturates at the largest `int` when the sum is unrepresentable. Unknown budgets retain fail-open behavior. Capacity inventory remains visible while readiness includes the existing public model gates and fleet-wide breaker/ejection fallback. Only affected models run the shared candidate scan with a minimal positive text reservation; healthy-but-busy peers suppress fail-open, and the read-only scan never commits or claims capacity. No wire schema, model reserve, quality-cap default, or pooled-KV numerical policy changes.

All eight assigned capacity/servability production files were inspected. Stable shared/private pool reconstruction, per-class solo-rate resolution, rejection ordering and inline KV-rate storage were retained. The focused normalization removes duplication; the correctness fixes and regression coverage increase the overall diff.

Validation:

- Actual WebSocket/dispatch-plan expiry fixture fails on master because the collector never settles; corrected source emits one timeout after demotion and closes.
- Actual routing versus capacity fixtures fail on master for broken-template and mixed dedicated-family pairs; corrected source keeps their model/warm inventory but reports not ready.
- Oversized request fixture fails on master for context, structural fleet and known provider budgets; corrected source rejects and preserves unknown-budget fallback.
- `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry -count=1`: PASS, 24.679s. Added explicit inventory-preservation assertion then reran its race test: PASS, 1.473s.
- Codex identified the missing fleet-wide health-breaker valve; ten added matrix cases compare capacity with actual dispatch. Four fail on the prior PR head. Corrected full registry race suite PASS24.626s; independent review of the corrected source/new tests is clean.
- Added the required Unreleased changelog entry; docs lint passes for all278 pages.
- All 13 associated test/benchmark files were inspected, including the executable assertions throughout the three large legacy matrices. Historical measurements were retained and benchmarks were not rerun as performance evidence. No model execution.

CI limitation: the Threat Model Review job fails before reviewing source because its Anthropic API key returns HTTP401 (invalid key). Local race validation above is complete; credentials were not changed.
