### PR TITLE
Fix completion accounting in load and startup measurement helpers

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `04fec721a`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -414,6 +414,13 @@ the default MicroMDM entrypoint script; see the
 The [startup measurement tool](../operations/coordinator-startup-measurement.md)
 requires Python 3.10+ and no third-party packages or build step. Its tests use
 local stub servers; its default observation mode sends only public GETs.
+
+The load-driver fixtures also need only Python 3.10+ and the standard library;
+they stub HTTP clients, worker completion and clocks
+(`scripts/test_load_measurements.py`, `SoakTests`, `LightBenchmarkTests`).
+Live `scripts/benchmark-light.py` (`worker`) and `scripts/benchmark-models.py`
+(`call_model`) require `aiohttp` and an authorized API key. Running these live
+scripts sends inference traffic; building or testing their fixtures does not.
 
 ## `make` targets
 

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `04fec721a`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -922,6 +922,22 @@ node --test landing/earn-calculator-core.test.js
 ```
 
 ### 6. Scripts and release integrity
+
+Run the measurement-helper fixtures without a provider, model, API key or network
+service:
+
+```bash
+PYTHONPATH=scripts python3 -m unittest test_load_measurements startup_measurement.test_http_probe startup_measurement.test_observer
+```
+
+`scripts/test_load_measurements.py` (`SoakTests`, `LightBenchmarkTests`) checks
+completion after the admission deadline, interruption before executor drain,
+consistent window/cumulative CSV counters, and response-body latency. The soak's
+last CSV window includes in-flight completions and their drain time; its existing
+`ttfb_*` columns still hold non-streaming total latency (`scripts/load_soak.py`,
+`run_soak`, `do_request`). The lightweight driver's token rate also uses completed
+response time (`scripts/benchmark-light.py`, `worker`), not streaming decode speed.
+These fixtures make no live inference calls and do not qualify cache hits.
 
 ```bash
 make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contbatch/tests -t .   (in scripts/)

--- a/docs/operations/coordinator-startup-measurement.md
+++ b/docs/operations/coordinator-startup-measurement.md
@@ -1,6 +1,6 @@
 # Measure coordinator startup after the old process stops
 
-> Last updated: 2026-09-08 · commit `501320342`
+> Last updated: 2026-09-12 · commit `04fec721a`
 
 Use `scripts/measure-coordinator-startup.py` to observe the interval after the
 old coordinator stops. The preceding drain is outside this measurement. The
@@ -95,6 +95,8 @@ The probe sends one fixed synthetic prompt, with at most three attempts per
 model and at most one request per second across all models. It only runs after
 candidate readiness and that model's capacity gate. It requires HTTP 200, a
 matching response model, non-empty content and a terminal `stop`/`length` reason.
+Malformed terminal reasons count as unavailable observations, preserving the
+bounded retry/report flow (`scripts/startup_measurement/http_probe.py`, `TestProbe.run`).
 It records completion time, not streaming TTFT. Later models' probe times
 include the observer's one-request-per-second scheduling delay; the report records
 probe start and elapsed time since first observed model capacity. Use

--- a/scripts/benchmark-light.py
+++ b/scripts/benchmark-light.py
@@ -58,6 +58,7 @@ async def worker(worker_id: int, model: str, prompt: str):
                         continue
 
                     data = await resp.json()
+                    elapsed = time.monotonic() - t0
                     usage = data.get("usage", {})
                     tokens = usage.get("completion_tokens", 0)
                     tps = round(tokens / elapsed, 1) if elapsed > 0 else 0

--- a/scripts/benchmark-models.py
+++ b/scripts/benchmark-models.py
@@ -56,10 +56,6 @@ async def call_model(session: aiohttp.ClientSession, model: str, run_id: int) ->
     print(f"  [{short_name} run={run_id}] sending request...")
 
     t0 = time.monotonic()
-    first_token_time = None
-    full_text = ""
-    token_count = 0
-
     try:
         async with session.post(
             f"{BASE_URL}/chat/completions",

--- a/scripts/load_soak.py
+++ b/scripts/load_soak.py
@@ -32,7 +32,6 @@ import csv
 import json
 import os
 import random
-import statistics
 import sys
 import threading
 import time
@@ -141,7 +140,8 @@ class Stats:
     def snapshot_and_reset(self, window_secs):
         with self.lock:
             ok, err, toks = self.w_ok, self.w_err, self.w_tokens
-            ttfb, tot, kinds = self.w_ttfb, self.w_total, dict(self.w_err_kinds)
+            ttfb, tot, kinds = self.w_ttfb, self.w_total, self.w_err_kinds
+            totals = {"cum_ok": self.total_ok, "cum_err": self.total_err}
             self.reset_window()
         return {
             "ok": ok,
@@ -154,6 +154,7 @@ class Stats:
             "total_p50": round(_percentile(tot, 50), 4),
             "total_p95": round(_percentile(tot, 95), 4),
             "err_kinds": kinds,
+            **totals,
         }
 
 
@@ -232,7 +233,7 @@ def do_request(args, n, stats, pool):
         stats.record_err(f"exc_{type(e).__name__}")
 
 
-def main():
+def main(argv=None):
     p = argparse.ArgumentParser(description="SSD KV-cache stress soak driver (stdlib-only)")
     p.add_argument("--base-url", default="http://127.0.0.1:8000/v1")
     p.add_argument("--model", required=True)
@@ -274,8 +275,11 @@ def main():
     p.add_argument("--request-timeout", type=float, default=600.0)
     p.add_argument("--report-every-seconds", type=float, default=60.0)
     p.add_argument("--out", default="soak_client.csv")
-    args = p.parse_args()
+    args = p.parse_args(argv)
+    return run_soak(args)
 
+
+def run_soak(args):
     # --prompt-tokens (if set) overrides --prefix-repeat via the calibration.
     effective_repeat = args.prefix_repeat
     if args.prompt_tokens > 0:
@@ -285,48 +289,45 @@ def main():
     stats = Stats()
     deadline = time.monotonic() + args.duration_minutes * 60.0
     stop = threading.Event()
-    counter = {"n": 0}
-    clock = {"start": time.monotonic()}
+    counter = 0
+    started = time.monotonic()
 
     # Context manager so the CSV handle is always closed deterministically,
     # even if an exception fires during setup or the soak run.
     with open(args.out, "w", newline="") as fout:
-        writer = csv.writer(fout)
-        writer.writerow(["elapsed_s", "ok", "err", "req_per_s", "tok_per_s",
-                         "ttfb_p50", "ttfb_p95", "ttfb_p99", "total_p50", "total_p95",
-                         "cum_ok", "cum_err", "err_kinds"])
+        writer = csv.DictWriter(fout, fieldnames=["elapsed_s", "ok", "err", "req_per_s", "tok_per_s",
+                                "ttfb_p50", "ttfb_p95", "ttfb_p99", "total_p50", "total_p95",
+                                "cum_ok", "cum_err", "err_kinds"])
+        writer.writeheader()
         fout.flush()
 
         def worker():
+            nonlocal counter
             while not stop.is_set() and time.monotonic() < deadline:
                 with stats.lock:
-                    counter["n"] += 1
-                    n = counter["n"]
+                    counter += 1
+                    n = counter
                 do_request(args, n, stats, pool)
 
-        def reporter():
-            last = time.monotonic()
-            while not stop.is_set() and time.monotonic() < deadline:
-                stop.wait(args.report_every_seconds)
-                now = time.monotonic()
-                window = now - last
-                last = now
-                if window <= 0:
-                    continue
-                snap = stats.snapshot_and_reset(window)
-                elapsed = round(now - clock["start"], 1)
-                line = [elapsed, snap["ok"], snap["err"], snap["req_per_s"],
-                        snap["tok_per_s"], snap["ttfb_p50"], snap["ttfb_p95"],
-                        snap["ttfb_p99"], snap["total_p50"], snap["total_p95"],
-                        stats.total_ok, stats.total_err, json.dumps(snap["err_kinds"])]
-                writer.writerow(line)
-                fout.flush()
-                print(f"[{elapsed:8.0f}s] ok={snap['ok']:4d} err={snap['err']:3d} "
-                      f"req/s={snap['req_per_s']:6.2f} tok/s={snap['tok_per_s']:7.1f} "
-                      f"ttfb p50/p95/p99={snap['ttfb_p50']:.2f}/{snap['ttfb_p95']:.2f}/{snap['ttfb_p99']:.2f}s "
-                      f"cum_err={stats.total_err}"
-                      + (f"  ERR={snap['err_kinds']}" if snap['err_kinds'] else ""),
-                      flush=True)
+        last_report = started
+
+        def report():
+            nonlocal last_report
+            now = time.monotonic()
+            window = now - last_report
+            if window <= 0:
+                return
+            last_report = now
+            snap = stats.snapshot_and_reset(window)
+            elapsed = round(now - started, 1)
+            writer.writerow({"elapsed_s": elapsed, **snap, "err_kinds": json.dumps(snap["err_kinds"])})
+            fout.flush()
+            print(f"[{elapsed:8.0f}s] ok={snap['ok']:4d} err={snap['err']:3d} "
+                  f"req/s={snap['req_per_s']:6.2f} tok/s={snap['tok_per_s']:7.1f} "
+                  f"ttfb p50/p95/p99={snap['ttfb_p50']:.2f}/{snap['ttfb_p95']:.2f}/{snap['ttfb_p99']:.2f}s "
+                  f"cum_err={snap['cum_err']}"
+                  + (f"  ERR={snap['err_kinds']}" if snap['err_kinds'] else ""),
+                  flush=True)
 
         if pool:
             tok = f" ~{args.prompt_tokens}tok" if args.prompt_tokens > 0 else ""
@@ -335,24 +336,28 @@ def main():
             mode = f"legacy shared={args.shared_fraction:.0%}"
         print(f"soak: {args.duration_minutes}min @ concurrency={args.concurrency} "
               f"model={args.model} {mode} -> {args.out}", flush=True)
-        rep = threading.Thread(target=reporter, daemon=True)
-        rep.start()
         try:
-            with ThreadPoolExecutor(max_workers=args.concurrency) as ex:
-                for _ in range(args.concurrency):
-                    ex.submit(worker)
-                while time.monotonic() < deadline and not stop.is_set():
-                    time.sleep(1.0)
+            with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+                futures = [executor.submit(worker) for _ in range(args.concurrency)]
+                try:
+                    while time.monotonic() < deadline:
+                        stop.wait(min(args.report_every_seconds, max(0, deadline - time.monotonic())))
+                        report()
+                finally:
+                    # Stop admission before the executor waits for in-flight requests.
+                    stop.set()
+                for future in futures:
+                    future.result()
         except KeyboardInterrupt:
             print("\ninterrupted — draining", flush=True)
         finally:
-            stop.set()
-            time.sleep(0.2)
-            fout.flush()  # the `with` closes the handle on exit (incl. SystemExit)
-            print(f"\nDONE: cum_ok={stats.total_ok} cum_err={stats.total_err} "
-                  f"cum_tokens={stats.total_tokens}. CSV: {args.out}", flush=True)
-            sys.exit(1 if stats.total_ok == 0 else 0)
+            # The executor has drained. This thread owns every CSV write, and
+            # the final window includes completions after the admission deadline.
+            report()
+        print(f"\nDONE: cum_ok={stats.total_ok} cum_err={stats.total_err} "
+              f"cum_tokens={stats.total_tokens}. CSV: {args.out}", flush=True)
+        return 1 if stats.total_ok == 0 else 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/scripts/startup_measurement/http_probe.py
+++ b/scripts/startup_measurement/http_probe.py
@@ -14,6 +14,8 @@ SYNTHETIC_ANSWER = "STARTUP_OK"
 
 
 def validate_base_url(value):
+    if not isinstance(value, str):
+        raise ValueError("base URL must be a string")
     parsed = urllib.parse.urlsplit(value)
     if (parsed.scheme not in {"http", "https"} or not parsed.hostname
             or parsed.username or parsed.password or parsed.query or parsed.fragment
@@ -109,7 +111,7 @@ class TestProbe:
         if hostname in {"api.darkbloom.dev", "api.darkbloom.ai", "console.darkbloom.dev"}:
             raise ValueError("synthetic startup inference is refused for known production origins")
         key_env = config.get("api_key_env", "")
-        if not re.fullmatch(r"[A-Z][A-Z0-9_]{0,95}", key_env):
+        if not isinstance(key_env, str) or not re.fullmatch(r"[A-Z][A-Z0-9_]{0,95}", key_env):
             raise ValueError("inference config requires an API-key environment variable name")
         api_key = os.environ.get(key_env, "")
         if not api_key or not all(33 <= ord(char) <= 126 for char in api_key):
@@ -128,7 +130,7 @@ class TestProbe:
         message = first.get("message")
         content = message.get("content") if isinstance(message, dict) else None
         available = (result.status == 200 and "error" not in body and body.get("model") == model
-                     and first.get("finish_reason") in {"stop", "length"}
+                     and first.get("finish_reason") in ("stop", "length")
                      and isinstance(content, str) and bool(content.strip()))
         return {**result.public(), "duration_ms": round((time.monotonic() - started) * 1000, 3),
                 "availability_success": available, "response_model_matches": body.get("model") == model,

--- a/scripts/startup_measurement/test_http_probe.py
+++ b/scripts/startup_measurement/test_http_probe.py
@@ -187,6 +187,36 @@ class HTTPProbeTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 validate_base_url(origin)
 
+    def test_malformed_config_is_refused_before_output_or_network(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "test.json"
+            output = root / "report.json"
+            origin = "http://127.0.0.1:9000"
+            for field in ("base_url", "api_key_env"):
+                for value in (None, 7, [], {}):
+                    with self.subTest(field=field, value=value):
+                        data = {"environment": "disposable-test", "base_url": origin,
+                                "api_key_env": "SYNTHETIC_KEY", field: value}
+                        config.write_text(json.dumps(data))
+                        with patch("urllib.request.OpenerDirector.open") as request, redirect_stderr(io.StringIO()):
+                            with self.assertRaises(SystemExit) as error:
+                                main(self.arguments(origin, output) + ["--allow-test-inference", "--test-inference-config", str(config)])
+                        self.assertEqual(2, error.exception.code)
+                        self.assertFalse(output.exists())
+                        request.assert_not_called()
+
+    def test_malformed_terminal_reason_remains_an_unavailable_observation(self):
+        for reason in ([], {}, None, True, 1, "tool_calls"):
+            with self.subTest(reason=reason):
+                body = {"model": "m1", "choices": [{"finish_reason": reason,
+                        "message": {"content": "private-response"}}]}
+                with patch.object(Client, "request", return_value=Result(200, "json", body)):
+                    result = TestProbe("key-secret").run(Client("http://127.0.0.1:9000"), "m1", 1)
+                self.assertFalse(result["availability_success"])
+                self.assertIsNone(result["synthetic_answer_matches"])
+                self.assertNotIn("private-response", json.dumps(result))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_load_measurements.py
+++ b/scripts/test_load_measurements.py
@@ -1,0 +1,138 @@
+"""CPU-only load-driver lifecycle and latency fixtures; no inference requests."""
+import asyncio
+from contextlib import redirect_stdout
+import csv
+import importlib.util
+import io
+from pathlib import Path
+import sys
+import tempfile
+import threading
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+import load_soak
+
+
+class SoakTests(unittest.TestCase):
+    def test_final_csv_accounts_for_requests_completed_after_deadline(self):
+        started = threading.Event()
+        finish = threading.Event()
+        stop = threading.Event()
+        clock = SimpleNamespace(now=0)
+        original_stop = stop.set
+
+        def tick(timeout):
+            self.assertTrue(started.wait(5), "worker did not start")
+            clock.now += timeout
+
+        def stop_admission():
+            original_stop()
+            finish.set()
+
+        def request(args, number, stats, pool):
+            started.set()
+            # Complete only after admission has stopped, with no timed sleep.
+            if not finish.wait(5):
+                raise AssertionError("admission did not stop before request drain")
+            clock.now += 0.1
+            stats.record_ok(0.4, 0.4, 7)
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "soak.csv"
+            args = ["--model", "fixture", "--duration-minutes", "0.005", "--concurrency", "1",
+                    "--report-every-seconds", "0.05", "--out", str(output)]
+            with patch.object(load_soak, "do_request", side_effect=request), \
+                 patch.object(load_soak, "threading", SimpleNamespace(Event=lambda: stop, Lock=threading.Lock)), \
+                 patch.object(stop, "wait", side_effect=tick), \
+                 patch.object(stop, "set", side_effect=stop_admission), \
+                 patch.object(load_soak.time, "monotonic", side_effect=lambda: clock.now), redirect_stdout(io.StringIO()):
+                self.assertEqual(0, load_soak.main(args))
+            self.assertTrue(started.is_set())
+            with output.open() as source:
+                rows = list(csv.DictReader(source))
+            self.assertEqual(1, sum(int(row["ok"]) for row in rows))
+            self.assertEqual(1, int(rows[-1]["cum_ok"]))
+            self.assertEqual(0, int(rows[-1]["cum_err"]))
+
+    def test_cumulative_counts_belong_to_the_same_snapshot(self):
+        stats = load_soak.Stats()
+        stats.record_ok(1, 2, 7)
+        stats.record_err("http_503")
+        first = stats.snapshot_and_reset(2)
+        stats.record_ok(3, 4, 11)
+        second = stats.snapshot_and_reset(2)
+        self.assertEqual((1, 1, 1, 1), (first["ok"], first["err"], first["cum_ok"], first["cum_err"]))
+        self.assertEqual((1, 0, 2, 1), (second["ok"], second["err"], second["cum_ok"], second["cum_err"]))
+        self.assertEqual({"http_503": 1}, first["err_kinds"])
+        self.assertEqual({}, second["err_kinds"])
+        self.assertEqual(3.5, first["tok_per_s"])
+        self.assertEqual(5.5, second["tok_per_s"])
+
+    def test_interrupt_stops_admission_before_executor_drains(self):
+        stop = threading.Event()
+
+        def interrupt(timeout):
+            raise KeyboardInterrupt
+
+        class Executor:
+            def __init__(self, **kwargs):
+                pass
+            def __enter__(self):
+                return self
+            def submit(self, worker):
+                return SimpleNamespace(result=lambda: None)
+            def __exit__(inner, *args):
+                self.assertTrue(stop.is_set(), "executor drain must follow admission stop")
+
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(load_soak, "threading", SimpleNamespace(Event=lambda: stop, Lock=threading.Lock)), \
+                 patch.object(stop, "wait", side_effect=interrupt), \
+                 patch.object(load_soak, "ThreadPoolExecutor", Executor), redirect_stdout(io.StringIO()):
+                result = load_soak.main(["--model", "fixture", "--out", str(Path(directory) / "soak.csv")])
+            self.assertEqual(1, result)
+
+
+class LightBenchmarkTests(unittest.TestCase):
+    def test_success_latency_includes_response_body(self):
+        clock = SimpleNamespace(now=0)
+
+        class Response:
+            status = 200
+            async def __aenter__(self):
+                clock.now = 1  # headers available
+                return self
+            async def json(self):
+                clock.now = 5  # complete JSON body available
+                return {"usage": {"completion_tokens": 20}}
+            async def __aexit__(self, *args):
+                # Stop this continuous worker after exactly one stub response.
+                raise asyncio.CancelledError
+
+        class Session:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *args):
+                pass
+            def post(self, *args, **kwargs):
+                self_payload = kwargs["json"]
+                assert self_payload["max_tokens"] == 200
+                return Response()
+
+        aiohttp = SimpleNamespace(ClientSession=Session, ClientTimeout=lambda **kwargs: kwargs)
+        path = Path(__file__).with_name("benchmark-light.py")
+        spec = importlib.util.spec_from_file_location("benchmark_light_fixture", path)
+        module = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, {"aiohttp": aiohttp}), patch.dict("os.environ", {"DARKBLOOM_API_KEY": "fixture-key"}):
+            spec.loader.exec_module(module)
+        output = io.StringIO()
+        with patch.object(module.time, "monotonic", side_effect=lambda: clock.now), redirect_stdout(output):
+            with self.assertRaises(asyncio.CancelledError):
+                asyncio.run(module.worker(1, "fixture", "fixture prompt"))
+        self.assertIn("5.0s, 20 tok, 4.0 tok/s", output.getvalue())
+        self.assertNotIn("fixture-key", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_load_measurements.py
+++ b/scripts/test_load_measurements.py
@@ -72,6 +72,7 @@ class SoakTests(unittest.TestCase):
 
     def test_interrupt_stops_admission_before_executor_drains(self):
         stop = threading.Event()
+        testcase = self
 
         def interrupt(timeout):
             raise KeyboardInterrupt
@@ -83,8 +84,8 @@ class SoakTests(unittest.TestCase):
                 return self
             def submit(self, worker):
                 return SimpleNamespace(result=lambda: None)
-            def __exit__(inner, *args):
-                self.assertTrue(stop.is_set(), "executor drain must follow admission stop")
+            def __exit__(self, *args):
+                testcase.assertTrue(stop.is_set(), "executor drain must follow admission stop")
 
         with tempfile.TemporaryDirectory() as directory:
             with patch.object(load_soak, "threading", SimpleNamespace(Event=lambda: stop, Lock=threading.Lock)), \


### PR DESCRIPTION
The soak can finish with a successful request missing from its CSV because its reporter stops at the admission deadline while workers are still running. The lightweight load driver also reports token throughput at response-header time, before reading the completed body. Malformed startup-probe terminal reasons can abort the observer instead of producing an unavailable observation.

The soak now has one reporting owner: stop admission, drain the executor, then write the final window. Named CSV fields replace repeated positional projection, and cumulative counters are captured under the same lock as window counters. The light driver measures successful completion through body decoding. Startup validation handles malformed origin/config values and terminal reasons through the existing refusal/report paths. Unused timing locals are removed from the parallel model benchmark.

All 13 soak CSV columns, percentile/rate formulas, prompt modes, request payloads, model selections, timeout defaults and credential requirements remain. The final soak window includes drain time and completions. Existing `ttfb_*` fields still represent non-streaming total latency; these scripts do not establish streaming decode speed or cache hits. Startup inference still requires both explicit flags, a disposable target config and an authorized environment-sourced key; its gates, schema and redaction remain.

**Before**
```mermaid
flowchart TD
  A[Soak main] --> B[Worker executor]
  A --> C[Daemon reporter stops at admission deadline]
  B --> D[Late request completes after last CSV window]
  A --> E[Timed sleep then close CSV]
  F[Light worker receives headers] --> G[Capture elapsed then read JSON]
  G --> H[Token rate divides by header time]
  I[Startup TestProbe.run] --> J[Set membership on untrusted terminal reason]
  J --> K[Array or object raises before report]
```

**After**
```mermaid
flowchart TD
  A[main delegates run_soak] --> B[One owner writes named CSV snapshots]
  B --> C[Stop admission in finally]
  C --> D[Executor drains in-flight requests]
  D --> E[Final locked snapshot then close CSV]
  F[Light worker receives headers] --> G[Read JSON then capture elapsed]
  G --> H[Token rate includes completed response]
  I[TestProbe validates JSON fields] --> J[Unavailable observation for malformed terminal reason]
  J --> K[Existing bounded retries and redacted report]
```

Validation: 23 CPU tests pass using owned loopback HTTP stubs, controlled worker barriers and fake clocks. The final load tests require no timed sleeps or optional aiohttp dependency. Original-source reproductions show a missing final CSV success, 20 tok/s instead of 4 tok/s for a five-second response, and malformed JSON exceptions. The old soak reproduction adapts only its callable CLI signature/exit for the fixture; its lifecycle is unchanged. A 1,000-window differential confirms all prior metric values remain exactly equal for mixed successes/errors. Docs lint passes on all 278 documents.

No live inference, Swift compilation, model/GPU execution, deploy or service mutation was run. These results validate helper behavior, not model latency or production readiness.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791765791&installation_model_id=21733&pr_number=949&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F949&signature=3bec69d8d737ed64ad504a1fcec0a7ad6b1be97fe38bd81ca461560b32e0411d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->