### PR TITLE
Reject non-finite routing settings and bound prompt calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - **Coordinator capacity and admission** — Model readiness honors public routing gates while retaining inventory and the fleet-wide health-breaker fallback. Expired capacity probes settle as timeouts; oversized prompt/output sums are rejected without integer wrapping.
-||||||| parent of 00d1ffad2 (Record finite coordinator configuration handling)
 - **Coordinator settings** — Reject non-finite warm-pool and quality-admission values before serving. Ignore non-finite prompt-calibration overrides and bound oversized calibrated estimates before integer conversion.
 
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - **Coordinator capacity and admission** — Model readiness honors public routing gates while retaining inventory and the fleet-wide health-breaker fallback. Expired capacity probes settle as timeouts; oversized prompt/output sums are rejected without integer wrapping.
+||||||| parent of 00d1ffad2 (Record finite coordinator configuration handling)
+- **Coordinator settings** — Reject non-finite warm-pool and quality-admission values before serving. Ignore non-finite prompt-calibration overrides and bound oversized calibrated estimates before integer conversion.
 
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 

--- a/coordinator/api/prompt_calibration.go
+++ b/coordinator/api/prompt_calibration.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -53,14 +54,20 @@ func calibratedContextPromptTokens(model string, est int) int {
 	if mult <= 1.0 {
 		return est
 	}
-	return int(float64(est) * mult)
+	// Bound before converting: an out-of-range float-to-int result is
+	// architecture-dependent and must never reduce a context estimate.
+	scaled := float64(est) * mult
+	if scaled >= float64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(scaled)
 }
 
 // SetPromptContextCalibrationFromEnv parses an override of the form
 // "family:factor,family:factor" (e.g. "gpt-oss:1.3,gemma:1.15") and REPLACES the
-// calibration map when at least one valid pair is present. Invalid pairs and
-// factors < 1.0 are skipped (a factor below 1 would under-reject, the wrong
-// direction). A blank string is a no-op (keeps the built-in default). Returns the
+// calibration map when at least one valid pair is present. Invalid pairs,
+// non-finite factors, and factors < 1.0 are skipped (a factor below 1 would
+// under-reject, the wrong direction). A blank string keeps the current map. Returns the
 // number of pairs applied. Called once at startup from main.go.
 func SetPromptContextCalibrationFromEnv(raw string) int {
 	raw = strings.TrimSpace(raw)
@@ -75,7 +82,7 @@ func SetPromptContextCalibrationFromEnv(raw string) int {
 		}
 		fam := strings.TrimSpace(kv[0])
 		factor, err := strconv.ParseFloat(strings.TrimSpace(kv[1]), 64)
-		if fam == "" || err != nil || factor < 1.0 {
+		if fam == "" || err != nil || math.IsNaN(factor) || math.IsInf(factor, 0) || factor < 1.0 {
 			continue
 		}
 		next[fam] = factor

--- a/coordinator/api/prompt_calibration_test.go
+++ b/coordinator/api/prompt_calibration_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"log/slog"
 	"math"
 	"testing"
 )
@@ -80,4 +82,12 @@ func TestSetPromptContextCalibrationFromEnv(t *testing.T) {
 	if got := calibratedContextPromptTokens("gpt-oss-20b", 100); got != math.MaxInt {
 		t.Errorf("overflowed finite product = %d, want saturated %d", got, math.MaxInt)
 	}
+	reg := registry.New(slog.Default())
+	verdict := reg.PredictServable("gpt-oss-20b", 100,
+		calibratedContextPromptTokens("gpt-oss-20b", 100),
+		1, 1000, registry.RequestTraits{}, false)
+	if verdict.Servable || verdict.Reason != registry.ServabilityContextExceeded {
+		t.Fatalf("saturated calibration bypassed the context gate: %+v", verdict)
+	}
+
 }

--- a/coordinator/api/prompt_calibration_test.go
+++ b/coordinator/api/prompt_calibration_test.go
@@ -1,6 +1,9 @@
 package api
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestCalibratedContextPromptTokens(t *testing.T) {
 	cases := []struct {
@@ -14,6 +17,7 @@ func TestCalibratedContextPromptTokens(t *testing.T) {
 		{"non_matching_family_unchanged", "gemma-4-26b-qat-4bit", 100000, 100000},
 		{"zero_unchanged", "gpt-oss-20b", 0, 0},
 		{"negative_unchanged", "gpt-oss-20b", -5, -5},
+		{"oversized_estimate_saturates", "gpt-oss-20b", math.MaxInt, math.MaxInt},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,8 +57,27 @@ func TestSetPromptContextCalibrationFromEnv(t *testing.T) {
 		// 0.5 < 1.0 is rejected (would under-reject), the others are malformed.
 		t.Errorf("all-invalid applied = %d, want 0", n)
 	}
+	for _, raw := range []string{"gpt-oss:NaN", "gpt-oss:+Inf", "gpt-oss:-Inf"} {
+		if n := SetPromptContextCalibrationFromEnv(raw); n != 0 {
+			t.Errorf("non-finite override %q applied %d pairs", raw, n)
+		}
+	}
+
 	// The last valid override (1.5) must still be in effect after the no-ops.
 	if got := calibratedContextPromptTokens("gpt-oss-20b", 100000); got != 150000 {
 		t.Errorf("after no-op overrides, gpt-oss = %d, want 150000 (unchanged)", got)
+	}
+
+	if n := SetPromptContextCalibrationFromEnv("gpt-oss:NaN,gemma:+Inf,qwen:1.5"); n != 1 {
+		t.Errorf("mixed override applied %d pairs, want only the finite pair", n)
+	}
+	if got := calibratedContextPromptTokens("qwen-3.5", 100); got != 150 {
+		t.Errorf("finite mixed override = %d, want 150", got)
+	}
+	if n := SetPromptContextCalibrationFromEnv("gpt-oss:1.7976931348623157e308"); n != 1 {
+		t.Fatalf("large finite multiplier rejected: %d", n)
+	}
+	if got := calibratedContextPromptTokens("gpt-oss-20b", 100); got != math.MaxInt {
+		t.Errorf("overflowed finite product = %d, want saturated %d", got, math.MaxInt)
 	}
 }

--- a/coordinator/registry/config.go
+++ b/coordinator/registry/config.go
@@ -281,8 +281,8 @@ func (c CacheRoutingConfig) Check() error {
 }
 
 func (c QualityCapConfig) Check() error {
-	if c.Overcommit < 0 {
-		return fmt.Errorf("registry: quality concurrency overcommit must be >= 0")
+	if math.IsNaN(c.Overcommit) || math.IsInf(c.Overcommit, 0) || c.Overcommit < 0 {
+		return fmt.Errorf("registry: quality concurrency overcommit must be finite and >= 0")
 	}
 	return nil
 }
@@ -319,6 +319,12 @@ func envModelIntMap(key string) map[string]int {
 }
 
 func (c WarmPoolConfig) Check() error {
+	// The decode floor also feeds admission when the warm controller is disabled.
+	for _, value := range []float64{c.WarmSaturationThreshold, c.DecodeFloorTPS, c.RampGapFraction, c.HeadroomLoadWindows} {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return fmt.Errorf("registry: warm pool target tunables must be finite")
+		}
+	}
 	if !c.Enabled && c.Interval == 0 {
 		return nil
 	}

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -233,3 +233,45 @@ func TestConfigureCacheRoutingRejectsExplicitZeroPercent(t *testing.T) {
 		t.Fatal("ConfigureCacheRouting rewrote explicit zero percent instead of rejecting it")
 	}
 }
+
+func TestRegistryConfigRejectsNonFiniteTargetTunables(t *testing.T) {
+	keys := []string{
+		"QUALITY_CONCURRENCY_OVERCOMMIT",
+		"WARM_POOL_WARM_SATURATION_THRESHOLD",
+		"WARM_POOL_DECODE_FLOOR_TPS",
+		"WARM_POOL_RAMP_GAP_FRACTION",
+		"WARM_POOL_HEADROOM_LOAD_WINDOWS",
+	}
+	for _, key := range keys {
+		t.Setenv(env.EnvPrefix+"_"+key, "")
+	}
+	clearWarmPoolEnv(t)
+	if err := ReadConfig().Check(); err != nil {
+		t.Fatalf("defaults rejected: %v", err)
+	}
+	for _, key := range keys {
+		for _, value := range []string{"NaN", "+Inf", "-Inf"} {
+			t.Run(key+"/"+value, func(t *testing.T) {
+				t.Setenv(env.EnvPrefix+"_"+key, value)
+				if err := ReadConfig().Check(); err == nil {
+					t.Fatalf("startup accepted %s=%s", key, value)
+				}
+			})
+		}
+	}
+	// The decode floor also configures admission when the controller is off.
+	if err := (WarmPoolConfig{DecodeFloorTPS: math.NaN()}).Check(); err == nil {
+		t.Fatal("disabled zero-interval controller accepted a non-finite decode floor")
+	}
+	if err := (WarmPoolConfig{}).Check(); err != nil {
+		t.Fatalf("disabled zero-value config rejected: %v", err)
+	}
+	for _, key := range keys {
+		t.Run(key+"/zero", func(t *testing.T) {
+			t.Setenv(env.EnvPrefix+"_"+key, "0")
+			if err := ReadConfig().Check(); err != nil {
+				t.Fatalf("valid zero setting rejected: %v", err)
+			}
+		})
+	}
+}

--- a/coordinator/registry/config_test.go
+++ b/coordinator/registry/config_test.go
@@ -275,3 +275,23 @@ func TestRegistryConfigRejectsNonFiniteTargetTunables(t *testing.T) {
 		})
 	}
 }
+
+func TestDisabledZeroIntervalWarmPoolPreservesFiniteRangeBypass(t *testing.T) {
+	clearWarmPoolEnv(t)
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_ENABLED", "false")
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_INTERVAL", "0s")
+	t.Setenv(env.EnvPrefix+"_WARM_POOL_DECODE_FLOOR_TPS", "-1")
+	cfg := ReadConfig()
+	if err := cfg.Check(); err != nil {
+		t.Fatalf("existing disabled-controller finite range bypass rejected: %v", err)
+	}
+	if cfg.WarmPool.DecodeFloorTPS != -1 {
+		t.Fatalf("decode floor silently normalized: %v", cfg.WarmPool.DecodeFloorTPS)
+	}
+	for _, value := range []string{"NaN", "+Inf", "-Inf"} {
+		t.Setenv(env.EnvPrefix+"_WARM_POOL_DECODE_FLOOR_TPS", value)
+		if err := ReadConfig().Check(); err == nil {
+			t.Fatalf("disabled-controller bypass accepted non-finite floor %s", value)
+		}
+	}
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `9f8ad60d4`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -113,7 +113,7 @@ Trust floor, model routing and per-request quality:
 | `EIGENINFERENCE_LONG_PROMPT_TOKENS` | integer > 0 | unset (preference off) | `coordinator/cmd/coordinator/main.go` (`SetLongPromptThreshold`) | Prompts above this size prefer the fastest provider tier. |
 | `EIGENINFERENCE_LONG_PROMPT_PREFILL_WEIGHT` | float (values below 1 clamp to neutral) | `2.0` | `coordinator/cmd/coordinator/main.go` (`SetLongPromptPrefillWeight`) | Prefill weight applied to long prompts; read only when the threshold is set. |
 | `EIGENINFERENCE_PREFILL_DECODE_RATIO` | float > 0 | `12.0` | `coordinator/cmd/coordinator/main.go`; `coordinator/registry/scheduler.go` (`SetPrefillToDecodeRatio`) | Prefill-to-decode speed ratio in the TTFT estimate. |
-| `EIGENINFERENCE_PROMPT_CALIBRATION` | `family:factor,…` (factors ≥ 1.0) | built-in table (`gpt-oss:1.3`) | `coordinator/api/prompt_calibration.go` (`SetPromptContextCalibrationFromEnv`) | Replaces the per-family prompt-token calibration used by the context gate. |
+| `EIGENINFERENCE_PROMPT_CALIBRATION` | `family:factor,…` (finite factors ≥ 1.0) | built-in table (`gpt-oss:1.3`) | `coordinator/api/prompt_calibration.go` (`SetPromptContextCalibrationFromEnv`) | Replaces the per-family prompt-token calibration used by the context gate when at least one valid pair exists; invalid pairs are skipped. Scaled estimates saturate at the maximum integer before conversion. |
 | `EIGENINFERENCE_MODEL_FIRST_CONTENT_BASES` | `model=upstream_ms,…` (`0`/`off` removes) | built-in table | `coordinator/modelpolicy/first_content_deadline.go` (`SetFirstContentBasesFromEnv`) | Overrides exact-model first-content deadline bases. |
 | `EIGENINFERENCE_HEALTH_EJECTION` | `off`/`0`/`false`/`no` disables | on | `coordinator/registry/health_ejection_switch.go` (`healthEjectionSwitch`, parsed once at package init); `coordinator/registry/health_ejection.go` (`healthEjectionEnabled`) | Kill switch for provider health ejection; see [`../architecture/routing.md`](../architecture/routing.md). |
 | `EIGENINFERENCE_DISABLE_CLIENT_ERROR_STOP` | bool | `false` | `coordinator/cmd/coordinator/main.go` (`SetDisableClientErrorStop`) | Lets deterministic provider 4xx errors fail over instead of stopping the dispatch ladder. |
@@ -163,7 +163,7 @@ Quality concurrency cap:
 | Variable | Values / type | Default | Read in | Effect |
 |---|---|---|---|---|
 | `EIGENINFERENCE_QUALITY_CONCURRENCY_CAP` | bool | `true` | `coordinator/registry/config.go` (`ReadConfig`) | Per-provider admission cap derived from each model's quality concurrency instead of the flat cap. |
-| `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT` | float ≥ 0 | `1.2` (`defaultQualityCapOvercommit`; the `2.0` fallback in `ReadConfig` is replaced when the variable is unset) | `coordinator/registry/config.go` (`ReadConfig`); `coordinator/registry/concurrency_cap.go` (`SetQualityConcurrencyCap`) | Multiplier on the strict decode-floor batch. |
+| `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT` | finite float ≥ 0 | `1.2` (`defaultQualityCapOvercommit`; the `2.0` fallback in `ReadConfig` is replaced when the variable is unset) | `coordinator/registry/config.go` (`ReadConfig`); `coordinator/registry/concurrency_cap.go` (`SetQualityConcurrencyCap`) | Multiplier on the strict decode-floor batch. |
 | `EIGENINFERENCE_QUALITY_CONCURRENCY_OVERCOMMIT_BY_MODEL` | `model=factor,…` | unset | `coordinator/registry/concurrency_cap.go` (`SetQualityConcurrencyCap`) | Per-model overcommit overrides. |
 | `EIGENINFERENCE_QUALITY_CAP_PER_MODEL_TPS` | bool | `true` | `coordinator/registry/concurrency_cap.go` | Use per-model solo decode rates (not the provider-level rate) for the cap. |
 | `EIGENINFERENCE_QUALITY_CAP_SOLO_MIN_SAMPLES` | integer | `5` | `coordinator/registry/concurrency_cap.go` | Solo samples required before a per-model median is trusted. |
@@ -183,13 +183,14 @@ they tune is explained in
 | `EIGENINFERENCE_WARM_POOL_MIN_DWELL` | Go duration | `5m` | `coordinator/registry/config.go` | Minimum time a model stays warm before it may be unloaded. |
 | `EIGENINFERENCE_WARM_POOL_QUEUE_AGE_THRESHOLD` | Go duration | `0` | `coordinator/registry/config.go` | Queue age that counts as pressure. |
 | `EIGENINFERENCE_WARM_POOL_CAPACITY_REJECT_THRESHOLD` | integer ≥ 1 | `1` | `coordinator/registry/config.go` | Capacity rejects per tick that count as pressure. |
-| `EIGENINFERENCE_WARM_POOL_WARM_SATURATION_THRESHOLD` | float 0–1 | `0.8` | `coordinator/registry/config.go` | Warm-slot utilisation that counts as pressure. |
+| `EIGENINFERENCE_WARM_POOL_WARM_SATURATION_THRESHOLD` | finite float 0–1 | `0.8` | `coordinator/registry/config.go` | Warm-slot utilisation that counts as pressure. |
 | `EIGENINFERENCE_WARM_POOL_TTFT_MISS_THRESHOLD` | integer ≥ 1 | `1` | `coordinator/registry/config.go` | TTFT misses per tick that count as pressure. |
 | `EIGENINFERENCE_WARM_POOL_SPECULATIVE_START_THRESHOLD` | integer ≥ 1 | `2` | `coordinator/registry/config.go` | Speculative dispatch starts per tick that count as pressure. |
 | `EIGENINFERENCE_WARM_POOL_SPECULATIVE_WIN_THRESHOLD` | integer ≥ 1 | `1` | `coordinator/registry/config.go` | Speculative wins per tick that count as pressure. |
 | `EIGENINFERENCE_WARM_POOL_COLD_DISPATCH_THRESHOLD` | integer ≥ 1 | `1` | `coordinator/registry/config.go` | Cold dispatches per tick that count as pressure. |
 | `EIGENINFERENCE_WARM_POOL_LOAD_DURATION_THRESHOLD` | Go duration | `20s` | `coordinator/registry/config.go` | Load duration above which a load is counted as slow. |
-| `EIGENINFERENCE_WARM_POOL_DECODE_FLOOR_TPS` | float (≤ 0 disables) | `15` | `coordinator/registry/config.go` | Per-request decode floor used to derive quality concurrency for the target. |
+| `EIGENINFERENCE_WARM_POOL_DECODE_FLOOR_TPS` | finite float ≥ 0 (`0` disables) | `15` | `coordinator/registry/config.go` | Per-request decode floor used to derive quality concurrency for the target. |
+| `EIGENINFERENCE_WARM_POOL_HEADROOM_LOAD_WINDOWS` | finite float ≥ 0 (`0` uses one window) | `1.0` | `coordinator/registry/config.go` | Control intervals of demand growth covered by the derived headroom floor. |
 | `EIGENINFERENCE_WARM_POOL_BURST_BUFFER` | integer ≥ 0 | `1` | `coordinator/registry/config.go` | Spare warm providers added to the demand-derived target. |
 | `EIGENINFERENCE_WARM_POOL_FALLBACK_QUALITY_CONCURRENCY` | integer ≥ 1 | `4` | `coordinator/registry/config.go` | Per-provider concurrency assumed when rates are unknown. |
 | `EIGENINFERENCE_WARM_POOL_ASSUMED_PROMPT_TOKENS` | integer ≥ 0 | `512` | `coordinator/registry/config.go` | Representative prompt size for the service-time estimate. |
@@ -197,8 +198,13 @@ they tune is explained in
 | `EIGENINFERENCE_WARM_POOL_MIN_WARM` | `model=count,…` | unset | `coordinator/registry/config.go` (`envModelIntMap`) | Operator floor of warm providers per concrete model id. |
 | `EIGENINFERENCE_WARM_POOL_MAX_LOADS_PER_TICK` | integer ≥ 0 (`0` = observe) | `4` | `coordinator/registry/config.go` | Baseline load burst per tick. |
 | `EIGENINFERENCE_WARM_POOL_MAX_LOADS_PER_TICK_CEILING` | integer ≥ 0 | `16` | `coordinator/registry/config.go` | Hard per-tick maximum after gap scaling. |
-| `EIGENINFERENCE_WARM_POOL_RAMP_GAP_FRACTION` | float ≥ 0 | `0.5` | `coordinator/registry/config.go` | Scales the burst with the remaining target gap. |
+| `EIGENINFERENCE_WARM_POOL_RAMP_GAP_FRACTION` | finite float ≥ 0 | `0.5` | `coordinator/registry/config.go` | Scales the burst with the remaining target gap. |
 | `EIGENINFERENCE_WARM_POOL_MAX_GLOBAL_PENDING_LOADS` | integer ≥ 0 | `16` | `coordinator/registry/config.go` | Fleet-wide cap on in-flight loads. |
+
+`QualityCapConfig.Check` and `WarmPoolConfig.Check` in
+`coordinator/registry/config.go` reject non-finite floating-point tunables at
+startup, including when the warm controller is disabled. Existing finite ranges
+and zero-value disable/fallback semantics remain in effect.
 
 Cache-aware routing (semantics in [`../architecture/cache-aware-routing.md`](../architecture/cache-aware-routing.md)). `refresh-env.sh` seeds absent keys from `deploy/gcp/prod/release-env-defaults` — production ships `MODE=off`, `PERCENT=1`, `MAX_PLAN_QPS=1` — and never overwrites a value an operator has set:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-11 · commit `9f8ad60d4`
+> Last updated: 2026-09-11 · commit `44109059f`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -204,7 +204,14 @@ they tune is explained in
 `QualityCapConfig.Check` and `WarmPoolConfig.Check` in
 `coordinator/registry/config.go` reject non-finite floating-point tunables at
 startup, including when the warm controller is disabled. Existing finite ranges
-and zero-value disable/fallback semantics remain in effect.
+and zero-value disable/fallback semantics remain in effect. Specifically,
+`EIGENINFERENCE_WARM_POOL_ENABLED=false` together with
+`EIGENINFERENCE_WARM_POOL_INTERVAL=0s` bypasses the
+warm-controller range checks after the finite checks. This preserves acceptance
+of a finite negative decode floor in that disabled-controller configuration;
+`coordinator/registry/concurrency_cap.go` (`qualityConcurrency`) treats a floor
+≤ 0 as disabling the quality cap. The ranges in the warm-pool table apply when
+that disabled, zero-interval exception is not selected.
 
 Cache-aware routing (semantics in [`../architecture/cache-aware-routing.md`](../architecture/cache-aware-routing.md)). `refresh-env.sh` seeds absent keys from `deploy/gcp/prod/release-env-defaults` — production ships `MODE=off`, `PERCENT=1`, `MAX_PLAN_QPS=1` — and never overwrites a value an operator has set:
 


### PR DESCRIPTION
Stacked on #943 (`refactor/coordinator-capacity`); merge #943 first. Its safe context-token addition is required for the calibrated estimate to reach the registry gate without wrapping.

Operator settings such as `NaN` and `+Inf` passed the registry's numeric range checks, and prompt-calibration overrides treated non-finite pairs as valid replacements. Reject non-finite quality/warm-pool settings during startup validation and skip non-finite calibration pairs. Bound large finite calibrated products before integer conversion so context estimates have consistent behavior across architectures.

```mermaid
flowchart LR
  subgraph Before
    E[Operator float settings] --> C[Config.Check range comparisons]
    C --> A[Nonfinite values reach target and admission math]
    P[Calibration pairs] --> S[SetPromptContextCalibrationFromEnv]
    S --> M[Replace map including NaN or infinity]
    M --> I[Unchecked float-to-int estimate]
  end
  subgraph After
    E2[Operator float settings] --> C2[Config.Check finite and range checks]
    C2 --> R[Reject nonfinite configuration before serving]
    P2[Calibration pairs] --> S2[Skip nonfinite or invalid pairs]
    S2 --> M2[Replace only when valid pairs remain]
    M2 --> I2[Clamp oversized calibrated product before int conversion]
    I2 --> T[Context-only estimate with stable bounds]
    T --> R2[PredictServable safe sum from parent PR943]
    R2 --> C3[Oversized context rejected]
  end
```

The checks include the decode floor even when the warm controller is disabled because admission also consumes it. Valid defaults, finite ranges, zero-value behavior, unmatched/nonpositive estimates, and truncation of ordinary products are unchanged. The shared `env.EnvFloat` parser and registry setter contracts remain unchanged; main already validates the assembled configuration before invoking those setters. The implementation remains focused on calibration/configuration; the PR now explicitly depends on #943 for the downstream safe context-token sum.

Validation:

- New fixtures fail on master for actual `ReadConfig().Check()` acceptance and calibration setter replacement/counts, including all-invalid and mixed overrides.
- Focused Go 1.25 race tests pass for both packages (registry 1.472s, API 1.774s).
- Full Go 1.25 registry/API race suites pass: registry 24.186s, API 225.665s.
- Calibration fixtures cover oversized estimates and a finite multiplier whose product overflows. Baseline arm64 Go already saturates those conversions; the explicit bound removes architecture dependence rather than claiming a negative baseline result on this host.
- Documentation lint passes (278 pages); independent review of all source and test changes found no blocker.

Review follow-up: an API-to-registry regression fails on the previously independent head (oversized calibrated prompt declared servable) and passes when stacked on #943. Focused stacked registry/API races pass (registry 1.510s, API 1.952s). Full stacked Go 1.25 race suites also pass (registry 24.721s, API 225.800s); pre-stack full results above remain explicitly historical.

The disabled, zero-interval warm-controller range bypass remains compatible: finite negative decode floors still disable the quality cap. This exception is now documented explicitly and covered through actual `ReadConfig().Check()` calls; non-finite floors remain rejected. Follow-up registry race passes 1.455s and docs lint passes 278 pages. No production code changed after the full stacked race run.

Ready for human review: all findings are resolved and the source/test checks pass. Fresh Codex review of final head `6317351e5` completed with a thumbs-up and no unresolved findings. Merge the explicit #943 dependency first.

