### PR TITLE
Validate replay artifact ownership and simplify benchmark evidence operations

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-12 · commit `2619389bc`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -244,6 +244,13 @@ and retain their hashes with the build's source/dependency inventory. See
 <a id="resident-prefix-benchmark-executable"></a>
 
 #### Prefix-cache benchmark executable
+
+The radix Python replay and process-cleanup fixtures run with the standard
+library alone, without building their native executables
+(`scripts/benchmarks/test_radix_prefix_cache.py`, `ReplayInputTests`;
+`scripts/benchmarks/test_radix_process_cleanup.py`, `ProcessCleanupTests`).
+Use the [prefix-cache benchmark checks](test.md#prefix-cache-benchmark-validation)
+before running an authorized live measurement.
 
 [`scripts/benchmarks/radix-engine`](../../scripts/benchmarks/radix-engine/Package.swift)
 links the real provider factory and MLX packages from an explicitly selected

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-12 · commit `2619389bc`
+> Last updated: 2026-09-12 · commit `9e79160f1`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -245,7 +245,7 @@ and retain their hashes with the build's source/dependency inventory. See
 
 #### Prefix-cache benchmark executable
 
-The radix Python replay and process-cleanup fixtures run with the standard
+The radix Python replay, wrapper-preflight and process-cleanup fixtures run with the standard
 library alone, without building their native executables
 (`scripts/benchmarks/test_radix_prefix_cache.py`, `ReplayInputTests`;
 `scripts/benchmarks/test_radix_process_cleanup.py`, `ProcessCleanupTests`).

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-12 · commit `2619389bc`
+> Last updated: 2026-09-12 · commit `9e79160f1`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -516,10 +516,14 @@ PYTHONPATH=scripts/benchmarks python3 -m unittest discover -s scripts/benchmarks
 ```
 
 Replay preflight requires nonempty, ordered rows with matching model IDs,
-earlier comparison targets and unique safe artifact names. It rejects path
-traversal, reserved filenames, case/Unicode filename collisions and empty plans
-before sending requests or creating output
-(`scripts/benchmarks/radix_prefix_cache.py`, `load_replay`).
+earlier comparison targets and unique safe artifact names. Non-null comparison
+targets must be nonempty strings. It rejects path traversal, reserved filenames,
+case/Unicode filename collisions, overlong filenames including the `.json` suffix,
+and empty plans before sending requests or creating output
+(`scripts/benchmarks/radix_prefix_cache.py`, `load_replay`). The owned provider
+wrapper calls the same preflight before host probes, output creation or model
+startup (`scripts/benchmarks/run_radix_http.py`, `main`); the HTTP child validates
+again before using the replay.
 `scripts/benchmarks/run_radix_http.py` (`terminate`) still reaps an owned process
 when its group disappears between polling and signaling. Permission errors and
 unconfirmed termination still fail. Comparison identities are hashed once per

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-12 · commit `2619389bc`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -508,6 +508,23 @@ The standalone scripts under [`scripts/benchmarks`](../../scripts/benchmarks/rad
 retain complete requests, SSE events, token counts, cache evidence, and GPU
 telemetry. Use a dedicated idle Mac with the model already downloaded. The
 runner refuses concurrent ranked work and owns only its child processes.
+
+Before live execution, run the CPU-only replay, cleanup and comparison fixtures:
+
+```bash
+PYTHONPATH=scripts/benchmarks python3 -m unittest discover -s scripts/benchmarks -p 'test_*radix*.py'
+```
+
+Replay preflight requires nonempty, ordered rows with matching model IDs,
+earlier comparison targets and unique safe artifact names. It rejects path
+traversal, reserved filenames, case/Unicode filename collisions and empty plans
+before sending requests or creating output
+(`scripts/benchmarks/radix_prefix_cache.py`, `load_replay`).
+`scripts/benchmarks/run_radix_http.py` (`terminate`) still reaps an owned process
+when its group disappears between polling and signaling. Permission errors and
+unconfirmed termination still fail. Comparison identities are hashed once per
+participating observation, with the same ordered records and strict/record policy
+(`scripts/benchmarks/radix_generation_comparison.py`, `comparison_records`).
 
 ```bash
 # Use the attention-analysis environment below for the NumPy-dependent tests.

--- a/scripts/benchmarks/radix_generation_comparison.py
+++ b/scripts/benchmarks/radix_generation_comparison.py
@@ -11,9 +11,12 @@ def comparison_records(report):
         return isinstance(value, list) and bool(value) and all(type(t) is int and t >= 0 for t in value)
     def digest(value):
         return hashlib.sha256(json.dumps(value, separators=(",", ":")).encode()).hexdigest()
+    identities = {}
     def identity(path, row):
-        return dict(path=path, **{key: row.get(key) for key in ("id", "kind", "scope", "finish", "completion_tokens")},
-                    token_ids_sha256=digest(row["token_ids"]), prompt_token_ids_sha256=digest(row["prompt_token_ids"]))
+        if path not in identities:
+            identities[path] = dict(path=path, **{key: row.get(key) for key in ("id", "kind", "scope", "finish", "completion_tokens")},
+                                   token_ids_sha256=digest(row["token_ids"]), prompt_token_ids_sha256=digest(row["prompt_token_ids"]))
+        return dict(identities[path])  # Each comparison keeps an independent value.
     result = []
     for i, (lp, left) in enumerate(rows):
         if not tokens(left.get("token_ids")) or not tokens(left.get("prompt_token_ids")):

--- a/scripts/benchmarks/radix_prefix_cache.py
+++ b/scripts/benchmarks/radix_prefix_cache.py
@@ -10,6 +10,7 @@ text/count equality is deliberately not presented as generated-token equality.
 import argparse
 import hashlib
 import json
+import os
 from pathlib import Path
 import time
 import unicodedata
@@ -164,12 +165,18 @@ def equality(left, right):
             "generated_token_ids_compared": False}
 
 
-def load_replay(path, model):
+def load_replay(path, model, output=None):
     """Validate replay ownership/order before creating artifacts or sending work."""
     report = json.loads(Path(path).read_text())
     rows = report.get("rows") if isinstance(report, dict) else None
     if not isinstance(rows, list) or not rows:
         raise ValueError("replay requires a nonempty row list")
+    # The run directory must remain absent until validation succeeds. Query
+    # its nearest existing ancestor for the destination filesystem's limit.
+    destination = Path(output).absolute() if output is not None else Path(path).absolute().parent
+    while not destination.exists():
+        destination = destination.parent
+    name_limit = os.pathconf(destination, "PC_NAME_MAX")
     reference = {}
     filenames = {"warmup", "cancellation", "report"}
     for row in rows:
@@ -177,6 +184,8 @@ def load_replay(path, model):
         name = case.get("id") if isinstance(case, dict) else None
         if not isinstance(name, str) or not name or any(char in name for char in ("/", "\\", "\x00")):
             raise ValueError("replay case ID must be one nonempty filename component")
+        if name_limit >= 0 and len(os.fsencode(name + ".json")) > name_limit:
+            raise ValueError("replay case ID exceeds the artifact filename byte limit")
         filename = unicodedata.normalize("NFC", name).casefold()
         if filename in filenames:
             raise ValueError("replay case ID duplicates or overwrites retained evidence")
@@ -184,7 +193,7 @@ def load_replay(path, model):
         if not isinstance(request_body, dict) or request_body.get("model") != model:
             raise ValueError("replay model must match baseline")
         equal_to = case.get("equal_to")
-        if equal_to and (not isinstance(equal_to, str) or equal_to not in reference):
+        if equal_to is not None and (not isinstance(equal_to, str) or not equal_to or equal_to not in reference):
             raise ValueError("replay comparison must reference an earlier case")
         reference[name] = row
         filenames.add(filename)
@@ -192,7 +201,7 @@ def load_replay(path, model):
 
 
 def run(args):
-    reference = load_replay(args.replay, args.model) if args.replay else {}
+    reference = load_replay(args.replay, args.model, args.output) if args.replay else {}
     out = Path(args.output)
     out.mkdir(parents=True, exist_ok=False)
     rows = []

--- a/scripts/benchmarks/radix_prefix_cache.py
+++ b/scripts/benchmarks/radix_prefix_cache.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 from pathlib import Path
 import time
+import unicodedata
 import urllib.request
 
 
@@ -163,12 +164,37 @@ def equality(left, right):
             "generated_token_ids_compared": False}
 
 
+def load_replay(path, model):
+    """Validate replay ownership/order before creating artifacts or sending work."""
+    report = json.loads(Path(path).read_text())
+    rows = report.get("rows") if isinstance(report, dict) else None
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("replay requires a nonempty row list")
+    reference = {}
+    filenames = {"warmup", "cancellation", "report"}
+    for row in rows:
+        case = row.get("case") if isinstance(row, dict) else None
+        name = case.get("id") if isinstance(case, dict) else None
+        if not isinstance(name, str) or not name or any(char in name for char in ("/", "\\", "\x00")):
+            raise ValueError("replay case ID must be one nonempty filename component")
+        filename = unicodedata.normalize("NFC", name).casefold()
+        if filename in filenames:
+            raise ValueError("replay case ID duplicates or overwrites retained evidence")
+        request_body = row.get("request")
+        if not isinstance(request_body, dict) or request_body.get("model") != model:
+            raise ValueError("replay model must match baseline")
+        equal_to = case.get("equal_to")
+        if equal_to and (not isinstance(equal_to, str) or equal_to not in reference):
+            raise ValueError("replay comparison must reference an earlier case")
+        reference[name] = row
+        filenames.add(filename)
+    return reference
+
+
 def run(args):
+    reference = load_replay(args.replay, args.model) if args.replay else {}
     out = Path(args.output)
     out.mkdir(parents=True, exist_ok=False)
-    reference = {}
-    if args.replay:
-        reference = {row["case"]["id"]: row for row in json.loads(Path(args.replay).read_text())["rows"]}
     rows = []
     by_id = {}
     # Model loading and kernel warmup are explicit, retained and excluded.
@@ -179,8 +205,6 @@ def run(args):
     for case in plan:
         if reference:
             req_body = reference[case["id"]]["request"]
-            if req_body["model"] != args.model:
-                raise ValueError("replay model must match baseline")
         else:
             messages = case.get("messages")
             if messages is None:

--- a/scripts/benchmarks/run_radix_http.py
+++ b/scripts/benchmarks/run_radix_http.py
@@ -26,11 +26,17 @@ def ranked_job():
 def terminate(process):
     if process is None or process.poll() is not None:
         return
-    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass  # The owned group exited between poll and signal; still reap it.
     try:
         process.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        os.killpg(process.pid, signal.SIGKILL)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         process.wait(timeout=5)
 
 

--- a/scripts/benchmarks/run_radix_http.py
+++ b/scripts/benchmarks/run_radix_http.py
@@ -17,6 +17,8 @@ import sys
 import time
 import urllib.request
 
+from radix_prefix_cache import load_replay
+
 
 def ranked_job():
     return subprocess.run(["pgrep", "-f", r"Runner\.Worker|benchctl measure-job|measure-job\.sh"],
@@ -53,6 +55,8 @@ def main():
     parser.add_argument("--lengths", default="512,2048,8192")
     parser.add_argument("--replay")
     args = parser.parse_args()
+    if args.replay:
+        load_replay(args.replay, args.model, args.output)
     if ranked_job() or subprocess.run(["pgrep", "-x", "darkbloom"], stdout=subprocess.DEVNULL).returncode == 0:
         raise SystemExit("Dedicated host is busy")
     if os.getloadavg()[0] > 4:

--- a/scripts/benchmarks/run_radix_http.py
+++ b/scripts/benchmarks/run_radix_http.py
@@ -36,7 +36,7 @@ def terminate(process):
         try:
             os.killpg(process.pid, signal.SIGKILL)
         except ProcessLookupError:
-            pass
+            pass  # The owned group exited after timeout; still reap its child.
         process.wait(timeout=5)
 
 

--- a/scripts/benchmarks/test_radix_generation_comparison.py
+++ b/scripts/benchmarks/test_radix_generation_comparison.py
@@ -2,7 +2,9 @@ import copy
 import contextlib
 import io
 import unittest
+from unittest.mock import patch
 
+import radix_generation_comparison
 from radix_generation_comparison import comparison_records, policy_errors
 from radix_engine_evidence import cancellation_errors, report_errors
 from run_radix_engine import arguments, probe_command
@@ -10,6 +12,19 @@ import test_radix_engine_evidence as fixtures
 
 
 class GenerationComparisonTests(unittest.TestCase):
+    def test_repeated_pairs_hash_each_observation_once_without_aliasing_records(self):
+        row = {"id": "same", "prompt_token_ids": [1, 2], "token_ids": [3, 4],
+               "kind": "first", "scope": "a", "finish": "stop", "completion_tokens": 2}
+        report = {"rows": [dict(row) for _ in range(4)]}
+        sha256 = radix_generation_comparison.hashlib.sha256
+        with patch.object(radix_generation_comparison.hashlib, "sha256", wraps=sha256) as hashes:
+            records = comparison_records(report)
+        self.assertEqual(6, len(records))
+        self.assertEqual(8, hashes.call_count)  # token IDs and prompt IDs once per observation
+        records[0]["left"]["id"] = "changed"
+        self.assertEqual("same", records[1]["left"]["id"])
+        self.assertTrue(all(row["tokens_equal"] for row in records))
+
     def fixture(self, policy="record"):
         r = fixtures.FinalEvidenceTests().primed_fixture()
         # The historical synthetic fixture aliases its two tenant-A rows.

--- a/scripts/benchmarks/test_radix_generation_comparison.py
+++ b/scripts/benchmarks/test_radix_generation_comparison.py
@@ -5,7 +5,6 @@ import unittest
 from unittest.mock import patch
 
 import radix_generation_comparison
-from radix_generation_comparison import comparison_records, policy_errors
 from radix_engine_evidence import cancellation_errors, report_errors
 from run_radix_engine import arguments, probe_command
 import test_radix_engine_evidence as fixtures
@@ -18,7 +17,7 @@ class GenerationComparisonTests(unittest.TestCase):
         report = {"rows": [dict(row) for _ in range(4)]}
         sha256 = radix_generation_comparison.hashlib.sha256
         with patch.object(radix_generation_comparison.hashlib, "sha256", wraps=sha256) as hashes:
-            records = comparison_records(report)
+            records = radix_generation_comparison.comparison_records(report)
         self.assertEqual(6, len(records))
         self.assertEqual(8, hashes.call_count)  # token IDs and prompt IDs once per observation
         records[0]["left"]["id"] = "changed"
@@ -45,7 +44,7 @@ class GenerationComparisonTests(unittest.TestCase):
         return self.seal(r)
 
     def seal(self, r):
-        r["generated_token_comparisons"] = comparison_records(r)
+        r["generated_token_comparisons"] = radix_generation_comparison.comparison_records(r)
         equal = bool(r["generated_token_comparisons"]) and all(c["tokens_equal"] for c in r["generated_token_comparisons"])
         r["generated_token_comparisons_pass"] = equal
         r["strict_generation_pass"] = r["generation_comparison_policy"] == "strict" and r["status"] == "completed" and equal
@@ -53,8 +52,8 @@ class GenerationComparisonTests(unittest.TestCase):
 
     def test_explicit_record_retains_failure_and_default_validator_rejects_it(self):
         r = self.fixture()
-        self.assertEqual(policy_errors(r, "record"), [])
-        self.assertIn("generation_comparison_policy_mismatch", policy_errors(r))
+        self.assertEqual(radix_generation_comparison.policy_errors(r, "record"), [])
+        self.assertIn("generation_comparison_policy_mismatch", radix_generation_comparison.policy_errors(r))
         self.assertEqual(cancellation_errors(r, "record"), [])
         self.assertEqual(report_errors(r, "record"), [])
         self.assertFalse(r["strict_generation_pass"])
@@ -102,13 +101,13 @@ class GenerationComparisonTests(unittest.TestCase):
                        lambda r: r["generated_token_comparisons"][0].update(outcome="PASS", tokens_equal=True, first_difference_zero_based=900),
                        lambda r: r.update(generation_comparison_policy="ignore")):
             r = self.fixture(); mutate(r)
-            self.assertTrue(policy_errors(r, "record"))
+            self.assertTrue(radix_generation_comparison.policy_errors(r, "record"))
         self.assertTrue(report_errors({"schema": 1}, "record"))
-        self.assertTrue(policy_errors(self.fixture(), "anything"))
+        self.assertTrue(radix_generation_comparison.policy_errors(self.fixture(), "anything"))
 
     def test_cancel_prefix_longer_than_donor_is_a_difference(self):
         r = self.fixture(); r["cancelled"]["token_ids"] = r["cancel_donor"]["token_ids"] + [99]
-        c = next(c for c in comparison_records(r) if c["left"]["path"] == "cancel_donor" and c["right"]["path"] == "cancelled")
+        c = next(c for c in radix_generation_comparison.comparison_records(r) if c["left"]["path"] == "cancel_donor" and c["right"]["path"] == "cancelled")
         self.assertFalse(c["tokens_equal"])
         self.assertEqual(c["first_difference_zero_based"], len(r["cancel_donor"]["token_ids"]))
 

--- a/scripts/benchmarks/test_radix_prefix_cache.py
+++ b/scripts/benchmarks/test_radix_prefix_cache.py
@@ -1,5 +1,11 @@
 import json
+from contextlib import redirect_stdout
+import io
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 import radix_prefix_cache as bench
 
@@ -55,6 +61,64 @@ class StreamEvidenceTests(unittest.TestCase):
         self.assertEqual(first["messages"][1]["content"][:32000], branch["messages"][1]["content"][:32000])
         self.assertNotEqual(first["messages"][0], plan[6]["messages"][0])
         self.assertEqual(plan[4]["parent"], first["id"])
+
+
+class ReplayInputTests(unittest.TestCase):
+    response = {"text": "answer", "reasoning": "", "finish_reasons": ["stop"],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2}, "ttft_s": 1}
+
+    def test_invalid_plan_is_refused_before_requests_and_artifact_writes(self):
+        def row(name, model="fixture", **case):
+            return {"case": {"id": name, "kind": "first", **case},
+                    "request": {"model": model}, "response": self.response}
+        plans = [[], [row("../escaped")], [row("/absolute")], [row("nested/file")],
+                 [row("a\\b")], [row("bad\x00id")], [row("warmup")], [row("REPORT")],
+                 [row("cancellation")], [row("same"), row("same")],
+                 [row("same"), row("SAME")], [row("first", "other-model")],
+                 [row("first", equal_to="missing")], [row(None)],
+                 [row("café"), row("cafe\u0301")], [row("first", equal_to=["missing"])]]
+        for rows in plans:
+            with self.subTest(rows=rows), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                rows = [{**item, "case": {**item["case"], "id": str(root / "absolute")}}
+                        if item["case"]["id"] == "/absolute" else item for item in rows]
+                source, output = root / "source.json", root / "run"
+                source.write_text(json.dumps({"rows": rows}))
+                args = SimpleNamespace(output=str(output), replay=str(source), model="fixture",
+                                       base="http://fixture.invalid", lengths=[512], repeats=1, label="fixture")
+                with patch.object(bench, "request", return_value=self.response) as request, \
+                     patch.object(bench, "metrics", return_value="stub") as metrics, \
+                     redirect_stdout(io.StringIO()), self.assertRaises(ValueError):
+                    bench.run(args)
+                request.assert_not_called()
+                metrics.assert_not_called()
+                self.assertFalse(output.exists())
+                self.assertFalse((root / "escaped.json").exists())
+
+    def test_replay_preserves_order_and_entire_request_body(self):
+        response = {"text": "retained answer", "reasoning": "", "finish_reasons": ["stop"],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 2}, "ttft_s": 1}
+        body = {"model": "fixture", "messages": [{"role": "user", "content": "authored"}],
+                "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                "temperature": 0.7, "max_tokens": 13, "_darkbloom_prompt_date": "2026-09-05"}
+        rows = [{"case": {"id": "custom-first", "kind": "first"}, "request": body, "response": response},
+                {"case": {"id": "custom-repeat", "kind": "repeat", "equal_to": "custom-first"},
+                 "request": dict(body, seed=42), "response": response}]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source, output = root / "source.json", root / "run"
+            source.write_text(json.dumps({"rows": rows}))
+            original = source.read_bytes()
+            args = SimpleNamespace(output=str(output), replay=str(source), model="fixture",
+                                   base="http://fixture.invalid", lengths=[512], repeats=1, label="fixture")
+            with patch.object(bench, "request", return_value=response) as request, \
+                 patch.object(bench, "metrics", return_value="stub metrics"), redirect_stdout(io.StringIO()):
+                bench.run(args)
+            self.assertEqual([call.args[1] for call in request.call_args_list[1:3]], [row["request"] for row in rows])
+            actual = json.loads((output / "report.json").read_text())["rows"]
+            self.assertEqual([item["case"] for item in actual], [row["case"] for row in rows])
+            self.assertEqual([item["request"] for item in actual], [row["request"] for row in rows])
+            self.assertEqual(source.read_bytes(), original)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/test_radix_prefix_cache.py
+++ b/scripts/benchmarks/test_radix_prefix_cache.py
@@ -1,6 +1,7 @@
 import json
 from contextlib import redirect_stdout
 import io
+import os
 from pathlib import Path
 import tempfile
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ import unittest
 from unittest.mock import patch
 
 import radix_prefix_cache as bench
+import run_radix_http
 
 
 def frame(delta=None, finish=None, usage=None):
@@ -76,7 +78,9 @@ class ReplayInputTests(unittest.TestCase):
                  [row("cancellation")], [row("same"), row("same")],
                  [row("same"), row("SAME")], [row("first", "other-model")],
                  [row("first", equal_to="missing")], [row(None)],
-                 [row("café"), row("cafe\u0301")], [row("first", equal_to=["missing"])]]
+                 [row("café"), row("cafe\u0301")], [row("first", equal_to=["missing"])],
+                 *[[row("first", equal_to=value)] for value in (0, False, [], {}, "")],
+                 [row("x" * 251)], [row("é" * 126)]]
         for rows in plans:
             with self.subTest(rows=rows), tempfile.TemporaryDirectory() as directory:
                 root = Path(directory)
@@ -94,6 +98,34 @@ class ReplayInputTests(unittest.TestCase):
                 metrics.assert_not_called()
                 self.assertFalse(output.exists())
                 self.assertFalse((root / "escaped.json").exists())
+
+    def test_wrapper_refuses_invalid_replay_before_host_work(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "invalid.json"
+            source.write_text('{"rows": []}')
+            output = root / "new-output"
+            argv = ["run_radix_http.py", "--binary", "/unused/provider", "--output", str(output),
+                    "--model", "fixture", "--replay", str(source)]
+            with patch.object(run_radix_http.sys, "argv", argv), \
+                 patch.object(run_radix_http, "ranked_job", side_effect=AssertionError("host probe")) as ranked, \
+                 patch.object(run_radix_http.subprocess, "Popen") as launch, \
+                 self.assertRaises(ValueError):
+                run_radix_http.main()
+            ranked.assert_not_called()
+            launch.assert_not_called()
+            self.assertFalse(output.exists())
+
+    def test_filename_byte_boundary_includes_json_suffix(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            limit = os.pathconf(root, "PC_NAME_MAX")
+            source = root / "source.json"
+            for name in ("x" * (limit - 5), "é" * ((limit - 5) // 2)):
+                row = {"case": {"id": name, "kind": "first", "equal_to": None},
+                       "request": {"model": "fixture"}}
+                source.write_text(json.dumps({"rows": [row]}))
+                self.assertEqual(list(bench.load_replay(source, "fixture")), [name])
 
     def test_replay_preserves_order_and_entire_request_body(self):
         response = {"text": "retained answer", "reasoning": "", "finish_reasons": ["stop"],

--- a/scripts/benchmarks/test_radix_process_cleanup.py
+++ b/scripts/benchmarks/test_radix_process_cleanup.py
@@ -1,0 +1,40 @@
+"""Owned process-group cleanup races, entirely stubbed without signaling a host."""
+import signal
+import subprocess
+import unittest
+from unittest.mock import Mock, call, patch
+
+from run_radix_http import terminate
+
+
+class ProcessCleanupTests(unittest.TestCase):
+    def process(self):
+        return Mock(pid=12345, poll=Mock(return_value=None))
+
+    def test_disappearance_before_term_still_reaps_the_owned_process(self):
+        process = self.process()
+        with patch("run_radix_http.os.killpg", side_effect=ProcessLookupError) as kill:
+            terminate(process)
+        kill.assert_called_once_with(process.pid, signal.SIGTERM)
+        process.wait.assert_called_once_with(timeout=5)
+
+    def test_disappearance_before_kill_still_reaps_the_owned_process(self):
+        process = self.process()
+        process.wait.side_effect = [subprocess.TimeoutExpired("fixture", 5), 0]
+        with patch("run_radix_http.os.killpg", side_effect=[None, ProcessLookupError]) as kill:
+            terminate(process)
+        self.assertEqual(kill.call_args_list, [call(process.pid, signal.SIGTERM), call(process.pid, signal.SIGKILL)])
+        self.assertEqual(process.wait.call_args_list, [call(timeout=5), call(timeout=5)])
+
+    def test_gone_processes_are_not_signaled_and_real_failures_propagate(self):
+        with patch("run_radix_http.os.killpg") as kill:
+            terminate(None)
+            terminate(Mock(poll=Mock(return_value=0)))
+        kill.assert_not_called()
+        process = self.process()
+        with patch("run_radix_http.os.killpg", side_effect=PermissionError), self.assertRaises(PermissionError):
+            terminate(process)
+        process.wait.assert_not_called()
+        process.wait.side_effect = subprocess.TimeoutExpired("fixture", 5)
+        with patch("run_radix_http.os.killpg"), self.assertRaises(subprocess.TimeoutExpired):
+            terminate(process)


### PR DESCRIPTION
Replay case IDs were used directly as artifact filenames, so a retained input could escape the new output directory, replace `warmup.json`/`report.json`, or silently collapse duplicate rows. An empty replay also fell back to generating a new workload, and a wrong model was rejected only after the warmup request. Separately, an owned process disappearing between `poll` and `killpg` could abort cleanup before it was reaped.

`load_replay` now validates the nonempty plan, model, non-null earlier comparison targets and unique safe artifact names (including the filesystem byte limit and `.json` suffix) before output creation or HTTP work. The owned-provider wrapper runs this preflight before host probes or model startup; the HTTP child revalidates before using the replay. Case/Unicode filename collisions are rejected for the Mac filesystem as well. Request bodies and ordered cases are preserved verbatim. Shared process cleanup treats a disappeared group as an exit race and still waits on the owned process; permission failures and unconfirmed termination still fail.

Pairwise generation comparisons now compute each participating observation's token/prompt identity hashes once, retaining independent dictionaries in every ordered comparison. Strict versus record policy, cancellation-prefix semantics, report schemas, generated-token gates and measured timing formulas are unchanged. No native source or dependency changes are in this PR; the separate native FIFO guard is #951.

**Before**
```mermaid
flowchart TD
  A[radix_prefix_cache.run] --> B[Create output and collapse replay rows into map]
  B --> C[Warmup before model validation]
  C --> D[Case ID becomes unchecked artifact path]
  E[run_radix_http.terminate] --> F[poll then signal]
  F --> G[Exit race raises before wait]
  H[comparison_records pair loop] --> I[Hash both identities for every pair]
```

**After**
```mermaid
flowchart TD
  A[Wrapper and HTTP run delegate load_replay] --> B[Validate model order comparison targets and bounded filenames]
  B --> C[Create output then warmup and exact replay requests]
  B --> D[Invalid plan refuses before HTTP or writes]
  E[terminate] --> F[Signal owned group]
  F --> G[Disappeared group still reaches owned wait]
  H[comparison_records pair loop] --> I[Lazy per-observation identity cache]
  I --> J[Independent ordered comparison values]
```

Validation: all 134 benchmark CPU tests pass using pinned Python 3.12/NumPy 2.4.2, including 95 scoped radix tests. New regressions reproduce the original replay failures, TERM/KILL exit races and repeated hashing. Fixtures use temporary owned directories and mocked HTTP/process operations; no real endpoint, `pgrep`, provider, macmon or signal is invoked. A 1,000-report differential matches exact prior JSON, including record/key order. Four same-prompt observations now use eight hashes instead of twenty-four. Docs lint passes on 278 documents.

Source review covers the remaining native benchmark packages and Python radix helpers; the reviewed native implementation and existing operator tests are unchanged here and were not executed. These CPU checks establish helper behavior, not model performance or release qualification.

All existing review findings are addressed. Final Codex approval is pending because the connector reports its review usage limit has been reached.
