### PR TITLE
Clarify privacy endpoints and fix root development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Darkbloom turns idle Macs into a private, OpenAI-compatible inference cloud.
 
 Today, AI compute reaches you through a stack of markups — chipmaker to hyperscaler to API vendor. Meanwhile, over 100 million Apple Silicon Macs sit mostly idle, each with up to 512 GB of unified memory and up to 819 GB/s of bandwidth — enough to run frontier-scale models at interactive speeds. Darkbloom connects that idle capacity directly to demand, and pays the people who own the machines.
 
-The hard part is privacy. The person running a provider node has root and physical custody of the machine doing your inference — yet they must **not** be able to read your prompts or the model's responses. Darkbloom closes every software path to that plaintext:
+The person running a provider node has root and physical custody of the machine doing your inference. Darkbloom is designed to keep prompts and responses inside the hardened provider process, using these controls:
 
-- **No observation surface.** Inference runs **in-process** via MLX — no subprocess, no local server, no IPC to tap.
-- **Locked-down process.** Debuggers are denied at the kernel level (`PT_DENY_ATTACH`); memory-reading APIs are blocked by Hardened Runtime. These protections are immutable for the process lifetime, because removing them requires disabling SIP, which requires a reboot that kills the process.
-- **End-to-end encryption.** The coordinator re-seals every request with NaCl Box (X25519 + XSalsa20-Poly1305) to the provider's attested key, so on the provider machine only the hardened process — never its owner — can decrypt it.
+- **In-process inference.** The network provider runs MLX inside its hardened process, without a separate inference server or subprocess.
+- **Runtime hardening.** `PT_DENY_ATTACH`, Hardened Runtime and coordinator-verified SIP restrict debugging, memory access and code injection.
+- **Hop-by-hop encryption.** The coordinator opens the request for routing and billing, then seals it with NaCl Box (X25519 + XSalsa20-Poly1305) to the provider's attested key. The provider process decrypts it to run the model.
 - **Hardware attestation.** A four-layer chain — Secure Enclave signatures, MDM cross-checks, Apple Managed Device Attestation, and APNs code-identity — proves each node's security posture and that it runs a genuine, unmodified binary.
 
-What remains is the same residual threat model Apple accepts for Private Cloud Compute: physically de-soldering and probing memory chips. Everything short of that is engineered out.
+These controls depend on the security of the operating system, hardware and attested software. See [privacy expectations](docs/consumer/privacy-expectations.md) for what each party can observe and what metadata is retained.
 
 The API is OpenAI- and Anthropic-compatible, so most clients work by changing one base URL.
 
@@ -42,7 +42,7 @@ The API is OpenAI- and Anthropic-compatible, so most clients work by changing on
 flowchart LR
     U["<b>Consumer</b><br/>OpenAI / Anthropic SDK · curl · Web UI"]
     subgraph coord["Coordinator · Go · GCP Confidential VM (AMD SEV)"]
-        CO["Auth · Routing · Billing<br/>Attestation · E2E relay"]
+        CO["Auth · Routing · Billing<br/>Attestation · Encrypted transport"]
     end
     subgraph prov["Provider · Swift CLI · hardened macOS process"]
         P["mlx-swift-lm (in-process)"] --> G["Apple Silicon GPU (Metal)"]
@@ -58,7 +58,7 @@ A consumer calls the coordinator over a standard HTTPS, OpenAI-compatible API. T
 
 ## Privacy & security
 
-Darkbloom is engineered so that **the operator of the Mac running your inference cannot read your prompt or the response.** The only plaintext exposure anywhere is transient — inside the coordinator's hardware-encrypted Confidential-VM memory — and it is never logged or retained.
+Plaintext exists in the coordinator's Confidential-VM memory while it handles the request and inside the provider process while it runs inference. The coordinator writes no prompt or completion content to logs or storage. Provider hardening and attestation constrain which process can decrypt and use that content.
 
 ### Encryption, hop by hop
 
@@ -83,7 +83,7 @@ sequenceDiagram
 | Coordinator → Provider | **Mandatory** per-request NaCl Box to the provider's attested X25519 key, with a fresh ephemeral key per request |
 | Provider → Coordinator | Response chunks encrypted back to the coordinator's ephemeral key |
 
-> **Precise claim:** Darkbloom is not "the coordinator never sees plaintext." The accurate statement is that plaintext is exposed *only* inside the coordinator's hardware-encrypted CVM memory, is never logged or retained, and is immediately re-encrypted for the selected provider. The provider is the final decryption endpoint, and it is bound to an attested Secure Enclave identity. See [`docs/architecture/security/encryption.md`](docs/architecture/security/encryption.md) and [`docs/consumer/privacy-expectations.md`](docs/consumer/privacy-expectations.md).
+The [encryption reference](docs/architecture/security/encryption.md) defines the keys, endpoint visibility and retained metadata for each hop. Sender sealing terminates at the coordinator; it does not hide the request from the coordinator or the provider process.
 
 ### Provider hardening
 
@@ -300,7 +300,7 @@ section. To roll back either optimization, set its key to `false` and run
 
 Running a node also makes your **own** inference free.
 
-- **Self-route** — *"use my own machine, for free."* Add `X-Darkbloom-Route: self` to any request to route **only** to a provider your account owns: free, end-to-end encrypted, with no fallback to the paid fleet (you get an explicit error if your machine can't serve). `X-Darkbloom-Route: prefer` routes to your machine first but falls back to the paid fleet so you're never stuck. An API key can also be pinned to owned-only with `self_route_only`. See [`docs/provider/self-route.md`](docs/provider/self-route.md).
+- **Self-route** — *"use my own machine, for free."* Add `X-Darkbloom-Route: self` to any request to route **only** to a provider your account owns, through the same encrypted coordinator hops, with no fallback to the paid fleet (you get an explicit error if your machine can't serve). `X-Darkbloom-Route: prefer` routes to your machine first but falls back to the paid fleet so you're never stuck. An API key can also be pinned to owned-only with `self_route_only`. See [`docs/provider/self-route.md`](docs/provider/self-route.md).
 
 - **Direct mode** — when the client can reach your Mac (same machine / LAN / tailnet), `darkbloom start --local` serves an OpenAI-compatible endpoint locally and **skips the coordinator entirely**: lowest latency, offline-capable, bytes never leave your network. See [`docs/provider/direct-mode.md`](docs/provider/direct-mode.md).
 
@@ -323,17 +323,18 @@ The coordinator and provider share WebSocket message types that must stay in syn
 ## Development
 
 ```bash
+# Run these commands from the repository root.
 # Coordinator (Go)
-cd coordinator && go test ./...
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o coordinator-linux ./cmd/coordinator   # container build
+go test ./coordinator/...
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o coordinator-linux ./coordinator/cmd/coordinator   # container build
 
 # Provider (Swift) — depends on libs/mlx-swift and libs/mlx-swift-lm submodules
-cd provider-swift && swift test
-cd provider-swift && swift build -c release      # → .build/release/darkbloom
+(cd provider-swift && swift test)
+(cd provider-swift && swift build -c release)    # → provider-swift/.build/release/darkbloom
 
 # Console UI (Next.js 16)
-cd console-ui && npm install && npm run dev
-cd console-ui && npm run build && npm test       # production build + vitest
+(cd console-ui && npm ci && npm run dev)
+(cd console-ui && npm run build && npm test)     # production build + vitest
 ```
 
 Build, test, and release details: [`docs/developer/build.md`](docs/developer/build.md), [`docs/developer/test.md`](docs/developer/test.md), [`docs/operations/provider-release.md`](docs/operations/provider-release.md).

--- a/coordinator/internal/e2e/coordinator_key.go
+++ b/coordinator/internal/e2e/coordinator_key.go
@@ -5,8 +5,7 @@
 // their request body to it, and POST as application/eigeninference-sealed+json.
 // Only the coordinator (which knows the private key) can decrypt.
 //
-// The private key is derived from the same BIP39 mnemonic used for billing,
-// but with a distinct HKDF domain so the two keys are unrelated.
+// The configured BIP39 mnemonic feeds a dedicated HKDF domain for sender sealing.
 
 package e2e
 
@@ -40,7 +39,7 @@ type CoordinatorKey struct {
 
 // DeriveCoordinatorKey derives the coordinator's X25519 keypair from a BIP39
 // mnemonic. It returns ErrNoMnemonic if mnemonic is empty so callers can run
-// the coordinator in environments without billing configured (the encryption
+// the coordinator without sender sealing configured (the encryption
 // endpoint will simply be unavailable).
 func DeriveCoordinatorKey(mnemonic string) (*CoordinatorKey, error) {
 	mnemonic = strings.TrimSpace(mnemonic)

--- a/coordinator/internal/e2e/e2e.go
+++ b/coordinator/internal/e2e/e2e.go
@@ -11,7 +11,7 @@
 // cross-language compatibility.
 //
 // Flow:
-//  1. Coordinator generates ephemeral X25519 key pair per request (forward secrecy)
+//  1. Coordinator generates an ephemeral X25519 key pair per request
 //  2. Encrypts prompt with: ephemeral private + provider public → shared secret
 //  3. Sends: ephemeral public key + nonce + ciphertext
 //  4. Provider decrypts with: provider private + ephemeral public → same shared secret
@@ -39,7 +39,7 @@ type EncryptedPayload struct {
 }
 
 // SessionKeys holds the ephemeral key pair for a single request.
-// The coordinator creates one per inference request for forward secrecy.
+// The coordinator creates one per inference request for key isolation.
 type SessionKeys struct {
 	PublicKey  [32]byte
 	PrivateKey [32]byte

--- a/docs/developer/build.md
+++ b/docs/developer/build.md
@@ -1,6 +1,6 @@
 # Build
 
-> Last updated: 2026-09-10 · commit `4f29957d2`
+> Last updated: 2026-09-11 · commit `908ecf832`
 
 How to build every component of Darkbloom from a fresh clone: the Go
 coordinator, the Rust prompt-contract sidecar, the Swift provider CLI (with its
@@ -16,6 +16,9 @@ Go/Swift fixture and focused checks are described in [test.md](test.md) and
 [prediction telemetry](../reference/prediction-decision-telemetry.md).
 
 ## Prerequisites
+
+- Start commands from the repository root. Component examples that use
+  `(cd path && command)` run in a subshell and preserve your current directory.
 
 - **Toolchain via [`mise`](https://mise.jdx.dev/).** Every version is pinned in
   [`mise.toml`](../../mise.toml); `mise install` installs them all.

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-11 · commit `d22ad0cf3`
+> Last updated: 2026-09-11 · commit `908ecf832`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -65,6 +65,10 @@ make test   # coordinator-test prompt-sidecar-test provider-test ui-test benchma
 ```
 
 ### 2. Coordinator (Go)
+
+The Go module lives at the repository root. Run `go test ./coordinator/...`
+there to select coordinator packages; keep component `cd` commands in separate
+shells when following the repository README examples.
 
 Run prediction telemetry checks from the repository root:
 


### PR DESCRIPTION
The README claimed plaintext existed only in the coordinator, although the provider decrypts requests to run inference. Describe both endpoints and the existing hardening controls, and link to the canonical privacy and encryption references. The related Go comments now describe sender sealing and per-request key isolation accurately; executable Go is unchanged.

The development examples now run from the repository root. Coordinator commands select the root Go module, and provider/UI commands use subshells so one example cannot silently change the working directory for the next. The UI install example uses its committed lockfile.

```mermaid
flowchart LR
  subgraph Before
    A[Reader follows privacy summary] --> B[Coordinator-only plaintext claim]
    B --> C[Provider inference endpoint omitted]
    D[Reader follows development commands] --> E[Persistent component directory changes]
    E --> F[Later commands target the wrong directory]
  end
  subgraph After
    A2[Reader follows privacy summary] --> B2[Coordinator opens and seals request]
    B2 --> C2[Attested provider decrypts for inference]
    D2[Reader follows development commands] --> E2[Root Go paths and component subshells]
    E2 --> F2[Each command targets its intended component]
  end
```

Validation: independent source review against the key derivation and transport helpers plus the canonical privacy references; non-comment Go lines are identical; `go list ./coordinator/cmd/coordinator` resolves; docs lint passes for all 278 pages. Documentation stamps point to reachable implementation commit `908ecf832`. This change does not require a new model or runtime test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791767275&installation_model_id=21733&pr_number=958&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F958&signature=b9463075cb04294a3d8d0ffeed5179c22943a7b9f46bd7d1e4b68a7dd07ec8d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->