### PR TITLE
fix(release): link the source commit in GitHub Release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python3 scripts/test-provider-release-resolution.py
           ./scripts/sync-install-embed.sh check
           ./scripts/test-prod-env-refresh.sh
+          ./scripts/test-release-notes.sh
       - name: Test startup observer against local stubs
         run: python3 -m unittest discover -s scripts/startup_measurement -t scripts -p 'test_*.py'
 

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -888,6 +888,7 @@ jobs:
           cat > /tmp/release-notes.md <<NOTES
           ## Provider v${VERSION} (Swift CLI)
 
+          **Commit:**        \`${GITHUB_SHA}\`
           **Binary hash:**   \`${BINARY_HASH}\`
           **Bundle hash:**   \`${BUNDLE_HASH}\`
           **Metallib hash:** \`${METALLIB_HASH}\` (built from mlx \`${{ steps.mlxkey.outputs.mlx_sha_short }}\`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased — release provenance
+
+- Name the source commit each prod provider bundle was built from in its GitHub Release notes, next to the binary, bundle and metallib hashes.
+
 ## Release candidate v0.9.2 — Gemma QAT caching, adaptive MTP and Nemotron Lightning (not shipped; 2026-09-10)
 
 Source changes since `v0.9.1`. Provider changes require a new signed bundle.

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ curl -fsSL https://api.darkbloom.dev/install.sh | bash
 
 Zero prerequisites and no `sudo`. The installer fetches the latest signed release, verifies the bundle / binary / `mlx.metallib` SHA-256 against the coordinator's release record, checks the Apple Developer ID code signature, provisions the Secure Enclave helper, and offers to install the MDM enrollment profile for hardware trust. See [`docs/provider/installation.md`](docs/provider/installation.md).
 
+Tagged production provider releases are also published as [GitHub Releases](https://github.com/Layr-Labs/d-inference/releases) on this repository, with the signed bundle, its SHA-256 hashes and the source commit it was built from.
+
 ### First run
 
 ```bash

--- a/docs/developer/test.md
+++ b/docs/developer/test.md
@@ -1,6 +1,6 @@
 # Test
 
-> Last updated: 2026-09-10 · commit `5a3ffc27f`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 How to run the unit tests for each component, the end-to-end suite that boots a
 real coordinator + Swift provider against ephemeral Postgres, and the docs
@@ -906,6 +906,7 @@ make benchmark-wrapper-test        # python3 -m unittest discover -s gemma_contb
 python3 scripts/test-provider-release-resolution.py # signed-validation and publication routing before credentials
 ./scripts/sync-install-embed.sh check   # coordinator/api/install.sh byte-identical to scripts/install.sh
 ./scripts/test-prod-env-refresh.sh      # deploy/gcp/prod/refresh-env.sh contract
+./scripts/test-release-notes.sh         # release notes name the source commit
 ./scripts/test-publish-model.sh         # scripts/publish-model.sh dry-run contract
 ```
 
@@ -1133,7 +1134,7 @@ token IDs are accepted.
 
 | Workflow | Trigger | Jobs (name → what runs) |
 |---|---|---|
-| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) | push, PR | **Release Integrity** — `scripts/check-release-version.sh`, `scripts/sync-install-embed.sh check`, `scripts/test-prod-env-refresh.sh` · **Docs Lint** — `scripts/docs-check.sh` · **Coordinator Tests** — `go test -race $(go list ./... \| grep -v /e2e)` with `postgres:16` service + `gofmt` on tracked Go files outside frozen report evidence · **Coordinator Lint** — `golangci-lint run` (v2.1.6) · **Prompt Sidecar Tests** — cargo fmt/check/clippy/test on Rust 1.88.0, static musl Docker stage, `verify-prompt-sidecar-linux.sh` · **Provider Tests** (macOS 12-vcpu) — `swift build --build-tests`, metallib staging, `swift test`, `verify-prompt-parity.sh`, six nested suites via `run-nested-suite.sh` (each its own step, `if: !cancelled()`), `test-install-atomic.sh` · **Swift Build + Cache** — release build of `darkbloom` + `darkbloom-fan-helper`, warms the SwiftPM cache · **Console UI Lint & Build** — Node 22, `npm ci`, `npx eslint src/`, `npm run build` |
+| [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) | push, PR | **Release Integrity** — `scripts/check-release-version.sh`, `scripts/sync-install-embed.sh check`, `scripts/test-prod-env-refresh.sh`, `scripts/test-release-notes.sh` · **Docs Lint** — `scripts/docs-check.sh` · **Coordinator Tests** — `go test -race $(go list ./... \| grep -v /e2e)` with `postgres:16` service + `gofmt` on tracked Go files outside frozen report evidence · **Coordinator Lint** — `golangci-lint run` (v2.1.6) · **Prompt Sidecar Tests** — cargo fmt/check/clippy/test on Rust 1.88.0, static musl Docker stage, `verify-prompt-sidecar-linux.sh` · **Provider Tests** (macOS 12-vcpu) — `swift build --build-tests`, metallib staging, `swift test`, `verify-prompt-parity.sh`, six nested suites via `run-nested-suite.sh` (each its own step, `if: !cancelled()`), `test-install-atomic.sh` · **Swift Build + Cache** — release build of `darkbloom` + `darkbloom-fan-helper`, warms the SwiftPM cache · **Console UI Lint & Build** — Node 22, `npm ci`, `npx eslint src/`, `npm run build` |
 | [`.github/workflows/integration.yml`](../../.github/workflows/integration.yml) | push to `master`/`main`, PR | **E2E Integration Tests** (macOS, 120 min budget): install Postgres 16, `swift build -c debug`, cargo sidecar build, metallib staging, HF snapshot downloads; lanes: paged @ 8 blocking gate (`TestIntegration\|TestProfile` minus exact-cache) → exact-cache routing paged @ 8 (expected red, `continue-on-error`) → default-posture smoke (`EXPECT_KV_BACKEND=contiguous`) → current coordinator vs released v0.7.12 provider (`scripts/fetch-v0712-provider.sh`, `DARKBLOOM_MIXED_VERSION_EXPECT=artifact`, fails unless `MIXED_VERSION_TIER_ARTIFACT_OK` appears) → released v0.7.12 coordinator (`git worktree add … v0.7.12`) vs candidate provider (`NonStreamingInference`, `StreamingInference`) |
 | [`.github/workflows/benchmarks.yml`](../../.github/workflows/benchmarks.yml) | PR, gated by the `benchmarks` environment (manual approval) | **E2E Benchmarks** — `go test ./e2e/ -count=1 -v -timeout 40m -p=1 -run 'TestBenchmark'`, posts `BENCHMARK_MD_PATH` as a PR comment |
 | [`.github/workflows/release-swift.yml`](../../.github/workflows/release-swift.yml) | tag `v*`, manual | Provider release; see [`../operations/provider-release.md`](../operations/provider-release.md) |

--- a/docs/operations/provider-release.md
+++ b/docs/operations/provider-release.md
@@ -1,6 +1,6 @@
 # Release a provider version
 
-> Last updated: 2026-09-10 · commit `5f021ba4d`
+> Last updated: 2026-09-11 · commit `ef7b5a9aa`
 
 Runbook for shipping a new `darkbloom` provider CLI: bump the two version
 constants, land the changelog, push a `vX.Y.Z` tag, approve the `prod`
@@ -249,7 +249,7 @@ shown in the run):
 | 11 | Hashes | computed **after** signing, notarizing, stapling and the tar rebuild: `BINARY_HASH = sha256(bin/darkbloom)` from the extracted tar, `BUNDLE_HASH = sha256(tar.gz)`, `METALLIB_HASH = sha256(flat mlx.metallib)` |
 | 12 | Upload bundle to R2 | `s3://$R2_BUCKET/releases/v$VERSION/darkbloom-bundle-macos-arm64.tar.gz`, plus `releases/latest/darkbloom-bundle-macos-arm64.tar.gz` and the legacy `releases/latest/eigeninference-bundle-macos-arm64.tar.gz` |
 | 13 | Register release with coordinator | `POST $COORDINATOR_URL/v1/releases` (below) |
-| 14 | Create GitHub Release | prod + tag only: `gh release create <tag> <tar.gz> --notes-file … --generate-notes`; notes list the three hashes, signer, "Notarized: yes", `Min macOS: 14.0`, and the `curl -fsSL <coordinator>/install.sh \| bash` install line |
+| 14 | Create GitHub Release | prod + tag only: `gh release create <tag> <tar.gz> --notes-file … --generate-notes`; notes list the source commit (`$GITHUB_SHA`), the three hashes, signer, "Notarized: yes", `Min macOS: 14.0`, and the `curl -fsSL <coordinator>/install.sh \| bash` install line |
 | 15 | Cleanup keychain | always |
 
 The registration payload (`coordinator/api/release_handlers.go`,

--- a/scripts/test-release-notes.sh
+++ b/scripts/test-release-notes.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Renders the GitHub Release notes heredoc from release-swift.yml the way the
+# "Create GitHub Release" step does, and checks that the notes name the source
+# commit the bundle was built from. The step itself only runs on a prod tag on a
+# macOS runner, so the heredoc is the part CI can exercise.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORKFLOW="$ROOT/.github/workflows/release-swift.yml"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/darkbloom-release-notes.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# Heredoc body, de-indented from the YAML block, with ${{ }} expressions
+# (resolved by Actions before the shell runs) replaced by a placeholder.
+body=$(awk '/cat > \/tmp\/release-notes.md <<NOTES/{f=1;next} f&&/^ *NOTES$/{exit} f' "$WORKFLOW" |
+    sed -e 's/^          //' -e 's/\${{[^}]*}}/EXPR/g')
+if [ -z "$body" ]; then
+    echo "heredoc not found in $WORKFLOW" >&2
+    exit 1
+fi
+
+# Same shell flags as the step.
+printf 'set -euo pipefail\ncat <<NOTES\n%s\nNOTES\n' "$body" > "$TEST_ROOT/render.sh"
+
+# Every shell variable the heredoc uses except GITHUB_SHA gets a placeholder, so
+# a new field needs no fixture here. Both greps may match nothing; that must not
+# abort the script under pipefail before the checks below can report.
+vars=$(printf '%s\n' "$body" | { grep -o '\${[A-Za-z_][A-Za-z0-9_]*}' || true; } |
+    tr -d '${}' | sort -u | { grep -vx GITHUB_SHA || true; } | sed 's/$/=x/')
+# env -i: CI exports GITHUB_SHA itself, which would hide the unset case.
+render() {
+    # shellcheck disable=SC2086 # $vars is NAME=x words, split on purpose
+    env -i PATH="$PATH" $vars "$@" bash "$TEST_ROOT/render.sh"
+}
+
+SHA=73093957b8f2f7058f9eabab3ab004c3d758ec16
+# Capture first: piping into grep -q would SIGPIPE render once grep exits early,
+# and pipefail would report that as a missing line.
+notes=$(render GITHUB_SHA="$SHA")
+if ! grep -qxF "**Commit:**        \`$SHA\`" <<<"$notes"; then
+    echo "release notes missing the source commit line" >&2
+    exit 1
+fi
+
+# Never publish notes with an empty commit.
+if render >/dev/null 2>&1; then
+    echo "release notes rendered without GITHUB_SHA" >&2
+    exit 1
+fi
+
+echo "release notes: ok"


### PR DESCRIPTION
## Summary

Release notes for a prod tag list the binary, CodeDirectory, bundle and metallib hashes but not the commit the bundle was built from, so getting from a published hash back to source means digging up the Actions run. The `Create GitHub Release` step now adds a `**Commit:**` line that links `GITHUB_SHA`. The job checks out without `ref:`, so that is the tagged commit. The README install section also says releases are published here.

```mermaid
flowchart LR
  subgraph Before
    T1[prod tag] --> N1["notes: hashes, signer, min macOS"]
  end
  subgraph After
    T2[prod tag] --> N2["notes: commit link, hashes, signer, min macOS"]
    N2 -. heredoc rendered in CI .-> C2[test-release-notes.sh]
  end
```

## Linked issue

Refs #717

## Test plan

- [x] `scripts/test-release-notes.sh` (new, added to Release Integrity) renders the notes heredoc from `release-swift.yml` under the step's `set -euo pipefail` and checks for the Commit line. It fails on master and passes here. It also fails if `GITHUB_SHA` is unset.
- [x] Ran the step's script with v0.9.3's commit and file hashes and `gh` stubbed out. GitHub's markdown API renders the line as a link to the commit:
  ```
  **Commit:**        [`2232503f85c044d62afcc4c30cb21fca0564f9ce`](https://github.com/Layr-Labs/d-inference/commit/2232503f85c044d62afcc4c30cb21fca0564f9ce)
  ```
- [x] The Release Integrity commands from `ci.yml`, `./scripts/docs-check.sh` and `make docs-impact-check BASE=origin/master` pass. actionlint only reports the existing `runs-on: xcode-27` label.
- [ ] The release job itself (prod tag, macOS runner, prod secrets)

## Components touched

- [ ] coordinator (Go)
- [ ] provider (Rust, legacy)
- [ ] provider-swift (Swift CLI)
- [ ] console-ui (Next.js)
- [ ] enclave (Swift)
- [x] infra / CI / release
- [x] docs

## Protocol / interface changes

- [x] No protocol/interface changes
- [ ] Yes — described above and matching side updated

## Documentation impact

- [x] Canonical documentation updated
- [ ] No documentation needed — reason:

## Notes for reviewers

- Only the GitHub Release notes change. The coordinator release record and `install.sh` still don't carry a commit.
- #717 also asks for releases on `darkbloomdev/darkbloom` and for the README to say which repo is canonical. That's a call for the org, so this refs the issue instead of closing it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Layr-Labs/codesmith/d-inference/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1792181602&installation_model_id=21733&pr_number=1108&repository=Layr-Labs%2Fd-inference&return_to=https%3A%2F%2Fgithub.com%2FLayr-Labs%2Fd-inference%2Fpull%2F1108&signature=74b13bd80578aff75235e84aa9e9a8c3c46b997ec3012a3ed4e6ca8c397d77a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->