### PR TITLE
fix(coordinator): commit invite redemption and credit atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ coordinator and console changes require their own deployments.
 
 ## Unreleased — stats request-flow refresh
 
+- Commit invite redemption and balance credit together, so a failed credit leaves the code available for retry.
+
 - Restore Stats refreshes on large usage windows by aggregating request origins before looking up provider locations. Preserve weighted coordinates, request/token counts, and the top-50 flow limit while avoiding large temporary sorts.
 
 ## Unreleased — provider console entry

--- a/coordinator/api/invite_credit_atomic_test.go
+++ b/coordinator/api/invite_credit_atomic_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/registry"
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+type separateInviteCreditFailure struct {
+	store.Store
+	calls int
+}
+
+func (s *separateInviteCreditFailure) Credit(string, int64, store.LedgerEntryType, string) error {
+	s.calls++
+	return errors.New("standalone balance write unavailable")
+}
+
+func TestInviteRedemptionDoesNotSplitCreditFromClaim(t *testing.T) {
+	memory := store.NewMemory(store.Config{})
+	if err := memory.CreateInviteCode(&store.InviteCode{Code: "INV-ATOMIC", AmountMicroUSD: 2_000_000, MaxUses: 1, Active: true}); err != nil {
+		t.Fatal(err)
+	}
+	st := &separateInviteCreditFailure{Store: memory}
+	srv := NewServer(registry.New(slog.Default()), st, ServerConfig{}, slog.Default())
+	defer srv.Close()
+	request := func() *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPost, "/v1/invite/redeem", strings.NewReader(`{"code":"inv-atomic"}`))
+		r = r.WithContext(context.WithValue(r.Context(), ctxKeyConsumer, "invite-account"))
+		w := httptest.NewRecorder()
+		srv.handleRedeemInviteCode(w, r)
+		return w
+	}
+	w := request()
+	if w.Code != http.StatusOK {
+		t.Errorf("status=%d body=%s; claimed=%v balance=%d", w.Code, w.Body.String(), memory.HasRedeemedInviteCode("INV-ATOMIC", "invite-account"), memory.GetBalance("invite-account"))
+	}
+	if st.calls != 0 {
+		t.Errorf("made %d standalone credit calls after claiming invite", st.calls)
+	}
+	if balance := memory.GetBalance("invite-account"); balance != 2_000_000 {
+		t.Errorf("balance=%d want2000000", balance)
+	}
+	if w := request(); w.Code != http.StatusBadRequest {
+		t.Errorf("duplicate status=%d body=%s", w.Code, w.Body.String())
+	}
+	if memory.GetWithdrawableBalance("invite-account") != 0 {
+		t.Fatal("invite credit became withdrawable")
+	}
+}

--- a/coordinator/api/invite_handlers.go
+++ b/coordinator/api/invite_handlers.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -187,16 +188,14 @@ func (s *Server) handleRedeemInviteCode(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Redeem atomically (checks active, expiry, max uses, double-redemption)
+	// Claim and credit together; a failed balance write leaves the invite usable.
 	if err := s.store.RedeemInviteCode(code, accountID); err != nil {
-		writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
-		return
-	}
-
-	// Credit the user's balance
-	if err := s.store.Credit(accountID, ic.AmountMicroUSD, store.LedgerInviteCredit, "invite:"+code); err != nil {
-		s.logger.Error("failed to credit invite balance", "account", accountID, "code", code, "error", err)
-		writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to credit balance"))
+		if errors.Is(err, store.ErrInviteCredit) {
+			s.logger.Error("failed to credit invite balance", "account", accountID, "code", code, "error", err)
+			writeJSON(w, http.StatusInternalServerError, errorResponse("internal_error", "failed to credit balance"))
+		} else {
+			writeJSON(w, http.StatusBadRequest, errorResponse("invalid_request_error", err.Error()))
+		}
 		return
 	}
 

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -549,7 +549,9 @@ type InviteStore interface {
 	// DeactivateInviteCode sets active=false on an invite code.
 	DeactivateInviteCode(code string) error
 
-	// RedeemInviteCode atomically increments used_count and records the redemption.
+	// RedeemInviteCode atomically increments used_count, records the redemption,
+	// and credits the invite amount to the non-withdrawable balance and ledger.
+	// A credit failure returns ErrInviteCredit and leaves no claim or use count.
 	// Returns error if code is inactive, expired, fully used, or already redeemed by this account.
 	RedeemInviteCode(code string, accountID string) error
 

--- a/coordinator/store/invite_credit_test.go
+++ b/coordinator/store/invite_credit_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestInviteRedemptionCreditsOneWinningAccount(t *testing.T) {
+	for name, s := range storeBackends(t) {
+		t.Run(name, func(t *testing.T) {
+			const code = "INV-SINGLE"
+			if err := s.CreateInviteCode(&InviteCode{Code: code, AmountMicroUSD: 2_000_000, MaxUses: 1, Active: true}); err != nil {
+				t.Fatal(err)
+			}
+			accounts := []string{"invite-a", "invite-b"}
+			for _, id := range accounts {
+				if err := s.CreateUser(&User{AccountID: id, PrivyUserID: "did:" + id}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			start := make(chan struct{})
+			results := make(chan error, 2)
+			var wg sync.WaitGroup
+			for _, id := range accounts {
+				wg.Add(1)
+				go func(id string) { defer wg.Done(); <-start; results <- s.RedeemInviteCode(code, id) }(id)
+			}
+			close(start)
+			wg.Wait()
+			close(results)
+			successes := 0
+			for err := range results {
+				if err == nil {
+					successes++
+				}
+			}
+			if successes != 1 {
+				t.Fatalf("successful redemptions=%d", successes)
+			}
+			total := int64(0)
+			for _, id := range accounts {
+				b, w := s.GetBalanceWithWithdrawable(id)
+				total += b
+				if w != 0 {
+					t.Errorf("invite funds withdrawable for %s: %d", id, w)
+				}
+				if s.HasRedeemedInviteCode(code, id) != (b == 2_000_000) {
+					t.Errorf("claim and balance disagree for %s: %d", id, b)
+				}
+				if err := s.RedeemInviteCode(code, id); err == nil {
+					t.Error("exhausted invite redeemed again")
+				}
+			}
+			if total != 2_000_000 {
+				t.Errorf("total credit=%d", total)
+			}
+			ic, err := s.GetInviteCode(code)
+			if err != nil || ic.UsedCount != 1 {
+				t.Errorf("invite=%+v err=%v", ic, err)
+			}
+		})
+	}
+}
+
+func TestPostgresInviteCreditFailureRollsBackClaim(t *testing.T) {
+	s := testPostgresStore(t)
+	ctx := context.Background()
+	const code, account = "INV-ROLLBACK", "invite-rollback"
+	if err := s.CreateUser(&User{AccountID: account, PrivyUserID: "did:" + account}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateInviteCode(&InviteCode{Code: code, AmountMicroUSD: 3_000_000, MaxUses: 1, Active: true}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := s.pool.Exec(ctx, `CREATE FUNCTION reject_invite_credit_test() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN IF NEW.entry_type = 'invite_credit' THEN RAISE EXCEPTION 'forced invite credit failure'; END IF; RETURN NEW; END $$; CREATE TRIGGER reject_invite_credit_test BEFORE INSERT ON ledger_entries FOR EACH ROW EXECUTE FUNCTION reject_invite_credit_test()`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.pool.Exec(context.Background(), `DROP TRIGGER IF EXISTS reject_invite_credit_test ON ledger_entries; DROP FUNCTION IF EXISTS reject_invite_credit_test()`)
+	})
+	if err := s.RedeemInviteCode(code, account); err == nil {
+		t.Fatal("forced credit failure accepted")
+	}
+	ic, err := s.GetInviteCode(code)
+	if err != nil || ic.UsedCount != 0 || s.HasRedeemedInviteCode(code, account) || s.GetBalance(account) != 0 {
+		t.Fatalf("partial redemption after failed credit: invite=%+v err=%v claimed=%v balance=%d", ic, err, s.HasRedeemedInviteCode(code, account), s.GetBalance(account))
+	}
+	if _, err := s.pool.Exec(ctx, `DROP TRIGGER reject_invite_credit_test ON ledger_entries`); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RedeemInviteCode(code, account); err != nil {
+		t.Fatalf("retry after rollback: %v", err)
+	}
+	if got := s.GetBalance(account); got != 3_000_000 {
+		t.Fatalf("retry balance=%d", got)
+	}
+	var rows int
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM ledger_entries WHERE account_id=$1 AND entry_type='invite_credit'`, account).Scan(&rows); err != nil || rows != 1 {
+		t.Fatalf("credit ledger rows=%d err=%v", rows, err)
+	}
+}

--- a/coordinator/store/invite_redemption.go
+++ b/coordinator/store/invite_redemption.go
@@ -1,0 +1,7 @@
+package store
+
+import "errors"
+
+// ErrInviteCredit identifies a balance or ledger write failure during invite
+// redemption. The store rolls back the claim so the same invite can be retried.
+var ErrInviteCredit = errors.New("invite credit failed")

--- a/coordinator/store/memory.go
+++ b/coordinator/store/memory.go
@@ -2720,6 +2720,7 @@ func (s *MemoryStore) RedeemInviteCode(code string, accountID string) error {
 		s.accountRedemptions[accountID] = make(map[string]bool)
 	}
 	s.accountRedemptions[accountID][code] = true
+	s.creditLocked(accountID, ic.AmountMicroUSD, LedgerInviteCredit, "invite:"+code, time.Now())
 	return nil
 }
 

--- a/coordinator/store/postgres.go
+++ b/coordinator/store/postgres.go
@@ -3918,6 +3918,11 @@ func (s *PostgresStore) RedeemInviteCode(code string, accountID string) error {
 		return fmt.Errorf("store: update invite code: %w", err)
 	}
 
+	// The claim, use count, non-withdrawable balance and ledger entry commit
+	// together. A failed credit leaves the invite available for retry.
+	if err := creditBalance(ctx, tx, accountID, ic.AmountMicroUSD, LedgerInviteCredit, "invite:"+code, time.Time{}); err != nil {
+		return errors.Join(ErrInviteCredit, err)
+	}
 	return tx.Commit(ctx)
 }
 

--- a/docs/architecture/billing.md
+++ b/docs/architecture/billing.md
@@ -1,6 +1,6 @@
 # Billing: pricing, reservations, ledger, and payouts
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-11 · commit `db30ab83c`
 
 Darkbloom is prepaid. A consumer account holds an integer micro-USD balance;
 the coordinator reserves the worst-case cost of a request before dispatch,
@@ -107,7 +107,7 @@ and which balance column moves:
 | `referral_reward` | `coordinator/billing/referral.go` `DistributeReferralReward` → `CreditWithdrawable` | both |
 | `stripe_deposit` | `handleStripeWebhook` → `Service.CreditDeposit` → `store.Credit` | `balance` |
 | `stripe_payout` | `coordinator/api/stripe_withdraw.go` `handleStripeWithdraw` → `CreateStripeWithdrawalWithDebit` | both (guarded by `withdrawable_micro_usd >= amount`) |
-| `invite_credit` | `coordinator/api/invite_handlers.go` `handleRedeemInviteCode` → `store.Credit` | `balance` |
+| `invite_credit` | `coordinator/api/invite_handlers.go` `handleRedeemInviteCode` → `store.RedeemInviteCode` | `balance` |
 | `admin_credit` | `handleAdminCredit` → `store.Credit` | `balance` |
 | `admin_reward` | `handleAdminReward` → `CreditWithdrawable` | both |
 | `provider_floor_draw` | `coordinator/store/postgres_base_rewards.go` `SettleProviderFloorDraw` | both |
@@ -123,7 +123,7 @@ Three credit primitives (`coordinator/store/postgres.go`):
 
 | Primitive | Effect | Used for |
 |---|---|---|
-| `Credit` (`creditTx`) | raises `balance_micro_usd` only; not reference-idempotent | deposits, invite/admin credits, reservation and settlement refunds, platform fee |
+| `Credit` (`creditTx`) | raises `balance_micro_usd` only; not reference-idempotent | deposits, admin credits, reservation and settlement refunds, platform fee |
 | `CreditWithdrawable` (`creditWithdrawableTx`) | raises both columns; not reference-idempotent | referral rewards, admin rewards |
 | `CreditWithdrawableOnce` | `CreditWithdrawable` guarded by a `pg_advisory_xact_lock` on `entry_type:reference` and an existence check on `(account_id, entry_type, reference)`; returns whether it applied | withdrawal principal and fee refunds |
 
@@ -225,8 +225,11 @@ Admins create (`POST /v1/admin/invite-codes`: `amount_usd`, optional `code`,
 account redeems with `POST /v1/invite/redeem`; `RedeemInviteCode` locks the
 code row and checks active, unexpired, under `max_uses`, then inserts into
 `invite_redemptions` whose primary key `(code, account_id)` blocks a second
-redemption by the same account; the credit is a non-withdrawable
-`invite_credit`. `POST /v1/admin/credit` (`admin_credit`, non-withdrawable)
+redemption by the same account. The use count, redemption, non-withdrawable
+`invite_credit` balance and ledger row commit together; a failed credit rolls
+back the claim so the code can be retried. PostgreSQL uses `creditBalance`
+inside the redemption transaction; memory applies `creditLocked` under the
+same store lock (`coordinator/store/postgres.go`, `coordinator/store/memory.go`). `POST /v1/admin/credit` (`admin_credit`, non-withdrawable)
 and `POST /v1/admin/reward` (`admin_reward`, withdrawable) credit by user
 email. These, plus free self-route, are the only free-credit paths — there is
 no sign-up credit or trial in code. Admin authorization for these routes is
@@ -331,9 +334,10 @@ the design record is [`design/base-rewards.md`](../design/base-rewards.md).
    `CreditProviderAccount` raise both by the same amount;
    `CreateStripeWithdrawalWithDebit` debits both and fails unless
    `withdrawable ≥ amount` (`coordinator/store/postgres.go`).
-9. **Only earned money is withdrawable.** `stripe_deposit`, `invite_credit`,
-   `admin_credit`, and reservation or settlement `refund` entries go through
-   `Credit`; `payout`, `referral_reward`, `admin_reward`,
+9. **Only earned money is withdrawable.** `stripe_deposit`, `admin_credit`,
+   and reservation or settlement `refund` entries go through `Credit`.
+   `invite_credit` uses the same non-withdrawable credit primitive inside
+   `RedeemInviteCode`, atomically with its claim and use count; `payout`, `referral_reward`, `admin_reward`,
    `provider_floor_draw`, and withdrawal refunds go through the withdrawable
    primitives (`coordinator/api/billing_handlers.go` `handleStripeWebhook`,
    `handleAdminCredit`, `handleAdminReward`; `coordinator/api/invite_handlers.go`

--- a/docs/consumer/billing.md
+++ b/docs/consumer/billing.md
@@ -1,6 +1,6 @@
 # Billing: fund an account and keep spend under control
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `db30ab83c`
 
 How to add credit, read your balance and usage, cap what a key can spend,
 redeem an invite code, and act on a `402`. Why the coordinator behaves this
@@ -170,7 +170,9 @@ curl -X POST https://api.darkbloom.dev/v1/invite/redeem \
 Invite codes are created by Darkbloom staff and carry a fixed amount. A
 successful redemption returns `credited_usd` and `balance_usd`; the credit is
 spendable but not withdrawable, and each account can redeem a given code once
-(`coordinator/api/invite_handlers.go` `handleRedeemInviteCode`).
+(`coordinator/api/invite_handlers.go` `handleRedeemInviteCode`). If redemption
+returns 500 with `failed to credit balance`, retry the same code: its claim
+and use count were rolled back with the failed credit.
 
 ### 8. High-volume integrations: service accounts
 

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,6 +1,6 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `db30ab83c`
 
 The complete public HTTP surface of the coordinator, derived from the 108 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
@@ -143,7 +143,7 @@ Ledger semantics, reservations and payouts: [`../architecture/billing.md`](../ar
 | POST | `/v1/referral/apply` | `handleReferralApply` (`coordinator/api/billing_handlers.go`) | `user` | `fin` | 400 `referral_error` |
 | GET | `/v1/referral/stats` | `handleReferralStats` (`coordinator/api/billing_handlers.go`) | `key` | — | 404 `referral_error` when no referral record exists |
 | GET | `/v1/referral/info` | `handleReferralInfo` (`coordinator/api/billing_handlers.go`) | `key` | — | 404 `referral_error` when no referral record exists |
-| POST | `/v1/invite/redeem` | `handleRedeemInviteCode` (`coordinator/api/invite_handlers.go`) | `key` | `fin` | Redeem an invite code |
+| POST | `/v1/invite/redeem` | `handleRedeemInviteCode` (`coordinator/api/invite_handlers.go`) | `key` | `fin` | Redeem an invite code; claim, use count and non-withdrawable credit commit together. A credit failure returns 500 and leaves the claim available for retry |
 | GET | `/v1/providers/attestation` | `handleProviderAttestation` (`coordinator/api/provider.go`) | `—` | — | Public attestation roster; see [`../architecture/security/attestation.md`](../architecture/security/attestation.md) |
 
 ### Public stats and health (5)

--- a/docs/reference/pricing-model.md
+++ b/docs/reference/pricing-model.md
@@ -1,6 +1,6 @@
 # Pricing model reference
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `db30ab83c`
 
 Constants, formulas, enums, routes, and environment variables of the
 coordinator's money path, each row cited to the code that defines it. How the
@@ -104,7 +104,7 @@ type is in [billing.md](../architecture/billing.md#ledger).
 | `referral_reward` | `LedgerReferralReward` | referrer's share of a platform fee | yes |
 | `stripe_deposit` | `LedgerStripeDeposit` | Stripe Checkout deposit, reference `stripe:<checkout_session_id>` | no |
 | `stripe_payout` | `LedgerStripePayout` | Stripe Connect withdrawal debit, reference `stripe_withdraw:<id>` | debit (both columns) |
-| `invite_credit` | `LedgerInviteCredit` | invite code redemption, reference `invite:<code>` | no |
+| `invite_credit` | `LedgerInviteCredit` | invite claim, use count, balance and ledger commit together; reference `invite:<code>` (`coordinator/store/postgres.go`, `RedeemInviteCode`) | no |
 | `refund` | `LedgerRefund` | reservation/settlement refund; withdrawal principal and fee refunds | reservation/settlement: no; withdrawal refunds: yes |
 | `admin_credit` | `LedgerAdminCredit` | `POST /v1/admin/credit` | no |
 | `admin_reward` | `LedgerAdminReward` | `POST /v1/admin/reward` | yes |


### PR DESCRIPTION
Invite redemption currently commits the claim and use count before crediting the account. If the separate balance write fails, the consumer gets 500 with no balance, but the code is already consumed and a retry is rejected.

`RedeemInviteCode` now commits the claim, use count, non-withdrawable balance and ledger entry together: one memory lock or the existing PostgreSQL transaction. The API no longer performs a second credit. The existing credit-failure 500 response is retained through `ErrInviteCredit`; eligibility and duplicate failures retain their current responses.

```mermaid
flowchart LR
  subgraph Before
    A[handleRedeemInviteCode] --> B[RedeemInviteCode commits claim and use count]
    B --> C[Separate Store.Credit]
    C -->|Failure| D[500, no credit, code consumed]
    C -->|Success| E[200 with balance]
  end
  subgraph After
    F[handleRedeemInviteCode] --> G[RedeemInviteCode locks and validates code]
    G --> H[Claim, count, creditBalance or creditLocked, ledger]
    H -->|Commit| I[200 with balance]
    H -->|Credit failure| J[Rollback claim and balance, 500, retry allowed]
  end
```

Validation:
- HTTP regression fails on baseline with `claimed=true`, balance 0 and 500. It passes after the change and confirms there is no standalone credit call, duplicate redemption remains rejected and invite credit is not withdrawable.
- Focused invite race tests pass (API 1.907s/store 1.274s).
- Full store race suite passes against isolated PostgreSQL16 and memory (22.153s). New fixtures race two accounts for one use and inject an actual PostgreSQL ledger-trigger failure, verifying claim/count/balance rollback followed by a successful retry and exactly one ledger credit. The database is stopped.
- Docs lint passes (278 pages); full coordinator Go suite passes (API 194.493s).

The transaction prevents new partial redemptions. It does not retroactively repair previously consumed codes whose old credit failed.
