### PR TITLE
Simplify trust bookkeeping and validate throughput anomaly inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Throughput anomaly validation** — Keep default detector thresholds when overrides are non-finite, and skip invalid observations or unusable expected rates so they cannot produce misleading anomaly reports. Existing valid thresholds, model classes and routing policy remain unchanged.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/api/throughput_anomaly.go
+++ b/coordinator/api/throughput_anomaly.go
@@ -12,6 +12,7 @@ package api
 
 import (
 	"context"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -67,7 +68,7 @@ func (s *Server) StartThroughputAnomalyDetector(ctx context.Context) {
 func throughputAnomalyConfigFromEnv() registry.ThroughputAnomalyConfig {
 	cfg := registry.DefaultThroughputAnomalyConfig()
 	if v := os.Getenv("EIGENINFERENCE_THROUGHPUT_ANOMALY_RATIO"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && !math.IsInf(f, 0) {
 			cfg.RatioThreshold = f
 		}
 	}
@@ -77,7 +78,7 @@ func throughputAnomalyConfigFromEnv() registry.ThroughputAnomalyConfig {
 		}
 	}
 	if v := os.Getenv("EIGENINFERENCE_THROUGHPUT_ANOMALY_EFFICIENCY"); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 && !math.IsInf(f, 0) {
 			cfg.Efficiency = f
 		}
 	}

--- a/coordinator/api/throughput_anomaly_test.go
+++ b/coordinator/api/throughput_anomaly_test.go
@@ -125,3 +125,21 @@ func TestThroughputAnomalySweep_EmitsDatadog(t *testing.T) {
 		t.Errorf("missing chip_family tag; got packets: %v", packets)
 	}
 }
+
+func TestThroughputAnomalyConfigRejectsNonFiniteOverrides(t *testing.T) {
+	keys := []string{"EIGENINFERENCE_THROUGHPUT_ANOMALY_RATIO", "EIGENINFERENCE_THROUGHPUT_ANOMALY_EFFICIENCY", "EIGENINFERENCE_THROUGHPUT_ANOMALY_MIN_SAMPLES"}
+	for _, key := range keys {
+		t.Setenv(key, "")
+	}
+	want := registry.DefaultThroughputAnomalyConfig()
+	for _, key := range keys[:2] {
+		for _, value := range []string{"NaN", "+Inf", "-Inf"} {
+			t.Run(key+"/"+value, func(t *testing.T) {
+				t.Setenv(key, value)
+				if got := throughputAnomalyConfigFromEnv(); got != want {
+					t.Fatalf("startup config=%+v, want finite defaults %+v", got, want)
+				}
+			})
+		}
+	}
+}

--- a/coordinator/registry/attestation_policy.go
+++ b/coordinator/registry/attestation_policy.go
@@ -394,10 +394,8 @@ func (r *Registry) markUntrusted(providerID string, recoverable bool) {
 
 // SetTrustLevel updates a provider's trust level (thread-safe).
 func (r *Registry) SetTrustLevel(providerID string, level TrustLevel) {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return
 	}
 	p.mu.Lock()
@@ -422,10 +420,8 @@ func (r *Registry) SetTrustLevel(providerID string, level TrustLevel) {
 // online. The caller uses that to push a fresh "online" trust_status so the
 // provider's locally persisted operator state reflects recovery.
 func (r *Registry) RecordChallengeSuccess(providerID string) bool {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return false
 	}
 
@@ -514,10 +510,8 @@ func (r *Registry) recoverIfTransientlyUntrusted(providerID string, p *Provider)
 // disabled, binary hash mismatch, etc.), routing eligibility is cleared
 // immediately because the provider actively failed a security check.
 func (r *Registry) RecordChallengeFailure(providerID string, transientOnly bool) int {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return 0
 	}
 
@@ -526,12 +520,8 @@ func (r *Registry) RecordChallengeFailure(providerID string, transientOnly bool)
 	p.Reputation.RecordChallengeFail()
 	count := p.FailedChallenges
 
-	if !transientOnly {
-		// Security failure — clear routing eligibility immediately.
-		p.LastChallengeVerified = time.Time{}
-		p.ChallengeVerifiedSIP = false
-	} else if count >= MaxFailedChallenges {
-		// Transient failures only clear after hitting the threshold.
+	// A security failure clears immediately; a timeout clears at the threshold.
+	if !transientOnly || count >= MaxFailedChallenges {
 		p.LastChallengeVerified = time.Time{}
 		p.ChallengeVerifiedSIP = false
 	}

--- a/coordinator/registry/reputation.go
+++ b/coordinator/registry/reputation.go
@@ -124,24 +124,9 @@ func (r *Reputation) Score() float64 {
 		jobRate = 0.5 // neutral if no jobs yet
 	}
 
-	// Uptime ratio (30%) — 24-hour expected-uptime baseline, FLOORED at the
-	// neutral 0.5 during ramp-up. Uptime only ever *adds* above the legacy
-	// baseline: it never pulls a provider below the score it had when uptime
-	// was untracked (== 0.5). Without this floor a freshly-connected or
-	// recently-restarted provider (small TotalUptime → tiny ratio) would score
-	// BELOW the old 0.85 cap for ~12h and be derouted — and because prod uses
-	// the in-memory store, TotalUptime resets on every coordinator restart /
-	// provider reconnect, so that penalty would re-apply fleet-wide.
-	uptimeRate := 0.5
-	expectedUptime := 24 * time.Hour
-	if r.TotalUptime > 0 {
-		if ratio := float64(r.TotalUptime) / float64(expectedUptime); ratio > uptimeRate {
-			uptimeRate = ratio
-		}
-		if uptimeRate > 1.0 {
-			uptimeRate = 1.0
-		}
-	}
+	// Uptime contributes above a neutral floor during the 24-hour ramp;
+	// newly connected providers are never penalized for missing uptime history.
+	uptimeRate := min(1.0, max(0.5, float64(r.TotalUptime)/float64(24*time.Hour)))
 
 	// Challenge pass rate (20%)
 	var challengeRate float64
@@ -170,14 +155,7 @@ func (r *Reputation) Score() float64 {
 
 	score := 0.4*jobRate + 0.3*uptimeRate + 0.2*challengeRate + 0.1*responseTimeFactor
 
-	// Clamp to [0.0, 1.0]
-	if score < 0.0 {
-		return 0.0
-	}
-	if score > 1.0 {
-		return 1.0
-	}
-	return score
+	return min(1.0, max(0.0, score))
 }
 
 // RecordJobSuccess records a successful job completion for the provider's
@@ -196,10 +174,8 @@ func (r *Reputation) Score() float64 {
 // same exposure the uptime counter already had. Failures still persist
 // immediately (RecordJobFailure).
 func (r *Registry) RecordJobSuccess(providerID string, latency time.Duration) {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return
 	}
 
@@ -226,10 +202,8 @@ func (r *Registry) RecordLatency(providerID string, latency time.Duration) {
 	if latency <= 0 {
 		return
 	}
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return
 	}
 	p.RecordLatency(latency)
@@ -251,10 +225,8 @@ func (p *Provider) RecordLatency(latency time.Duration) {
 
 // RecordJobFailure records a failed job for the provider's reputation.
 func (r *Registry) RecordJobFailure(providerID string) {
-	r.mu.RLock()
-	p, ok := r.providers[providerID]
-	r.mu.RUnlock()
-	if !ok {
+	p := r.GetProvider(providerID)
+	if p == nil {
 		return
 	}
 

--- a/coordinator/registry/reputation_test.go
+++ b/coordinator/registry/reputation_test.go
@@ -262,8 +262,8 @@ func TestReputationNoUptimeStillNeutral(t *testing.T) {
 
 // TestReputationRampUptimeNeverBelowLegacyCap is the ramp-down
 // regression flagged in review: once Heartbeat starts crediting uptime, a
-// freshly-connected (or freshly-restarted, since prod uses the in-memory store
-// that resets TotalUptime) provider has a TINY TotalUptime. Without the neutral
+// freshly-connected provider with no restored history has a TINY TotalUptime.
+// Without the neutral
 // floor, uptimeRate = 30s/24h ≈ 0.0003 would crater a perfect provider from
 // 0.85 to ~0.70 for ~12h and deroute it. The floor must hold the score at or
 // above the legacy 0.85 throughout the ramp, only ever adding above it.

--- a/coordinator/registry/throughput_anomaly.go
+++ b/coordinator/registry/throughput_anomaly.go
@@ -124,16 +124,20 @@ var ChipBandwidthGBps = map[string]float64{
 //
 //	expected ≈ bandwidth_GBps × efficiency / (active_params × bytes_per_param)
 //
-// Returns 0 if any input is non-positive.
+// Returns 0 if an input or the derived expectation is non-finite or non-positive.
 func ExpectedDecodeTPS(activeParams, bytesPerParam, bandwidthGBps, efficiency float64) float64 {
-	if activeParams <= 0 || bytesPerParam <= 0 || bandwidthGBps <= 0 || efficiency <= 0 {
+	if !finitePositive(activeParams) || !finitePositive(bytesPerParam) || !finitePositive(bandwidthGBps) || !finitePositive(efficiency) {
 		return 0
 	}
 	readGBPerToken := activeParams * bytesPerParam / 1e9 // bytes → GB
 	if readGBPerToken <= 0 {
 		return 0
 	}
-	return bandwidthGBps * efficiency / readGBPerToken
+	expected := bandwidthGBps * efficiency / readGBPerToken
+	if !finitePositive(expected) {
+		return 0
+	}
+	return expected
 }
 
 // LookupModelDecodeClass resolves a model id to its decode class. It tries an
@@ -283,13 +287,13 @@ func DefaultThroughputAnomalyConfig() ThroughputAnomalyConfig {
 	}
 }
 
-// withDefaults fills any zero/negative field with its default, so a partially
+// withDefaults replaces invalid fields with their defaults, so a partially
 // populated config (or the zero value) still behaves sensibly.
 func (c ThroughputAnomalyConfig) withDefaults() ThroughputAnomalyConfig {
-	if c.Efficiency <= 0 {
+	if !finitePositive(c.Efficiency) {
 		c.Efficiency = DefaultDecodeEfficiency
 	}
-	if c.RatioThreshold <= 0 {
+	if !finitePositive(c.RatioThreshold) {
 		c.RatioThreshold = DefaultAnomalyRatioThreshold
 	}
 	if c.MinSamples <= 0 {
@@ -350,15 +354,15 @@ func EvaluateThroughputAnomaly(in ThroughputAnomalyInput, cfg ThroughputAnomalyC
 	res.BytesPerParam = class.BytesPerParam
 
 	bw := in.BandwidthGBps
-	if bw <= 0 {
+	if !finitePositive(bw) {
 		bw = ChipBandwidthForClass(in.ChipClass)
 	}
 	res.BandwidthGBps = bw
-	if bw <= 0 {
+	if !finitePositive(bw) {
 		res.SkipReason = "unknown_chip"
 		return res
 	}
-	if in.ObservedTPS <= 0 {
+	if !finitePositive(in.ObservedTPS) {
 		res.SkipReason = "no_observation"
 		return res
 	}

--- a/coordinator/registry/throughput_anomaly_test.go
+++ b/coordinator/registry/throughput_anomaly_test.go
@@ -266,3 +266,48 @@ func TestChipBandwidthForClass(t *testing.T) {
 		t.Errorf("empty class bandwidth = %g, want 0", bw)
 	}
 }
+
+func TestThroughputAnomalyNonFiniteConfigUsesDefaults(t *testing.T) {
+	for _, in := range []ThroughputAnomalyInput{
+		{Model: "gpt-oss-20b", ChipClass: "M3 Max", ObservedTPS: 69, Samples: 10},
+		{Model: "gemma-4-26b", ChipClass: "M3 Max", ObservedTPS: 21, Samples: 10},
+	} {
+		want := EvaluateThroughputAnomaly(in, DefaultThroughputAnomalyConfig())
+		for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			for _, field := range []string{"efficiency", "ratio"} {
+				cfg := DefaultThroughputAnomalyConfig()
+				if field == "efficiency" {
+					cfg.Efficiency = value
+				} else {
+					cfg.RatioThreshold = value
+				}
+				if got := EvaluateThroughputAnomaly(in, cfg); got != want {
+					t.Errorf("%s non-finite %s=%v changed verdict: got %+v want %+v", in.Model, field, value, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestThroughputAnomalyInvalidMeasurementsAreNotAnomalies(t *testing.T) {
+	for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		in := ThroughputAnomalyInput{Model: "gpt-oss-20b", ChipClass: "M3 Max", ObservedTPS: value, Samples: 10}
+		if got := EvaluateThroughputAnomaly(in, DefaultThroughputAnomalyConfig()); got.Evaluated || got.Anomalous || got.SkipReason != "no_observation" {
+			t.Errorf("invalid observation %v was evaluated: %+v", value, got)
+		}
+		in.ObservedTPS, in.BandwidthGBps = 69, value
+		if got := EvaluateThroughputAnomaly(in, DefaultThroughputAnomalyConfig()); !got.Evaluated || got.Anomalous || got.BandwidthGBps != 400 {
+			t.Errorf("invalid bandwidth %v did not use class fallback: %+v", value, got)
+		}
+		for index := range 4 {
+			inputs := []float64{3.6e9, BytesPerParam4Bit, 400, .8}
+			inputs[index] = value
+			if got := ExpectedDecodeTPS(inputs[0], inputs[1], inputs[2], inputs[3]); got != 0 {
+				t.Errorf("invalid input %d=%v yielded expectation %v", index, value, got)
+			}
+		}
+	}
+	if got := ExpectedDecodeTPS(1, 1, math.MaxFloat64, 2); got != 0 {
+		t.Errorf("overflowed expectation=%v", got)
+	}
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `fa6d62dcd`
 
 Every environment variable read by the coordinator, the provider CLI
 (`darkbloom`), console-ui and admin-ui: accepted values, the compiled default,
@@ -253,9 +253,11 @@ Throughput anomaly detector:
 | Variable | Values / type | Default | Read in | Effect |
 |---|---|---|---|---|
 | `EIGENINFERENCE_THROUGHPUT_ANOMALY_INTERVAL` | Go duration > 0 | `5m` | `coordinator/api/throughput_anomaly.go` (`StartThroughputAnomalyDetector`) | Sweep cadence comparing observed decode rate to expectation per (model, chip class). |
-| `EIGENINFERENCE_THROUGHPUT_ANOMALY_RATIO` | float > 0 | `0.35` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Observed/expected ratio below which a bucket is anomalous. |
+| `EIGENINFERENCE_THROUGHPUT_ANOMALY_RATIO` | finite float > 0 | `0.35` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Observed/expected ratio below which a bucket is anomalous. |
 | `EIGENINFERENCE_THROUGHPUT_ANOMALY_MIN_SAMPLES` | integer > 0 | `3` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Providers required in a bucket before it is judged. |
-| `EIGENINFERENCE_THROUGHPUT_ANOMALY_EFFICIENCY` | float > 0 | `0.80` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Expected decode efficiency relative to the chip's theoretical rate. |
+| `EIGENINFERENCE_THROUGHPUT_ANOMALY_EFFICIENCY` | finite float > 0 | `0.80` | `coordinator/api/throughput_anomaly.go` (`throughputAnomalyConfigFromEnv`) | Expected decode efficiency relative to the chip's theoretical rate. |
+
+Invalid throughput-detector overrides, including `NaN` and infinity, retain the field's default; startup logs report the resulting settings (`coordinator/api/throughput_anomaly.go`, `throughputAnomalyConfigFromEnv`).
 
 ### Billing, Stripe and base rewards
 

--- a/docs/reference/telemetry-inventory.md
+++ b/docs/reference/telemetry-inventory.md
@@ -1,6 +1,6 @@
 # Telemetry inventory
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `fa6d62dcd`
 
 Every datum the system collects today, with its producer, sink, cadence and
 retention. Anything not on this page is not emitted by the code at this commit.
@@ -96,6 +96,14 @@ lists every name).
 | `provider_version_below_minimum` (no `provider.` prefix) | count | `gate:registration`, `challenge_revalidation`, `manifest_sync`; `version` | provider below `EIGENINFERENCE_MIN_PROVIDER_VERSION` at one of the three gates |
 | `provider.load_model_status_rejected` | count | `reason:invalid_status`, `no_pending_command` | `load_model_status` frame that did not match an outstanding `load_model` |
 | `attestation.challenges_sent`, `attestation.challenges` (`outcome:passed`, `failed`, `status_sig_missing`, `status_sig_failed`), `attestation.failures{reason}`, `attestation.force_reconnect{reason}` | count | as listed | SE challenge lifecycle per provider session |
+
+The throughput detector evaluates finite positive observed and expected decode rates.
+An invalid bandwidth uses the existing chip-class fallback; an invalid observation
+or unusable derived expectation skips the bucket without emitting an anomaly.
+Threshold validation and defaults are described in [`configuration.md`](configuration.md).
+The detector remains read-only with respect to provider routing and trust
+(`coordinator/registry/throughput_anomaly.go`, `EvaluateThroughputAnomaly`;
+`coordinator/api/throughput_anomaly.go`, `sweepThroughputAnomalies`).
 
 ### From request outcomes
 


### PR DESCRIPTION
Malformed throughput-detector overrides such as `+Inf` could flag a healthy bucket, while invalid observations or expected rates could enter the comparison. Require finite positive inputs and expectations, retain the existing defaults for invalid threshold overrides, and keep startup logs consistent with those settings.

The related trust/reputation review also removes six repeated registry lookup blocks using the existing `GetProvider` lock contract, combines the identical challenge-clear assignments, and expresses uptime and score bounds directly. Security failures still clear verification immediately; timeouts still wait for the existing consecutive-failure threshold. Trust recovery, quarantine, proof invalidation, persistence ordering, routing defaults, model classes and measured constants stay unchanged.

```mermaid
flowchart LR
  subgraph Before
    E[Threshold override] --> P[ParseFloat and positive comparison]
    P --> I[Infinity accepted]
    I --> V[EvaluateThroughputAnomaly]
    O[Invalid measurement] --> V
    V --> A[Misleading anomaly or unusable comparison]
    T[Challenge or reputation update] --> L[Repeated registry lookup lock blocks]
    L --> D[Duplicated challenge-clear branches]
    D --> S[Existing state and persistence transitions]
  end
  subgraph After
    E2[Threshold override] --> P2[Finite positive validation]
    P2 --> C[Valid override or existing default]
    C --> V2[Finite input and expected-rate checks]
    O2[Invalid measurement] --> V2
    V2 --> A2[Existing verdict or explicit skipped bucket]
    T2[Challenge or reputation update] --> L2[GetProvider releases registry read lock]
    L2 --> D2[One security-or-threshold predicate]
    D2 --> S2[Same state and persistence transitions]
  end
```

Validation:

- New evaluator and actual environment-parser regressions fail against unchanged master for non-finite configuration, observations, bandwidth and overflowed expectations.
- Focused Go 1.25 race suites pass: registry 2.482s, API 8.331s. Final fixtures include healthy and anomalous default verdicts.
- Full Go 1.25 race suites pass: registry 24.077s, API 226.601s.
- Documentation lint passes (278 pages). Independent production/test review found no blocker.
- No live provider, model, GPU, deployment or Swift operations were performed.

Production code is 33 lines smaller overall; regression tests and documentation add coverage. This changes invalid detector-input handling, not the detector's finite operating thresholds or provider trust policy.

Current CI limitation: Threat Model Review fails before review with an Anthropic authentication error (401, invalid API key; run 34663207576). Source checks and the separate Codex review pass.
