### PR TITLE
fix(coordinator): preserve newer settlements on stale instant payout failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ coordinator and console changes require their own deployments.
 
 ## Unreleased — stats request-flow refresh
 
+- Preserve newer withdrawal settlements when an older instant-payout failure arrives concurrently; payout ownership is rechecked in the store transition.
+
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.
 
 ## Unreleased — provider console entry

--- a/coordinator/api/stripe_payout_bounce_race_test.go
+++ b/coordinator/api/stripe_payout_bounce_race_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/eigeninference/d-inference/coordinator/billing"
+	"github.com/eigeninference/d-inference/coordinator/payments"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// Return an instant payout snapshot after another delivery has detached it
+// and a later automatic sweep has completed the same withdrawal.
+type replacedPayoutStore struct {
+	*store.MemoryStore
+	t *testing.T
+}
+
+func (s *replacedPayoutStore) GetStripeWithdrawalByPayoutID(id string) (*store.StripeWithdrawal, error) {
+	row, err := s.MemoryStore.GetStripeWithdrawalByPayoutID(id)
+	if err != nil {
+		return row, err
+	}
+	stale := *row
+	row.Status, row.PayoutID = "transferred", ""
+	if err := s.MemoryStore.UpdateStripeWithdrawal(row); err != nil {
+		s.t.Fatal(err)
+	}
+	if applied, err := s.MemoryStore.MarkStripeWithdrawalPaid(row.ID, "", "po_new"); err != nil || !applied {
+		s.t.Fatalf("new sweep completion: applied=%v err=%v", applied, err)
+	}
+	return &stale, nil
+}
+
+func TestConnectWebhookOldInstantBouncePreservesNewSweepCompletion(t *testing.T) {
+	fakeStripe := accountServingStripe("full")
+	defer fakeStripe.Close()
+	srv, mem := stripePayoutsTestServer(t, false, fakeStripe)
+	st := &replacedPayoutStore{MemoryStore: mem, t: t}
+	srv.SetBilling(billing.NewService(st, payments.NewLedger(st), srv.logger, billing.Config{
+		StripeSecretKey: "sk_test_fake", StripeConnectWebhookSecret: "whsec_test",
+		StripeConnectReturnURL: "https://app.test/billing", StripeConnectRefreshURL: "https://app.test/billing",
+		StripeConnectPlatformCountry: "US",
+	}))
+	user := readyUser(t, mem, "acct-sweep-race", "alice@example.com", false)
+	mkWithdrawal(t, mem, store.StripeWithdrawal{
+		ID: "wd-sweep-race", AccountID: user.AccountID, StripeAccountID: user.StripeAccountID,
+		AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000,
+		Method: "instant", Status: "paid", TransferID: "tr_sweep_race", PayoutID: "po_old",
+	})
+	before := mem.GetBalance(user.AccountID)
+	response := deliverConnectWebhook(t, srv, payoutEventPayload("po_old", user.StripeAccountID, "failed", false, time.Now().Unix()))
+	if response.Code != http.StatusOK {
+		t.Fatalf("webhook returned %d: %s", response.Code, response.Body.String())
+	}
+	wd, err := mem.GetStripeWithdrawal("wd-sweep-race")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wd.Status != "paid" || wd.SweepPayoutID != "po_new" || mem.GetBalance(user.AccountID) != before {
+		t.Fatalf("new sweep completion overwritten: status=%s sweep=%q balance=%d want=%d", wd.Status, wd.SweepPayoutID, mem.GetBalance(user.AccountID), before)
+	}
+}

--- a/coordinator/api/stripe_payouts_webhooks.go
+++ b/coordinator/api/stripe_payouts_webhooks.go
@@ -172,8 +172,10 @@ func (s *Server) handlePayoutTerminal(event *billing.WebhookEvent, connectedAcct
 	// This applies to "paid" rows too: Stripe documents payout.failed arriving
 	// AFTER payout.paid for the same payout when the bank later bounces it.
 	// Because this row was looked up BY the event's payout ID, the failure is
-	// provably about the row's own in-flight payout — not a stale one — so we
-	// reopen the row for the sweep to retry. Stale failures from an older
+	// about the observed in-flight payout. The store rechecks that ownership
+	// before applying the transition: a concurrent failure may detach it and a
+	// newer sweep may complete the row after this lookup. For a match, we
+	// reopen the row for the sweep to retry. Later failures from an older
 	// payout can never reach this path: processing a failure detaches the
 	// payout ID from the row (below), so a redelivered or out-of-order event
 	// for that payout misses the lookup and falls into
@@ -221,14 +223,14 @@ func (s *Server) handlePayoutTerminal(event *billing.WebhookEvent, connectedAcct
 	// overwrite the refund back to a sweep-eligible state.
 	reason := "payout_failed " + pe.FailureCode + ": " + pe.FailureReason +
 		" (payout " + pe.ID + "; auto-payout will retry)"
-	applied, err := s.billing.Store().ReopenStripeWithdrawalAfterPayoutFailure(wd.ID, reason, wd.FeeRefunded)
+	applied, err := s.billing.Store().ReopenStripeWithdrawalAfterPayoutFailure(wd.ID, pe.ID, reason, wd.FeeRefunded)
 	if err != nil {
 		s.logger.Error("stripe connect webhook: persist payout failure failed",
 			"error", err, "withdrawal_id", wd.ID)
 		return err
 	}
 	if !applied {
-		s.logger.Warn("stripe connect webhook: payout failure not applied — row terminalized concurrently (reversal wins)",
+		s.logger.Warn("stripe connect webhook: payout failure not applied — row terminalized or payout ownership changed concurrently",
 			"withdrawal_id", wd.ID, "payout_id", pe.ID)
 		return nil
 	}

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -388,10 +388,12 @@ type BillingStore interface {
 	// ReopenStripeWithdrawalAfterPayoutFailure atomically reopens a
 	// withdrawal whose own payout failed: status back to "transferred",
 	// payout ID detached, failure reason recorded, FeeRefunded OR-ed in —
-	// but only while the row is not refunded and not terminally failed
+	// but only while its payout ID equals the non-empty expectedPayoutID,
+	// the row is not refunded and not terminally failed
 	// (a concurrent transfer.reversed wins; its refund must never be
-	// overwritten back to sweep-eligible). Returns whether it was applied.
-	ReopenStripeWithdrawalAfterPayoutFailure(id, failureReason string, feeRefunded bool) (bool, error)
+	// overwritten back to sweep-eligible). A stale failure cannot detach a
+	// newer payout or reopen a later sweep settlement. Returns whether applied.
+	ReopenStripeWithdrawalAfterPayoutFailure(id, expectedPayoutID, failureReason string, feeRefunded bool) (bool, error)
 
 	// ListStripeWithdrawalsBySweepPayoutID returns the withdrawals a given
 	// automatic sweep payout claimed (SweepPayoutID stamp). Used to reopen

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2441,9 +2441,9 @@ func (s *MemoryStore) MarkStripeWithdrawalPaid(id, expectedPayoutID, sweepPayout
 
 // ReopenStripeWithdrawalAfterPayoutFailure atomically reopens a bounced
 // withdrawal for sweep retry under the store lock (see interface doc).
-func (s *MemoryStore) ReopenStripeWithdrawalAfterPayoutFailure(id, failureReason string, feeRefunded bool) (bool, error) {
-	if id == "" {
-		return false, errors.New("stripe withdrawal id is required")
+func (s *MemoryStore) ReopenStripeWithdrawalAfterPayoutFailure(id, expectedPayoutID, failureReason string, feeRefunded bool) (bool, error) {
+	if id == "" || expectedPayoutID == "" {
+		return false, errors.New("stripe withdrawal id and expected payout id are required")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2451,8 +2451,8 @@ func (s *MemoryStore) ReopenStripeWithdrawalAfterPayoutFailure(id, failureReason
 	if !ok {
 		return false, fmt.Errorf("stripe withdrawal %q: %w", id, ErrNotFound)
 	}
-	if w.Refunded || w.Status == "failed" {
-		return false, nil // a concurrent reversal terminalized it — never reopen
+	if w.Refunded || w.Status == "failed" || w.PayoutID != expectedPayoutID {
+		return false, nil // reversal or a different payout owns the current state
 	}
 	if w.PayoutID != "" {
 		delete(s.stripeWithdrawalsByPayoutID, w.PayoutID)

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -3451,9 +3451,9 @@ func (s *PostgresStore) MarkStripeWithdrawalPaid(id, expectedPayoutID, sweepPayo
 
 // ReopenStripeWithdrawalAfterPayoutFailure atomically reopens a bounced
 // withdrawal for sweep retry with an in-database guard (see interface doc).
-func (s *PostgresStore) ReopenStripeWithdrawalAfterPayoutFailure(id, failureReason string, feeRefunded bool) (bool, error) {
-	if id == "" {
-		return false, errors.New("stripe withdrawal id is required")
+func (s *PostgresStore) ReopenStripeWithdrawalAfterPayoutFailure(id, expectedPayoutID, failureReason string, feeRefunded bool) (bool, error) {
+	if id == "" || expectedPayoutID == "" {
+		return false, errors.New("stripe withdrawal id and expected payout id are required")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -3467,8 +3467,9 @@ func (s *PostgresStore) ReopenStripeWithdrawalAfterPayoutFailure(id, failureReas
 		     updated_at = NOW()
 		 WHERE id = $1
 		   AND refunded = FALSE
-		   AND status <> 'failed'`,
-		id, failureReason, feeRefunded,
+		   AND status <> 'failed'
+		   AND payout_id = $4`,
+		id, failureReason, feeRefunded, expectedPayoutID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("store: reopen stripe withdrawal: %w", err)

--- a/coordinator/store/stripe_payout_failure_test.go
+++ b/coordinator/store/stripe_payout_failure_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripePayoutFailureChecksCurrentOwnership(t *testing.T) {
+	for backend, s := range storeBackends(t) {
+		t.Run(backend, func(t *testing.T) {
+			if err := s.CreateUser(&User{AccountID: "acct-sweep-guard", PrivyUserID: "did:privy:sweep-guard"}); err != nil {
+				t.Fatal(err)
+			}
+			for _, tc := range []struct {
+				id, status, payout string
+				refunded, applied  bool
+			}{
+				{"matching", "paid", "matching", false, true},
+				{"pending", "pending", "matching", false, true},
+				{"transferred", "transferred", "matching", false, true},
+				{"new-sweep", "paid", "different", false, false},
+				{"reopened", "transferred", "", false, false},
+				{"refunded", "paid", "matching", true, false},
+				{"failed", "failed", "matching", false, false},
+			} {
+				t.Run(tc.id, func(t *testing.T) {
+					wd := &StripeWithdrawal{ID: tc.id, AccountID: "acct-sweep-guard", StripeAccountID: "acct_stripe_guard",
+						AmountMicroUSD: 5_000_000, NetMicroUSD: 4_500_000, FeeMicroUSD: 500_000,
+						Method: "instant", Status: tc.status, TransferID: "tr_" + tc.id,
+						PayoutID: tc.payout, Refunded: tc.refunded, FeeRefunded: false}
+					if wd.PayoutID != "" {
+						wd.PayoutID += "_" + tc.id
+					}
+					if tc.id == "reopened" {
+						wd.Status = "paid"
+						wd.SweepPayoutID = "po_new_sweep"
+					}
+					if err := s.CreateStripeWithdrawal(wd); err != nil {
+						t.Fatal(err)
+					}
+					before, err := s.GetStripeWithdrawal(wd.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					applied, err := s.ReopenStripeWithdrawalAfterPayoutFailure(wd.ID, "matching_"+tc.id, "payout bounced", true)
+					if err != nil || applied != tc.applied {
+						t.Fatalf("applied=%v want=%v err=%v", applied, tc.applied, err)
+					}
+					got, err := s.GetStripeWithdrawal(wd.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if applied {
+						before.Status, before.PayoutID, before.FailureReason = "transferred", "", "payout bounced"
+						before.FeeRefunded = true
+						if got.UpdatedAt.Before(before.UpdatedAt) {
+							t.Fatal("updated timestamp moved backwards")
+						}
+						before.UpdatedAt = got.UpdatedAt
+					}
+					if !reflect.DeepEqual(before, got) {
+						t.Fatalf("unexpected state change: expected=%+v actual=%+v", before, got)
+					}
+					if applied, err := s.ReopenStripeWithdrawalAfterPayoutFailure(wd.ID, "matching_"+tc.id, "redelivery", true); err != nil || applied {
+						t.Fatalf("duplicate/stale delivery applied=%v err=%v", applied, err)
+					}
+					if s.GetBalance(wd.AccountID) != 0 {
+						t.Fatal("sweep bounce moved ledger balance")
+					}
+				})
+			}
+			for _, ids := range [][2]string{{"", "matching"}, {"matching", ""}} {
+				if applied, err := s.ReopenStripeWithdrawalAfterPayoutFailure(ids[0], ids[1], "bounce", true); err == nil || applied {
+					t.Fatalf("invalid ids accepted: %v applied=%v err=%v", ids, applied, err)
+				}
+			}
+		})
+	}
+}

--- a/coordinator/store/stripe_withdrawals_memory_test.go
+++ b/coordinator/store/stripe_withdrawals_memory_test.go
@@ -219,7 +219,7 @@ func TestMemoryReopenStripeWithdrawalAfterPayoutFailureGuards(t *testing.T) {
 	}
 
 	mk("wd-ro-ok", "paid", "po_ro1", false)
-	applied, err := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-ok", "payout_failed: bounce", true)
+	applied, err := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-ok", "po_ro1", "payout_failed: bounce", true)
 	if err != nil || !applied {
 		t.Fatalf("live row: applied=%v err=%v, want applied", applied, err)
 	}
@@ -233,11 +233,11 @@ func TestMemoryReopenStripeWithdrawalAfterPayoutFailureGuards(t *testing.T) {
 	}
 
 	mk("wd-ro-refunded", "transferred", "po_ro2", true)
-	if applied, _ := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-refunded", "x", false); applied {
+	if applied, _ := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-refunded", "po_ro2", "x", false); applied {
 		t.Error("refunded row must not reopen (reversal owns it)")
 	}
 	mk("wd-ro-failed", "failed", "", false)
-	if applied, _ := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-failed", "x", false); applied {
+	if applied, _ := s.ReopenStripeWithdrawalAfterPayoutFailure("wd-ro-failed", "po_ro3", "x", false); applied {
 		t.Error("failed row must not reopen")
 	}
 }

--- a/docs/architecture/billing.md
+++ b/docs/architecture/billing.md
@@ -1,6 +1,6 @@
 # Billing: pricing, reservations, ledger, and payouts
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-11 · commit `72a6210b7`
 
 Darkbloom is prepaid. A consumer account holds an integer micro-USD balance;
 the coordinator reserves the worst-case cost of a request before dispatch,
@@ -348,7 +348,9 @@ the design record is [`design/base-rewards.md`](../design/base-rewards.md).
     (`coordinator/api/stripe_withdraw.go` `creditRefundOnceWithRetry`;
     `coordinator/api/stripe_payouts_webhooks.go` `handlePayoutTerminal`,
     `handleTransferFailed`; `coordinator/store/postgres.go`
-    `CreditWithdrawableOnce`).
+    `CreditWithdrawableOnce`). Matched payout-failure transitions also
+    recheck the event payout ID inside the store update; a detached payout
+    cannot reopen a newer settlement (`ReopenStripeWithdrawalAfterPayoutFailure`).
 11. **A capped key never debits.** `checkKeySpendCap` runs before the `Debit`
     in `reserveInferenceBalance`, `topUpReservationForInlinedMedia`, and
     `reserveAdditionalForProvider`, so a rejected request leaves no ledger
@@ -436,7 +438,7 @@ help (`coordinator/api/stripe_payouts_webhooks.go`).
 |---|---|
 | `account.updated` | `handleAccountUpdated` mirrors Stripe's view into `users.stripe_*` (`stripeStatusForAccount`: `pending`, `ready`, `restricted`, or `rejected`). Best-effort; the status endpoint re-syncs on page load. |
 | `payout.paid` | `handlePayoutTerminal(success=true)`: matched by payout id → `MarkStripeWithdrawalPaid` (no-op on an already `paid` row; a refunded/terminal row is logged for manual review, never overwritten). Unmatched → `reconcileUnmatchedPayout`: only automatic sweep payouts reconcile; they mark every `transferred` row of that connected account whose funds had become available (`stripeRecipientTransferDelay = 24 * time.Hour` for `recipient` accounts, immediate for `full`) and that has no in-flight payout of its own as `paid`. Amounts are ignored (FX-converted). |
-| `payout.failed`, `payout.canceled` | `handlePayoutTerminal(success=false)`: refund the instant fee via `CreditWithdrawableOnce(stripe_withdraw_fee:<id>)`, detach the payout id, reopen the row as `transferred` so the sweep retries. A refunded+paid row is logged for manual review. |
+| `payout.failed`, `payout.canceled` | `handlePayoutTerminal(success=false)`: refund the instant fee via `CreditWithdrawableOnce(stripe_withdraw_fee:<id>)`, detach the payout id and reopen the row as `transferred` only while `ReopenStripeWithdrawalAfterPayoutFailure` still matches the event's non-empty payout ID and the row is neither refunded nor failed. A stale lookup cannot reopen a later sweep settlement. A refunded+paid row is logged for manual review. |
 | `transfer.reversed` | `handleTransferFailed`: refund the net principal (`stripe_withdraw:<id>`) and the fee (`stripe_withdraw_fee:<id>`) once each via `CreditWithdrawableOnce`, mark the row `failed`. |
 | anything else | acknowledged, ignored |
 

--- a/docs/consumer/billing.md
+++ b/docs/consumer/billing.md
@@ -1,6 +1,6 @@
 # Billing: fund an account and keep spend under control
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `72a6210b7`
 
 How to add credit, read your balance and usage, cap what a key can spend,
 redeem an invite code, and act on a `402`. Why the coordinator behaves this
@@ -221,6 +221,7 @@ Choose **Unlink Stripe account and start over** to remove the destination curren
 | `401` `auth_error` on `POST /v1/keys`, `/v1/referral/register`, `/v1/referral/apply` | Called with an API key | Use the Privy access token |
 | `429` on `create-session`, key mutations, referral or invite calls | The [financial rate limiter](../reference/pricing-model.md#constants) | Back off for `Retry-After` |
 | Balance dropped by more than the response should cost, then recovered | Reservation debited at admission, refund at settlement | Expected; read balance after the response completes |
+| Instant payout fails after reporting paid | Funds return to the connected account for the daily sweep; stale failure events preserve any newer settlement | Monitor the existing withdrawal; see [instant payout recovery](../reference/pricing-model.md#instant-payout-failure-recovery) |
 | `503` `billing_error` | Stripe or the referral service is not configured on this coordinator | Operator issue |
 
 Mechanism for each error, including the exact functions, is in

--- a/docs/reference/pricing-model.md
+++ b/docs/reference/pricing-model.md
@@ -1,6 +1,6 @@
 # Pricing model reference
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `72a6210b7`
 
 Constants, formulas, enums, routes, and environment variables of the
 coordinator's money path, each row cited to the code that defines it. How the
@@ -87,6 +87,12 @@ updated_at)`, primary key `(account_id, model)`
 | Withdrawal fee | `0` (standard); `max(gross × InstantFeeBps / 10_000, InstantFeeMinMicroUSD)` (instant) | `coordinator/billing/stripe_connect.go` (`FeeForMethodMicroUSD`) |
 | Withdrawal net | `gross − fee`, transferred as `microUSDToCents(net)`; must be ≥ 1 cent | `coordinator/api/stripe_withdraw.go` (`handleStripeWithdraw`) |
 | Key spend | `Σ usage.cost_micro_usd` for the key since `KeySpendWindowStart(limit_reset, now)`; request rejected when `spend + additional > LimitMicroUSD` | `coordinator/store/postgres.go` (`KeySpendSince`); `coordinator/api/apikey_handlers.go` (`checkKeySpendCap`) |
+
+## Instant payout failure recovery
+
+| Event | Result | Code |
+|---|---|---|
+| Matched instant payout fails or is canceled | The fee refund remains reference-idempotent. Reopening for the daily sweep requires the current, non-empty payout ID to still match the event and the row to remain unrefunded and not failed; a newer settlement is preserved. | `coordinator/api/stripe_payouts_webhooks.go` (`handlePayoutTerminal`); `coordinator/store/postgres.go` (`ReopenStripeWithdrawalAfterPayoutFailure`) |
 
 ## Ledger entry types
 


### PR DESCRIPTION
A delayed instant-payout failure can read its withdrawal before another delivery detaches the payout. If a later automatic sweep settles the row before the first handler resumes, the old failure currently reopens that newer paid settlement.

The existing `ReopenStripeWithdrawalAfterPayoutFailure` transition now requires the event's non-empty payout ID to still match inside the memory lock or PostgreSQL conditional update. Refunded/failed guards, matching paid-bounce recovery, fee-flag OR behavior, ledger reference handling and webhook redelivery behavior stay intact.

```mermaid
flowchart LR
  subgraph Before
    A[Old instant failure] --> B[GetStripeWithdrawalByPayoutID snapshot]
    B --> C[Concurrent detach then newer sweep marks paid]
    C --> D[Reopen checks only refunded and failed]
    D --> E[New paid settlement becomes transferred]
  end
  subgraph After
    F[Old instant failure] --> G[GetStripeWithdrawalByPayoutID snapshot]
    G --> H[Concurrent detach then newer sweep marks paid]
    H --> I[Reopen checks expected payout ID atomically]
    I -->|Ownership changed| J[Preserve newer settlement]
    I -->|Still matches and eligible| K[Detach failed payout and reopen for daily sweep]
  end
```

Validation:
- The deterministic HTTP webhook regression failed before the fix: the newer sweep's paid row became transferred. It passes after the change.
- Focused payout/sweep/transfer webhook race tests pass (1.786s).
- Full store race tests pass against an isolated PostgreSQL16 instance and memory backend (22.534s); the instance is stopped. New shared fixtures compare the complete row, test matching pending/transferred/paid rows, stale payout/sweep ownership, refunded/failed guards, empty IDs and duplicate delivery.
- Three existing direct store tests now supply the expected payout ID; their original assertions are retained.
- Docs lint passes (278 pages). Full coordinator Go suite passes.

This fixes ownership of the matched payout-failure transition. Transfer/payout-creation updates remain a separate lifecycle review; this PR does not claim that every withdrawal operation is concurrency-proven.
