### PR TITLE
Stop cache soak monitoring cleanly and count complete log lines once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python3 scripts/test-provider-release-resolution.py
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
+          python3 scripts/test_cache_soak_monitor.py
       - name: Test startup observer against local stubs
         run: python3 -m unittest discover -s scripts/startup_measurement -t scripts -p 'test_*.py'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The cache soak monitor stops after an interrupt or termination signal and counts cache markers once when log lines arrive across multiple writes.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `223f4cb25`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -16,6 +16,10 @@ Go/Swift fixture and focused checks are described in [test.md](test.md) and
 [prediction telemetry](../reference/prediction-decision-telemetry.md).
 
 ## Prerequisites
+
+- The cache soak observer uses macOS Bash 3.2 and stock logging tools. Its
+  [offline fixtures](test.md#6-scripts-and-release-integrity) use Python and owned
+  command stubs; they require no provider build or running inference service.
 
 - **Toolchain via [`mise`](https://mise.jdx.dev/).** Every version is pinned in
   [`mise.toml`](../../mise.toml); `mise install` installs them all.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `223f4cb25`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -922,6 +922,13 @@ node --test landing/earn-calculator-core.test.js
 ```
 
 ### 6. Scripts and release integrity
+
+`python3 scripts/test_cache_soak_monitor.py` runs the actual Bash observer with
+owned log, process and sampling stubs. It checks that INT/TERM stop sampling and
+clean up once, split log lines are counted after completion, and successive
+windows preserve marker counts and the latest hit rate. This runs in Release
+Integrity CI and makes no provider or system-log request. See
+[cache rollout observation](../operations/cache-routing-rollout.md#provider-soak-observation).
 
 ```bash
 make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contbatch/tests -t .   (in scripts/)

--- a/docs/operations/cache-routing-rollout.md
+++ b/docs/operations/cache-routing-rollout.md
@@ -1,6 +1,6 @@
 # Cache-aware routing: activation, ramp and rollback
 
-> Last updated: 2026-09-11 · commit `ef7b5a9aa`
+> Last updated: 2026-09-11 · commit `223f4cb25`
 
 How to turn provider-confirmed prefix-cache routing on for the production
 coordinator, widen its activation bounds one at a time, and turn it off again.
@@ -267,6 +267,20 @@ cache-selected reported-hit subset. This remains a scheduler estimate, not a
 measured uncached comparison. Admin metrics expose the same counters and timing
 histograms. See the [metric inventory](../reference/telemetry-inventory.md#cache-results-by-model-internal).
 These breakdowns start at deployment and cannot reconstruct prior model counts.
+
+### Provider soak observation
+
+For an already running local provider soak, run `scripts/cache_soak_monitor.sh`
+on its Mac with separate output paths for the CSV, events and raw unified log.
+Use `--help` for the sampling, duration and path options. The observer starts
+only its own log capture; it does not start inference or change cache settings.
+
+The CSV counts complete new log lines per sample. A line split across writes
+is carried into the next sample until its newline arrives, and the latest
+reported hit rate persists between stats lines. INT or TERM exits after the
+current foreground sample command returns, then stops and waits for the owned
+capture once. Keep the raw log when interpreting a partial final line; these
+local markers complement the coordinator evidence above.
 
 ## Rollback
 

--- a/scripts/cache_soak_monitor.sh
+++ b/scripts/cache_soak_monitor.sh
@@ -60,19 +60,23 @@ ts() { date '+%Y-%m-%dT%H:%M:%S'; }
 # Debug level is needed for the per-file store/write markers; the failure and
 # eviction markers are info/warning. --style compact keeps lines greppable.
 echo "$(ts) monitor: starting log stream (subsystem=$SUBSYSTEM) -> $RAW_LOG" | tee -a "$EVENTS_LOG"
-: > "$RAW_LOG"
+: > "$RAW_LOG" || exit 1
+exec 3< "$RAW_LOG" || exit 1
 log stream \
   --predicate "subsystem == \"$SUBSYSTEM\"" \
   --level debug \
-  --style compact >> "$RAW_LOG" 2>&1 &
+  --style compact >> "$RAW_LOG" 2>&1 3<&- &
 LOG_PID=$!
 
 cleanup() {
   echo "$(ts) monitor: stopping (log stream pid=$LOG_PID)" | tee -a "$EVENTS_LOG"
   kill "$LOG_PID" 2>/dev/null
   wait "$LOG_PID" 2>/dev/null
+  exec 3<&-
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # ---- marker patterns (extended regex) -----------------------------------------
 # Each maps to a CSV column counting NEW occurrences in the window. Keep these
@@ -100,8 +104,9 @@ if [ ! -s "$OUT_CSV" ]; then
   echo "ts,elapsed_s,disk_kb,file_count,rss_kb,cpu_speed_limit,active,store,sweep,evict,ram_evict,decrypt_fail,mb1_drop,hash_mismatch,disabled,ephemeral,hit_rate" > "$OUT_CSV"
 fi
 
-# byte offset into RAW_LOG already consumed
-RAW_OFFSET=0
+# File descriptor 3 owns the read position. Keep an unfinished log line until
+# its newline arrives, so a marker split across writes belongs to one window.
+RAW_PARTIAL=""
 # latest cumulative hit rate seen in a "prefix cache stats: ... hitRate=NN.N%"
 # line (logged every DARKBLOOM_PREFIX_CACHE_STATS_INTERVAL_SECS, default 120s).
 # Persisted across ticks since the stats line is sparser than the sample tick.
@@ -156,15 +161,13 @@ while true; do
   CPU_SPEED_LIMIT=$(pmset -g therm 2>/dev/null | awk -F'= ' '/CPU_Speed_Limit/{print $2; exit}')
   [ -z "$CPU_SPEED_LIMIT" ] && CPU_SPEED_LIMIT=NA
 
-  # --- new log bytes since last tick ---
-  RAW_SIZE=$(wc -c < "$RAW_LOG" 2>/dev/null | tr -d ' ')
-  [ -z "$RAW_SIZE" ] && RAW_SIZE=0
-  if [ "$RAW_SIZE" -gt "$RAW_OFFSET" ]; then
-    WINDOW=$(tail -c +$(( RAW_OFFSET + 1 )) "$RAW_LOG" 2>/dev/null)
-    RAW_OFFSET=$RAW_SIZE
-  else
-    WINDOW=""
-  fi
+  # --- complete new log lines since last tick ---
+  WINDOW=""
+  while IFS= read -r LINE <&3; do
+    WINDOW="${WINDOW}${RAW_PARTIAL}${LINE}"$'\n'
+    RAW_PARTIAL=""
+  done
+  RAW_PARTIAL="${RAW_PARTIAL}${LINE}"
 
   C_ACTIVE=$(count_new_markers "$RE_ACTIVE")
   C_STORE=$(count_new_markers "$RE_STORE")

--- a/scripts/test_cache_soak_monitor.py
+++ b/scripts/test_cache_soak_monitor.py
@@ -1,0 +1,147 @@
+"""Exercise the Bash monitor with owned log, process and sampling stubs."""
+
+import csv
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("cache_soak_monitor.sh")
+
+
+class MonitorTests(unittest.TestCase):
+    def fixture(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        root = Path(temporary.name)
+        commands = root / "commands"
+        commands.mkdir()
+        common = f"#!{sys.executable}\n" + '''import os, signal, time
+from pathlib import Path
+root = Path(os.environ["SOAK_MONITOR_FIXTURE"])
+def await_file(path):
+    deadline = time.monotonic() + 10
+    while not path.exists():
+        if time.monotonic() > deadline:
+            raise SystemExit("fixture rendezvous timed out: " + str(path))
+        time.sleep(0.005)
+'''
+        stubs = {
+            "log": common + '''signal.signal(signal.SIGTERM, lambda *_: exit(0))
+(root / "log-ready").touch()
+index = 0
+while True:
+    path = root / ("chunk-" + str(index))
+    await_file(path)
+    os.write(1, path.read_bytes())
+    (root / ("written-" + str(index))).touch()
+    index += 1
+''',
+            "sleep": common + '''path = root / "tick-count"
+index = int(path.read_text()) if path.exists() else 0
+path.write_text(str(index + 1))
+(root / ("tick-" + str(index))).touch()
+await_file(root / ("advance-" + str(index)))
+''',
+            "pgrep": "#!/bin/sh\nexit 1\n",
+            "pmset": "#!/bin/sh\nprintf 'CPU_Speed_Limit = 100\\n'\n",
+        }
+        for name, source in stubs.items():
+            path = commands / name
+            path.write_text(source)
+            path.chmod(0o755)
+        log = (root / "monitor-output").open("w")
+        self.addCleanup(log.close)
+        process = subprocess.Popen(
+            ["/bin/bash", str(SCRIPT), "--kv-dir", str(root / "absent-cache"),
+             "--proc", "fixture-only", "--interval", "1", "--out-csv", str(root / "samples.csv"),
+             "--events-log", str(root / "events.log"), "--raw-log", str(root / "raw.log")],
+            env={**os.environ, "PATH": str(commands) + os.pathsep + os.environ["PATH"],
+                 "SOAK_MONITOR_FIXTURE": str(root)},
+            stdout=log, stderr=subprocess.STDOUT, start_new_session=True,
+        )
+
+        def cleanup():
+            if process.poll() is None:
+                # The fixture exclusively owns the new session and its stubs.
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+
+        self.addCleanup(cleanup)
+        self.wait_file(root / "log-ready")
+        self.wait_file(root / "tick-0")
+        return root, process
+
+    def wait_file(self, path):
+        deadline = time.monotonic() + 5
+        while not path.exists() and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.assertTrue(path.exists(), f"fixture did not reach {path.name}")
+
+    def append(self, root, index, chunk):
+        (root / f"chunk-{index}").write_bytes(chunk)
+        self.wait_file(root / f"written-{index}")
+
+    def tick(self, root, index):
+        (root / f"advance-{index}").touch()
+        self.wait_file(root / f"tick-{index + 1}")
+
+    def stop(self, root, process, tick, signum=signal.SIGTERM):
+        process.send_signal(signum)
+        # Bash delivers the trap after its owned foreground sampler returns.
+        (root / f"advance-{tick}").touch()
+        try:
+            result = process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            self.fail("monitor resumed sampling after its stop signal")
+        self.assertEqual(result, 128 + signum)
+        self.assertEqual((root / "events.log").read_text().count("monitor: stopping"), 1)
+
+    def rows(self, root):
+        with (root / "samples.csv").open() as source:
+            return list(csv.DictReader(source))
+
+    def test_stop_signals_end_sampling_and_cleanup_once(self):
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            with self.subTest(signum=signum):
+                root, process = self.fixture()
+                self.stop(root, process, 0, signum)
+                self.assertEqual(len(self.rows(root)), 1)
+
+    def test_partial_log_line_is_counted_once_when_completed(self):
+        root, process = self.fixture()
+        self.append(root, 0, b"prefix read ")
+        self.tick(root, 0)
+        self.assertEqual(self.rows(root)[-1]["decrypt_fail"], "0")
+        self.append(root, 1, b"failed: owned fixture\n")
+        self.tick(root, 1)
+        self.assertEqual(self.rows(root)[-1]["decrypt_fail"], "1")
+        self.tick(root, 2)
+        self.assertEqual(self.rows(root)[-1]["decrypt_fail"], "0")
+        self.assertEqual(sum(int(row["decrypt_fail"]) for row in self.rows(root)), 1)
+        self.assertIn("prefix read failed: owned fixture", (root / "events.log").read_text())
+        self.stop(root, process, 3)
+
+    def test_complete_lines_and_partial_suffix_preserve_marker_windows(self):
+        root, process = self.fixture()
+        self.append(root, 0, b"encrypted prefix cache active\nwrote 3 chunks to x\n"
+                    b"wrote 2 chunks to y\nprefix cache stats: hitRate=83.5%\nprefix cache dis")
+        self.tick(root, 0)
+        first = self.rows(root)[-1]
+        self.assertEqual((first["active"], first["store"], first["hit_rate"], first["disabled"]),
+                         ("1", "2", "83.5", "0"))
+        self.append(root, 1, b"abled\n")
+        self.tick(root, 1)
+        second = self.rows(root)[-1]
+        self.assertEqual((second["active"], second["store"], second["hit_rate"], second["disabled"]),
+                         ("0", "0", "83.5", "1"))
+        self.stop(root, process, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The cache soak observer resumed sampling after INT/TERM had stopped its log capture. It also lost cache-error markers when a log line arrived in separate writes, and its size-then-tail cursor could count concurrently appended bytes twice. Stop signals now exit through one cleanup owner; a persistent read descriptor consumes complete lines and retains a partial suffix for the next sample.

The CSV columns, marker patterns, sampling defaults and retained hit rate stay compatible. A final unfinished line remains available in the raw log. The observer still only captures logs and samples local state.

```mermaid
flowchart LR
  subgraph Before
    S1[INT or TERM] --> C1[cleanup capture] --> L1[sampling loop resumes]
    W1[log writer] --> T1[wc snapshot then tail] --> O1[advance to old size]
    O1 --> R1[split marker lost or concurrent bytes recounted]
  end
  subgraph After
    S2[INT or TERM] --> E2[exit 130 or 143] --> C2[EXIT stops and waits for capture once]
    W2[log writer] --> F2[descriptor 3 read position]
    F2 --> P2[retain partial line until newline]
    P2 --> R2[complete marker counted once in CSV window]
  end
```

Validation: the actual script runs under macOS `/bin/bash` 3.2 with owned log/process/sampling stubs. All 3 test functions pass, covering both signals, split failure markers, multiple lines, partial suffixes and persistent hit rate. The same fixtures fail on the original source (4 failures). Independent source review and rerun passed. Shell syntax, CI YAML parsing and docs-check (278 documents) pass. The fixture is included in Release Integrity CI. No provider, model, real system-log capture or deployment was executed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791766687&installation_model_id=21733&pr_number=954&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F954&signature=55fd01a5ecee437fd37a776d49e73b6d8cb332cf78185be6c7b481dab70d5dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->