### PR TITLE
Preserve newer Stripe withdrawal state during submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Withdrawal progress ownership** — Preserve newer Stripe withdrawal payment/refund state when a delayed submission response arrives. Compare progress atomically, recognize an already-applied retry, and ask clients to check history after a concurrent update instead of overwriting it.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/api/stripe_payouts_fixes_test.go
+++ b/coordinator/api/stripe_payouts_fixes_test.go
@@ -552,6 +552,14 @@ func (f *flakyPayoutStore) UpdateStripeWithdrawal(wd *store.StripeWithdrawal) er
 	return f.MemoryStore.UpdateStripeWithdrawal(wd)
 }
 
+// Production updates compare their lookup/submission snapshot atomically.
+func (f *flakyPayoutStore) CompareAndSwapStripeWithdrawal(previous, next *store.StripeWithdrawal) (bool, error) {
+	if f.failUpdates {
+		return false, errors.New("connection reset by peer")
+	}
+	return f.MemoryStore.CompareAndSwapStripeWithdrawal(previous, next)
+}
+
 // newFlakyPayoutServer wires a Server + billing around a flakyPayoutStore.
 func newFlakyPayoutServer(t *testing.T, fakeStripe *httptest.Server) (*Server, *flakyPayoutStore) {
 	t.Helper()

--- a/coordinator/api/stripe_payouts_webhooks.go
+++ b/coordinator/api/stripe_payouts_webhooks.go
@@ -190,8 +190,9 @@ func (s *Server) handlePayoutTerminal(event *billing.WebhookEvent, connectedAcct
 		// Legacy row already refunded under the old semantics — leave it
 		// terminal so we never double-account.
 		if wd.Status != "failed" {
-			wd.Status = "failed"
-			if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+			next := *wd
+			next.Status = "failed"
+			if _, err := s.billing.Store().CompareAndSwapStripeWithdrawal(wd, &next); err != nil {
 				s.logger.Error("stripe connect webhook: status flip failed", "error", err)
 				return err
 			}
@@ -498,8 +499,9 @@ func (s *Server) handleTransferFailed(event *billing.WebhookEvent) error {
 		// sweep reconciliation — if it fails, return the error so Stripe
 		// redelivers rather than leaving a refunded row claimable.
 		if wd.Status != "failed" {
-			wd.Status = "failed"
-			if err := s.billing.Store().UpdateStripeWithdrawal(wd); err != nil {
+			next := *wd
+			next.Status = "failed"
+			if _, err := s.billing.Store().CompareAndSwapStripeWithdrawal(wd, &next); err != nil {
 				s.logger.Error("stripe connect webhook: refunded-row status flip failed",
 					"error", err, "withdrawal_id", wd.ID)
 				return err

--- a/coordinator/api/stripe_withdraw.go
+++ b/coordinator/api/stripe_withdraw.go
@@ -219,6 +219,17 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Keep the last acknowledged state across external Stripe calls so a
+	// webhook transition cannot be overwritten by our older local copy.
+	persisted := *wd
+	persistUpdate := func(stage string) error {
+		err := s.persistWithdrawalUpdate(&persisted, wd, stage)
+		if err == nil {
+			persisted = *wd
+		}
+		return err
+	}
+
 	// markFailedRefund refunds the ledger and marks the row failed
 	// (best-effort — neither store call has rollback). Returns whether the
 	// refund credit is durably applied; the Refunded flag prevents webhook
@@ -230,7 +241,7 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 		}
 		wd.Status = "failed"
 		wd.FailureReason = reason
-		if uerr := s.persistWithdrawalUpdate(wd, "failure"); uerr != nil {
+		if uerr := persistUpdate("failure"); uerr != nil {
 			s.logger.Error("stripe payout: mark failed failed", "error", uerr, "withdrawal_id", withdrawalID)
 		}
 		return refunded
@@ -257,7 +268,12 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 		// alert and completes the row from the Stripe dashboard via the
 		// idempotency key; if it didn't, the same alert drives the refund.
 		wd.FailureReason = "transfer_create_unconfirmed: " + err.Error()
-		if uerr := s.persistWithdrawalUpdate(wd, "ambiguous transfer"); uerr != nil {
+		if uerr := persistUpdate("ambiguous transfer"); uerr != nil {
+			if errors.Is(uerr, errWithdrawalStateChanged) {
+				s.writeWithdrawalStateChanged(w, withdrawalID)
+				return
+			}
+
 			s.logger.Error("stripe payout: persist ambiguous-transfer state failed",
 				"error", uerr, "withdrawal_id", withdrawalID)
 		}
@@ -299,7 +315,12 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 	}
 	wd.TransferID = transfer.ID
 	wd.Status = "transferred"
-	if err := s.persistWithdrawalUpdate(wd, "transfer_id"); err != nil {
+	if err := persistUpdate("transfer_id"); err != nil {
+		if errors.Is(err, errWithdrawalStateChanged) {
+			s.writeWithdrawalStateChanged(w, withdrawalID)
+			return
+		}
+
 		// Transfer succeeded but we lost track of it: the row is stuck
 		// "pending" with no transfer_id, invisible to the webhook matcher and
 		// sweep reconciler. Money is in the connected account and the daily
@@ -363,7 +384,12 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 		// idempotency key. If it didn't land, the daily sweep delivers and
 		// completes the row; ops refunds the fee from the same alert trail.
 		wd.FailureReason = "instant_payout_unconfirmed: " + err.Error()
-		if uerr := s.persistWithdrawalUpdate(wd, "ambiguous payout"); uerr != nil {
+		if uerr := persistUpdate("ambiguous payout"); uerr != nil {
+			if errors.Is(uerr, errWithdrawalStateChanged) {
+				s.writeWithdrawalStateChanged(w, withdrawalID)
+				return
+			}
+
 			s.logger.Error("stripe payout: persist ambiguous-payout state failed",
 				"error", uerr, "withdrawal_id", withdrawalID)
 		}
@@ -399,7 +425,12 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 			wd.FeeRefunded = true
 			wd.FailureReason += " (instant fee refunded)"
 		}
-		if uerr := s.persistWithdrawalUpdate(wd, "payout failure"); uerr != nil {
+		if uerr := persistUpdate("payout failure"); uerr != nil {
+			if errors.Is(uerr, errWithdrawalStateChanged) {
+				s.writeWithdrawalStateChanged(w, withdrawalID)
+				return
+			}
+
 			s.logger.Error("stripe payout: persist payout failure failed",
 				"error", uerr, "withdrawal_id", withdrawalID)
 		}
@@ -423,7 +454,12 @@ func (s *Server) handleStripeWithdraw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	wd.PayoutID = payout.ID
-	if err := s.persistWithdrawalUpdate(wd, "payout_id"); err != nil {
+	if err := persistUpdate("payout_id"); err != nil {
+		if errors.Is(err, errWithdrawalStateChanged) {
+			s.writeWithdrawalStateChanged(w, withdrawalID)
+			return
+		}
+
 		// Payout succeeded but we couldn't persist the ID. Webhook will
 		// arrive with the payout ID — without the index entry the sweep
 		// matcher will still reconcile it by connected account. Log loudly
@@ -498,24 +534,38 @@ func (s *Server) creditRefundOnceWithRetry(accountID string, amountMicroUSD int6
 	return false
 }
 
-// persistWithdrawalUpdate retries a withdrawal-row update with short backoff.
+// persistWithdrawalUpdate retries transient errors with the same expected state.
+// A changed row returns immediately; retrying it must not overwrite a webhook.
 // Used after money has moved (transfer/payout created): losing the update
 // strands the row in a state the webhook matcher and sweep reconciler don't
 // look at, so it's worth riding out a transient store blip in-request. Like
 // creditRefundOnceWithRetry, it deliberately ignores request-context
 // cancellation (bounded at 600ms total backoff) — abandoning the persist on
 // client disconnect is exactly how rows get orphaned.
-func (s *Server) persistWithdrawalUpdate(wd *store.StripeWithdrawal, stage string) error {
+func (s *Server) persistWithdrawalUpdate(previous, wd *store.StripeWithdrawal, stage string) error {
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
 		if attempt > 0 {
 			time.Sleep(time.Duration(attempt) * 200 * time.Millisecond)
 		}
-		if err = s.billing.Store().UpdateStripeWithdrawal(wd); err == nil {
+		var applied bool
+		applied, err = s.billing.Store().CompareAndSwapStripeWithdrawal(previous, wd)
+		if err == nil {
+			if !applied {
+				return errWithdrawalStateChanged
+			}
 			return nil
 		}
 		s.logger.Warn("stripe payout: persist "+stage+" attempt failed",
 			"attempt", attempt+1, "error", err, "withdrawal_id", wd.ID)
 	}
 	return err
+}
+
+var errWithdrawalStateChanged = errors.New("withdrawal state changed during submission")
+
+func (s *Server) writeWithdrawalStateChanged(w http.ResponseWriter, withdrawalID string) {
+	s.logger.Warn("stripe payout: submission state changed; preserving webhook state", "withdrawal_id", withdrawalID)
+	writeJSON(w, http.StatusConflict, errorResponse("withdrawal_state_changed",
+		"your withdrawal was updated while it was being submitted — check its status before retrying"))
 }

--- a/coordinator/api/stripe_withdrawal_progress_test.go
+++ b/coordinator/api/stripe_withdrawal_progress_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eigeninference/d-inference/coordinator/store"
+)
+
+// A webhook can settle or refund the transfer while the HTTP withdrawal
+// handler is still awaiting payouts.create. Its later progress write must not
+// overwrite that newer terminal state with the handler's old transferred row.
+func TestStripeWithdrawalProgressPreservesConcurrentTerminal(t *testing.T) {
+	for _, terminal := range []string{"paid", "refunded"} {
+		t.Run(terminal, func(t *testing.T) {
+			var srv *Server
+			var st *store.MemoryStore
+			snapshots := make(chan store.StripeWithdrawal, 1)
+			callbackErrors := make(chan error, 1)
+			fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/accounts/"):
+					_, _ = w.Write([]byte(healthyAccountJSON(strings.TrimPrefix(r.URL.Path, "/v1/accounts/"), "US", "full", true)))
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/transfers":
+					_, _ = w.Write([]byte(`{"id":"tr_progress","amount":450,"currency":"usd"}`))
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/payouts":
+					row, err := st.GetStripeWithdrawalByTransferID("tr_progress")
+					if err == nil {
+						if terminal == "paid" {
+							var applied bool
+							applied, err = st.MarkStripeWithdrawalPaid(row.ID, "", "po_sweep")
+							if err == nil && !applied {
+								err = fmt.Errorf("paid transition not applied")
+							}
+						} else {
+							result := deliverConnectWebhook(t, srv, transferReversedPayload("tr_progress"))
+							if result.Code != http.StatusOK {
+								err = fmt.Errorf("reversal status%d: %s", result.Code, result.Body.String())
+							}
+						}
+					}
+					if err == nil {
+						row, err = st.GetStripeWithdrawal(row.ID)
+					}
+					if err != nil {
+						callbackErrors <- err
+						http.Error(w, "fixture failed", 500)
+						return
+					}
+					snapshots <- *row
+					_, _ = w.Write([]byte(`{"id":"po_progress","amount":450,"status":"pending","method":"instant"}`))
+				default:
+					http.Error(w, "unexpected path "+r.URL.Path, 500)
+				}
+			}))
+			defer fake.Close()
+			srv, st = stripePayoutsTestServer(t, false, fake)
+			defer srv.Close()
+			user := readyUser(t, st, "progress-user", "progress@example.com", true)
+			if err := st.CreditWithdrawable(user.AccountID, 10_000_000, store.LedgerPayout, "progress-funding"); err != nil {
+				t.Fatal(err)
+			}
+			req := withPrivyUser(httptest.NewRequest(http.MethodPost, "/v1/billing/withdraw/stripe", strings.NewReader(`{"amount_usd":"5.00","method":"instant"}`)), user)
+			w := httptest.NewRecorder()
+			srv.handleStripeWithdraw(w, req)
+			select {
+			case err := <-callbackErrors:
+				t.Fatal(err)
+			default:
+			}
+			var want store.StripeWithdrawal
+			select {
+			case want = <-snapshots:
+			default:
+				t.Fatalf("payout callback did not run: status%d %s", w.Code, w.Body.String())
+			}
+			got, err := st.GetStripeWithdrawal(want.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "withdrawal_state_changed") {
+				t.Fatalf("concurrent update response=%d %s", w.Code, w.Body.String())
+			}
+			if !reflect.DeepEqual(*got, want) {
+				t.Fatalf("late progress replaced terminal row: got%+v want%+v", *got, want)
+			}
+		})
+	}
+}

--- a/coordinator/store/interface_domains.go
+++ b/coordinator/store/interface_domains.go
@@ -369,8 +369,16 @@ type BillingStore interface {
 	// ID (tr_…). Used in transfer.failed webhook handlers.
 	GetStripeWithdrawalByTransferID(transferID string) (*StripeWithdrawal, error)
 
-	// UpdateStripeWithdrawal persists status/transfer/payout/fail-reason changes.
+	// UpdateStripeWithdrawal is an unconditional legacy update. New production
+	// read-modify-write paths must use CompareAndSwapStripeWithdrawal or a
+	// purpose-specific atomic transition.
 	UpdateStripeWithdrawal(withdrawal *StripeWithdrawal) error
+
+	// CompareAndSwapStripeWithdrawal changes mutable progress only while it
+	// matches previous. An exact next state is an idempotent success. Missing
+	// or concurrently changed rows return false; immutable money/account fields
+	// are preserved. Use this for submission and legacy status-only updates.
+	CompareAndSwapStripeWithdrawal(previous, next *StripeWithdrawal) (bool, error)
 
 	// MarkStripeWithdrawalPaid atomically flips a withdrawal to "paid" —
 	// but only from a non-terminal, non-refunded state ("pending" or

--- a/coordinator/store/stripe_withdrawal_progress.go
+++ b/coordinator/store/stripe_withdrawal_progress.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// withdrawalProgress is the mutable state shared by submission and webhook
+// writers. Account, amounts, method and creation time are never progress fields.
+type withdrawalProgress struct {
+	TransferID, PayoutID, SweepPayoutID, Status, FailureReason string
+	Refunded, FeeRefunded                                      bool
+}
+
+func progressOf(w *StripeWithdrawal) withdrawalProgress {
+	return withdrawalProgress{w.TransferID, w.PayoutID, w.SweepPayoutID, w.Status, w.FailureReason, w.Refunded, w.FeeRefunded}
+}
+
+func validWithdrawalUpdate(previous, next *StripeWithdrawal) error {
+	if previous == nil || next == nil || next.ID == "" || previous.ID != next.ID {
+		return errors.New("matching stripe withdrawal ids are required")
+	}
+	return nil
+}
+
+func (s *MemoryStore) CompareAndSwapStripeWithdrawal(previous, next *StripeWithdrawal) (bool, error) {
+	if err := validWithdrawalUpdate(previous, next); err != nil {
+		return false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.stripeWithdrawalsByID[next.ID]
+	if current == nil {
+		return false, nil
+	}
+	currentState, nextState := progressOf(current), progressOf(next)
+	if currentState == nextState {
+		return true, nil
+	}
+	if currentState != progressOf(previous) {
+		return false, nil
+	}
+	if current.TransferID != next.TransferID {
+		delete(s.stripeWithdrawalsByTransferID, current.TransferID)
+		if next.TransferID != "" {
+			s.stripeWithdrawalsByTransferID[next.TransferID] = next.ID
+		}
+	}
+	if current.PayoutID != next.PayoutID {
+		delete(s.stripeWithdrawalsByPayoutID, current.PayoutID)
+		if next.PayoutID != "" {
+			s.stripeWithdrawalsByPayoutID[next.PayoutID] = next.ID
+		}
+	}
+	current.TransferID = next.TransferID
+	current.PayoutID = next.PayoutID
+	current.SweepPayoutID = next.SweepPayoutID
+	current.Status = next.Status
+	current.FailureReason = next.FailureReason
+	current.Refunded = next.Refunded
+	current.FeeRefunded = next.FeeRefunded
+	current.UpdatedAt = time.Now()
+	return true, nil
+}
+
+func (s *PostgresStore) CompareAndSwapStripeWithdrawal(previous, next *StripeWithdrawal) (bool, error) {
+	if err := validWithdrawalUpdate(previous, next); err != nil {
+		return false, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// The desired-state arm recognizes a successful write whose acknowledgement
+	// was lost. Only the expected-state arm changes fields or the timestamp.
+	tag, err := s.pool.Exec(ctx, `UPDATE stripe_withdrawals SET
+ transfer_id=$2,payout_id=$3,sweep_payout_id=$4,status=$5,
+ failure_reason=$6,refunded=$7,fee_refunded=$8,
+ updated_at=CASE WHEN ROW(transfer_id,payout_id,sweep_payout_id,status,failure_reason,refunded,fee_refunded)
+ IS NOT DISTINCT FROM ROW($2::text,$3::text,$4::text,$5::text,$6::text,$7::boolean,$8::boolean)
+ THEN updated_at ELSE NOW() END
+ WHERE id=$1 AND (
+ ROW(transfer_id,payout_id,sweep_payout_id,status,failure_reason,refunded,fee_refunded)
+ IS NOT DISTINCT FROM ROW($9::text,$10::text,$11::text,$12::text,$13::text,$14::boolean,$15::boolean)
+ OR ROW(transfer_id,payout_id,sweep_payout_id,status,failure_reason,refunded,fee_refunded)
+ IS NOT DISTINCT FROM ROW($2::text,$3::text,$4::text,$5::text,$6::text,$7::boolean,$8::boolean))`,
+		next.ID, next.TransferID, next.PayoutID, next.SweepPayoutID, next.Status, next.FailureReason, next.Refunded, next.FeeRefunded,
+		previous.TransferID, previous.PayoutID, previous.SweepPayoutID, previous.Status, previous.FailureReason, previous.Refunded, previous.FeeRefunded)
+	if err != nil {
+		return false, fmt.Errorf("store: compare stripe withdrawal progress: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/coordinator/store/stripe_withdrawal_progress_test.go
+++ b/coordinator/store/stripe_withdrawal_progress_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestStripeWithdrawalProgressCompareAndSwap(t *testing.T) {
+	for backend, s := range storeBackends(t) {
+		t.Run(backend, func(t *testing.T) {
+			const account = "progress-cas-account"
+			if err := s.CreateUser(&User{AccountID: account, PrivyUserID: "did:privy:progress-cas"}); err != nil {
+				t.Fatal(err)
+			}
+			mutations := []func(*StripeWithdrawal){
+				func(w *StripeWithdrawal) { w.TransferID = "tr-new" }, func(w *StripeWithdrawal) { w.PayoutID = "po-new" },
+				func(w *StripeWithdrawal) { w.SweepPayoutID = "sweep-new" }, func(w *StripeWithdrawal) { w.Status = "paid" },
+				func(w *StripeWithdrawal) { w.FailureReason = "new reason" }, func(w *StripeWithdrawal) { w.Refunded = true }, func(w *StripeWithdrawal) { w.FeeRefunded = true },
+			}
+			for i, change := range mutations {
+				t.Run(fmt.Sprint(i), func(t *testing.T) {
+					row := &StripeWithdrawal{ID: fmt.Sprintf("progress-cas-%d", i), AccountID: account, StripeAccountID: "acct_progress", AmountMicroUSD: 5_000_000, NetMicroUSD: 4_500_000, FeeMicroUSD: 500_000, Method: "instant", Status: "transferred", TransferID: fmt.Sprintf("tr_old_%d", i), PayoutID: fmt.Sprintf("po_old_%d", i)}
+					if err := s.CreateStripeWithdrawal(row); err != nil {
+						t.Fatal(err)
+					}
+					before, err := s.GetStripeWithdrawal(row.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					next := *before
+					change(&next)
+					// Immutable field edits are ignored by both implementations.
+					next.AccountID = "wrong"
+					next.AmountMicroUSD = 1
+					next.Method = "wrong"
+					if ok, err := s.CompareAndSwapStripeWithdrawal(before, &next); err != nil || !ok {
+						t.Fatalf("update=%t error=%v", ok, err)
+					}
+					got, err := s.GetStripeWithdrawal(row.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := *before
+					change(&want)
+					want.UpdatedAt = got.UpdatedAt
+					if !reflect.DeepEqual(*got, want) {
+						t.Fatalf("changed unrelated fields: got%+v want%+v", *got, want)
+					}
+					if ok, err := s.CompareAndSwapStripeWithdrawal(before, &next); err != nil || !ok {
+						t.Fatalf("idempotent retry=%t error=%v", ok, err)
+					}
+					duplicate, _ := s.GetStripeWithdrawal(row.ID)
+					if !reflect.DeepEqual(got, duplicate) {
+						t.Fatalf("idempotent retry mutated row: %+v %+v", got, duplicate)
+					}
+					stale := *before
+					stale.FailureReason = "stale submission"
+					if ok, err := s.CompareAndSwapStripeWithdrawal(before, &stale); err != nil || ok {
+						t.Fatalf("stale update=%t error=%v", ok, err)
+					}
+					after, _ := s.GetStripeWithdrawal(row.ID)
+					if !reflect.DeepEqual(got, after) {
+						t.Fatalf("stale update mutated row: %+v %+v", got, after)
+					}
+					if want.TransferID != "" {
+						if found, err := s.GetStripeWithdrawalByTransferID(want.TransferID); err != nil || found.ID != row.ID {
+							t.Fatalf("transfer index: row=%+v error=%v", found, err)
+						}
+					}
+					if want.PayoutID != "" {
+						if found, err := s.GetStripeWithdrawalByPayoutID(want.PayoutID); err != nil || found.ID != row.ID {
+							t.Fatalf("payout index: row=%+v error=%v", found, err)
+						}
+					}
+					if before.TransferID != want.TransferID {
+						if _, err := s.GetStripeWithdrawalByTransferID(before.TransferID); err == nil {
+							t.Fatal("old transfer index retained")
+						}
+					}
+					if before.PayoutID != want.PayoutID {
+						if _, err := s.GetStripeWithdrawalByPayoutID(before.PayoutID); err == nil {
+							t.Fatal("old payout index retained")
+						}
+					}
+					if s.GetBalance(account) != 0 || s.GetWithdrawableBalance(account) != 0 {
+						t.Fatal("state update moved balance")
+					}
+				})
+			}
+			if ok, err := s.CompareAndSwapStripeWithdrawal(&StripeWithdrawal{ID: "missing"}, &StripeWithdrawal{ID: "missing"}); err != nil || ok {
+				t.Fatalf("missing row=%t error=%v", ok, err)
+			}
+			if ok, err := s.CompareAndSwapStripeWithdrawal(nil, &StripeWithdrawal{ID: "missing"}); err == nil || ok {
+				t.Fatalf("nil previous=%t error=%v", ok, err)
+			}
+		})
+	}
+}
+
+func TestStripeWithdrawalProgressConcurrentWriters(t *testing.T) {
+	for backend, s := range storeBackends(t) {
+		t.Run(backend, func(t *testing.T) {
+			const account = "progress-race-account"
+			if err := s.CreateUser(&User{AccountID: account, PrivyUserID: "did:privy:progress-race"}); err != nil {
+				t.Fatal(err)
+			}
+			row := &StripeWithdrawal{ID: "progress-race", AccountID: account, AmountMicroUSD: 5_000_000, NetMicroUSD: 5_000_000, Status: "pending", Method: "standard"}
+			if err := s.CreateStripeWithdrawal(row); err != nil {
+				t.Fatal(err)
+			}
+			before, err := s.GetStripeWithdrawal(row.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			start := make(chan struct{})
+			results := make(chan bool, 2)
+			errs := make(chan error, 2)
+			var wg sync.WaitGroup
+			for _, status := range []string{"paid", "failed"} {
+				wg.Add(1)
+				go func(status string) {
+					defer wg.Done()
+					next := *before
+					next.Status = status
+					<-start
+					ok, err := s.CompareAndSwapStripeWithdrawal(before, &next)
+					results <- ok
+					errs <- err
+				}(status)
+			}
+			close(start)
+			wg.Wait()
+			close(results)
+			close(errs)
+			count := 0
+			for ok := range results {
+				if ok {
+					count++
+				}
+			}
+			for err := range errs {
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if count != 1 {
+				t.Fatalf("concurrent winners=%d, want1", count)
+			}
+		})
+	}
+}

--- a/docs/architecture/billing.md
+++ b/docs/architecture/billing.md
@@ -1,6 +1,6 @@
 # Billing: pricing, reservations, ledger, and payouts
 
-> Last updated: 2026-09-06 · commit `23e6f986f`
+> Last updated: 2026-09-11 · commit `1ac25845d`
 
 Darkbloom is prepaid. A consumer account holds an integer micro-USD balance;
 the coordinator reserves the worst-case cost of a request before dispatch,
@@ -186,6 +186,8 @@ sequence is stated under Failure modes.
 Withdrawal row state machine: `pending → transferred → paid | failed`
 (`handleStripeWithdraw` comment block). There is no coordinator-side payout
 schedule or threshold beyond `MinWithdrawMicroUSD`.
+
+Submission progress is conditional on the last acknowledged row state. `persistWithdrawalUpdate` calls `CompareAndSwapStripeWithdrawal` (`coordinator/store/stripe_withdrawal_progress.go`), comparing transfer/payout/sweep IDs, status, failure reason and both refund flags under one memory lock or PostgreSQL update. An exact desired state is an idempotent retry success; another state is preserved. Account, amounts, method and creation time are never overwritten. Legacy already-refunded status flips use the same comparison against their lookup snapshot. A submission conflict stops subsequent steps and returns 409 `withdrawal_state_changed`; it does not undo an external Stripe call or move ledger balance by itself.
 
 ### International bank withdrawals
 

--- a/docs/consumer/billing.md
+++ b/docs/consumer/billing.md
@@ -1,6 +1,6 @@
 # Billing: fund an account and keep spend under control
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `1ac25845d`
 
 How to add credit, read your balance and usage, cap what a key can spend,
 redeem an invite code, and act on a `402`. Why the coordinator behaves this
@@ -206,6 +206,8 @@ Choose **Unlink Stripe account and start over** to remove the destination curren
   `remaining_usd` shrinking toward `0`.
 
 ## Troubleshooting
+
+If a Connect withdrawal reports that its status changed during submission, refresh withdrawal history before submitting again. A bank update or refund may have arrived while the request was waiting for Stripe. The newer status is preserved; the message does not mean the earlier transfer was canceled (`coordinator/api/stripe_withdraw.go`, `writeWithdrawalStateChanged`).
 
 | Symptom | Cause | Fix |
 |---|---|---|

--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -1,6 +1,6 @@
 # HTTP API contracts
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `1ac25845d`
 
 The complete public HTTP surface of the coordinator, derived from the 108 `HandleFunc` registrations in `routes()` (`coordinator/api/server.go`), including the `/v1/` catch-all. Every route is listed once below with its handler symbol, authentication requirement, and rate-limit bucket; the second half of the page gives the wire shapes, headers, error table, SSE framing, limits, timeouts, and version-gate semantics that those routes share. For *why* the pipeline is built this way see [`../architecture/components/consumer.md`](../architecture/components/consumer.md); for the crypto model behind sealed transport see [`../architecture/security/encryption.md`](../architecture/security/encryption.md).
 
@@ -531,6 +531,10 @@ Sealed mode hides request and response bodies from TLS-terminating intermediarie
 ### Device code shapes
 
 See the [Device-code flow](#device-code-flow-3) table for the three bodies. `verification_uri` is `<console>/link` when `EIGENINFERENCE_CONSOLE_URL` is set, else `<scheme>://<request host>/link` (`handleDeviceCode`).
+
+### Connect withdrawal submission conflicts
+
+`POST /v1/billing/withdraw/stripe` returns 409 `withdrawal_state_changed` when a webhook changes the withdrawal while its Connect submission is awaiting Stripe. The newer row is preserved and the handler stops subsequent submission steps. Check `GET /v1/billing/stripe/withdrawals` before retrying; this response does not mean prior Stripe calls or ledger activity were rolled back (`coordinator/api/stripe_withdraw.go`, `persistWithdrawalUpdate`).
 
 ### International withdrawal confirmation
 

--- a/docs/reference/pricing-model.md
+++ b/docs/reference/pricing-model.md
@@ -1,6 +1,6 @@
 # Pricing model reference
 
-> Last updated: 2026-09-06 · commit `8c22f0cdb`
+> Last updated: 2026-09-11 · commit `1ac25845d`
 
 Constants, formulas, enums, routes, and environment variables of the
 coordinator's money path, each row cited to the code that defines it. How the
@@ -154,6 +154,8 @@ Connected-account status `users.stripe_account_status`
 (`coordinator/api/stripe_payouts.go`): `""` → `pending` → `ready` \|
 `restricted` \| `rejected`. Service agreements (`coordinator/billing/stripe_regions.go`):
 `full`, `recipient`.
+
+Connect submission and legacy refunded-row progress writes use `CompareAndSwapStripeWithdrawal` in `coordinator/store/stripe_withdrawal_progress.go`. They require the caller's previous mutable state, preserve newer webhook transitions, and treat the exact desired state as successful retry. Immutable account and money fields stay unchanged. Concurrent progress returns 409 `withdrawal_state_changed` from the submission endpoint; inspect withdrawal history before submitting again.
 
 ## Base rewards
 


### PR DESCRIPTION
A Stripe webhook can mark a withdrawal paid or refunded while its submission handler is waiting for `payouts.create`. The handler then writes its older transferred row, erasing the sweep ID, refund flags and terminal status. The new regression exercises the actual submission handler and a concurrent paid/reversal transition; both cases fail on master.

Submission now retains its last acknowledged mutable state and updates through `CompareAndSwapStripeWithdrawal`. Memory performs the comparison and index changes under one lock; PostgreSQL uses one conditional UPDATE. An exact desired state is successful retry after a lost database acknowledgement. A different current state is preserved, the handler stops subsequent submission steps, and the client receives 409 `withdrawal_state_changed` with instructions to check history. Immutable account, amount, method and creation fields stay unchanged.

The two legacy already-refunded status-only webhook updates use their lookup snapshot with the same comparison. Sweep-bounce and reversal transitions are addressed separately by #933 and #925; after those changes are composed, production no longer calls the unconditional legacy setter. This does not make Stripe calls and database transactions atomic or reconcile a previously unknown payout ID.

Before:
```mermaid
flowchart LR
  S[Submission reads pending or transferred] --> C[Stripe call]
  C --> W[Write old whole row]
  H[Concurrent paid or reversal webhook] --> T[New terminal state]
  T --> W
  W --> L[Terminal ownership and refund evidence lost]
```

After:
```mermaid
flowchart LR
  S[Submission retains acknowledged state] --> C[Stripe call]
  C --> CAS[Atomic mutable-state comparison]
  H[Concurrent webhook] --> CAS
  CAS -->|expected state| U[Update progress and indexes]
  CAS -->|exact desired state| R[Idempotent retry success]
  CAS -->|different state| P[Preserve newer row and return 409]
```

Validation:

- Actual submission/webhook interleaving regression fails on master (both paid and refunded cases, 0.568s), passes with the change, and verifies 409 plus the complete unchanged terminal row.
- Focused Stripe withdrawal/webhook race suite passes 3.772s; final regression with response assertions passes 3.949s.
- Full store race suite passes against an owned isolated PostgreSQL 16 cluster (23.496s); cluster stopped afterward. Cross-store fixtures cover each of seven mutable fields, immutable-field preservation, index replacement, idempotent retry with unchanged timestamp, stale writes, missing/invalid identity and concurrent competing writers.
- Existing injected update-error tests retain their fault behavior through a new guarded-update override.
- Documentation lint passes 278 pages. Full `GOTOOLCHAIN=go1.25.0 go test ./coordinator/...` passes (API 193.782s).
- Independent source review found no blocker. Automated Codex review was requested but rejected by the review usage limit; no automated approval is claimed.
