### PR TITLE
Isolate CLI config mutation fixtures from the operator home

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `31e63a9d9`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -125,6 +125,9 @@ production prompt vectors against a Linux sidecar binary (CI job "Prompt
 Sidecar Tests").
 
 ### 5. Provider CLI (Swift) with source-matched metallib
+
+Config-mutation test builds use the same CLI helpers with migration disabled
+for temporary fixtures; see [the provider test procedure](test.md#4-provider-swift--unit-tests-with-a-source-matched-metallib).
 
 ```bash
 make provider-build

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `31e63a9d9`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -189,6 +189,15 @@ production prompt vectors against it with
 
 CI also applies the [restored-resource cleanup](build.md#restored-swiftpm-runtime-resources)
 before building the debug test product.
+
+`BetaCommandTests` and `IdleCommandTests` pass `migrateOnDisk: false` through
+`setBetaFeature` and `setIdleUnloadMinutes` to the existing runtime-snapshot
+loader. Their unique temporary config directories are the only mutation and
+cleanup targets; they never create or remove the operator's canonical config.
+The mixed-mutation fixture checks both explicit pins and unrelated legacy
+settings. Run these with `RuntimeSnapshotConfigTests` when changing
+`provider-swift/Sources/darkbloom/ConfigMutation.swift` (`withMutableConfig`).
+CLI calls retain default-on migration before the sidecar lock and reload.
 
 The general provider suite passes `--no-parallel` explicitly to Swift Testing.
 Unrelated cases share process-wide MLX state and executor capacity; overlapping

--- a/provider-swift/Sources/darkbloom/BetaCommand.swift
+++ b/provider-swift/Sources/darkbloom/BetaCommand.swift
@@ -189,13 +189,14 @@ private func unknownFeatureError(_ id: String) -> ValidationError {
 func setBetaFeature(
     _ id: String,
     enabled: Bool,
-    configPath: String?
+    configPath: String?,
+    migrateOnDisk: Bool = true
 ) throws {
     guard let feature = BetaFeatures.feature(id: id) else {
         throw unknownFeatureError(id)
     }
 
-    try withMutableConfig(configPath: configPath) { savePath, config in
+    try withMutableConfig(configPath: configPath, migrateOnDisk: migrateOnDisk) { savePath, config in
         // No-op only when the file already PINS the requested value. An absent
         // key (or absent [section]) can decode to the same effective value via
         // the default, but an explicit enable/disable means "make it so,

--- a/provider-swift/Sources/darkbloom/ConfigMutation.swift
+++ b/provider-swift/Sources/darkbloom/ConfigMutation.swift
@@ -7,11 +7,13 @@ import Darwin
 /// Resolve migrations before taking the stable sidecar lock, then reload inside
 /// the lock so concurrent beta/idle changes cannot overwrite each other. Callers
 /// own their key-presence/no-op check and save, preserving explicit pin semantics.
+/// Fixture callers disable migration to keep temporary configs out of the user home.
 func withMutableConfig<Result>(
     configPath: String?,
+    migrateOnDisk: Bool = true,
     _ body: (URL, inout ProviderConfig) throws -> Result
 ) throws -> Result {
-    let snapshot = try loadRuntimeSnapshot(configPath: configPath)
+    let snapshot = try loadRuntimeSnapshot(configPath: configPath, migrateOnDisk: migrateOnDisk)
     // Default-path lookup must happen after a possible legacy migration.
     let savePath = try configPath != nil ? snapshot.configPath : ConfigManager.defaultConfigPath()
     return try withExclusiveConfigLock(at: savePath) {

--- a/provider-swift/Sources/darkbloom/IdleCommand.swift
+++ b/provider-swift/Sources/darkbloom/IdleCommand.swift
@@ -131,13 +131,14 @@ enum IdleUnloadPolicy {
 @discardableResult
 func setIdleUnloadMinutes(
     _ minutes: UInt64,
-    configPath: String?
+    configPath: String?,
+    migrateOnDisk: Bool = true
 ) throws -> (path: URL, changed: Bool) {
     if let problem = IdleUnloadPolicy.validate(minutes: minutes) {
         throw ValidationError(problem)
     }
 
-    return try withMutableConfig(configPath: configPath) { savePath, config in
+    return try withMutableConfig(configPath: configPath, migrateOnDisk: migrateOnDisk) { savePath, config in
         if config.backend.idleTimeoutMins == minutes,
            let content = try? String(contentsOf: savePath, encoding: .utf8),
            tomlKeyPresent(content, section: "backend", key: "idle_timeout_mins") {

--- a/provider-swift/Tests/DarkbloomCLITests/BetaCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/BetaCommandTests.swift
@@ -8,12 +8,7 @@ import Testing
 @Suite("Beta command config mutation")
 struct BetaCommandTests {
 
-    /// Write `toml` (when non-nil) into a unique temp `provider.toml` and
-    /// return its URL. `~/.config/darkbloom/provider.toml` is guarded around
-    /// every toggle call: a non-canonical config path triggers
-    /// loadRuntimeSnapshot's legacy→canonical copy when the canonical file is
-    /// ABSENT, which would otherwise plant test fixtures in the operator's
-    /// real config on a fresh machine.
+    /// Write a unique temporary config; mutation calls disable home-directory migration.
     private func makeTempConfig(_ toml: String?) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("beta-cfg-\(UUID().uuidString)")
@@ -25,22 +20,6 @@ struct BetaCommandTests {
         }
         return url
     }
-
-    private func withGuardedCanonicalConfig(
-        _ body: () throws -> Void
-    ) rethrows {
-        let canonical = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/darkbloom/provider.toml")
-        let existedBefore = FileManager.default.fileExists(atPath: canonical.path)
-        defer {
-            if !existedBefore,
-               FileManager.default.fileExists(atPath: canonical.path) {
-                try? FileManager.default.removeItem(at: canonical)
-            }
-        }
-        try body()
-    }
-
 
     @Test("beta projections distinguish automatic MTP from on and off")
     func automaticProjection() throws {
@@ -73,9 +52,7 @@ struct BetaCommandTests {
 
         // weightedR1 already decodes to true via the default; the old code
         // no-oped ("already enabled") without pinning anything.
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path)
-        }
+        try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path, migrateOnDisk: false)
 
         let written = try String(contentsOf: url, encoding: .utf8)
         #expect(written.contains("[gemma_optimizations]"))
@@ -92,15 +69,13 @@ struct BetaCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path)
-            let pinned = try String(contentsOf: url, encoding: .utf8)
+        try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path, migrateOnDisk: false)
+        let pinned = try String(contentsOf: url, encoding: .utf8)
 
-            try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path)
-            let after = try String(contentsOf: url, encoding: .utf8)
+        try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path, migrateOnDisk: false)
+        let after = try String(contentsOf: url, encoding: .utf8)
 
-            #expect(after == pinned)
-        }
+        #expect(after == pinned)
     }
 
     @Test("a key pinned at the target value is a no-op without a rewrite")
@@ -117,9 +92,7 @@ struct BetaCommandTests {
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         let before = try String(contentsOf: url, encoding: .utf8)
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path)
-        }
+        try setBetaFeature("gemma-weighted-r1", enabled: true, configPath: url.path, migrateOnDisk: false)
 
         let after = try String(contentsOf: url, encoding: .utf8)
         #expect(after == before)
@@ -127,7 +100,7 @@ struct BetaCommandTests {
 
     @Test("disable with an absent key materializes an explicit off override")
     func disableMaterializesAbsentKey() throws {
-        // MTP defaults to automatic Qwen-only policy. Disabling an absent key
+        // MTP defaults to automatic model-aware policy. Disabling an absent key
         // must persist the operator's stronger all-target rollback.
         let url = try makeTempConfig("""
             [provider]
@@ -135,9 +108,7 @@ struct BetaCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("mtp", enabled: false, configPath: url.path)
-        }
+        try setBetaFeature("mtp", enabled: false, configPath: url.path, migrateOnDisk: false)
 
         let written = try String(contentsOf: url, encoding: .utf8)
         #expect(written.contains("mtp_mode = 'off'"))
@@ -156,9 +127,7 @@ struct BetaCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("mtp", enabled: false, configPath: url.path)
-        }
+        try setBetaFeature("mtp", enabled: false, configPath: url.path, migrateOnDisk: false)
 
         let written = try String(contentsOf: url, encoding: .utf8)
         #expect(written.contains("mtp_mode = 'off'"))
@@ -177,9 +146,7 @@ struct BetaCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("gemma-weighted-r1", enabled: false, configPath: url.path)
-        }
+        try setBetaFeature("gemma-weighted-r1", enabled: false, configPath: url.path, migrateOnDisk: false)
 
         let reloaded = try ConfigManager.load(from: url)
         #expect(!reloaded.gemmaOptimizations.weightedR1)
@@ -199,7 +166,7 @@ struct BetaCommandTests {
         let before = try String(contentsOf: url, encoding: .utf8)
 
         do {
-            try setBetaFeature("gemma-expert-packing", enabled: true, configPath: url.path)
+            try setBetaFeature("gemma-expert-packing", enabled: true, configPath: url.path, migrateOnDisk: false)
             Issue.record("gemma-expert-packing is not a beta feature in this build")
         } catch {
             // ValidationError naming the known feature ids.
@@ -214,12 +181,39 @@ struct BetaCommandTests {
         let url = try makeTempConfig(nil)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            try setBetaFeature("gemma-prefill-layer18", enabled: false, configPath: url.path)
-        }
+        try setBetaFeature("gemma-prefill-layer18", enabled: false, configPath: url.path, migrateOnDisk: false)
 
         let written = try String(contentsOf: url, encoding: .utf8)
         #expect(written.contains("prefill_layer18 = false"))
+    }
+
+    @Test("fixture mutations retain unrelated legacy settings without migration")
+    func isolatedMutationsPreserveOtherSettings() throws {
+        let url = try makeTempConfig("""
+            config_version = 1
+
+            [provider]
+            name = "isolated-mutations"
+
+            [coordinator]
+            url = "ws://localhost:8080/ws/provider"
+
+            [backend]
+            idle_timeout_mins = 60
+            """)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        try setBetaFeature("mtp", enabled: false, configPath: url.path, migrateOnDisk: false)
+        let idle = try setIdleUnloadMinutes(45, configPath: url.path, migrateOnDisk: false)
+
+        #expect(idle.path == url)
+        let reloaded = try ConfigManager.load(from: url)
+        #expect(reloaded.coordinator.url == "ws://localhost:8080/ws/provider")
+        #expect(reloaded.provider.name == "isolated-mutations")
+        #expect(reloaded.backend.idleTimeoutMins == 45)
+        let written = try String(contentsOf: url, encoding: .utf8)
+        #expect(written.contains("mtp_mode = 'off'"))
+        #expect(tomlKeyPresent(written, section: "backend", key: "idle_timeout_mins"))
     }
 
     // MARK: - tomlKeyPresent

--- a/provider-swift/Tests/DarkbloomCLITests/IdleCommandTests.swift
+++ b/provider-swift/Tests/DarkbloomCLITests/IdleCommandTests.swift
@@ -142,21 +142,6 @@ struct IdleCommandTests {
         return url
     }
 
-    /// Mirrors BetaCommandTests: a non-canonical config path triggers the
-    /// legacy→canonical copy when the canonical file is ABSENT; never plant
-    /// fixtures in the operator's real config.
-    private func withGuardedCanonicalConfig(_ body: () throws -> Void) rethrows {
-        let canonical = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/darkbloom/provider.toml")
-        let existedBefore = FileManager.default.fileExists(atPath: canonical.path)
-        defer {
-            if !existedBefore, FileManager.default.fileExists(atPath: canonical.path) {
-                try? FileManager.default.removeItem(at: canonical)
-            }
-        }
-        try body()
-    }
-
     @Test("keep-loaded pins idle_timeout_mins = 0 under [backend]")
     func keepLoadedPersistsZero() throws {
         let url = try makeTempConfig("""
@@ -165,11 +150,9 @@ struct IdleCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            let result = try setIdleUnloadMinutes(0, configPath: url.path)
-            #expect(result.changed)
-            #expect(result.path == url)
-        }
+        let result = try setIdleUnloadMinutes(0, configPath: url.path, migrateOnDisk: false)
+        #expect(result.changed)
+        #expect(result.path == url)
         let written = try String(contentsOf: url, encoding: .utf8)
         #expect(tomlKeyPresent(written, section: "backend", key: "idle_timeout_mins"))
         #expect(written.contains("idle_timeout_mins = 0"))
@@ -186,18 +169,16 @@ struct IdleCommandTests {
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         #expect(!idleTimeoutPinned(at: url))
 
-        try withGuardedCanonicalConfig {
-            // Decodes to 60 already, but "Free when idle" must be pinned so a
-            // future default flip cannot silently move this provider.
-            let first = try setIdleUnloadMinutes(60, configPath: url.path)
-            #expect(first.changed)
-            // Now pinned at the requested value: a true no-op, no rewrite.
-            let pinned = try String(contentsOf: url, encoding: .utf8)
-            let second = try setIdleUnloadMinutes(60, configPath: url.path)
-            #expect(second.changed == false)
-            let after = try String(contentsOf: url, encoding: .utf8)
-            #expect(after == pinned)
-        }
+        // Decodes to 60 already, but "Free when idle" must be pinned so a
+        // future default flip cannot silently move this provider.
+        let first = try setIdleUnloadMinutes(60, configPath: url.path, migrateOnDisk: false)
+        #expect(first.changed)
+        // Now pinned at the requested value: a true no-op, no rewrite.
+        let pinned = try String(contentsOf: url, encoding: .utf8)
+        let second = try setIdleUnloadMinutes(60, configPath: url.path, migrateOnDisk: false)
+        #expect(second.changed == false)
+        let after = try String(contentsOf: url, encoding: .utf8)
+        #expect(after == pinned)
         #expect(idleTimeoutPinned(at: url))
     }
 
@@ -209,10 +190,8 @@ struct IdleCommandTests {
             """)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try withGuardedCanonicalConfig {
-            let result = try setIdleUnloadMinutes(45, configPath: url.path)
-            #expect(result.changed)
-        }
+        let result = try setIdleUnloadMinutes(45, configPath: url.path, migrateOnDisk: false)
+        #expect(result.changed)
         let config = try ConfigManager.load(from: url)
         #expect(config.backend.idleTimeoutMins == 45)
         let written = try String(contentsOf: url, encoding: .utf8)
@@ -228,10 +207,8 @@ struct IdleCommandTests {
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         let before = try String(contentsOf: url, encoding: .utf8)
 
-        withGuardedCanonicalConfig {
-            #expect(throws: (any Error).self) {
-                try setIdleUnloadMinutes(IdleUnloadPolicy.maxMinutes + 1, configPath: url.path)
-            }
+        #expect(throws: (any Error).self) {
+            try setIdleUnloadMinutes(IdleUnloadPolicy.maxMinutes + 1, configPath: url.path, migrateOnDisk: false)
         }
         #expect(try String(contentsOf: url, encoding: .utf8) == before)
     }


### PR DESCRIPTION
Stacked on #904 (`refactor/repository-provider`); merge that refactor first.

Beta and Idle mutation tests could copy their temporary config into the operator's real home when no canonical config existed. Their cleanup then removed any file at that path, including a file another process could have created meanwhile. Pass the existing `migrateOnDisk: false` option through the internal mutation helpers and remove both home-directory cleanup wrappers.

```mermaid
flowchart LR
  subgraph Before
    F[Temporary Beta or Idle fixture] --> M[Mutator and withMutableConfig]
    M --> L[loadRuntimeSnapshot migration enabled]
    L --> H[May copy into real canonical user config]
    H --> G[Cleanup may remove real user config]
  end
  subgraph After
    F2[Temporary Beta or Idle fixture] --> M2[Mutator passes migrateOnDisk false]
    M2 --> L2[Existing snapshot migration guard]
    L2 --> S[Same sidecar lock reload and explicit pin save]
    S --> T[Only owned temporary path mutated and removed]
    CLI[Normal CLI caller] --> D[Default true preserves production migration]
  end
```

All CLI callers retain the default-on migration behavior. Config path resolution, sidecar locking, reload, key materialization and no-op semantics stay the same. The new mixed-mutation fixture preserves a legacy coordinator URL and unrelated provider name while verifying both requested pins and the saved path.

Validation: independent source/caller review is clean; documentation lint passes (278 pages). Exact-head Codex review returned no findings and a thumbs-up.

Dedicated M5 validation passed on private combined source `0db74e7da` (previous validated provider union `93c4caa5c` plus this PR's `63ca90cf1`):
- Fresh release build with tests: 464.75s.
- `BetaCommandTests|IdleCommandTests|RuntimeSnapshotConfigTests`: 33 tests in 3 suites, 2.949s, zero skipped; owned guard exit 0.
- All 5,093 source inputs matched before/after; dependency pins unchanged. The canonical provider config's content, device, inode and mtime were identical before/after.
- Built binary SHA-256: `5c0eea6fda218f91a0c9ba975f1b5c8697eb7cbe8d65bab9e19d532dc4eb2073`.

Validation used the root-owned dedicated M5. No live generation was run for this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791766715&installation_model_id=21733&pr_number=955&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F955&signature=1dcd9fddfec3d7525c7cd4c0a23965e80b15dadc74b05a59c3c2ba62cf2a3c87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->