### PR TITLE
Validate MTP artifact and performance evidence from exact inputs

### DIFF
--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-11 · commit `bbb46b21f`
+> Last updated: 2026-09-12 · commit `9cf1d20be`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -432,7 +432,7 @@ local stub servers; its default observation mode sends only public GETs.
 | `provider-build` | `swift build` + `scripts/fetch-metallib.sh <bin-path>` |
 | `provider-test` | `swift build --build-tests`, stage `mlx.metallib` into the bin dir and every `*PackageTests.xctest/Contents/MacOS`, then `swift test --skip-build` |
 | `provider` | `provider-build` + `provider-test` |
-| `benchmark-wrapper-test` | Python unittest discovery in `scripts/gemma_contbatch/tests` and `scripts/mtp_benchmark/tests` |
+| `benchmark-wrapper-test` | Python unittest discovery in `scripts/gemma_contbatch/tests` and `scripts/mtp_benchmark/tests`, including bounded artifact and malformed performance-evidence fixtures |
 | `benchmark-gemma-contbatch` | `python3 scripts/benchmark-gemma-contbatch.py $(GEMMA_BENCHMARK_ARGS)` (needs GPU + weights) |
 | `ui-install` / `ui-lint` / `ui-test` / `ui-build` / `ui` | `npm install` / `npx eslint src/` / `npm test` / `npm run build` in `console-ui/` |
 | `e2e-integration` | `go test ./e2e/... -run TestIntegration -v` |

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `bbb46b21f`
+> Last updated: 2026-09-12 · commit `9cf1d20be`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -948,7 +948,11 @@ python3 scripts/run-mtp-benchmark.py --self-test-artifact-provenance
 
 The tests use synthetic 40-case reports and mocked child launch, checking rejection
 messages, incomplete/stale evidence, inactive and automatic-verifier policy,
-symlink containment, supervisor command/manifest and cleanup. They do not certify
+symlink containment, supervisor command/manifest and cleanup. The synthetic
+config replacement fixture checks that `artifact_facts` hashes and parses one
+bounded payload. Production report fixtures reject boolean, negative and nonfinite
+elapsed/aggregate-throughput values while retaining zero and finite numeric ranges
+(`scripts/mtp_benchmark/report.py`, `nonnegative_finite_number`). They do not certify
 model speed or numerical parity. The live CLI keeps its external process-group
 deadline and cache-only artifact resolution.
 

--- a/scripts/mtp_benchmark/artifacts.py
+++ b/scripts/mtp_benchmark/artifacts.py
@@ -242,12 +242,14 @@ def artifact_facts(model_id: str, snapshot: Path) -> dict[str, Any]:
     config_size = config.stat().st_size
     if config_size > 4 * 1024 * 1024:
         raise ValueError("config.json exceeds the 4 MiB launch-side cap")
-    config_digest = sha256_file(config)
     # Independently parse the coverage-relevant metadata from the SAME bytes
     # that were hashed, so the supervisor's coverage gates do not depend
     # solely on the Swift inspector's transcription of these fields.
     with open(config, "rb") as handle:
-        parsed = json.loads(read_bounded(handle.fileno(), 4 * 1024 * 1024))
+        config_bytes = read_bounded(handle.fileno(), 4 * 1024 * 1024)
+    config_size = len(config_bytes)
+    config_digest = hashlib.sha256(config_bytes).hexdigest()
+    parsed = json.loads(config_bytes)
     if not isinstance(parsed, dict):
         raise ValueError("config.json root is not an object")
     # Mirrors MTPBenchmarkModelFacts.swift: "quantization" falls back to the HF "quantization_config" key.

--- a/scripts/mtp_benchmark/report.py
+++ b/scripts/mtp_benchmark/report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
+import math
 from typing import Any
 
 from .constants import REPORT_NAME, MAX_REPORT_BYTES, REPORT_SCHEMA_VERSION, PERFORMANCE_KEYS, HEX_DIGITS
@@ -136,6 +137,17 @@ def validate_report_artifact(
         raise ValueError(f"report {label} quantization bits do not match launch config.json")
 
 
+def nonnegative_finite_number(value: Any) -> bool:
+    # Zero is valid for one-token/zero-interval samples. Booleans are JSON
+    # control values, even though Python treats them as integers.
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value >= 0
+        and (not isinstance(value, float) or math.isfinite(value))
+    )
+
+
 def validate_report(
     run: SecureRunDirectory,
     *,
@@ -217,8 +229,12 @@ def validate_report(
             raise ValueError(
                 f"non-performance report recursively exposes performance keys: {sorted(exposed)}"
             )
-    elif not isinstance(report.get("elapsedMs"), (int, float)):
-        raise ValueError("production performance report omitted elapsedMs")
+    else:
+        elapsed = report.get("elapsedMs")
+        if elapsed is None:
+            raise ValueError("production performance report omitted elapsedMs")
+        if not nonnegative_finite_number(elapsed):
+            raise ValueError("production performance elapsedMs must be a finite nonnegative number")
 
     started_at = parse_timestamp(report.get("startedAt"), "startedAt")
     generated_at = parse_timestamp(report.get("generatedAt"), "generatedAt")
@@ -305,8 +321,11 @@ def validate_report(
         elif baseline_rows.get(batch) != row_evidence:
             raise ValueError(f"{label} opaque evidence differs from baseline")
         if mode != "raw-parity":
-            if case.get("medianAggregateDecodeTokensPerSecond") is None:
+            throughput = case.get("medianAggregateDecodeTokensPerSecond")
+            if throughput is None:
                 raise ValueError("production performance case omitted aggregate throughput")
+            if not nonnegative_finite_number(throughput):
+                raise ValueError(f"{label} aggregate throughput must be a finite nonnegative number")
 
         validate_case_metrics(
             case.get("metrics", {}), kind=kind, width=width, batch=batch,

--- a/scripts/mtp_benchmark/tests/test_evidence_validation.py
+++ b/scripts/mtp_benchmark/tests/test_evidence_validation.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-import test_contract as contracts
+from mtp_benchmark.tests import test_contract as contracts
 from mtp_benchmark import artifacts
 
 

--- a/scripts/mtp_benchmark/tests/test_evidence_validation.py
+++ b/scripts/mtp_benchmark/tests/test_evidence_validation.py
@@ -1,0 +1,67 @@
+"""Offline malformed-evidence regressions; no child process or model execution."""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import test_contract as contracts
+from mtp_benchmark import artifacts
+
+
+class EvidenceValidationTests(unittest.TestCase):
+    def test_config_facts_describe_the_same_bounded_payload(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            snapshot = Path(temporary) / "repository" / "snapshots" / "revision"
+            snapshot.mkdir(parents=True)
+            config = snapshot / "config.json"
+            config.write_bytes(b'{"quantization":{"bits":4}}')
+            (snapshot / "model.safetensors").write_bytes(b"synthetic weights")
+            replacement = b'{"model_type":"gemma4_text","quantization":{"bits":8}}'
+            read_bounded = artifacts.read_bounded
+            observed = []
+
+            def replace_before_read(descriptor, maximum_bytes):
+                # Deterministic replacement between the old independent hash
+                # and parse reads. The new implementation hashes this payload.
+                config.write_bytes(replacement)
+                payload = read_bounded(descriptor, maximum_bytes)
+                observed.append(payload)
+                return payload
+
+            with patch.object(artifacts, "read_bounded", side_effect=replace_before_read):
+                facts = artifacts.artifact_facts("example/model", snapshot)
+            self.assertEqual(observed, [replacement])
+            self.assertEqual(facts["configMetadata"]["effective_quantization_bits"], 8)
+            self.assertEqual(facts["configSHA256"], hashlib.sha256(replacement).hexdigest())
+            self.assertEqual(facts["configSizeBytes"], len(replacement))
+
+    def test_production_rejects_malformed_elapsed_and_aggregate_metrics(self):
+        invalid = (None, True, False, "20", {}, [], -1, -0.5,
+                   float("nan"), float("inf"), float("-inf"))
+        for field in ("elapsedMs", "medianAggregateDecodeTokensPerSecond"):
+            for value in invalid:
+                with self.subTest(field=field, value=value):
+                    report, artifact = contracts.report_fixture("production-performance")
+                    destination = report if field == "elapsedMs" else report["cases"][0]
+                    destination[field] = value
+                    with self.assertRaises(ValueError):
+                        contracts.ReportContractTests().validate(report, artifact, mode="production-performance")
+
+    def test_production_retains_zero_and_finite_metric_ranges(self):
+        # A one-token stream has zero decode intervals; zero throughput is
+        # valid evidence, not a speedup claim. No positive threshold is added.
+        for value in (0, 0.0, 1, 0.125, sys.float_info.min, sys.float_info.max):
+            with self.subTest(value=value):
+                report, artifact = contracts.report_fixture("production-performance")
+                report["elapsedMs"] = value
+                for case in report["cases"]:
+                    case["medianAggregateDecodeTokensPerSecond"] = value
+                contracts.ReportContractTests().validate(report, artifact, mode="production-performance")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A changing `config.json` could give an MTP artifact receipt the hash of one payload and quantization metadata from another. Production reports also accepted malformed elapsed/aggregate throughput values such as booleans, negative numbers and nonfinite floats. These cases could misrepresent benchmark evidence.

Read the bounded config payload once and derive its size, SHA256 and parsed metadata from those bytes. Require production elapsed time and aggregate throughput to be finite, nonnegative numbers. Zero remains valid for a stream with no decode intervals; no speedup threshold, model default, report schema or native measurement formula changes.

Stacked on #901 so the fix uses the separated artifact/report modules. The process-group supervisor and runtime approvals remain unchanged.

```mermaid
flowchart TB
  subgraph Before
    A[artifact_facts] --> B[Hash config through one read]
    B --> C[Reopen and parse config]
    C --> D[Replacement can mismatch hash and metadata]
    E[validate_report] --> F[Check elapsed type and throughput presence]
    F --> G[Malformed measurements can pass]
  end
  subgraph After
    H[artifact_facts] --> I[One bounded config payload]
    I --> J[Size SHA256 and metadata from same bytes]
    K[validate_report] --> L[nonnegative_finite_number]
    L --> M[Malformed measurements refused]
    L --> N[Zero and finite numeric measurements retained]
  end
```

Validation: new CPU fixtures produce 18 failures on the unchanged #901 source (one deterministic config mutation and 17 accepted malformed metrics). The exact canonical `make benchmark-wrapper-test` passes (65 Gemma + 11 MTP CPU tests), after correcting the fixture import for package discovery; including unchanged raw-parity, expected-inactive and production matrix contracts. Sixty-four stable synthetic artifact receipts match baseline exactly, including JSON key order. Docs lint passes for 278 files. No Swift, real model, signing or native benchmark was executed; this is evidence validation, not a new performance claim.
