### PR TITLE
Isolate retained dispatch-plan admission transaction

### DIFF
--- a/coordinator/registry/dispatch_plan.go
+++ b/coordinator/registry/dispatch_plan.go
@@ -424,55 +424,11 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 		}
 		relaxTrust := owned && (pr.SelfRouteOnly || pr.PreferOwner)
 
-		// Snapshot, cost, admit and reservation under ONE p.mu hold — the same
-		// commit sequence as commitProviderReservation, so nothing can change
-		// the provider between the admit re-check and the debit.
-		p.mu.Lock()
-		// Registry/provider lock waits consume the same request clock as the
-		// dispatcher's earlier refresh. Recheck after both locks, before any
-		// admission debit, and tighten an enabled TTFT ceiling to what remains.
-		now := time.Now()
-		if !pr.RefreshFirstContentBudget(now) {
-			p.mu.Unlock()
+		candidate := r.commitPlanEntry(p, model, pr, relaxTrust, enforceTTFT)
+		if candidate == nil {
 			skip(PlanSkipGateRejected)
 			return nil, RoutingDecision{}, false
 		}
-		var snap routingSnapshot
-		if ok, _ := r.snapshotProviderIntoPLockedEx(&snap, p, model, pr.Traits, relaxTrust, false, now); !ok {
-			p.mu.Unlock()
-			skip(PlanSkipGateRejected)
-			return nil, RoutingDecision{}, false
-		}
-		candidate, _, ok := r.buildCandidateWithReason(snap, pr, now)
-		if !ok {
-			p.mu.Unlock()
-			skip(PlanSkipGateRejected)
-			return nil, RoutingDecision{}, false
-		}
-		if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
-			p.mu.Unlock()
-			skip(PlanSkipGateRejected)
-			return nil, RoutingDecision{}, false
-		}
-		if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false, now) ||
-			(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
-			p.mu.Unlock()
-			skip(PlanSkipGateRejected)
-			return nil, RoutingDecision{}, false
-		}
-		// Half-open capacity probe: check-and-claim under gate.mu, identical to
-		// the primary reservation path (p.mu → gate.mu).
-		if !r.tryClaimCapacityProbe(p, model, now) {
-			p.mu.Unlock()
-			skip(PlanSkipGateRejected)
-			return nil, RoutingDecision{}, false
-		}
-		pr.ProviderID = p.ID
-		p.addPendingLocked(pr)
-		if p.Status != StatusUntrusted && p.Status != StatusOffline {
-			p.Status = StatusServing
-		}
-		p.mu.Unlock()
 
 		if !slotStateModelLoaded(candidate.snapshot.slotState) {
 			r.RecordWarmPoolColdDispatch(model)
@@ -547,6 +503,47 @@ func (r *Registry) ReserveNextFromPlan(pr *PendingRequest, plan *DispatchPlan, e
 	}
 	skips = append(skips, PlanSkip{Reason: PlanSkipExhausted})
 	return nil, RoutingDecision{Model: model}, skips
+}
+
+// commitPlanEntry snapshots, checks and debits one identity-verified alternate
+// under a single provider lock. Caller holds the registry commit lock, preserving
+// session identity. Rejections leave no pending debit; telemetry runs in the
+// caller only after this method releases p.mu.
+func (r *Registry) commitPlanEntry(p *Provider, model string, pr *PendingRequest, relaxTrust, enforceTTFT bool) *routingCandidate {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Lock waits consume the request clock. Refresh after both locks, before
+	// admission, and tighten an enabled TTFT ceiling to the remaining budget.
+	now := time.Now()
+	if !pr.RefreshFirstContentBudget(now) {
+		return nil
+	}
+	var snap routingSnapshot
+	if ok, _ := r.snapshotProviderIntoPLockedEx(&snap, p, model, pr.Traits, relaxTrust, false, now); !ok {
+		return nil
+	}
+	candidate, _, ok := r.buildCandidateWithReason(snap, pr, now)
+	if !ok {
+		return nil
+	}
+	if enforceTTFT && snap.hasBackendCapacity && candidate.breakdown.TTFTMs > pr.MaxTTFTMs {
+		return nil
+	}
+	if !r.providerCanAdmitLockedEx(p, model, pr.Traits, relaxTrust, false, now) ||
+		(pr.RequiresVision && !r.providerServesVisionModelLocked(p, model, relaxTrust)) {
+		return nil
+	}
+	// Claim the half-open capacity probe in the existing p.mu -> gate.mu order.
+	if !r.tryClaimCapacityProbe(p, model, now) {
+		return nil
+	}
+	pr.ProviderID = p.ID
+	p.addPendingLocked(pr)
+	if p.Status != StatusUntrusted && p.Status != StatusOffline {
+		p.Status = StatusServing
+	}
+	return candidate
 }
 
 // RefreshDispatchPlan performs the plan's single full re-scan refresh: a fresh

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -1,6 +1,6 @@
 # Routing: how a request becomes a provider choice
 
-> Last updated: 2026-09-08 · commit `0c162cdae`
+> Last updated: 2026-09-11 · commit `31e1e1c2a`
 
 Routing is the part of the coordinator that, given one inference request and
 the live fleet, picks the provider that should run it. It filters the fleet
@@ -511,8 +511,10 @@ onto the formerly cheapest provider), the admit re-check
 (`providerCanAdmitLockedEx`), the half-open capacity-probe claim
 (`tryClaimCapacityProbe`, check-and-claim under `gate.mu`) and the pending
 debit (`addPendingLocked`). `ReserveNextFromPlan`
-(`coordinator/registry/dispatch_plan.go`) commits each plan entry the same
-way. `commitLock` (`coordinator/registry/gate_commit_mode.go`) selects the
+(`coordinator/registry/dispatch_plan.go`) delegates that atomic provider
+transaction to `commitPlanEntry`, which acquires and releases `p.mu` on every
+path. The caller handles the common rejection outcome and publishes successful
+cold-dispatch/calibration telemetry after the provider lock is released. `commitLock` (`coordinator/registry/gate_commit_mode.go`) selects the
 mode: `reserveCommitShared` as described, or `reserveCommitGlobal`, which
 takes `r.mu.Lock()` for the commit — the previous fleet-wide serialization,
 kept as the kill switch behind


### PR DESCRIPTION
Retained dispatch-plan admission repeated provider unlocking and the same rejection outcome at every gate. Move its snapshot/check/debit transaction into `commitPlanEntry`, with one provider-lock lifetime, and keep plan traversal, skip reporting and successful telemetry in `ReserveNextFromPlan`.

```mermaid
flowchart LR
  subgraph Before
    P[ReserveNextFromPlan walks retained identities] --> G[Inline provider lock and six gate exits]
    G --> U[Repeated unlock and gate_rejected handling]
    G --> D[Pending debit and status update]
    D --> T[Unlock then telemetry]
  end
  subgraph After
    P2[ReserveNextFromPlan checks identity and request filters] --> C[commitPlanEntry owns provider lock]
    C --> G2[Same deadline, snapshot, cost, TTFT, admission and probe gates]
    G2 --> N[Unlock and return nil; caller reports gate_rejected]
    G2 --> D2[Same pending debit and status update]
    D2 --> T2[Unlock and return candidate; caller publishes telemetry]
  end
```

The registry commit lock still spans identity validation and both version-diversity passes. The helper releases the provider lock before cold-dispatch/calibration telemetry; half-open probe claim and pending debit stay in the same critical section. No numerical, selection, fallback or routing-gate changes. The production file is three lines smaller, with fewer repeated failure exits and a shorter outer operation.

All four assigned production files and five associated test files were read. Cold-spill eligibility, tool-constraint advertisement and lock-observer helpers were retained because their operation boundaries are already clear. Historical comments are not new benchmark evidence.

Validation:

- Existing deadline, reconnect, gate rejection, exclusion, version fallback, concurrency-budget and observer characterization suite passes on master: Go1.25 race2.063s.
- Full `GOTOOLCHAIN=go1.25.0 go test -race ./coordinator/registry -count=1` passes after extraction:24.620s. Existing tests were unchanged.
- Independent source review found no gate, lock-order, debit or telemetry-order difference.
- Documentation lint passes for278 pages. No models, deployments or performance benchmarks executed.

CI limitation: the Threat Model Review job fails before reviewing source because its Anthropic API key returns HTTP401 (invalid key). Local race validation above is complete; credentials were not changed.
