### PR TITLE
fix(promptcontract): own provisioning inputs and clean publication losers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Prompt artifact provisioning** — Snapshot catalog file lists and the configured download origin, validate every manifest before sharing a download, and remove read-only staging trees after another cache instance wins publication.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/coordinator/promptcontract/artifact_cache.go
+++ b/coordinator/promptcontract/artifact_cache.go
@@ -75,6 +75,8 @@ func NewArtifactCache(config ArtifactCacheConfig) (*ArtifactCache, error) {
 	if config.BaseURL.User != nil || config.BaseURL.RawQuery != "" || config.BaseURL.Fragment != "" {
 		return nil, ErrUnsafeArtifactPath
 	}
+	// Retain the validated origin independently of caller-owned URL storage.
+	baseURL := *config.BaseURL
 	client := config.HTTPClient
 	if client == nil {
 		client = &http.Client{}
@@ -82,7 +84,7 @@ func NewArtifactCache(config ArtifactCacheConfig) (*ArtifactCache, error) {
 	clientCopy := *client
 	originalRedirectPolicy := client.CheckRedirect
 	clientCopy.CheckRedirect = func(request *http.Request, via []*http.Request) error {
-		if !sameOrigin(request.URL, config.BaseURL) {
+		if !sameOrigin(request.URL, &baseURL) {
 			return ErrArtifactIntegrity
 		}
 		if originalRedirectPolicy != nil {
@@ -100,7 +102,7 @@ func NewArtifactCache(config ArtifactCacheConfig) (*ArtifactCache, error) {
 	}
 	return &ArtifactCache{
 		root:            root,
-		baseURL:         config.BaseURL,
+		baseURL:         &baseURL,
 		httpClient:      client,
 		downloadTimeout: downloadTimeout,
 		inflight:        make(map[string]*artifactCall),
@@ -116,6 +118,14 @@ func (c *ArtifactCache) Ensure(ctx context.Context, manifest Manifest) (string, 
 	}
 	contractID, err := ContractID(artifacts, CurrentVersions())
 	if err != nil {
+		return "", err
+	}
+	// Every caller supplies its own model manifest, even when prompt artifacts
+	// share one contract and download. Validate before joining that work.
+	if !validRelativePath(manifest.R2Prefix) {
+		return "", ErrUnsafeArtifactPath
+	}
+	if err := verifyManifestAggregate(manifest); err != nil {
 		return "", err
 	}
 	c.mu.Lock()
@@ -141,12 +151,6 @@ func (c *ArtifactCache) Ensure(ctx context.Context, manifest Manifest) (string, 
 }
 
 func (c *ArtifactCache) ensureOne(ctx context.Context, manifest Manifest, artifacts []Artifact, contractID string) (string, error) {
-	if !validRelativePath(manifest.R2Prefix) {
-		return "", ErrUnsafeArtifactPath
-	}
-	if err := verifyManifestAggregate(manifest); err != nil {
-		return "", err
-	}
 	root, err := openVerifiedRoot(c.root, 0o700)
 	if err != nil {
 		if errors.Is(err, ErrUnsafeArtifactPath) {
@@ -216,8 +220,8 @@ func (c *ArtifactCache) ensureOne(ctx context.Context, manifest Manifest, artifa
 	}
 	if err := renameRootEntry(root, c.root, tempName, contractID); err != nil {
 		if ok, verifyErr := verifyPublished(root, contractID); ok {
-			_ = root.RemoveAll(tempName)
-			published = true
+			// Another publisher won. The deferred cleanup makes our read-only
+			// staging directories writable before removing only our tree.
 			return path.Join(c.root, contractID), nil
 		} else if verifyErr != nil &&
 			!errors.Is(verifyErr, fs.ErrNotExist) &&

--- a/coordinator/promptcontract/artifact_ownership_test.go
+++ b/coordinator/promptcontract/artifact_ownership_test.go
@@ -1,0 +1,177 @@
+package promptcontract
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestArtifactCacheOwnsConfiguredOrigin(t *testing.T) {
+	body := []byte(`{"version":"1.0"}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/original/pinned/tokenizer.json" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+	base, _ := url.Parse(server.URL + "/original/")
+	cache, err := NewArtifactCache(ArtifactCacheConfig{
+		Root: readOnlyTempRoot(t), BaseURL: base, HTTPClient: server.Client(), AllowHTTP: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.Path = "/caller-reused-url/"
+	if _, err := cache.Ensure(context.Background(), fixtureManifest(map[string][]byte{"tokenizer.json": body})); err != nil {
+		t.Fatalf("caller URL mutation changed configured artifact source: %v", err)
+	}
+}
+
+func TestArtifactPublicationLoserRemovesReadOnlyStaging(t *testing.T) {
+	body := []byte(`{"version":"1.0"}`)
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entered <- struct{}{}
+		select {
+		case <-release:
+			_, _ = w.Write(body)
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	defer unblock()
+	base, _ := url.Parse(server.URL + "/")
+	root := readOnlyTempRoot(t)
+	manifest := fixtureNestedManifest("nested/tokenizer.json", body)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	results := make(chan error, 2)
+	for range 2 {
+		cache, err := NewArtifactCache(ArtifactCacheConfig{Root: root, BaseURL: base, HTTPClient: server.Client(), AllowHTTP: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() { _, err := cache.Ensure(ctx, manifest); results <- err }()
+	}
+	for range 2 {
+		select {
+		case <-entered:
+		case <-ctx.Done():
+			t.Fatal("both independent publishers did not reach their download")
+		}
+	}
+	unblock()
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || strings.HasPrefix(entries[0].Name(), ".tmp-") {
+		t.Fatalf("publication retained staging alongside the winner: %v", entries)
+	}
+	if mode := fileMode(t, filepath.Join(root, entries[0].Name())).Perm(); mode != 0o500 {
+		t.Fatalf("winner permissions changed during loser cleanup: %o", mode)
+	}
+}
+
+func TestProvisionerOwnsQueuedManifestFiles(t *testing.T) {
+	body := []byte(`{"version":"1.0"}`)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/pinned/first.json" {
+			close(started)
+			select {
+			case <-release:
+			case <-r.Context().Done():
+				return
+			}
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+	defer unblock()
+	base, _ := url.Parse(server.URL + "/")
+	cache, err := NewArtifactCache(ArtifactCacheConfig{Root: readOnlyTempRoot(t), BaseURL: base, HTTPClient: server.Client(), AllowHTTP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisioner, err := NewProvisioner(context.Background(), cache, ProvisionerConfig{MaxConcurrent: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer provisioner.Close()
+	manifests := []Manifest{fixtureNestedManifest("first.json", body), fixtureNestedManifest("second.json", body)}
+	manifests[0].ModelID, manifests[1].ModelID = "first", "second"
+	if err := provisioner.Reconcile(manifests); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first download did not start")
+	}
+	// One worker is blocked above: the second file has not been read by Ensure.
+	// Callers can reuse their manifest backing arrays after Reconcile returns.
+	manifests[1].Files[0].Path = "caller-mutated.json"
+	unblock()
+	waitForProvision(t, provisioner, 2)
+	status, ok := provisioner.Status("second")
+	if !ok || filepath.Base(status.Path) != status.PromptContractID {
+		t.Fatalf("queued artifact changed after its contract was recorded: %+v", status)
+	}
+	if _, err := os.Stat(filepath.Join(status.Path, "second.json")); err != nil {
+		t.Fatalf("original queued artifact not published: %v", err)
+	}
+}
+
+func TestArtifactCacheValidatesEveryJoiningManifest(t *testing.T) {
+	body := []byte(`{"version":"1.0"}`)
+	manifest := fixtureManifest(map[string][]byte{"tokenizer.json": body})
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	base, _ := url.Parse(server.URL + "/")
+	cache, err := NewArtifactCache(ArtifactCacheConfig{Root: readOnlyTempRoot(t), BaseURL: base, HTTPClient: server.Client(), AllowHTTP: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	finished := make(chan struct{})
+	go func() { defer close(finished); _, _ = cache.Ensure(ctx, manifest) }()
+	defer func() { cancel(); <-finished }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("leader download did not start")
+	}
+	invalid := manifest
+	invalid.AggregateSHA256 = strings.Repeat("0", 64)
+	follower, cancelFollower := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelFollower()
+	if _, err := cache.Ensure(follower, invalid); !errors.Is(err, ErrArtifactIntegrity) {
+		t.Fatalf("joining manifest escaped its integrity check: %v", err)
+	}
+}

--- a/coordinator/promptcontract/preload_controller.go
+++ b/coordinator/promptcontract/preload_controller.go
@@ -245,13 +245,17 @@ func (c *PreloadController) matches(provisioned ProvisionSnapshot, child Supervi
 
 func (c *PreloadController) setUnavailable(reason string) {
 	c.mu.Lock()
+	c.setUnavailableLocked(boundedStatusError(reason))
+	c.mu.Unlock()
+}
+
+func (c *PreloadController) setUnavailableLocked(reason string) {
 	c.status.Ready = false
 	c.status.CatalogGeneration = 0
 	c.status.ChildGeneration = 0
 	c.status.ContractCount = 0
-	c.status.LastError = boundedStatusError(reason)
+	c.status.LastError = reason
 	c.contracts = make(map[string]struct{})
-	c.mu.Unlock()
 }
 
 func (c *PreloadController) recordFailure(
@@ -271,13 +275,8 @@ func (c *PreloadController) recordFailure(
 	c.retryCatalogGeneration = catalogGeneration
 	c.retryChildGeneration = childGeneration
 	c.retryAt = time.Now().Add(c.failureBackoff)
-	c.status.Ready = false
-	c.status.CatalogGeneration = 0
-	c.status.ChildGeneration = 0
-	c.status.ContractCount = 0
+	c.setUnavailableLocked(errorText)
 	c.status.Failures++
-	c.status.LastError = errorText
-	c.contracts = make(map[string]struct{})
 	backoff := c.failureBackoff
 	c.mu.Unlock()
 	slog.Warn("prompt sidecar active-set preload failed",

--- a/coordinator/promptcontract/provisioner.go
+++ b/coordinator/promptcontract/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -95,8 +96,10 @@ func (p *Provisioner) Reconcile(manifests []Manifest) error {
 	if len(manifests) > p.maxModels {
 		return p.rejectCatalog(ErrInvalidConfig)
 	}
-	copied := make([]Manifest, len(manifests))
-	copy(copied, manifests)
+	copied := slices.Clone(manifests)
+	for index := range copied {
+		copied[index].Files = slices.Clone(copied[index].Files)
+	}
 	seen := make(map[string]bool, len(copied))
 	statuses := make(map[string]ProvisionStatus, len(copied))
 	for _, manifest := range copied {

--- a/coordinator/promptcontract/supervisor.go
+++ b/coordinator/promptcontract/supervisor.go
@@ -149,7 +149,7 @@ func (s *Supervisor) run(ctx context.Context) {
 			continue
 		}
 		s.setRestartSuppressed(time.Time{})
-		reason, detail, stderr, ran, stable := s.runChild(ctx)
+		reason, detail, stderr, stable := s.runChild(ctx)
 		if ctx.Err() != nil {
 			break
 		}
@@ -157,8 +157,6 @@ func (s *Supervisor) run(ctx context.Context) {
 		restartTimes = append(restartTimes, time.Now())
 		if stable {
 			backoff = s.config.RestartBackoffMin
-		} else if ran {
-			backoff = nextBackoff(backoff, s.config.RestartBackoffMax)
 		} else {
 			backoff = nextBackoff(backoff, s.config.RestartBackoffMax)
 		}
@@ -170,11 +168,11 @@ func (s *Supervisor) run(ctx context.Context) {
 }
 
 // runChild returns a bounded reason/detail/stderr record and whether the child
-// started and ever answered liveness. Readiness degradation alone never ends
+// ever answered liveness. Readiness degradation alone never ends
 // the child; it only closes the cache-routing gate.
-func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool, bool) {
+func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool) {
 	if err := prepareSocketDirectory(s.config.SocketPath); err != nil {
-		return "socket_error", err.Error(), "", false, false
+		return "socket_error", err.Error(), "", false
 	}
 	stderr := newTailBuffer(s.config.StderrMaxBytes)
 	cmd := exec.Command(s.config.BinaryPath, s.arguments()...)
@@ -182,7 +180,7 @@ func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool
 	cmd.Stdout = io.Discard
 	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
-		return "start_error", err.Error(), stderr.String(), false, false
+		return "start_error", err.Error(), stderr.String(), false
 	}
 	generation := s.noteChildStarted(processRSSBytes(cmd.Process.Pid))
 	waited := make(chan error, 1)
@@ -197,16 +195,16 @@ func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool
 		select {
 		case <-ctx.Done():
 			s.terminate(cmd, waited)
-			return "shutdown", "", stderr.String(), true, live
+			return "shutdown", "", stderr.String(), live
 		case err := <-waited:
 			detail := childExitReason(err, cmd.ProcessState)
 			s.setChildStopped(generation)
-			return "child_exit", detail, stderr.String(), true, live
+			return "child_exit", detail, stderr.String(), live
 		case <-startup.C:
 			if !live {
 				s.terminate(cmd, waited)
 				s.setChildStopped(generation)
-				return "startup_timeout", "liveness startup deadline exceeded", stderr.String(), true, false
+				return "startup_timeout", "liveness startup deadline exceeded", stderr.String(), false
 			}
 		case <-ticker.C:
 			rss := processRSSBytes(cmd.Process.Pid)
@@ -214,7 +212,7 @@ func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool
 				s.setRuntimeState(generation, true, false, rss, consecutiveFailures)
 				s.terminate(cmd, waited)
 				s.setChildStopped(generation)
-				return "rss_limit", fmt.Sprintf("RSS %d exceeded %d MiB", rss, s.config.MemoryLimitMiB), stderr.String(), true, live
+				return "rss_limit", fmt.Sprintf("RSS %d exceeded %d MiB", rss, s.config.MemoryLimitMiB), stderr.String(), live
 			}
 			if err := s.client.Health(ctx); err != nil {
 				if live {
@@ -224,7 +222,7 @@ func (s *Supervisor) runChild(ctx context.Context) (string, string, string, bool
 				if live && consecutiveFailures >= s.config.HealthFailureThreshold {
 					s.terminate(cmd, waited)
 					s.setChildStopped(generation)
-					return "health_failure_threshold", err.Error(), stderr.String(), true, true
+					return "health_failure_threshold", err.Error(), stderr.String(), true
 				}
 				continue
 			}

--- a/docs/architecture/prompt-contract-sidecar.md
+++ b/docs/architecture/prompt-contract-sidecar.md
@@ -1,6 +1,6 @@
 # Prompt-contract sidecar
 
-> Last updated: 2026-09-09 · commit `884d97862`
+> Last updated: 2026-09-11 · commit `4a3c92016`
 
 How the coordinator's `promptsidecar` child process derives deterministic,
 provider-compatible token boundaries so exact-cache routing can predict which
@@ -102,8 +102,10 @@ use the same singleflight implementation and configured LRU capacity; the
 planner semaphore bounds concurrent loads and plans.
 
 At startup the sidecar binds its socket and reports live but not ready; it does
-not discover or load every directory left on disk. After asynchronous artifact
-provisioning finishes (`Provisioner.Reconcile`,
+not discover or load every directory left on disk. Catalog reconciliation
+snapshots each manifest and its file list before starting background work, so
+later caller changes cannot separate the published path from its recorded
+contract identity. After asynchronous artifact provisioning finishes (`Provisioner.Reconcile`,
 `coordinator/promptcontract/provisioner.go`), the coordinator sends the
 complete, deduplicated active set to `POST /v1/preload`, which loads that set
 sequentially before traffic (`coordinator/promptsidecar/src/preload.rs`). This
@@ -231,13 +233,17 @@ its layout-epoch binding includes the block size.
 The Go cache (`ArtifactCache.Ensure`,
 `coordinator/promptcontract/artifact_cache.go`) accepts catalog manifest data,
 filters to prompt roles, verifies the model aggregate identity
-(`verifyManifestAggregate`), downloads each declared file from the configured
-HTTPS origin, rejects cross-origin redirects (`sameOrigin`), verifies size and
+(`verifyManifestAggregate`) for every caller before joining a shared download,
+and downloads each declared file from an owned snapshot of the configured
+HTTPS origin. It rejects cross-origin redirects (`sameOrigin`), verifies size and
 SHA-256 while writing, fsyncs files and directories, and atomically renames a
 random same-root temporary directory. `os.Root`, exclusive creation,
 relative-path validation, and symlink checks (`rejectSymlinks`) contain
 traversal. Published files are mode `0400` and directories mode `0500`; every
-reuse re-hashes every artifact (`verifyPublished`).
+reuse re-hashes every artifact (`verifyPublished`). When another cache instance
+wins publication, the loser verifies that winner, restores write permission
+only within its own staging tree, and removes that tree through the existing
+scoped cleanup. The published winner remains read-only.
 
 The Rust process never downloads. It opens every path component from `/` with
 `O_NOFOLLOW` (`load`, `coordinator/promptsidecar/src/artifacts.rs`), so a


### PR DESCRIPTION
Prompt artifact work now owns the inputs it retains, validates every joining manifest, and removes its staging directory when another cache instance publishes first. Previously caller mutation could change a queued contract's files or configured origin, an invalid follower could reuse a valid leader's result without aggregate verification, and a publication loser could retain read-only temporary directories.

The API currently builds fresh manifests; the mutation fixtures demonstrate ownership-contract defects, not an observed production incident. Catalog reconciliation now clones nested file lists, cache construction snapshots the validated origin, and each caller checks its own aggregate before singleflight. Publication losers use the existing scoped writable cleanup and preserve the immutable winner. The supervisor's duplicate backoff branches and preload's repeated unavailable-state clearing are consolidated without changing their policies. Production source is +4 lines overall; the improvement is explicit ownership and less repeated control flow.

```mermaid
flowchart TB
  subgraph Before
    B1[Caller-owned URL and manifest file list] --> B2[Cache and Provisioner retain aliases]
    B2 --> B3[Later mutation can change download or contract path]
    B4[Ensure follower] --> B5[Join before aggregate verification]
    B6[Publication loses race] --> B7[Ignore removal error and skip deferred cleanup]
    B7 --> B8[Read-only staging can remain]
    B9[runChild ran flag] --> B10[Two identical backoff branches]
  end
  subgraph After
    A1[NewArtifactCache and Reconcile] --> A2[Own URL value and each file list]
    A2 --> A3[Stable origin and queued contract identity]
    A4[Ensure each caller] --> A5[Validate aggregate then join]
    A6[Publication loses race] --> A7[Verify winner and defer owned staging cleanup]
    A7 --> A8[Immutable winner retained; duplicate removed]
    A9[runChild lifecycle result] --> A10[One unchanged backoff path]
  end
```

Validation on Go 1.25.0:
- Four offline regression cases failed before their fixes: mutated origin, queued file-list mutation, competing read-only publication, and invalid singleflight follower. They use owned temporary roots and local HTTP fixtures.
- `go test -race ./promptcontract -count=1`: PASS, 4.177s. Includes existing endpoint/hash vectors, cancellation, socket client, provisioning, preload and synthetic supervisor-child tests.
- `go test -race ./api -run '^TestCatalogReconcileProvisionsPromptArtifacts$' -count=1`: PASS, 1.681s.
- `scripts/docs-check.sh`: PASS, 278 files. `git diff --check`: PASS.
- Independent source and regression-test review: clean. No provider, Swift, model, deployment or real artifact download executed; no timed fuzz campaign.

Source reviewed: all nine assigned Go artifact/client/endpoint/preload/provisioner/date/supervisor operation files and direct tests; unchanged endpoint lowering and hash fixtures preserve their existing byte contracts. Canonical documentation is stamped against reachable source commit `4a3c92016`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791767328&installation_model_id=21733&pr_number=959&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F959&signature=abd0438f4e060e1707aca85d176a1cac690c3d665b782a2eddddfa81564ceb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->