### PR TITLE
Refuse non-regular attention replay inputs without blocking

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `1c4670fdf`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -223,6 +223,11 @@ ATTENTION_REPLAY_SOURCE_ROOT="$REPLAY_SOURCE_ROOT" \
 Retain the executable SHA-256, source/dependency inventory, build graph,
 `mlx.metallib` and SwiftPM resource bundles. An executable hash alone does not
 bind external Metal resources. The Python driver never builds or downloads them.
+After building against those reviewed resources, run the host-only input checks
+with the same source-root binding and scratch directory using `swift test`
+and `--filter ReplayHostTests`
+(`scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift`,
+`fifoInputIsRejectedWithoutWaitingForAWriter`).
 Use the [offline NumPy environment](#offline-attention-analysis-environment) for
 packet validation and the independent reference. See [replay validation](test.md#attention-operator-replay)
 and the [source/test milestone](../reports/2026-09-06-attention-operator-replay.md).

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `1c4670fdf`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -471,7 +471,10 @@ checked after evaluation. Paged dispatch is observed through the existing hook;
 the synthetic selection is never marked as a confirmed model sample. Native SDPA
 identifies the API invoked, not an instrumented internal MLX kernel variant.
 
-`ReplayHostTests` covers bounded transfer/IO/options. `ReplayOperatorTests` executes
+`ReplayHostTests` covers bounded transfer/IO/options, including refusing an owned
+FIFO without waiting for a writer
+(`scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift`,
+`fifoInputIsRejectedWithoutWaitingForAWriter`). `ReplayOperatorTests` executes
 24 synthetic operator cases plus one host guard, with all three genuine arms in
 each operator case. The existing native reference ceiling `1e-2` and paged bound
 `max(3 * contiguous relativeL2, 1e-2)` remain unchanged. Exact storage bytes and

--- a/scripts/benchmarks/attention-replay/README.md
+++ b/scripts/benchmarks/attention-replay/README.md
@@ -4,6 +4,8 @@ This standalone diagnostic consumes one confirmed [attention packet v1](../atten
 
 The Python driver validates the complete packet before creating a fresh output directory, preserves all six native FP16/BF16/FP32 buffers and writes a bounded, hashed transfer. The Swift CLI checks transfer and raw lengths/hashes/packing before constructing an MLX array. Both enforce a 32 MiB input limit and a conservative 256 MiB allocation plan. That plan bounds these arrays and pools; it does not bound process RSS or the framework allocator cache.
 
+`ReplayIO.readBounded` opens inputs without following symlinks or blocking on FIFO writers, then requires a regular file and the exact bounded byte count. `ReplayHostTests` checks this path without invoking any attention operator.
+
 Three arms run sequentially in separate processes:
 
 - `nativeSDPA`: actual `MLXFast.scaledDotProductAttention`, with original Q and the production conversion of stored K/V to Q dtype.

--- a/scripts/benchmarks/attention-replay/Sources/attention-replay/ReplayIO.swift
+++ b/scripts/benchmarks/attention-replay/Sources/attention-replay/ReplayIO.swift
@@ -13,7 +13,8 @@ func sha256(_ bytes: Data) -> String {
 }
 
 func readBounded(_ url: URL, limit: Int) throws -> Data {
-    let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+    // Non-regular inputs must reach fstat instead of waiting for a FIFO writer.
+    let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK)
     try require(descriptor >= 0, "cannot open regular input")
     let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
     var status = stat()

--- a/scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift
+++ b/scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import MLX
 import Testing
 @_spi(Benchmarking) import MLXLMCommon
@@ -6,6 +7,27 @@ import Testing
 
 /// These fixtures construct only Data and JSON; no operator or model is called.
 struct ReplayHostTests {
+    @Test func fifoInputIsRejectedWithoutWaitingForAWriter() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fifo = root.appendingPathComponent("input.fifo")
+        try #require(mkfifo(fifo.path, 0o600) == 0)
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            defer { finished.signal() }
+            #expect(throws: (any Error).self) { try readBounded(fifo, limit: 3) }
+        }
+        let withoutWriter = finished.wait(timeout: .now() + .seconds(2))
+        if withoutWriter == .timedOut {
+            // Unblock a regressed reader so a failed fixture does not leak work.
+            let writer = open(fifo.path, O_WRONLY | O_NONBLOCK | O_CLOEXEC)
+            if writer >= 0 { close(writer) }
+            #expect(finished.wait(timeout: .now() + .seconds(2)) == .success)
+        }
+        #expect(withoutWriter == .success)
+    }
+
     private func options(input: URL, hash: String, output: URL) throws -> ReplayOptions {
         try ReplayOptions(["--input", input.path, "--input-sha256", hash,
                            "--output", output.path, "--arm", "nativeSDPA"])

--- a/scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift
+++ b/scripts/benchmarks/attention-replay/Tests/AttentionReplayTests/ReplayHostTests.swift
@@ -20,10 +20,13 @@ struct ReplayHostTests {
         }
         let withoutWriter = finished.wait(timeout: .now() + .seconds(2))
         if withoutWriter == .timedOut {
-            // Unblock a regressed reader so a failed fixture does not leak work.
-            let writer = open(fifo.path, O_WRONLY | O_NONBLOCK | O_CLOEXEC)
-            if writer >= 0 { close(writer) }
-            #expect(finished.wait(timeout: .now() + .seconds(2)) == .success)
+            // Keep a writer open until the owned reader has exited, including
+            // a reader that the scheduler has not started yet. O_RDWR does not
+            // require that reader to have entered open before recovery begins.
+            let writer = open(fifo.path, O_RDWR | O_NONBLOCK | O_CLOEXEC)
+            try #require(writer >= 0)
+            finished.wait()
+            close(writer)
         }
         #expect(withoutWriter == .success)
     }


### PR DESCRIPTION
The standalone replay CLI opens inputs before checking their file type. A FIFO supplied as the transfer or native buffer path therefore waits for a writer instead of reaching the existing regular-file refusal.

`readBounded` now opens with `O_NONBLOCK` alongside its existing read-only/no-follow/close-on-exec flags. The same descriptor is still checked for regular-file type, size and exact bytes. A host fixture supplies an owned FIFO without a writer; its failure recovery keeps a read/write descriptor open and joins the owned reader even if scheduling delayed its initial open. No operator, tensor math, allocation bound, hash, report schema or package pin changes.

**Before**
```mermaid
flowchart LR
  A[ReplayTransfer.load] --> B[readBounded opens input]
  B --> C[FIFO waits for writer]
  C -. cannot reach .-> D[fstat regular-file refusal]
```

**After**
```mermaid
flowchart LR
  A[ReplayTransfer.load] --> B[readBounded opens without blocking or following symlinks]
  B --> C[fstat rejects FIFO or other non-regular input]
  B --> D[Regular file retains exact size and byte checks]
  E[ReplayHostTests owned FIFO] --> C
```

Validation completed here: an owned Python/POSIX reproduction using the exact old flags times out before fstat; the new flags open immediately and identify the FIFO for refusal. The subprocess is killed/reaped by its timeout. The recovery descriptor also opens successfully on Darwin before any reader exists. Docs lint passes.

Root validation also completed at head `2b4be4e8831930edd719b150cbf1bfe214020092` on the dedicated M5: release build with tests passed in 131.97s, and all **5 ReplayHostTests passed with zero skips**. The test executable and replay binary hashes stayed identical before/after the run. All 7 package files and 5,093 reviewed dependency/source files were verified; all 31 resolved dependency pins matched the existing provider lockfile. No operator or model tests were run.

The first wrapper rejected Swift's “5 tests in 1 suite” summary even though the tests passed. That failure is retained. A corrected summary parser and fresh guarded verification reran the same compiled host suite successfully (exit 0); no source or package pins changed. Replay binary SHA-256: `94cea11bdf321493444388f9639847b737d21171975878a5ea837d0d6a1f48c8`.
